### PR TITLE
feat(cli, outdated): Adds 'Homepage' to outdated --long output.

### DIFF
--- a/doc/cli/npm-outdated.md
+++ b/doc/cli/npm-outdated.md
@@ -27,6 +27,7 @@ In the output:
 * `package type` (when using `--long` / `-l`) tells you whether this package is
   a `dependency` or a `devDependency`. Packages not included in `package.json`
   are always marked `dependencies`.
+* `homepage` (when using `--long` / `-l`) is the `homepage` value contained in the package's `package.json`
 * Red means there's a newer version matching your semver requirements, so you should update now.
 * Yellow indicates that there's a newer version above your semver requirements (usually new major, or new 0.x minor) so proceed with caution.
 

--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -94,7 +94,7 @@ function outdated (args, silent, cb) {
           'Latest',
           'Location'
         ]
-        if (long) outHead.push('Package Type')
+        if (long) outHead.push('Package Type', 'Homepage')
         var outTable = [outHead].concat(outList)
 
         if (npm.color) {
@@ -123,6 +123,7 @@ function makePretty (p) {
   var latest = p[4]
   var type = p[6]
   var deppath = p[7]
+  var homepage = p[0].package.homepage
 
   var columns = [ depname,
     has || 'MISSING',
@@ -130,7 +131,10 @@ function makePretty (p) {
     latest,
     deppath
   ]
-  if (long) columns[5] = type
+  if (long) {
+    columns[5] = type
+    columns[6] = homepage
+  }
 
   if (npm.color) {
     columns[0] = color[has === want || want === 'linked' ? 'yellow' : 'red'](columns[0]) // dep
@@ -181,7 +185,10 @@ function makeJSON (list) {
       latest: latest,
       location: dir
     }
-    if (long) out[depname].type = type
+    if (long) {
+      out[depname].type = type
+      out[depname].homepage = dep.package.homepage
+    }
   })
   return JSON.stringify(out, null, 2)
 }

--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -161,7 +161,7 @@ function makeParseable (list) {
       (has ? (depname + '@' + has) : 'MISSING'),
       depname + '@' + latest
     ]
-    if (long) out.push(type,  dep.package.homepage);
+    if (long) out.push(type, dep.package.homepage)
 
     return out.join(':')
   }).join(os.EOL)

--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -161,7 +161,7 @@ function makeParseable (list) {
       (has ? (depname + '@' + has) : 'MISSING'),
       depname + '@' + latest
     ]
-    if (long) out.push(type)
+    if (long) out.push(type,  dep.package.homepage);
 
     return out.join(':')
   }).join(os.EOL)

