### PR TITLE
cli: literally don't run update-notifier in CI environment

### DIFF
--- a/bin/npm-cli.js
+++ b/bin/npm-cli.js
@@ -78,16 +78,15 @@
     if (er) return errorHandler(er)
     if (
       !isGlobalNpmUpdate &&
+      !require('ci-info').isCI &&
       npm.config.get('update-notifier') &&
       !unsupported.checkVersion(process.version).unsupported
     ) {
       const pkg = require('../package.json')
       let notifier = require('update-notifier')({pkg})
-      const isCI = require('ci-info').isCI
       if (
         notifier.update &&
-        notifier.update.latest !== pkg.version &&
-        !isCI
+        notifier.update.latest !== pkg.version
       ) {
         const color = require('ansicolors')
         const useColor = npm.config.get('color')


### PR DESCRIPTION
This is a followup to #33 that changes the logic to literally *not* run update-notifier in CI environment, instead of running it and omitting the result.

Checking environment variables is a “cheap” check and, as such, should ideally come before other, potentially more expensive checks such as those that hit the filesystem or the network.

/cc @Sibiraj-S @zkat 