### PR TITLE
Mention registry terms of use in manpage and registry doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,7 @@ You can configure npm to use any compatible registry you
 like, and even run your own registry. Check out the [doc on
 registries](https://docs.npmjs.com/misc/registry).
 
-Use of someone else's registry may be governed by terms of use. The
-terms of use for the default public registry are available at
-<https://www.npmjs.com>.
+Use of someone else's registry may be governed by terms of use. 
 
 ## Super Easy Install
 

--- a/README.md
+++ b/README.md
@@ -16,14 +16,13 @@ Much more info will be available via `npm help` once it's installed.
 To install an old **and unsupported** version of npm that works on node v5
 and prior, clone the git repo and dig through the old tags and branches.
 
-**npm is configured to use npm, Inc.'s public package registry at
-<https://registry.npmjs.org> by default.**
+**npm is configured to use npm, Inc.'s public registry at
+<https://registry.npmjs.org> by default.** Use of the npm public registry
+is subject to terms of use available at <https://www.npmjs.com/policies/terms>.
 
 You can configure npm to use any compatible registry you
 like, and even run your own registry. Check out the [doc on
 registries](https://docs.npmjs.com/misc/registry).
-
-Use of someone else's registry may be governed by terms of use. 
 
 ## Super Easy Install
 

--- a/doc/cli/npm.md
+++ b/doc/cli/npm.md
@@ -21,6 +21,16 @@ programs.
 
 Run `npm help` to get a list of available commands.
 
+## IMPORTANT
+
+npm is configured to use npm, Inc.'s public registry at
+https://registry.npmjs.org by default. Use of the npm public registry is
+subject to terms of use available at https://www.npmjs.com/policies/terms.
+
+You can configure npm to use any compatible registry you like, and even run
+your own registry. Use of someone else's registry may be governed by their
+terms of use.
+
 ## INTRODUCTION
 
 You probably got npm because you want to install stuff.

--- a/doc/misc/npm-registry.md
+++ b/doc/misc/npm-registry.md
@@ -7,12 +7,20 @@ To resolve packages by name and version, npm talks to a registry website
 that implements the CommonJS Package Registry specification for reading
 package info.
 
-Additionally, npm's package registry implementation supports several
+npm is configured to use npm, Inc.'s public registry at
+<https://registry.npmjs.org> by default. Use of the npm public registry is
+subject to terms of use available at <https://www.npmjs.com/policies/terms>.
+
+You can configure npm to use any compatible registry you like, and even run
+your own registry. Use of someone else's registry may be governed by their
+terms of use.
+
+npm's package registry implementation supports several
 write APIs as well, to allow for publishing packages and managing user
 account information.
 
-The official public npm registry is at <https://registry.npmjs.org/>.  It
-is powered by a CouchDB database, of which there is a public mirror at
+The npm public registry is powered by a CouchDB database,
+of which there is a public mirror at
 <https://skimdb.npmjs.com/registry>.  The code for the couchapp is
 available at <https://github.com/npm/npm-registry-couchapp>.
 


### PR DESCRIPTION
This small PR spruces up the language on registry terms of use in `README`, and adds parallel language to source files for `npm-registry` and `man npm` doc.

The general thrust is to increase the notice folks using `npm` get that their registry server---whoever runs it---potentially comes with terms of service they should be aware of.  If there are other places where that message should appear, I'd be very interested in pushing more commits.

cc & thanks: @iarna