### PR TITLE
README.md improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 npm(1) -- a JavaScript package manager
 ==============================
 
-[![Build Status](https://img.shields.io/travis/npm/npm/latest.svg)](https://travis-ci.org/npm/npm)
+[![Build Status](https://img.shields.io/travis/npm/cli/latest.svg)](https://travis-ci.org/npm/cli)
 
 ## SYNOPSIS
 
@@ -88,7 +88,7 @@ experience if you run a recent version of npm. To upgrade, either use [Microsoft
 upgrade tool](https://github.com/felixrieseberg/npm-windows-upgrade),
 [download a new version of Node](https://nodejs.org/en/download/),
 or follow the Windows upgrade instructions in the
-[npm Troubleshooting Guide](./TROUBLESHOOTING.md).
+[Installing/upgrading npm](https://npm.community/t/installing-upgrading-npm/251/2) post.
 
 If that's not fancy enough for you, then you can fetch the code with
 git, and mess with it directly.


### PR DESCRIPTION
- Fixed link from `./TROUBLESHOOTING.md` to <https://npm.community/t/installing-upgrading-npm/251/2> as per [this post](https://npm.community/t/npm-troubleshooting-guide-link-in-readme-leads-to-404/601).
- Fixed Travis badge and its link from `npm/npm` to `npm/cli`.