### PR TITLE
Prevent blowing up on audit malformed response

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -834,8 +834,12 @@ Installer.prototype.printInstalledForHuman = function (diffs, auditResult) {
   if (removed) actions.push('removed ' + packages(removed))
   if (updated) actions.push('updated ' + packages(updated))
   if (moved) actions.push('moved ' + packages(moved))
-  if (auditResult && auditResult.metadata && auditResult.metadata.totalDependencies) {
-    actions.push('audited ' + packages(auditResult.metadata.totalDependencies))
+  if (auditResult) {
+    if (auditResult.metadata && auditResult.metadata.totalDependencies) {
+      actions.push('audited ' + packages(auditResult.metadata.totalDependencies))
+    } else {
+      log.warn('invalid audit result', 'audit result doesn\'t contain `metadata`')
+    }
   }
   if (actions.length === 0) {
     report += 'up to date'

--- a/lib/install.js
+++ b/lib/install.js
@@ -766,6 +766,9 @@ Installer.prototype.printInstalled = function (cb) {
     if (!this.auditSubmission) return
     return Bluebird.resolve(this.auditSubmission).timeout(10000).catch(() => null)
   }).then((auditResult) => {
+    if (auditResult && !auditResult.metadata) {
+      log.warn('audit', 'Audit result from registry missing metadata. This is probably an issue with the registry.')
+    }
     // maybe write audit report w/ hash of pjson & shrinkwrap for later reading by `npm audit`
     if (npm.config.get('json')) {
       return this.printInstalledForJSON(diffs, auditResult)
@@ -837,8 +840,6 @@ Installer.prototype.printInstalledForHuman = function (diffs, auditResult) {
   if (auditResult) {
     if (auditResult.metadata && auditResult.metadata.totalDependencies) {
       actions.push('audited ' + packages(auditResult.metadata.totalDependencies))
-    } else {
-      log.warn('invalid audit result', 'audit result doesn\'t contain `metadata`')
     }
   }
   if (actions.length === 0) {

--- a/lib/install.js
+++ b/lib/install.js
@@ -837,10 +837,8 @@ Installer.prototype.printInstalledForHuman = function (diffs, auditResult) {
   if (removed) actions.push('removed ' + packages(removed))
   if (updated) actions.push('updated ' + packages(updated))
   if (moved) actions.push('moved ' + packages(moved))
-  if (auditResult) {
-    if (auditResult.metadata && auditResult.metadata.totalDependencies) {
-      actions.push('audited ' + packages(auditResult.metadata.totalDependencies))
-    }
+  if (auditResult && auditResult.metadata && auditResult.metadata.totalDependencies) {
+    actions.push('audited ' + packages(auditResult.metadata.totalDependencies))
   }
   if (actions.length === 0) {
     report += 'up to date'

--- a/lib/install.js
+++ b/lib/install.js
@@ -834,7 +834,7 @@ Installer.prototype.printInstalledForHuman = function (diffs, auditResult) {
   if (removed) actions.push('removed ' + packages(removed))
   if (updated) actions.push('updated ' + packages(updated))
   if (moved) actions.push('moved ' + packages(moved))
-  if (auditResult && auditResult.metadata.totalDependencies) {
+  if (auditResult && auditResult.metadata && auditResult.metadata.totalDependencies) {
     actions.push('audited ' + packages(auditResult.metadata.totalDependencies))
   }
   if (actions.length === 0) {


### PR DESCRIPTION
npm is failing our builds with:
```
npm ERR! Cannot read property 'totalDependencies' of undefined
```

which it's coming out of auditing

There must be something wrong in whatever code is generating the response - this only prevents blowing up a valid installation because of this.