### PR TITLE
cli,outdated: default homepage to an empty string

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -123,7 +123,7 @@ function makePretty (p) {
   var latest = p[4]
   var type = p[6]
   var deppath = p[7]
-  var homepage = p[0].package.homepage
+  var homepage = p[0].package.homepage || ''
 
   var columns = [ depname,
     has || 'MISSING',


### PR DESCRIPTION
This patch default package's homepage to an empty string in case the
homepage isn't specificied in the package manifest.

Before this patch, if at least one package didn't set an associated
homepage, running npm outdated --long would break.

After this patch, it won't display anything for this specific package
Homepage row and it won't break for the other packages.