### PR TITLE
Fix inline code in npm-scripts

### DIFF
--- a/doc/misc/npm-scripts.md
+++ b/doc/misc/npm-scripts.md
@@ -52,8 +52,8 @@ following scripts:
 Additionally, arbitrary scripts can be executed by running `npm
 run-script <stage>`. *Pre* and *post* commands with matching
 names will be run for those as well (e.g. `premyscript`, `myscript`,
-`postmyscript`). Scripts from dependencies can be run with `npm explore
-<pkg> -- npm run <stage>`.
+`postmyscript`). Scripts from dependencies can be run with
+`npm explore <pkg> -- npm run <stage>`.
 
 ## PREPUBLISH AND PREPARE
 


### PR DESCRIPTION
The inline code previously had a word break. This made the `<pkg>` render as an entire containing element on the page, breaking all markdown afterwards: https://docs.npmjs.com/misc/scripts

![firefox_2018-12-01_00-17-53](https://user-images.githubusercontent.com/4585677/49321318-93013300-f4fe-11e8-9da5-c6b22b096624.png)
