### PR TITLE
config: accept auth tokens from environment variables

### DIFF
--- a/lib/config/get-credentials-by-uri.js
+++ b/lib/config/get-credentials-by-uri.js
@@ -34,6 +34,12 @@ function getCredentialsByURI (uri) {
     return c
   }
 
+  if (this.get(nerfed + ':-authtoken')) {
+    c.token = this.get(nerfed + ':-authtoken')
+    // the bearer token is enough, don't confuse things
+    return c
+  }
+
   // Handle the old-style _auth=<base64> style for the default
   // registry, if set.
   var authDef = this.get('_auth')


### PR DESCRIPTION
As discussed on [npm.community][1], the fact that npm registry authentication tokens cannot be defined using environment variables does not seem justified anymore.

The restriction is caused by the config loader translating

* all `_` to `-`
* the whole variable name to lowercase

while the credential checker expects a key ending in `:_authToken`.

As suggested, this change fixes the problem by limiting the translation by the config loader to the part *before* the first colon.

Closes npm/npm#15565

[1]: https://npm.community/t/cannot-set-npm-config-keys-containing-underscores-registry-auth-tokens-for-example-via-npm-config-environment-variables/233