--- a/test/tap/outdated-long.js
+++ b/test/tap/outdated-long.js
@@ -77,7 +77,7 @@ test('it should not throw', function (t) {
           // since it's possible for the homepage of a package to change, after the
           // install we read the value from the package.json directly to specify our
           // expected output.
-          expOut[1] = expOut[1] + ':' + JSON.parse(fs.readFileSync(path.resolve(pkg, 'node_modules', 'underscore', 'package.json'))).homepage;
+          expOut[1] = expOut[1] + ':' + JSON.parse(fs.readFileSync(path.resolve(pkg, 'node_modules', 'underscore', 'package.json'))).homepage
           npm.outdated(function (er, d) {
             t.ifError(err, 'npm outdated ran without error')
             t.is(process.exitCode, 1, 'exit code set to 1')

--- a/test/tap/outdated-long.js
+++ b/test/tap/outdated-long.js
@@ -74,6 +74,10 @@ test('it should not throw', function (t) {
         npm.install('.', function (err) {
           t.ifError(err, 'install success')
           npm.config.set('long', true)
+          // since it's possible for the homepage of a package to change, after the
+          // install we read the value from the package.json directly to specify our
+          // expected output.
+          expOut[1] = expOut[1] + ':' + JSON.parse(fs.readFileSync(path.resolve(pkg, 'node_modules', 'underscore', 'package.json'))).homepage;
           npm.outdated(function (er, d) {
             t.ifError(err, 'npm outdated ran without error')
             t.is(process.exitCode, 1, 'exit code set to 1')


### PR DESCRIPTION
My current workflow (which I _assume_ is fairly common) is:

- Run `npm outdated`
- Search npm for a/the packages
- Go to the package's homepage (or repository)
- Search for a changelog to determine an upgrade path

It seems like the `npm outdated` utility could provide a little more information to smooth out this process (and possibly enable some standardization around the changelog location).

This change proposes the output of `homepage` when using the `--long` flag. I realize this is likely not the ideal solution (`homepage` might not always contain a changelog), but it seems like it would be a reasonable and helpful link to provide.

I've been digging into `npm`'s handling of `CHANGELOG` files (and it's permutations) to determine if there could be a more helpful link to provide here, but I haven't found anything that seems standardized or well documented.

`TODO`
- [x] Include `homepage` when use `--parseable`
- [x] Add `homepage` specific  `npm outdated --long` tests.

===

- `package.json`'s `homepage` property is displayed when using the `--long` option for `npm outdated`

Example pretty" Output (generated from `npm/cli`:
```bash
Package             Current  Wanted  Latest  Location  Package Type  Homepage
aproba                1.2.0   1.2.0   2.0.0  npm       dependencies  https://github.com/iarna/aproba
bluebird              3.5.1   3.5.2   3.5.2  npm       dependencies  https://github.com/petkaantonov/bluebird
chownr                1.0.1   1.0.1   1.1.1  npm       dependencies  https://github.com/isaacs/chownr#readme
ci-info               1.4.0   1.6.0   1.6.0  npm       dependencies  https://github.com/watson/ci-info
cli-table3            0.5.0   0.5.1   0.5.1  npm       dependencies  https://github.com/cli-table/cli-table3
config-chain         1.1.11  1.1.12  1.1.12  npm       dependencies  http://github.com/dominictarr/config-chain
figgy-pudding         3.4.1   3.5.1   3.5.1  npm       dependencies  https://github.com/zkat/figgy-pudding#readme
glob                  7.1.2   7.1.3   7.1.3  npm       dependencies  https://github.com/isaacs/node-glob#readme
is-cidr               2.0.6   2.0.7   3.0.0  npm       dependencies  https://github.com/silverwind/is-cidr#readme
JSONStream            1.3.4   1.3.5   1.3.5  npm       dependencies  http://github.com/dominictarr/JSONStream
libcipm               2.0.2   2.0.2   3.0.2  npm       dependencies  https://github.com/zkat/cipm#readme
libnpmhook            4.0.1   4.0.1   5.0.2  npm       dependencies  https://github.com/npm/libnpmhook#readme
npm-packlist         1.1.11  1.1.12  1.1.12  npm       dependencies  https://www.npmjs.com/package/npm-packlist
npm-profile           3.0.2   3.0.2   4.0.1  npm       dependencies  https://github.com/npm/npm-profile/tree/latest/lib#readme
npm-registry-fetch    1.1.0   1.1.0   3.8.0  npm       dependencies  https://github.com/npm/registry-fetch#readme
opener                1.5.0   1.5.1   1.5.1  npm       dependencies  https://github.com/domenic/opener#readme
pacote                8.1.6   8.1.6   9.1.0  npm       dependencies  https://github.com/zkat/pacote#readme
query-string          6.1.0   6.2.0   6.2.0  npm       dependencies  https://github.com/sindresorhus/query-string#readme
readable-stream       2.3.6   2.3.6   3.0.6  npm       dependencies  https://github.com/nodejs/readable-stream#readme
semver                5.5.0   5.6.0   5.6.0  npm       dependencies  https://github.com/npm/node-semver#readme
ssri                  6.0.0   6.0.1   6.0.1  npm       dependencies  https://github.com/zkat/ssri#readme
unique-filename       1.1.0   1.1.1   1.1.1  npm       dependencies  https://github.com/iarna/unique-filename
```