### PR TITLE
docs: fix tag in inline code

### DIFF
--- a/doc/misc/npm-scripts.md
+++ b/doc/misc/npm-scripts.md
@@ -52,8 +52,8 @@ following scripts:
 Additionally, arbitrary scripts can be executed by running `npm
 run-script <stage>`. *Pre* and *post* commands with matching
 names will be run for those as well (e.g. `premyscript`, `myscript`,
-`postmyscript`). Scripts from dependencies can be run with `npm explore
-<pkg> -- npm run <stage>`.
+`postmyscript`). Scripts from dependencies can be run with 
+`npm explore <pkg> -- npm run <stage>`.
 
 ## PREPUBLISH AND PREPARE
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1732164/48548613-61864600-e908-11e8-8168-28ead6ecab43.png)

For now the "npm scripts" page (<https://docs.npmjs.com/misc/scripts>) is broken due to the `npm explore <pkg> -- npm run <stage>` inline code is separated into two parts, and the second parts is starting with a tag-like thing `<pkg>`, thus the markdown parser may be error.