### PR TITLE
Add semver link and note on empty string format to `deprecate` doc

### DIFF
--- a/doc/cli/npm-deprecate.md
+++ b/doc/cli/npm-deprecate.md
@@ -10,8 +10,7 @@ npm-deprecate(1) -- Deprecate a version of a package
 This command will update the npm registry entry for a package, providing
 a deprecation warning to all who attempt to install it.
 
-It works on [version ranges](https://semver.npmjs.com/) as well as specific versions, so you can do
-something like this:
+It works on [version ranges](https://semver.npmjs.com/) as well as specific versions, so you can do something like this:
 
     npm deprecate my-thing@"< 0.2.3" "critical bug fixed in v0.2.3"
 

--- a/doc/cli/npm-deprecate.md
+++ b/doc/cli/npm-deprecate.md
@@ -10,14 +10,17 @@ npm-deprecate(1) -- Deprecate a version of a package
 This command will update the npm registry entry for a package, providing
 a deprecation warning to all who attempt to install it.
 
-It works on [version ranges](https://semver.npmjs.com/) as well as specific versions, so you can do something like this:
+It works on [version ranges](https://semver.npmjs.com/) as well as specific 
+versions, so you can do something like this:
 
     npm deprecate my-thing@"< 0.2.3" "critical bug fixed in v0.2.3"
 
 Note that you must be the package owner to deprecate something.  See the
 `owner` and `adduser` help topics.
 
-To un-deprecate a package, specify an empty string (`""`) for the `message` argument. Note that you must use double quotes with no space between them to format an empty string.
+To un-deprecate a package, specify an empty string (`""`) for the `message` 
+argument. Note that you must use double quotes with no space between them to 
+format an empty string.
 
 ## SEE ALSO
 

--- a/doc/cli/npm-deprecate.md
+++ b/doc/cli/npm-deprecate.md
@@ -10,7 +10,7 @@ npm-deprecate(1) -- Deprecate a version of a package
 This command will update the npm registry entry for a package, providing
 a deprecation warning to all who attempt to install it.
 
-It works on version ranges as well as specific versions, so you can do
+It works on [version ranges](https://semver.npmjs.com/) as well as specific versions, so you can do
 something like this:
 
     npm deprecate my-thing@"< 0.2.3" "critical bug fixed in v0.2.3"
@@ -18,7 +18,7 @@ something like this:
 Note that you must be the package owner to deprecate something.  See the
 `owner` and `adduser` help topics.
 
-To un-deprecate a package, specify an empty string (`""`) for the `message` argument.
+To un-deprecate a package, specify an empty string (`""`) for the `message` argument. Note that you must use double quotes with no space between them to format an empty string.
 
 ## SEE ALSO
 


### PR DESCRIPTION
I got feedback from our support team that some users are confused about semver range formatting and the format needed for the empty string in this doc, so I've made a few small tweaks to reduce confusion.