### PR TITLE
Fix isInLink tracking and improve recording of transitive deps file: in locks

### DIFF
--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -177,7 +177,7 @@ function makeFakeChild (name, topPath, tree, sw, requested) {
     realpath: requested.type === 'directory' ? requested.fetchSpec : childPath(tree.realpath, pkg),
     location: (tree.location === '/' ? '' : tree.location + '/') + pkg.name,
     isLink: requested.type === 'directory',
-    isInLink: tree.isLink,
+    isInLink: tree.isLink || tree.isInLink,
     swRequires: sw.requires
   })
   tree.children.push(child)

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -110,7 +110,7 @@ function shrinkwrapDeps (deps, top, tree, seen) {
     var childIsOnlyDev = isOnlyDev(child)
     var pkginfo = deps[moduleName(child)] = {}
     var requested = getRequested(child) || child.package._requested || {}
-    var linked = child.isLink || child.isInLInk
+    var linked = child.isLink || child.isInLink
     var linkedFromHere = linked && path.relative(top.realpath, child.realpath)[0] !== '.'
     pkginfo.version = childVersion(top, child, requested)
     if (requested.type === 'git' && child.package._from) {

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -110,6 +110,8 @@ function shrinkwrapDeps (deps, top, tree, seen) {
     var childIsOnlyDev = isOnlyDev(child)
     var pkginfo = deps[moduleName(child)] = {}
     var requested = getRequested(child) || child.package._requested || {}
+    var linked = child.isLink || child.isInLInk
+    var linkedFromHere = linked && path.relative(top.realpath, child.realpath)[0] !== '.'
     pkginfo.version = childVersion(top, child, requested)
     if (requested.type === 'git' && child.package._from) {
       pkginfo.from = child.package._from
@@ -139,7 +141,8 @@ function shrinkwrapDeps (deps, top, tree, seen) {
         pkginfo.requires[moduleName(required)] = childRequested(top, required, requested)
       })
     }
-    if (child.children.length) {
+    // only iterate into links when they're
+    if (child.children.length && (!child.isLink || linkedFromHere)) {
       pkginfo.dependencies = {}
       shrinkwrapDeps(pkginfo.dependencies, top, child, seen)
     }

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -116,7 +116,7 @@ function shrinkwrapDeps (deps, top, tree, seen) {
     if (requested.type === 'git' && child.package._from) {
       pkginfo.from = child.package._from
     }
-    if (child.fromBundle || child.isInLink) {
+    if (child.fromBundle && !linked) {
       pkginfo.bundled = true
     } else {
       if (isRegistry(requested)) {
@@ -141,7 +141,7 @@ function shrinkwrapDeps (deps, top, tree, seen) {
         pkginfo.requires[moduleName(required)] = childRequested(top, required, requested)
       })
     }
-    // only iterate into links when they're
+    // iterate into children on non-links and links contained within the top level package
     if (child.children.length && (!child.isLink || linkedFromHere)) {
       pkginfo.dependencies = {}
       shrinkwrapDeps(pkginfo.dependencies, top, child, seen)

--- a/test/tap/shrinkwrap-local-dependency.js
+++ b/test/tap/shrinkwrap-local-dependency.js
@@ -20,8 +20,7 @@ var shrinkwrap = {
       version: 'file:' + unixFormatPath(path.join('mods', 'mod2')),
       dependencies: {
         mod1: {
-          version: 'file:' + unixFormatPath(path.join('mods', 'mod1')),
-          bundled: true
+          version: 'file:' + unixFormatPath(path.join('mods', 'mod1'))
         }
       }
     }

--- a/test/tap/spec-local-specifiers.js
+++ b/test/tap/spec-local-specifiers.js
@@ -585,9 +585,7 @@ test('save behavior', function (t) {
       var deps = pjson.dependencies || {}
       t.is(deps['sb-transitive'], 'file:../sb-transitive', 'package.json')
       var sdep = shrinkwrap.dependencies['sb-transitive'] || {}
-      var tdep = sdep.dependencies.sbta
-      t.like(tdep, {bundled: true, version: 'file:../sb-transitive/sbta'}, 'npm-shrinkwrap.json transitive dep')
-      t.like(sdep, {bundled: null, version: 'file:../sb-transitive'}, 'npm-shrinkwrap.json direct dep')
+      t.like(sdep, {bundled: null, dependencies: null, version: 'file:../sb-transitive'}, 'npm-shrinkwrap.json direct dep')
       t.done()
     })
   })


### PR DESCRIPTION
* [ ] Repro test from https://npm.community/t/npm-install-for-package-with-local-dependency-fails/754/10

Also fixes: https://npm.community/t/issue-npm-install-with-local-packages-and-symlinks-enoent/518
