### PR TITLE
Fix misleading on npm install with git url

### DIFF
--- a/doc/cli/npm-install.md
+++ b/doc/cli/npm-install.md
@@ -199,7 +199,7 @@ after packing it up into a tarball (b).
     be any valid semver range or exact version, and npm will look for any tags
     or refs matching that range in the remote repository, much as it would for a
     registry dependency. If neither `#<commit-ish>` or `#semver:<semver>` is
-    specified, then `master` is used.
+    specified, then the default branch of the repository is used.
 
     If the repository makes use of submodules, those submodules will be cloned
     as well.


### PR DESCRIPTION
With some tests I note npm use default branch of repository instead of `master`.