### PR TITLE
Update `npm audit fix` message to provide more instruction

### DIFF
--- a/lib/audit.js
+++ b/lib/audit.js
@@ -245,7 +245,8 @@ function auditCmd (args, cb) {
               if (installMajor) {
                 output('  (installed due to `--force` option)')
               } else {
-                output('  (use `npm audit fix --force` to install breaking changes; or do it by hand)')
+                output('  (use `npm audit fix --force` to install breaking changes;' +
+                       ' or refer to `npm audit` for steps to fix these manually)')
               }
             }
           }


### PR DESCRIPTION
Discussed this here:
https://npm.community/t/npm-audit-fix-does-not-provide-enough-information/377/4

### Before
```
$ npm audit fix
npm WARN npm-test No description
npm WARN npm-test No repository field.
npm WARN npm-test No license field.
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@1.2.4 (node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.2.4: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})

up to date in 1.537s
fixed 0 of 12 vulnerabilities in 396 scanned packages
  1 package update for 12 vulns involved breaking changes
  (use `npm audit fix --force` to install breaking changes; or do it by hand)
```

### After
```
$ npm audit fix
npm WARN npm-test No description
npm WARN npm-test No repository field.
npm WARN npm-test No license field.
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@1.2.4 (node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.2.4: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})

up to date in 1.547s
fixed 0 of 12 vulnerabilities in 396 scanned packages
  1 package update for 12 vulns involved breaking changes
  (use `npm audit fix --force` to install breaking changes; or refer to `npm audit` for steps to fix these manually)
```