### PR TITLE
dist-tag: make 'ls' the default action

### DIFF
--- a/doc/cli/npm-dist-tag.md
+++ b/doc/cli/npm-dist-tag.md
@@ -26,6 +26,8 @@ Add, remove, and enumerate distribution tags on a package:
   Show all of the dist-tags for a package, defaulting to the package in
   the current prefix.
 
+  This is the default action if none is specified.
+
 A tag can be used when installing packages as a reference to a version instead
 of using a specific version number:
 

--- a/lib/dist-tag.js
+++ b/lib/dist-tag.js
@@ -40,7 +40,7 @@ function distTag (args, cb) {
     case 'ls': case 'l': case 'sl': case 'list':
       return list(args[0], cb)
     default:
-      return cb('Usage:\n' + distTag.usage)
+      return list(cmd, cb)
   }
 }
 

--- a/test/tap/dist-tag.js
+++ b/test/tap/dist-tag.js
@@ -20,7 +20,13 @@ function mocks (server) {
   server.get('/-/package/@scoped%2fpkg/dist-tags')
     .reply(200, { latest: '1.0.0', a: '0.0.1', b: '0.5.0' })
 
+  server.get('/-/package/@scoped%2fpkg/dist-tags')
+    .reply(200, { latest: '1.0.0', a: '0.0.1', b: '0.5.0' })
+
   // ls named package
+  server.get('/-/package/@scoped%2fanother/dist-tags')
+    .reply(200, { latest: '2.0.0', a: '0.0.2', b: '0.6.0' })
+
   server.get('/-/package/@scoped%2fanother/dist-tags')
     .reply(200, { latest: '2.0.0', a: '0.0.2', b: '0.6.0' })
 
@@ -83,11 +89,50 @@ test('npm dist-tags ls in current package', function (t) {
   )
 })
 
+test('npm dist-tags ls default in current package', function (t) {
+  common.npm(
+    [
+      'dist-tags',
+      '--registry', common.registry,
+      '--loglevel', 'silent'
+    ],
+    { cwd: pkg },
+    function (er, code, stdout, stderr) {
+      t.ifError(er, 'npm access')
+      t.notOk(code, 'exited OK')
+      t.notOk(stderr, 'no error output')
+      t.equal(stdout, 'a: 0.0.1\nb: 0.5.0\nlatest: 1.0.0\n')
+
+      t.end()
+    }
+  )
+})
+
 test('npm dist-tags ls on named package', function (t) {
   common.npm(
     [
       'dist-tags',
       'ls', '@scoped/another',
+      '--registry', common.registry,
+      '--loglevel', 'silent'
+    ],
+    { cwd: pkg },
+    function (er, code, stdout, stderr) {
+      t.ifError(er, 'npm access')
+      t.notOk(code, 'exited OK')
+      t.notOk(stderr, 'no error output')
+      t.equal(stdout, 'a: 0.0.2\nb: 0.6.0\nlatest: 2.0.0\n')
+
+      t.end()
+    }
+  )
+})
+
+test('npm dist-tags ls default, named package', function (t) {
+  common.npm(
+    [
+      'dist-tags',
+      '@scoped/another',
       '--registry', common.registry,
       '--loglevel', 'silent'
     ],


### PR DESCRIPTION
I keep typing `npm dist-tags` expecting it to print out a list of
dist-tags and instead it yells at me and that feels very un-npm-y.