### PR TITLE
config: fix figgy-config for default params

### DIFF
--- a/lib/config/figgy-config.js
+++ b/lib/config/figgy-config.js
@@ -24,7 +24,11 @@ let baseConfig
 module.exports = mkConfig
 function mkConfig (...providers) {
   if (!baseConfig) {
-    baseConfig = NpmConfig(npm.config, {
+    const allOpts = {}
+    npm.config.forEach(k => {
+      allOpts[k] = npm.config.get(k)
+    })
+    baseConfig = NpmConfig(allOpts, {
       // Add some non-npm-config opts by hand.
       cache: path.join(npm.config.get('cache'), '_cacache'),
       // NOTE: npm has some magic logic around color distinct from the config


### PR DESCRIPTION
Fixes: https://npm.community/t/npm-audit-error-messaging-update-for-401s/3983

Note: We should probably release this PR as part of 6.6.0