### PR TITLE
added a header for usage with process.env

### DIFF
--- a/doc/misc/npm-scripts.md
+++ b/doc/misc/npm-scripts.md
@@ -143,11 +143,9 @@ The package.json fields are tacked onto the `npm_package_` prefix. So,
 for instance, if you had `{"name":"foo", "version":"1.2.5"}` in your
 package.json file, then your package scripts would have the
 `npm_package_name` environment variable set to "foo", and the
-`npm_package_version` set to "1.2.5".
-
-#### Usage
-As an example, you could access the `npm_package_version` variable by 
-referencing `process.env.npm_package_version` in your code.
+`npm_package_version` set to "1.2.5".  You can access these variables 
+in your code with `process.env.npm_package_name` and 
+`process.env.npm_package_version`, and so on for other fields.
 
 ### configuration
 

--- a/doc/misc/npm-scripts.md
+++ b/doc/misc/npm-scripts.md
@@ -176,6 +176,8 @@ whichever stage of the cycle is being executed. So, you could have a
 single script used for different parts of the process which switches
 based on what's currently happening.
 
+### process.env usage
+
 Objects are flattened following this format, so if you had
 `{"scripts":{"install":"foo.js"}}` in your package.json, then you'd
 see this in the script:

--- a/doc/misc/npm-scripts.md
+++ b/doc/misc/npm-scripts.md
@@ -143,7 +143,11 @@ The package.json fields are tacked onto the `npm_package_` prefix. So,
 for instance, if you had `{"name":"foo", "version":"1.2.5"}` in your
 package.json file, then your package scripts would have the
 `npm_package_name` environment variable set to "foo", and the
-`npm_package_version` set to "1.2.5"
+`npm_package_version` set to "1.2.5".
+
+#### Usage
+As an example, you could access the `npm_package_version` variable by 
+referencing `process.env.npm_package_version` in your code.
 
 ### configuration
 
@@ -175,8 +179,6 @@ Lastly, the `npm_lifecycle_event` environment variable is set to
 whichever stage of the cycle is being executed. So, you could have a
 single script used for different parts of the process which switches
 based on what's currently happening.
-
-### process.env usage
 
 Objects are flattened following this format, so if you had
 `{"scripts":{"install":"foo.js"}}` in your package.json, then you'd


### PR DESCRIPTION
added a header for usage with process.env to separate section from 'current lifecycle event' and make it easier to find