### PR TITLE
Fix link as code in npm-ci

### DIFF
--- a/doc/cli/npm-ci.md
+++ b/doc/cli/npm-ci.md
@@ -37,7 +37,7 @@ cache:
 
 ## DESCRIPTION
 
-This command is similar to `npm-install(1)`, except it's meant to be used in
+This command is similar to npm-install(1), except it's meant to be used in
 automated environments such as test platforms, continuous integration, and
 deployment. It can be significantly faster than a regular npm install by
 skipping certain user-oriented features. It is also more strict than a regular


### PR DESCRIPTION
**related:** #92

---

Link to `npm-install` doc is shown as code:

![selection_216](https://user-images.githubusercontent.com/1212392/48426196-8c389900-e766-11e8-90ff-f3ac18f63e53.png)

Removing the backtick surrounding it should fix this.