### PR TITLE
meta: add back engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -275,6 +275,9 @@
     "tacks": "^1.2.7",
     "tap": "^12.0.1"
   },
+  "engines": {
+    "node": ">=6"
+  },
   "scripts": {
     "dumpconf": "env | grep npm | sort | uniq",
     "prepare": "node bin/npm-cli.js --no-audit --no-timing prune --prefix=. --no-global && rimraf test/*/*/node_modules && make -j4 doc",


### PR DESCRIPTION
Add back engine restrictions, as npm 6 is incompatible with node 4 but still tries to update.

See [https://npm.community/t/2837](https://npm.community/t/2837?u=larsgw)
See c6ddb64