### PR TITLE
doc: Remove code block from command reference

### DIFF
--- a/doc/cli/npm-config.md
+++ b/doc/cli/npm-config.md
@@ -20,7 +20,7 @@ variables, `npmrc` files, and in some cases, the `package.json` file.
 
 See npmrc(5) for more information about the npmrc files.
 
-See `npm-config(7)` for a more thorough discussion of the mechanisms
+See npm-config(7) for a more thorough discussion of the mechanisms
 involved.
 
 The `npm config` command can be used to update and edit the contents


### PR DESCRIPTION
# Remove code block from npm command reference

### What I Wanted to Do
I want the link to `npm config` in the [npm-config](https://docs.npmjs.com/cli/config) article to not be rendered in a `<code>` block.

### What Happened Instead
This command reference is transcoded from markdown to HTML, this reference appears within a `<code>` block. This is interpreted in various ways by different markdown preprocessors:

---

**marky-markdown** styles the text using a monospace typeface.
<img width="642" alt="screen shot 2018-11-06 at 14 37 57" src="https://user-images.githubusercontent.com/1410204/48071205-a3f5a780-e1d1-11e8-878c-8b6a1cb03623.png">

---

**kramdown** escapes the HTML:
<img width="694" alt="screen shot 2018-11-06 at 14 39 33" src="https://user-images.githubusercontent.com/1410204/48071269-ce476500-e1d1-11e8-86f7-8d2bdb852ae1.png">

This is causing an issue for an internal docs project.

