### PR TITLE
version: fix -S argument passing for sign-git-commit

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -296,7 +296,11 @@ function _commit (version, localData, cb) {
   const message = npm.config.get('message').replace(/%s/g, version)
   const signTag = npm.config.get('sign-git-tag')
   const signCommit = npm.config.get('sign-git-commit')
-  const commitArgs = buildCommitArgs([ 'commit', signCommit ? '-S -m' : '-m', message ])
+  const commitArgs = buildCommitArgs([
+    'commit',
+    ...(signCommit ? ['-S', '-m'] : ['-m']),
+    message
+  ])
   const flagForTag = signTag ? '-sm' : '-am'
 
   stagePackageFiles(localData, options).then(() => {


### PR DESCRIPTION
Oops: 7984206e2f41b8d8361229cde88d68f0c96ed0b8 did the
wrong thing with the git params, and it breaks anyone
trying to sign their git commits with npm version.

Fixes: https://npm.community/t/1661
Credit: @zkat

/cc @dpogue 