### PR TITLE
Docs: mention --otp flag when prompting for OTP

### DIFF
--- a/lib/utils/read-user-info.js
+++ b/lib/utils/read-user-info.js
@@ -21,9 +21,9 @@ function read (opts) {
 function readOTP (msg, otp, isRetry) {
   if (!msg) {
     msg = [
-      'There was an error while trying authentication due to OTP (One-Time-Password).',
-      'The One-Time-Password is generated via applications like Authy or',
-      'Google Authenticator, for more information see:',
+      'This command requires a one-time password (OTP) from your authenticator app.',
+      'Enter one below. You can also pass one on the command line by appending --otp=123456.',
+      'For more information, see:',
       'https://docs.npmjs.com/getting-started/using-two-factor-authentication',
       'Enter OTP: '
     ].join('\n')


### PR DESCRIPTION
It's nice to surface this a little more.

Also, I tweaked the wording a bit, since I was surprised that `npm publish` said there was an error before it prompted for an OTP. Prompting for an OTP is not an error condition.