### PR TITLE
install: correct reqBy spec for opt deps

### DIFF
--- a/lib/install/get-requested.js
+++ b/lib/install/get-requested.js
@@ -7,6 +7,7 @@ module.exports = function (child, reqBy) {
   if (!reqBy) reqBy = child.requiredBy[0]
   const deps = reqBy.package.dependencies || {}
   const devDeps = reqBy.package.devDependencies || {}
+  const optDeps = reqBy.package.optionalDependencies || {}
   const name = moduleName(child)
-  return npa.resolve(name, deps[name] || devDeps[name], reqBy.realpath)
+  return npa.resolve(name, deps[name] || devDeps[name] || optDeps[name], reqBy.realpath)
 }


### PR DESCRIPTION
Return the correct spec for optional dependencies in getRequested.

See https://npm.community/t/242