### PR TITLE
edit: scoped packages

### DIFF
--- a/doc/cli/npm-edit.md
+++ b/doc/cli/npm-edit.md
@@ -3,12 +3,14 @@ npm-edit(1) -- Edit an installed package
 
 ## SYNOPSIS
 
-    npm edit <pkg>[@<version>]
+    npm edit <pkg>[/<subpkg>...]
 
 ## DESCRIPTION
 
-Opens the package folder in the default editor (or whatever you've
-configured as the npm `editor` config -- see `npm-config(7)`.)
+Selects a (sub)dependency in the current
+working directory and opens the package folder in the default editor
+(or whatever you've configured as the npm `editor` config -- see
+`npm-config(7)`.)
 
 After it has been edited, the package is rebuilt so as to pick up any
 changes in compiled packages.

--- a/lib/edit.js
+++ b/lib/edit.js
@@ -22,6 +22,20 @@ function edit (args, cb) {
     ))
   }
   p = p.split('/')
+    // combine scoped parts
+    .reduce(function (parts, part) {
+      if (parts.length === 0) {
+        return [part]
+      }
+      var lastPart = parts[parts.length - 1]
+      // check if previous part is the first part of a scoped package
+      if (lastPart[0] === '@' && !lastPart.includes('/')) {
+        parts[parts.length - 1] += '/' + part
+      } else {
+        parts.push(part)
+      }
+      return parts
+    }, [])
     .join('/node_modules/')
     .replace(/(\/node_modules)+/, '/node_modules')
   var f = path.resolve(npm.dir, p)

--- a/lib/edit.js
+++ b/lib/edit.js
@@ -2,7 +2,7 @@
 // open the package folder in the $EDITOR
 
 module.exports = edit
-edit.usage = 'npm edit <pkg>[@<version>]'
+edit.usage = 'npm edit <pkg>[/<subpkg>...]'
 
 edit.completion = require('./utils/completion/installed-shallow.js')
 


### PR DESCRIPTION
* handle scoped packages properly
* change usage info so it matches old (and current) behavior.

There's an easier way to do this, but that handles some edge cases differently (namely, ignore leading and trailing forward slashes instead of trying to edit root folders), and I don't know if that is allowed.

```diff
diff --git a/lib/edit.js b/lib/edit.js
index 48bcd5d34..2b2a02224 100644
--- a/lib/edit.js
+++ b/lib/edit.js
@@ -21,7 +21,7 @@ function edit (args, cb) {
       "No editor set.  Set the 'editor' config, or $EDITOR environ."
     ))
   }
-  p = p.split('/')
+  p = (p.match(/(@[^/]+\/[^/]+|[^/]+)/g) || [])
     .join('/node_modules/')
     .replace(/(\/node_modules)+/, '/node_modules')
   var f = path.resolve(npm.dir, p)
```

See [https://npm.community/t/2258](https://npm.community/t/2258?u=larsgw).