### PR TITLE
Fix IPv6  issue on npm install

### DIFF
--- a/doc/spec/file-specifiers.md
+++ b/doc/spec/file-specifiers.md
@@ -55,9 +55,6 @@ note for the `npm-shrinkwrap.json` as it means the specifier there will
 be different then the original `package.json` (where it was relative to that
 `package.json`).
 
-# No, for `file:` type specifiers, we SHOULD shrinkwrap.  Other symlinks we
-# should not. Other symlinks w/o the link spec should be an error.
-
 When shrinkwrapping file specifiers, the contents of the destination
 package's `node_modules` WILL NOT be included in the shrinkwrap. If you want to lock
 down the destination package's `node_modules` you should create a shrinkwrap for it

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -385,11 +385,13 @@ function getLocalAddresses () {
   } catch (e) {
     interfaces = {}
   }
-
+  
   return Object.keys(interfaces).map(function (nic) {
-    .map(function (addr) {
-      return addr.address
+    return interfaces[nic].filter(function (addr) {
     })
+      .map(function (addr) {
+        return addr.address
+      })
   }).reduce(function (curr, next) {
     return curr.concat(next)
   }, []).concat(undefined)

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -387,12 +387,9 @@ function getLocalAddresses () {
   }
 
   return Object.keys(interfaces).map(function (nic) {
-    return interfaces[nic].filter(function (addr) {
-      return addr.family === 'IPv4'
+    .map(function (addr) {
+      return addr.address
     })
-      .map(function (addr) {
-        return addr.address
-      })
   }).reduce(function (curr, next) {
     return curr.concat(next)
   }, []).concat(undefined)

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -305,8 +305,6 @@ exports.types = {
   key: [null, String],
   'legacy-bundling': Boolean,
   link: Boolean,
-  // local-address must be listed as an IP for a local network interface
-  // must be IPv4 due to node bug
   'local-address': getLocalAddresses(),
   loglevel: ['silent', 'error', 'warn', 'notice', 'http', 'timing', 'info', 'verbose', 'silly'],
   logstream: Stream,
@@ -385,16 +383,10 @@ function getLocalAddresses () {
   } catch (e) {
     interfaces = {}
   }
-  
-  return Object.keys(interfaces).map(function (nic) {
-    return interfaces[nic].filter(function (addr) {
-    })
-      .map(function (addr) {
-        return addr.address
-      })
-  }).reduce(function (curr, next) {
-    return curr.concat(next)
-  }, []).concat(undefined)
+
+  return Object.keys(interfaces).map(
+    nic => interfaces[nic].map(({address}) => address)
+  ).reduce((curr, next) => curr.concat(next), []).concat(undefined)
 }
 
 exports.shorthands = {


### PR DESCRIPTION
Remove hardcoded IPv4 adress familly

https://npm.community/t/npm-work-only-in-old-ipv4-world/986