### PR TITLE
fix(doc): move line for markdown renderers

### DIFF
--- a/doc/misc/npm-scripts.md
+++ b/doc/misc/npm-scripts.md
@@ -52,8 +52,8 @@ following scripts:
 Additionally, arbitrary scripts can be executed by running `npm
 run-script <stage>`. *Pre* and *post* commands with matching
 names will be run for those as well (e.g. `premyscript`, `myscript`,
-`postmyscript`). Scripts from dependencies can be run with `npm explore
-<pkg> -- npm run <stage>`.
+`postmyscript`). Scripts from dependencies can be run with
+`npm explore <pkg> -- npm run <stage>`.
 
 ## PREPUBLISH AND PREPARE
 


### PR DESCRIPTION
Certain markdown renderers (psst, Jekyll) insert a closing <p> tag here in the middle of this code block, which leads the browser to assume that <pkg> is a tag that you want. This is fixed by keeping the code block in its own line.