### PR TITLE
Print out tar version when the flag is supported

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -98,8 +98,10 @@ fi
 
 if [ $ret -eq 0 ] && [ -x "$tar" ]; then
   echo "tar=$tar"
-  echo "version:"
-  $tar --version
+  if [ $tar --version > /dev/null 2>&1 ]; then
+    echo "version:"
+    $tar --version
+  fi
   ret=$?
 fi
 


### PR DESCRIPTION
### What

Not all the tar implementations support `--version` flag.

E.g. the one used in openbsd doesn't, so the installation process fails trying to print out tar version.