### PR TITLE
Better explanation on OTP

### DIFF
--- a/lib/auth/legacy.js
+++ b/lib/auth/legacy.js
@@ -52,7 +52,7 @@ function login (conf) {
     })
     .catch((err) => {
       if (err.code !== 'EOTP') throw err
-      return read.otp('Authenticator provided OTP:').then((otp) => {
+      return read.otp('Enter one-time password from your authenticator app: ').then((otp) => {
         conf.auth.otp = otp
         const u = conf.creds.username
         const p = conf.creds.password

--- a/lib/profile.js
+++ b/lib/profile.js
@@ -195,7 +195,7 @@ function set (args) {
       newUser[prop] = value
       return profile.set(newUser, conf).catch((err) => {
         if (err.code !== 'EOTP') throw err
-        return readUserInfo.otp('Enter OTP:  ').then((otp) => {
+        return readUserInfo.otp().then((otp) => {
           conf.auth.otp = otp
           return profile.set(newUser, conf)
         })
@@ -262,7 +262,7 @@ function enable2fa (args) {
         return pulseTillDone.withPromise(profile.set({tfa: {password, mode: 'disable'}}, conf))
       } else {
         if (conf.auth.otp) return
-        return readUserInfo.otp('Enter OTP:  ').then((otp) => {
+        return readUserInfo.otp('Enter one-time password from your authenticator app: ').then((otp) => {
           conf.auth.otp = otp
         })
       }

--- a/lib/token.js
+++ b/lib/token.js
@@ -164,7 +164,7 @@ function rm (args) {
       return profile.removeToken(key, conf).catch((ex) => {
         if (ex.code !== 'EOTP') throw ex
         log.info('token', 'failed because revoking this token requires OTP')
-        return readUserInfo.otp('Authenticator provided OTP:').then((otp) => {
+        return readUserInfo.otp().then((otp) => {
           conf.auth.otp = otp
           return profile.removeToken(key, conf)
         })
@@ -192,7 +192,7 @@ function create (args) {
     return profile.createToken(password, readonly, validCIDR, conf).catch((ex) => {
       if (ex.code !== 'EOTP') throw ex
       log.info('token', 'failed because it requires OTP')
-      return readUserInfo.otp('Authenticator provided OTP:').then((otp) => {
+      return readUserInfo.otp().then((otp) => {
         conf.auth.otp = otp
         log.info('token', 'creating with OTP')
         return pulseTillDone.withPromise(profile.createToken(password, readonly, validCIDR, conf))


### PR DESCRIPTION
Re-import of https://github.com/npm/npm/pull/21119

Use the defaut OTP explanation everywhere except when the context is "OTP-aware" (like when setting double-authentication).

@zkat I followed your recommendation about `npm login`, I just changed the message a little to be more understandable than the previous one, but not as verbose as the default one ;)

