### PR TITLE
install: match git semver ranges

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -58,8 +58,9 @@ function doesChildVersionMatch (child, requested, requestor) {
   }
 
   if (requested.type === 'git' && requested.gitRange) {
+    const sameRepo = npa(child.package._from).fetchSpec === requested.fetchSpec
     try {
-      return semver.satisfies(child.package.version, requested.gitRange, true)
+      return sameRepo && semver.satisfies(child.package.version, requested.gitRange, true)
     } catch (e) {
       return false
     }

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -57,6 +57,14 @@ function doesChildVersionMatch (child, requested, requestor) {
     if (fromSw.toString() === requested.toString()) return true
   }
 
+  if (requested.type === 'git' && requested.gitRange) {
+    try {
+      return semver.satisfies(child.package.version, requested.gitRange, true)
+    } catch (e) {
+      return false
+    }
+  }
+
   if (!registryTypes[requested.type]) {
     var childReq = child.package._requested
     if (childReq) {

--- a/test/tap/dedupe-git-semver.js
+++ b/test/tap/dedupe-git-semver.js
@@ -5,7 +5,6 @@ const test = require('tap').test
 const requireInject = require('require-inject')
 const Tacks = require('tacks')
 const File = Tacks.File
-const Symlink = Tacks.Symlink
 const Dir = Tacks.Dir
 
 const manifests = {
@@ -37,7 +36,6 @@ const npm = requireInject.installGlobally('../../lib/npm.js', {
 const basedir = path.join(__dirname, path.basename(__filename, '.js'))
 const testdir = path.join(basedir, 'testdir')
 const cachedir = path.join(basedir, 'cache')
-const globaldir = path.join(basedir, 'global')
 const tmpdir = path.join(basedir, 'tmp')
 
 const cwd = process.cwd()
@@ -45,12 +43,10 @@ const cwd = process.cwd()
 const conf = {
   cache: cachedir,
   tmp: tmpdir,
-  prefix: testdir,
   loglevel: 'silent',
   'package-lock-only': true
 }
 
-let server
 const fixture = new Tacks(Dir({
   cache: Dir(),
   global: Dir(),
@@ -74,7 +70,7 @@ const fixture = new Tacks(Dir({
     //     }
     //   })
     // }),
-    'git-wrap-1.0.0.tgz': File(new Buffer(
+    'git-wrap-1.0.0.tgz': File(Buffer.from(
       '1f8b0800000000000003ed8fcd0ac23010843df729423caaf9c13642df26' +
       'b44bad9a3434f107a4efeec68aa7de2c8898ef32cb0c3bec3a5d1d7503dc' +
       '8dca0ebeb38b991142a83c27537e44ee30db164a48a994c01987a210a873' +

--- a/test/tap/dedupe-git-semver.js
+++ b/test/tap/dedupe-git-semver.js
@@ -1,0 +1,138 @@
+'use strict'
+const fs = require('fs')
+const path = require('path')
+const test = require('tap').test
+const requireInject = require('require-inject')
+const Tacks = require('tacks')
+const File = Tacks.File
+const Symlink = Tacks.Symlink
+const Dir = Tacks.Dir
+
+const manifests = {
+  'git-wrap': {
+    name: 'git-wrap',
+    version: '1.0.0',
+    dependencies: {
+      git: 'git+https://example.com/git#semver:1.0'
+    }
+  },
+  git: {
+    name: 'git',
+    version: '1.0.0'
+  }
+}
+
+const npm = requireInject.installGlobally('../../lib/npm.js', {
+  pacote: {
+    manifest: function (spec) {
+      const manifest = manifests[spec.name]
+      manifest._requested = spec
+      manifest._resolved = spec.saveSpec.replace(/^file:/, '').replace(/(:?#.*)$/, '#0000000000000000000000000000000000000000')
+      manifest._from = spec.rawSpec
+      return Promise.resolve(manifest)
+    }
+  }
+})
+
+const basedir = path.join(__dirname, path.basename(__filename, '.js'))
+const testdir = path.join(basedir, 'testdir')
+const cachedir = path.join(basedir, 'cache')
+const globaldir = path.join(basedir, 'global')
+const tmpdir = path.join(basedir, 'tmp')
+
+const cwd = process.cwd()
+
+const conf = {
+  cache: cachedir,
+  tmp: tmpdir,
+  prefix: testdir,
+  loglevel: 'silent',
+  'package-lock-only': true
+}
+
+let server
+const fixture = new Tacks(Dir({
+  cache: Dir(),
+  global: Dir(),
+  tmp: Dir(),
+  testdir: Dir({
+    'package.json': File({
+      name: 'fixture',
+      version: '1.0.0',
+      dependencies: {
+        git: 'git+https://example.com/git#semver:1',
+        'git-wrap': 'file:git-wrap-1.0.0.tgz'
+      }
+    }),
+    // Tarball source:
+    // 'git-wrap': Dir({
+    //   'package.json': File({
+    //     name: 'git-wrap',
+    //     version: '1.0.0',
+    //     dependencies: {
+    //       git: 'git+https://example.com/git#semver:1.0'
+    //     }
+    //   })
+    // }),
+    'git-wrap-1.0.0.tgz': File(new Buffer(
+      '1f8b0800000000000003ed8fcd0ac23010843df729423caaf9c13642df26' +
+      'b44bad9a3434f107a4efeec68aa7de2c8898ef32cb0c3bec3a5d1d7503dc' +
+      '8dca0ebeb38b991142a83c27537e44ee30db164a48a994c01987a210a873' +
+      '1f32c5d907dde3299ff68cbf90b7fe08f78c106ab5015a12dab46173edb5' +
+      'a3ebe85ea0f76d676320996062746b70606bb0550b1ea3b84f9e9baf82d5' +
+      '3e04e74bcee1a68d3b01ab3ac3d15f7a30d8586215c59d211bb26fff9e48' +
+      '2412ffcc034458283d00080000',
+      'hex'
+    ))
+  })
+}))
+
+function setup () {
+  cleanup()
+  fixture.create(basedir)
+}
+
+function cleanup () {
+  fixture.remove(basedir)
+}
+
+test('setup', function (t) {
+  setup()
+  process.chdir(testdir)
+  npm.load(conf, function (err) {
+    if (err) throw err
+    t.done()
+  })
+})
+
+test('dedupe matching git semver ranges', function (t) {
+  npm.commands.install(function (err) {
+    if (err) throw err
+    const packageLock = JSON.parse(fs.readFileSync('package-lock.json'))
+    t.same(packageLock, {
+      name: 'fixture',
+      version: '1.0.0',
+      lockfileVersion: 1,
+      requires: true,
+      dependencies: {
+        git: {
+          from: 'git+https://example.com/git#semver:1',
+          version: 'git+https://example.com/git#0000000000000000000000000000000000000000'
+        },
+        'git-wrap': {
+          version: 'file:git-wrap-1.0.0.tgz',
+          requires: {
+            git: 'git+https://example.com/git#0000000000000000000000000000000000000000'
+          }
+        }
+      }
+    })
+    t.done()
+  })
+})
+
+test('cleanup', function (t) {
+  process.chdir(cwd)
+  cleanup()
+  t.done()
+})

--- a/test/tap/dedupe-git-semver.js
+++ b/test/tap/dedupe-git-semver.js
@@ -30,6 +30,9 @@ const npm = requireInject.installGlobally('../../lib/npm.js', {
       manifest._from = spec.rawSpec
       return Promise.resolve(manifest)
     }
+  },
+  '../../lib/utils/output.js': function () {
+    // do not output to stdout
   }
 })
 

--- a/test/tap/dedupe-git-semver.js
+++ b/test/tap/dedupe-git-semver.js
@@ -118,7 +118,7 @@ test('dedupe matching git semver ranges', function (t) {
         'git-wrap': {
           version: 'file:git-wrap-1.0.0.tgz',
           requires: {
-            git: 'git+https://example.com/git#0000000000000000000000000000000000000000'
+            git: 'git+https://example.com/git#semver:1'
           }
         }
       }


### PR DESCRIPTION
Let equivalent git semver ranges match. I'm not really sure how to integration-test this without actually cloning git projects at the moment.

See https://npm.community/t/3784.