### PR TITLE
Set modified to undefined when not retrievable

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -243,7 +243,7 @@ function prettyView (packument, manifest, opts) {
         name: color.yellow(manifest._npmUser.name),
         email: color.cyan(manifest._npmUser.email)
       }),
-      modified: color.yellow(relativeDate(packument.time[packument.version])),
+      modified: packument.time ? color.yellow(relativeDate(packument.time[packument.version])) : undefined,
       maintainers: (packument.maintainers || []).map((u) => unparsePerson({
         name: color.yellow(u.name),
         email: color.cyan(u.email)


### PR DESCRIPTION
Fixes [5145](https://npm.community/t/npm6-npm-show-errors-with-cannot-read-property-1-0-0-of-undefined/5145).
Also fixes [20169](https://github.com/npm/npm/issues/20169) in the archived npm repo.

Here is a pre- and post-change screenshot:

![image](https://user-images.githubusercontent.com/8005145/52298744-b6f35180-2951-11e9-87b4-42a07d9b5e88.png)
