### PR TITLE
audit: report any errors above 400 as potentially not supporting audit

### DIFF
--- a/lib/audit.js
+++ b/lib/audit.js
@@ -189,8 +189,16 @@ function auditCmd (args, cb) {
   }).then((auditReport) => {
     return audit.submitForFullReport(auditReport)
   }).catch((err) => {
-    if (err.statusCode === 404 || err.statusCode >= 500) {
-      const ne = new Error(`Your configured registry (${opts.registry}) does not support audit requests.`)
+    if (err.statusCode >= 400) {
+      let msg
+      if (err.statusCode === 401) {
+        msg = `Either your login credentials are invalid or your registry (${opts.registry}) does not support audit.`
+      } else if (err.statusCode === 404) {
+        msg = `Your configured registry (${opts.registry}) does not support audit requests.`
+      } else {
+        msg = `Your configured registry (${opts.registry}) does not support audit requests, or the audit endpoint is temporarily unavailable.`
+      }
+      const ne = new Error(msg)
       ne.code = 'ENOAUDIT'
       ne.wrapped = err
       throw ne


### PR DESCRIPTION
Fixes: https://npm.community/t/npm-audit-fails-with-enoaudit-on-500-response/3629
Fixes: https://npm.community/t/npm-audit-error-messaging-update-for-401s/3983