### PR TITLE
Replace hardcoded URL to advisory with a URL from audit response

### DIFF
--- a/node_modules/npm-audit-report/reporters/detail.js
+++ b/node_modules/npm-audit-report/reporters/detail.js
@@ -117,7 +117,7 @@ const report = function (data, options) {
               {'Package': advisory.module_name},
               {'Dependency of': `${resolution.path.split('>')[0]} ${resolution.dev ? '[dev]' : ''}`},
               {'Path': `${resolution.path.split('>').join(Utils.color(' > ', 'grey', config.withColor))}`},
-              {'More info': `https://nodesecurity.io/advisories/${advisory.id}`}
+              {'More info': advisory.url ? advisory.url : `https://nodesecurity.io/advisories/${advisory.id}`}
             )
 
             log(table.toString() + '\n\n')
@@ -160,7 +160,7 @@ const report = function (data, options) {
               {'Patched in': patchedIn},
               {'Dependency of': `${resolution.path.split('>')[0]} ${resolution.dev ? '[dev]' : ''}`},
               {'Path': `${resolution.path.split('>').join(Utils.color(' > ', 'grey', config.withColor))}`},
-              {'More info': `https://nodesecurity.io/advisories/${advisory.id}`}
+              {'More info': advisory.url ? advisory.url : `https://nodesecurity.io/advisories/${advisory.id}`}
             )
             log(table.toString())
           })

--- a/node_modules/npm-audit-report/reporters/parseable.js
+++ b/node_modules/npm-audit-report/reporters/parseable.js
@@ -30,7 +30,7 @@ const report = function (data, options) {
           l.sevLevel = advisory.severity
           l.severity = advisory.title
           l.package = advisory.module_name
-          l.moreInfo = `https://nodesecurity.io/advisories/${advisory.id}`
+          l.moreInfo = advisory.url ? advisory.url : `https://nodesecurity.io/advisories/${advisory.id}`
           l.path = action.resolves[0].path
 
           accumulator[advisory.severity] += [action.action, l.package, l.sevLevel, l.recommendation, l.severity, l.moreInfo, l.path, l.breaking]
@@ -44,7 +44,7 @@ const report = function (data, options) {
             l.sevLevel = advisory.severity
             l.severity = advisory.title
             l.package = advisory.module_name
-            l.moreInfo = `https://nodesecurity.io/advisories/${advisory.id}`
+            l.moreInfo = advisory.url ? advisory.url : `https://nodesecurity.io/advisories/${advisory.id}`
             l.patchedIn = advisory.patched_versions.replace(' ', '') === '<0.0.0' ? 'No patch available' : advisory.patched_versions
             l.path = resolution.path
 


### PR DESCRIPTION
By this PR, we can see a correct advisory URL in the "More info" field.
