### PR TITLE
cli: don't check for updates to npm when we are updating npm itself

### DIFF
--- a/bin/npm-cli.js
+++ b/bin/npm-cli.js
@@ -69,12 +69,15 @@
     npm.command = 'help'
   }
 
+  var isGlobalNpmUpdate = conf.global && ['install', 'update'].includes(npm.command) && npm.argv.includes('npm')
+
   // now actually fire up npm and run the command.
   // this is how to use npm programmatically:
   conf._exit = true
   npm.load(conf, function (er) {
     if (er) return errorHandler(er)
     if (
+      !isGlobalNpmUpdate &&
       npm.config.get('update-notifier') &&
       !unsupported.checkVersion(process.version).unsupported
     ) {

--- a/doc/spec/file-specifiers.md
+++ b/doc/spec/file-specifiers.md
@@ -55,9 +55,6 @@ note for the `npm-shrinkwrap.json` as it means the specifier there will
 be different then the original `package.json` (where it was relative to that
 `package.json`).
 
-# No, for `file:` type specifiers, we SHOULD shrinkwrap.  Other symlinks we
-# should not. Other symlinks w/o the link spec should be an error.
-
 When shrinkwrapping file specifiers, the contents of the destination
 package's `node_modules` WILL NOT be included in the shrinkwrap. If you want to lock
 down the destination package's `node_modules` you should create a shrinkwrap for it


### PR DESCRIPTION
This is to resolve: https://npm.community/t/npm-warns-about-new-version-while-installing-new-npm-version/655

Skip checking for updates if we are updating npm [similar to how pnpm does it](https://github.com/pnpm/pnpm/blob/31595a918f61e1be16d225a260941f5c1b7c02e6/packages/pnpm/src/main.ts#L174)