### PR TITLE
bash_completion.d dir found in /etc not /usr/local

### DIFF
--- a/doc/cli/npm-completion.md
+++ b/doc/cli/npm-completion.md
@@ -17,9 +17,10 @@ everywhere:
     npm completion >> ~/.bashrc
     npm completion >> ~/.zshrc
 
-You may of course also pipe the output of npm completion to a file
-such as `/usr/local/etc/bash_completion.d/npm` if you have a system
-that will read that file for you.
+You may of course also pipe the output of `npm completion` to a file
+such as `/usr/local/etc/bash_completion.d/npm` or 
+`/etc/bash_completion.d/npm` if you have a system that will read 
+that file for you.
 
 When `COMP_CWORD`, `COMP_LINE`, and `COMP_POINT` are defined in the
 environment, `npm completion` acts in "plumbing mode", and outputs


### PR DESCRIPTION
I found this page useful for setting up npm command completion. Thank you npm-cli
documentation team.

This suggested change is based on my system which runs Ubuntu where
the completion directory path for bash is found in /etc/bash_completion.d and not /usr/local/etc/bash_completion.d

I dug around docs for this in [The Bash Manual](https://www.gnu.org/software/bash/manual/bashref.html#Programmable-Completion) and on an old (sadly retired) Debian Admin Site [An Introduction to Bash Completion](https://debian-administration.org/article/317/An_introduction_to_bash_completion_part_2) which seemed supportive of the dir being in /etc but I do not have access to an OS X machine where I guess bash_completion.d could be in /usr/local/etc so I left it in.