### PR TITLE
enable audit for npm i -g

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -239,7 +239,7 @@ function Installer (where, dryrun, args, opts) {
   this.link = opts.link != null ? opts.link : npm.config.get('link')
   this.saveOnlyLock = opts.saveOnlyLock
   this.global = opts.global != null ? opts.global : this.where === path.resolve(npm.globalDir, '..')
-  this.audit = npm.config.get('audit') && !this.global
+  this.audit = npm.config.get('audit')
   this.started = Date.now()
 }
 Installer.prototype = {}


### PR DESCRIPTION
I think `npm i -g` should show if there are any possible security vulnerabilities from the dependencies, if I would do `npm i -g cordova@7` for example.

(In comparison: `npm i cordova@7` shows the following message at the end: `found 55 vulnerabilities (4 low, 45 moderate, 6 high)`)

These changes pass Travis CI on my fork. I wonder if this behavior should be covered more deeply?