### PR TITLE
token: use figgy-config to make sure extra opts are there

### DIFF
--- a/test/tap/unit-token-validate-cidr.js
+++ b/test/tap/unit-token-validate-cidr.js
@@ -1,7 +1,6 @@
 'use strict'
 const test = require('tap').test
-const requireInject = require('require-inject')
-const validateCIDRList = requireInject('../../lib/token.js', {'../../lib/npm.js': {}})._validateCIDRList
+const validateCIDRList = require('../../lib/token.js')._validateCIDRList
 
 test('validateCIDRList', (t) => {
   t.plan(10)


### PR DESCRIPTION
This fixes a reversion reported by @evilpacket and co, where we weren't sending some metadata and auth info on `npm token ls`. This has to do with the npm@6.6.0 rework.