### PR TITLE
Automatically audit dependency licenses

### DIFF
--- a/.licensee.json
+++ b/.licensee.json
@@ -1,0 +1,9 @@
+{
+  "license": "(MIT OR BSD-2-Clause OR BSD-3-Clause OR Apache-2.0 OR ISC OR Unlicense OR CC-BY-3.0 OR CC0-1.0 OR Artistic-2.0)",
+  "whitelist": {
+    "config-chain": "1.1.11",
+    "cyclist": "0.2.2",
+    "json-schema": "0.2.3",
+    "qrcode-terminal": "0.12.0"
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,4 @@ install:
   - "node . install"
 script:
   - "node . run tap -- \"test/tap/*.js\" \"test/broken-under-nyc/*.js\""
+  - "node . run licenses"

--- a/package-lock.json
+++ b/package-lock.json
@@ -186,6 +186,12 @@
         }
       }
     },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
     "array-includes": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
@@ -966,6 +972,12 @@
       "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
       "dev": true
     },
+    "docopt": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/docopt/-/docopt-0.6.2.tgz",
+      "integrity": "sha1-so6eIiDaXsSffqW7JKR3h0Be6xE=",
+      "dev": true
+    },
     "doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -1624,6 +1636,15 @@
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
+      }
+    },
+    "fs-access": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
+      "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
+      "dev": true,
+      "requires": {
+        "null-check": "^1.0.0"
       }
     },
     "fs-exists-cached": {
@@ -2304,6 +2325,12 @@
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
     },
+    "json-parse-errback": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/json-parse-errback/-/json-parse-errback-2.0.1.tgz",
+      "integrity": "sha1-x6nCvjqFWzQvgqv8ibyFk1tYhPo=",
+      "dev": true
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -2444,6 +2471,23 @@
         "which": "^1.3.0",
         "y18n": "^4.0.0",
         "yargs": "^11.0.0"
+      }
+    },
+    "licensee": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/licensee/-/licensee-5.0.0.tgz",
+      "integrity": "sha512-g243BLsJYWWyNhwDEMewc2f6Ebyy1yiJmMDgO8MCQtLOXA8JO4O2/kbJ1QwwWdlmrwDgYECdl9CJBrKsr4ZezA==",
+      "dev": true,
+      "requires": {
+        "docopt": "^0.6.2",
+        "fs-access": "^1.0.0",
+        "json-parse-errback": "^2.0.1",
+        "read-package-tree": "^5.2.1",
+        "run-parallel": "^1.1.9",
+        "semver": "^5.5.0",
+        "simple-concat": "^1.0.0",
+        "spdx-expression-validate": "^1.0.1",
+        "spdx-satisfies": "^4.0.0"
       }
     },
     "load-json-file": {
@@ -3173,6 +3217,12 @@
         "gauge": "~2.7.3",
         "set-blocking": "~2.0.0"
       }
+    },
+    "null-check": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
+      "integrity": "sha1-l33/1xdgErnsMNKjnbXPcqBDnt0=",
+      "dev": true
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -6679,6 +6729,12 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
+    "simple-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
+      "dev": true
+    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -6791,6 +6847,17 @@
         "source-map": "^0.6.0"
       }
     },
+    "spdx-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-compare/-/spdx-compare-1.0.0.tgz",
+      "integrity": "sha512-C1mDZOX0hnu0ep9dfmuoi03+eOdDoz2yvK79RxbcrVEG1NO1Ph35yW102DHWKN4pk80nwCgeMmSY5L25VE4D9A==",
+      "dev": true,
+      "requires": {
+        "array-find-index": "^1.0.2",
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-ranges": "^2.0.0"
+      }
+    },
     "spdx-correct": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
@@ -6814,10 +6881,44 @@
         "spdx-license-ids": "^3.0.0"
       }
     },
+    "spdx-expression-validate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-expression-validate/-/spdx-expression-validate-1.0.2.tgz",
+      "integrity": "sha1-Wk5NdhbtHJuIFQNmtCF/dnwn6eM=",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^1.0.0"
+      },
+      "dependencies": {
+        "spdx-expression-parse": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+          "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+          "dev": true
+        }
+      }
+    },
     "spdx-license-ids": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
       "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+    },
+    "spdx-ranges": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-ranges/-/spdx-ranges-2.0.0.tgz",
+      "integrity": "sha512-AUUXLfqkwD7GlzZkXv8ePPCpPjeVWI9xJCfysL8re/uKb6H10umMnC7bFRsHmLJan4fslUtekAgpHlSgLc/7mA==",
+      "dev": true
+    },
+    "spdx-satisfies": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-satisfies/-/spdx-satisfies-4.0.0.tgz",
+      "integrity": "sha512-OcARj6U1OuVv98SVrRqgrR30sVocONtoPpnX8Xz4vXNrFVedqtbgkA+0KmQoXIQ2xjfltPPRVIMeNzKEFLWWKQ==",
+      "dev": true,
+      "requires": {
+        "spdx-compare": "^1.0.0",
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-ranges": "^2.0.0"
+      }
     },
     "sprintf-js": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -265,6 +265,7 @@
   ],
   "devDependencies": {
     "deep-equal": "~1.0.1",
+    "licensee": "^5.0.0",
     "marked": "^0.5.0",
     "marked-man": "~0.2.1",
     "npm-registry-couchapp": "^2.7.1",
@@ -279,6 +280,7 @@
     "dumpconf": "env | grep npm | sort | uniq",
     "prepare": "node bin/npm-cli.js --no-audit --no-timing prune --prefix=. --no-global && rimraf test/*/*/node_modules && make -j4 doc",
     "preversion": "bash scripts/update-authors.sh && git add AUTHORS && git commit -m \"update AUTHORS\" || true",
+    "licenses": "licensee --production --errors-only",
     "tap": "tap --reporter=classic --timeout 300",
     "tap-cover": "tap --reporter=classic --nyc-arg='--cache' --coverage --timeout 600",
     "test": "standard && npm run test-tap",


### PR DESCRIPTION
This PR adds an npm script and Travis CI script line to check dependencies' licenses against a configured acceptable-license rule.  I've also added dependencies that lack proper license metadata to a whitelist, after checking their terms by hand.

Please note that I've only whitelisted _the current versions_ of dependencies without valid license metadata.  If we bump those deps, and the new versions don't have valid metadata, either, the license check will fail until the new versions are added to the whitelist.  There are only four of those deps at present.

cc @iarna