### PR TITLE
travis: use Ubuntu 16.04.5 LTS (Xenial Xerus)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 sudo: false
 # need to declare the language as well as the matrix below
 language: node_js


### PR DESCRIPTION
This pull request updates the test environment from [Ubuntu 14.04.5 LTS](https://docs.travis-ci.com/user/reference/trusty/), released at August 4, 2016, to [16.04.5 LTS](https://docs.travis-ci.com/user/reference/xenial/), released at August 2, 2018.
