### PR TITLE
deps: fix test for semver@5.5.1

### DIFF
--- a/doc/misc/semver.md
+++ b/doc/misc/semver.md
@@ -274,7 +274,7 @@ logical-or ::= ( ' ' ) * '||' ( ' ' ) *
 range      ::= hyphen | simple ( ' ' simple ) * | ''
 hyphen     ::= partial ' - ' partial
 simple     ::= primitive | partial | tilde | caret
-primitive  ::= ( '<' | '>' | '>=' | '<=' | '=' | ) partial
+primitive  ::= ( '<' | '>' | '>=' | '<=' | '=' ) partial
 partial    ::= xr ( '.' xr ( '.' xr qualifier ? )? )?
 xr         ::= 'x' | 'X' | '*' | nr
 nr         ::= '0' | ['1'-'9'] ( ['0'-'9'] ) *


### PR DESCRIPTION
Fixes a test failure on the `release-next` branch introduced by the `semver@5.5.1` update: https://github.com/npm/cli/commit/03840dced865abdca6e6449ea030962e5b19db0c

cc/ @iarna 