### PR TITLE
fix escaping breaking out over line wrap

### DIFF
--- a/doc/misc/npm-scripts.md
+++ b/doc/misc/npm-scripts.md
@@ -52,8 +52,8 @@ following scripts:
 Additionally, arbitrary scripts can be executed by running `npm
 run-script <stage>`. *Pre* and *post* commands with matching
 names will be run for those as well (e.g. `premyscript`, `myscript`,
-`postmyscript`). Scripts from dependencies can be run with `npm explore
-<pkg> -- npm run <stage>`.
+`postmyscript`). Scripts from dependencies can be run with 
+<code>npm explore &lt;pkg&gt; -- npm run &lt;stage&gt;</code>.
 
 ## PREPUBLISH AND PREPARE
 


### PR DESCRIPTION
Here's what the markdown is supposed to look like:

![image](https://user-images.githubusercontent.com/4307307/49051233-f7e22380-f1b4-11e8-9b1a-e67836f5ff7d.png)

But here's what the same section looks like on the [live docs site](https://docs.npmjs.com/misc/scripts):

![image](https://user-images.githubusercontent.com/4307307/49051249-04ff1280-f1b5-11e8-9d78-faaa90eb022e.png)

If we look at the markdown source, we can see the inline code block is opened on line 55 and then the text is automatically wrapped to fit into 80 character column width.

![image](https://user-images.githubusercontent.com/4307307/49051354-83f44b00-f1b5-11e8-8e9d-b65f2c1771b9.png)

Which means whatever is converting the markdown to markup is not escaping the `<pkg>` tag on line 56 and opens up a tag that is never closed.  Here's proof via inspect element on the [live docs page](https://docs.npmjs.com/misc/scripts):

![image](https://user-images.githubusercontent.com/4307307/49051388-ad14db80-f1b5-11e8-97d9-929a8ee4b7b8.png)


Whatever script automatically wrapped at 80 chars may have caused other issues as well that only show up depending on the engine rendering the markdown
