### PR TITLE
docs: described exit codes in npm-audit docs

### DIFF
--- a/doc/cli/npm-audit.md
+++ b/doc/cli/npm-audit.md
@@ -65,7 +65,8 @@ $ npm audit --parseable | awk -F $'\t' '{print $1,$4}'
 The audit command submits a description of the dependencies configured in
 your project to your default registry and asks for a report of known
 vulnerabilities. The report returned includes instructions on how to act on
-this information.
+this information. The command will exit with a 0 exit code if no
+vulnerabilities were found.
 
 You can also have npm automatically fix the vulnerabilities by running `npm
 audit fix`. Note that some vulnerabilities cannot be fixed automatically and
@@ -98,6 +99,13 @@ the following dependency types:
 The non-reversible identifiers are a sha256 of a session-specific UUID and the
 value being replaced, ensuring a consistent value within the payload that is
 different between runs.
+
+## EXIT CODE
+
+The `npm audit` command will exit with a 0 exit code if no vulnerabilities were found.
+
+If vulnerabilities were found the exit code will depend on the `audit-level`
+configuration setting.
 
 ## SEE ALSO
 

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -167,6 +167,8 @@ function childVersion (top, child, req) {
 function childRequested (top, child, requested) {
   if (requested.type === 'directory' || requested.type === 'file') {
     return 'file:' + unixFormatPath(path.relative(top.path, child.package._resolved || requested.fetchSpec))
+  } else if (requested.type === 'git' && child.package._from) {
+    return child.package._from
   } else if (!isRegistry(requested) && !child.fromBundle) {
     return child.package._resolved || requested.saveSpec || requested.rawSpec
   } else if (requested.type === 'tag') {

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -111,9 +111,6 @@ function shrinkwrapDeps (deps, top, tree, seen) {
     var pkginfo = deps[moduleName(child)] = {}
     var requested = getRequested(child) || child.package._requested || {}
     pkginfo.version = childVersion(top, child, requested)
-    if (requested.type === 'git' && child.package._from) {
-      pkginfo.from = child.package._from
-    }
     if (child.fromBundle || child.isInLink) {
       pkginfo.bundled = true
     } else {


### PR DESCRIPTION
## Background

It was very easy to just append `npm audit` to my `npm test` script, because it returns a correct exit status when vulnerabilities are found.

I think the doc page (https://docs.npmjs.com/cli/audit) should tell readers about the exit status. Had to run my own mini-experiment to see if it works the way I expected.

## Change

* I added a sentence about the exit status to the description block.
* I added a section with further description to the page:
    * below CONTENT SUBMITTED, because of the order in the DESCRIPTION paragraph,
    * felt the need to mention `audit-level` configuration setting.