### PR TITLE
 pack: add dryRun option to packDirectory

### DIFF
--- a/lib/pack.js
+++ b/lib/pack.js
@@ -68,23 +68,16 @@ function pack_ (pkg, dir) {
       : mani.name
     const target = `${name}-${mani.version}.tgz`
     return pinflight(target, () => {
-      if (mani._requested.type === 'directory') {
-        return cacache.tmp.withTmp(npm.tmp, {tmpPrefix: 'packing'}, (tmp) => {
-          const tmpTarget = path.join(tmp, path.basename(target))
-          return prepareDirectory(mani._resolved)
-            .then(() => {
-              return packDirectory(mani, mani._resolved, tmpTarget, target, true)
-            })
-            .tap(() => {
-              if (npm.config.get('dry-run')) {
-                log.verbose('pack', '--dry-run mode enabled. Skipping write.')
-              } else {
-                return move(tmpTarget, target, {Promise: BB, fs})
-              }
-            })
-        })
-      } else if (npm.config.get('dry-run')) {
+      const dryRun = npm.config.get('dry-run')
+      if (dryRun) {
         log.verbose('pack', '--dry-run mode enabled. Skipping write.')
+      }
+      if (mani._requested.type === 'directory') {
+        return prepareDirectory(mani._resolved)
+          .then(() => {
+            return packDirectory(mani, mani._resolved, target, target, true, dryRun)
+          })
+      } else if (dryRun) {
         return cacache.tmp.withTmp(npm.tmp, {tmpPrefix: 'packing'}, (tmp) => {
           const tmpTarget = path.join(tmp, path.basename(target))
           return packFromPackage(pkg, tmpTarget, target)
@@ -137,7 +130,7 @@ function prepareDirectory (dir) {
 }
 
 module.exports.packDirectory = packDirectory
-function packDirectory (mani, dir, target, filename, logIt) {
+function packDirectory (mani, dir, target, filename, logIt, dryRun) {
   deprCheck(mani)
   return readJson(path.join(dir, 'package.json')).then((pkg) => {
     return lifecycle(pkg, 'prepack', dir)
@@ -165,7 +158,11 @@ function packDirectory (mani, dir, target, filename, logIt) {
         .then((files) => tar.create(tarOpt, files.map((f) => `./${f}`)))
         .then(() => getContents(pkg, tmpTarget, filename, logIt))
         // thread the content info through
-        .tap(() => move(tmpTarget, target, {Promise: BB, fs}))
+        .tap(() => {
+          if (!dryRun) {
+            return move(tmpTarget, target, {Promise: BB, fs})
+          }
+        })
         .tap(() => lifecycle(pkg, 'postpack', dir))
     })
   })

--- a/lib/pack.js
+++ b/lib/pack.js
@@ -69,15 +69,13 @@ function pack_ (pkg, dir) {
     const target = `${name}-${mani.version}.tgz`
     return pinflight(target, () => {
       const dryRun = npm.config.get('dry-run')
-      if (dryRun) {
-        log.verbose('pack', '--dry-run mode enabled. Skipping write.')
-      }
       if (mani._requested.type === 'directory') {
         return prepareDirectory(mani._resolved)
           .then(() => {
             return packDirectory(mani, mani._resolved, target, target, true, dryRun)
           })
       } else if (dryRun) {
+        log.verbose('pack', '--dry-run mode enabled. Skipping write.')
         return cacache.tmp.withTmp(npm.tmp, {tmpPrefix: 'packing'}, (tmp) => {
           const tmpTarget = path.join(tmp, path.basename(target))
           return packFromPackage(pkg, tmpTarget, target)
@@ -159,7 +157,9 @@ function packDirectory (mani, dir, target, filename, logIt, dryRun) {
         .then(() => getContents(pkg, tmpTarget, filename, logIt))
         // thread the content info through
         .tap(() => {
-          if (!dryRun) {
+          if (dryRun) {
+            log.verbose('pack', '--dry-run mode enabled. Skipping write.')
+          } else {
             return move(tmpTarget, target, {Promise: BB, fs})
           }
         })


### PR DESCRIPTION
Add `dryRun` option to `packDirectory`. This makes it possible to run postscript after the archive has been written to cwd. Something similar could probably be done for `packFromPackage`.

See https://npm.community/t/592?u=larsgw