### PR TITLE
feat(pacote): pass git opts to pacote

### DIFF
--- a/lib/config/pacote.js
+++ b/lib/config/pacote.js
@@ -25,6 +25,7 @@ function pacoteOpts (moreOpts) {
     cert: npm.config.get('cert'),
     defaultTag: npm.config.get('tag'),
     dirPacker: pack.packGitDep,
+    git: npm.config.get('git'),
     hashAlgorithm: 'sha1',
     includeDeprecated: false,
     key: npm.config.get('key'),


### PR DESCRIPTION
Pass git binary path config to pacote.

See zkat/pacote#164
See https://npm.community/t/3278