### PR TITLE
Remove unused dependency wrappy

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,6 @@
     "validate-npm-package-name": "~3.0.0",
     "which": "^1.3.1",
     "worker-farm": "^1.6.0",
-    "wrappy": "~1.0.2",
     "write-file-atomic": "^2.3.0"
   },
   "bundleDependencies": [
@@ -251,7 +250,6 @@
     "validate-npm-package-license",
     "validate-npm-package-name",
     "which",
-    "wrappy",
     "write-file-atomic",
     "safe-buffer",
     "worker-farm",


### PR DESCRIPTION
The dependency [wrappy](https://www.npmjs.com/package/wrappy) is nowhere used throughout the entire project which is why I removed it.