### PR TITLE
package-lock.json no longer created when there is no package.json

### DIFF
--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -196,6 +196,11 @@ function save (dir, pkginfo, opts, cb) {
     checkPackageFile(dir, PKGLOCK),
     checkPackageFile(dir, 'package.json'),
     (shrinkwrap, lockfile, pkg) => {
+      if (!pkg) {
+        // If no pkg, do not continue with package-lock
+        cb(null, pkginfo)
+        return
+      }
       const info = (
         shrinkwrap ||
         lockfile ||


### PR DESCRIPTION
Fix for https://npm.community/t/running-npm-i-in-a-directory-without-package-json-creates-a-new-package-locks-json/4937