### PR TITLE
access: ls-collaborators is ok with non-scoped

### DIFF
--- a/lib/access.js
+++ b/lib/access.js
@@ -154,7 +154,7 @@ access['ls-packages'] = access.lsPackages = ([owner], opts) => {
 }
 
 access['ls-collaborators'] = access.lsCollaborators = ([pkg, usr], opts) => {
-  return getPackage(pkg).then(pkgName =>
+  return getPackage(pkg, false).then(pkgName =>
     libaccess.lsCollaborators(pkgName, usr, opts)
   ).then(collabs => {
     // TODO - print these out nicely (breaking change)

--- a/test/tap/access.js
+++ b/test/tap/access.js
@@ -469,6 +469,34 @@ test('npm access ls-collaborators on package', function (t) {
   )
 })
 
+test('npm access ls-collaborators on unscoped', function (t) {
+  var serverCollaborators = {
+    'myorg:myteam': 'write',
+    'myorg:anotherteam': 'read'
+  }
+  var clientCollaborators = {
+    'myorg:myteam': 'read-write',
+    'myorg:anotherteam': 'read-only'
+  }
+  server.get(
+    '/-/package/pkg/collaborators?format=cli'
+  ).reply(200, serverCollaborators)
+  common.npm(
+    [
+      'access',
+      'ls-collaborators',
+      'pkg',
+      '--registry', common.registry
+    ],
+    { cwd: pkg },
+    function (er, code, stdout, stderr) {
+      t.ifError(er, 'npm access ls-collaborators')
+      t.same(JSON.parse(stdout), clientCollaborators)
+      t.end()
+    }
+  )
+})
+
 test('npm access ls-collaborators on current w/user filter', function (t) {
   var serverCollaborators = {
     'myorg:myteam': 'write',


### PR DESCRIPTION
Fixes: https://npm.community/t/npm-6-6-0-breaks-access-to-ls-collaborators/5101