### PR TITLE
Update OTP documentation for dist-tag add

### DIFF
--- a/doc/cli/npm-dist-tag.md
+++ b/doc/cli/npm-dist-tag.md
@@ -15,9 +15,9 @@ Add, remove, and enumerate distribution tags on a package:
 
 * add:
   Tags the specified version of the package with the specified tag, or the
-  `--tag` config if not specified. If the tag you're adding is `latest` and you
-  have two-factor authentication on auth-and-writes then you'll need to include
-  an otp on the command line with `--otp`.
+  `--tag` config if not specified. If you have two-factor authentication on
+  auth-and-writes then you’ll need to include a one-time password on the
+  command line with `--otp <one-time password>`.
 
 * rm:
   Clear a tag that is no longer in use from the package.


### PR DESCRIPTION
See discussion here: https://npm.community/t/npm-dist-tag-add-with-2fa-enabled-fails-for-non-latest-tag-with-500/2432

TL;DR:

> To be clear, you can specify an existing tag and it’ll change it. If you have 2FA enabled, you do need to specify `--otp` and if you don’t, you should get a `401` as above.