### PR TITLE
Improved repository examples

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -366,15 +366,15 @@ command will be able to find you.
 
 Do it like this:
 
-    "repository" :
-      { "type" : "git"
-      , "url" : "https://github.com/npm/cli.git"
-      }
+    "repository": {
+      "type" : "git",
+      "url" : "https://github.com/npm/cli.git"
+    }
 
-    "repository" :
-      { "type" : "svn"
-      , "url" : "https://v8.googlecode.com/svn/trunk/"
-      }
+    "repository": {
+      "type" : "svn",
+      "url" : "https://v8.googlecode.com/svn/trunk/"
+    }
 
 The URL should be a publicly available (perhaps read-only) url that can be handed
 directly to a VCS program without any modification.  It should not be a url to an

--- a/doc/spec/file-specifiers.md
+++ b/doc/spec/file-specifiers.md
@@ -55,9 +55,6 @@ note for the `npm-shrinkwrap.json` as it means the specifier there will
 be different then the original `package.json` (where it was relative to that
 `package.json`).
 
-# No, for `file:` type specifiers, we SHOULD shrinkwrap.  Other symlinks we
-# should not. Other symlinks w/o the link spec should be an error.
-
 When shrinkwrapping file specifiers, the contents of the destination
 package's `node_modules` WILL NOT be included in the shrinkwrap. If you want to lock
 down the destination package's `node_modules` you should create a shrinkwrap for it


### PR DESCRIPTION
This better reflects the syntax expected when declaring the `repository` field.