### PR TITLE
Check run script existence with undefined

### DIFF
--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -136,7 +136,7 @@ function run (pkg, wd, cmd, args, cb) {
       'prestart', 'start', 'poststart'
     ]
   } else {
-    if (!pkg.scripts[cmd]) {
+    if (pkg.scripts[cmd] === undefined) {
       if (cmd === 'test') {
         pkg.scripts.test = 'echo \'Error: no test specified\''
       } else if (cmd === 'env') {

--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -136,7 +136,7 @@ function run (pkg, wd, cmd, args, cb) {
       'prestart', 'start', 'poststart'
     ]
   } else {
-    if (pkg.scripts[cmd] === undefined) {
+    if (pkg.scripts[cmd] == null) {
       if (cmd === 'test') {
         pkg.scripts.test = 'echo \'Error: no test specified\''
       } else if (cmd === 'env') {


### PR DESCRIPTION
Makes it possible to run empty script instead of outputting slightly confusing error message.

In `package.json`:
```
"scripts": {
    "empty": ""
  },
```

Before
```
> npm run empty
npm ERR! missing script: empty
npm ERR!
npm ERR! Did you mean this?
npm ERR!     empty

npm ERR! A complete log of this run can be found in:
...
>
```

After
```
> npm run empty
> 
```