### PR TITLE
Handle git branch references correctly

### DIFF
--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -167,6 +167,8 @@ function childVersion (top, child, req) {
 function childRequested (top, child, requested) {
   if (requested.type === 'directory' || requested.type === 'file') {
     return 'file:' + unixFormatPath(path.relative(top.path, child.package._resolved || requested.fetchSpec))
+  } else if (requested.type === 'git' && child.package._from) {
+    return child.package._from
   } else if (!isRegistry(requested) && !child.fromBundle) {
     return child.package._resolved || requested.saveSpec || requested.rawSpec
   } else if (requested.type === 'tag') {


### PR DESCRIPTION
When a dependency is installed with a branch reference inside `package.json`, the shrinkwrap is using an expanded references in `requires`.

This causes the referenced packages to be removed during `npm prune --production`

Test:

```json
{
  "name": "npm-test",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "author": "",
  "license": "ISC",
  "dependencies": {
    "pg-promise": "github:johanneswuerbach/pg-promise#pool-racing"
  }
}
```

Before (`from` points to the branch, but `requires` points to the sha)

```json
{
  "name": "npm-test",
  "version": "1.0.0",
  "lockfileVersion": 1,
  "requires": true,
  "dependencies": {
    "buffer-writer": {
      "version": "2.0.0",
      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
    },
    "manakin": {
      "version": "0.5.2",
      "resolved": "https://registry.npmjs.org/manakin/-/manakin-0.5.2.tgz",
      "integrity": "sha512-pfDSB7QYoVg0Io4KMV9hhPoXpj6p0uBscgtyUSKCOFZe8bqgbpStfgnKIbF/ulnr6U3ICu4OqdyxAqBgOhZwBQ=="
    },
    "packet-reader": {
      "version": "0.3.1",
      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.3.1.tgz",
      "integrity": "sha1-zWLmCvjX/qinBexP+ZCHHEaHHyc="
    },
    "pg": {
      "version": "github:johanneswuerbach/node-postgres#d02759e30c958e93234076f6f76af14e36578b3a",
      "from": "github:johanneswuerbach/node-postgres#pool-racing",
      "requires": {
        "buffer-writer": "2.0.0",
        "packet-reader": "0.3.1",
        "pg-connection-string": "0.1.3",
        "pg-pool": "github:johanneswuerbach/node-pg-pool#1068272ce687d7efdfc8dadab66850040b831bf6",
        "pg-types": "~1.12.1",
        "pgpass": "1.x",
        "semver": "4.3.2"
      }
    },
    "pg-connection-string": {
      "version": "0.1.3",
      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
      "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
    },
    "pg-minify": {
      "version": "0.5.5",
      "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-0.5.5.tgz",
      "integrity": "sha512-7Pf9h6nV1RFqED1hkRosePqvpPwNUUtW06TT4+lHwzesxa5gffxkShTjYH6JXV5sSSfh5+2yHOTTWEkCyCQ0Eg=="
    },
    "pg-pool": {
      "version": "github:johanneswuerbach/node-pg-pool#1068272ce687d7efdfc8dadab66850040b831bf6",
      "from": "github:johanneswuerbach/node-pg-pool#pool-racing"
    },
    "pg-promise": {
      "version": "github:johanneswuerbach/pg-promise#56bcaa382902d5fb052f6865cbbd04c7933cc75c",
      "from": "github:johanneswuerbach/pg-promise#pool-racing",
      "requires": {
        "manakin": "0.5.2",
        "pg": "github:johanneswuerbach/node-postgres#d02759e30c958e93234076f6f76af14e36578b3a",
        "pg-minify": "0.5.5",
        "spex": "2.1.0"
      }
    },
    "pg-types": {
      "version": "1.12.1",
      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.12.1.tgz",
      "integrity": "sha1-1kCH45A7WP+q0nnnWVxSIIoUw9I=",
      "requires": {
        "postgres-array": "~1.0.0",
        "postgres-bytea": "~1.0.0",
        "postgres-date": "~1.0.0",
        "postgres-interval": "^1.1.0"
      }
    },
    "pgpass": {
      "version": "1.0.2",
      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
      "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
      "requires": {
        "split": "^1.0.0"
      }
    },
    "postgres-array": {
      "version": "1.0.3",
      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.3.tgz",
      "integrity": "sha512-5wClXrAP0+78mcsNX3/ithQ5exKvCyK5lr5NEEEeGwwM6NJdQgzIJBVxLvRW+huFpX92F2QnZ5CcokH0VhK2qQ=="
    },
    "postgres-bytea": {
      "version": "1.0.0",
      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU="
    },
    "postgres-date": {
      "version": "1.0.3",
      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.3.tgz",
      "integrity": "sha1-4tiXAu/bJY/52c7g/pG9BpdSV6g="
    },
    "postgres-interval": {
      "version": "1.1.2",
      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.1.2.tgz",
      "integrity": "sha512-fC3xNHeTskCxL1dC8KOtxXt7YeFmlbTYtn7ul8MkVERuTmf7pI4DrkAxcw3kh1fQ9uz4wQmd03a1mRiXUZChfQ==",
      "requires": {
        "xtend": "^4.0.0"
      }
    },
    "semver": {
      "version": "4.3.2",
      "resolved": "http://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
      "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
    },
    "spex": {
      "version": "2.1.0",
      "resolved": "https://registry.npmjs.org/spex/-/spex-2.1.0.tgz",
      "integrity": "sha512-nZ1LA8v1o0Maf9pdWKUXuUM855EqyE+DP0NT0ddZqXqXmr9xKlXjYWN97w+yWehTbM+Ox0aEvQ8Ufqk/OuLCOQ=="
    },
    "split": {
      "version": "1.0.1",
      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
      "requires": {
        "through": "2"
      }
    },
    "through": {
      "version": "2.3.8",
      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
    },
    "xtend": {
      "version": "4.0.1",
      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
    }
  }
}
```

After (`requires` points to the branch similar to `from` and only `version` contains the sha)

```json
{
  "name": "npm-test",
  "version": "1.0.0",
  "lockfileVersion": 1,
  "requires": true,
  "dependencies": {
    "buffer-writer": {
      "version": "2.0.0",
      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
    },
    "manakin": {
      "version": "0.5.2",
      "resolved": "https://registry.npmjs.org/manakin/-/manakin-0.5.2.tgz",
      "integrity": "sha512-pfDSB7QYoVg0Io4KMV9hhPoXpj6p0uBscgtyUSKCOFZe8bqgbpStfgnKIbF/ulnr6U3ICu4OqdyxAqBgOhZwBQ=="
    },
    "packet-reader": {
      "version": "0.3.1",
      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.3.1.tgz",
      "integrity": "sha1-zWLmCvjX/qinBexP+ZCHHEaHHyc="
    },
    "pg": {
      "version": "github:johanneswuerbach/node-postgres#d02759e30c958e93234076f6f76af14e36578b3a",
      "from": "github:johanneswuerbach/node-postgres#pool-racing",
      "requires": {
        "buffer-writer": "2.0.0",
        "packet-reader": "0.3.1",
        "pg-connection-string": "0.1.3",
        "pg-pool": "github:johanneswuerbach/node-pg-pool#pool-racing",
        "pg-types": "~1.12.1",
        "pgpass": "1.x",
        "semver": "4.3.2"
      }
    },
    "pg-connection-string": {
      "version": "0.1.3",
      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
      "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
    },
    "pg-minify": {
      "version": "0.5.5",
      "resolved": "https://registry.npmjs.org/pg-minify/-/pg-minify-0.5.5.tgz",
      "integrity": "sha512-7Pf9h6nV1RFqED1hkRosePqvpPwNUUtW06TT4+lHwzesxa5gffxkShTjYH6JXV5sSSfh5+2yHOTTWEkCyCQ0Eg=="
    },
    "pg-pool": {
      "version": "github:johanneswuerbach/node-pg-pool#1068272ce687d7efdfc8dadab66850040b831bf6",
      "from": "github:johanneswuerbach/node-pg-pool#pool-racing"
    },
    "pg-promise": {
      "version": "github:johanneswuerbach/pg-promise#56bcaa382902d5fb052f6865cbbd04c7933cc75c",
      "from": "github:johanneswuerbach/pg-promise#pool-racing",
      "requires": {
        "manakin": "0.5.2",
        "pg": "github:johanneswuerbach/node-postgres#pool-racing",
        "pg-minify": "0.5.5",
        "spex": "2.1.0"
      }
    },
    "pg-types": {
      "version": "1.12.1",
      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.12.1.tgz",
      "integrity": "sha1-1kCH45A7WP+q0nnnWVxSIIoUw9I=",
      "requires": {
        "postgres-array": "~1.0.0",
        "postgres-bytea": "~1.0.0",
        "postgres-date": "~1.0.0",
        "postgres-interval": "^1.1.0"
      }
    },
    "pgpass": {
      "version": "1.0.2",
      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
      "integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
      "requires": {
        "split": "^1.0.0"
      }
    },
    "postgres-array": {
      "version": "1.0.3",
      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.3.tgz",
      "integrity": "sha512-5wClXrAP0+78mcsNX3/ithQ5exKvCyK5lr5NEEEeGwwM6NJdQgzIJBVxLvRW+huFpX92F2QnZ5CcokH0VhK2qQ=="
    },
    "postgres-bytea": {
      "version": "1.0.0",
      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU="
    },
    "postgres-date": {
      "version": "1.0.3",
      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.3.tgz",
      "integrity": "sha1-4tiXAu/bJY/52c7g/pG9BpdSV6g="
    },
    "postgres-interval": {
      "version": "1.1.2",
      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.1.2.tgz",
      "integrity": "sha512-fC3xNHeTskCxL1dC8KOtxXt7YeFmlbTYtn7ul8MkVERuTmf7pI4DrkAxcw3kh1fQ9uz4wQmd03a1mRiXUZChfQ==",
      "requires": {
        "xtend": "^4.0.0"
      }
    },
    "semver": {
      "version": "4.3.2",
      "resolved": "http://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
      "integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
    },
    "spex": {
      "version": "2.1.0",
      "resolved": "https://registry.npmjs.org/spex/-/spex-2.1.0.tgz",
      "integrity": "sha512-nZ1LA8v1o0Maf9pdWKUXuUM855EqyE+DP0NT0ddZqXqXmr9xKlXjYWN97w+yWehTbM+Ox0aEvQ8Ufqk/OuLCOQ=="
    },
    "split": {
      "version": "1.0.1",
      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
      "requires": {
        "through": "2"
      }
    },
    "through": {
      "version": "2.3.8",
      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
    },
    "xtend": {
      "version": "4.0.1",
      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
    }
  }
}
```

I'm not entirely sure where to add a test case for this, pointers would be appreciated.