### PR TITLE
licensee@6.1.0

### DIFF
--- a/.licensee.json
+++ b/.licensee.json
@@ -1,5 +1,6 @@
 {
   "license": "(MIT OR BSD-2-Clause OR BSD-3-Clause OR Apache-2.0 OR ISC OR Unlicense OR CC-BY-3.0 OR CC0-1.0 OR Artistic-2.0)",
+  "corrections": true,
   "whitelist": {
     "config-chain": "1.1.12",
     "cyclist": "0.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -829,6 +829,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "correct-license-metadata": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/correct-license-metadata/-/correct-license-metadata-1.1.0.tgz",
+      "integrity": "sha512-OLrNAu9lNK12jVZpy6KrI2NYP0hcHvYBZT6hdjhVFHCjKO1y3jkr2vJXOnu/teM7uC8Ikni/huQ6JhhOlljLyA==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-validate": "^2.0.0"
+      }
+    },
     "couchapp": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/couchapp/-/couchapp-0.11.0.tgz",
@@ -1740,9 +1749,9 @@
       }
     },
     "fs-access": {
-      "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
-      "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-2.0.0.tgz",
+      "integrity": "sha512-Vt45hBKJrYDQeAD9ja43liw8JfK75uB7XexIXWEtDKwFLQNmzmvuulh28hRxexxuFm0zsGGq7nISGQSK6KnGrA==",
       "dev": true,
       "requires": {
         "null-check": "^1.0.0"
@@ -2724,19 +2733,21 @@
       }
     },
     "licensee": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/licensee/-/licensee-5.0.0.tgz",
-      "integrity": "sha512-g243BLsJYWWyNhwDEMewc2f6Ebyy1yiJmMDgO8MCQtLOXA8JO4O2/kbJ1QwwWdlmrwDgYECdl9CJBrKsr4ZezA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/licensee/-/licensee-6.1.0.tgz",
+      "integrity": "sha512-z0zTmZmHHXlbHMYYUQncutJ0u19SwaidkMdm4t37jvxuJL3HnxcESfzNfXRYnazi6VwGUUYheZcHw+U9mqYr7A==",
       "dev": true,
       "requires": {
+        "correct-license-metadata": "^1.0.1",
         "docopt": "^0.6.2",
-        "fs-access": "^1.0.0",
+        "fs-access": "^2.0.0",
         "json-parse-errback": "^2.0.1",
+        "npm-license-corrections": "^1.0.0",
         "read-package-tree": "^5.2.1",
         "run-parallel": "^1.1.9",
-        "semver": "^5.5.0",
+        "semver": "^5.6.0",
         "simple-concat": "^1.0.0",
-        "spdx-expression-validate": "^1.0.1",
+        "spdx-expression-validate": "^2.0.0",
         "spdx-satisfies": "^4.0.0"
       }
     },
@@ -3218,6 +3229,12 @@
       "requires": {
         "semver": "^2.3.0 || 3.x || 4 || 5"
       }
+    },
+    "npm-license-corrections": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/npm-license-corrections/-/npm-license-corrections-1.2.0.tgz",
+      "integrity": "sha512-B+10Mrfwah16sR33cE2NtRwxt/r5rp80Df3GCCn+nrpyIdC+DqaFZXPPZ/yqWGinbDh6A1dmU88ZdTMvd7/k6w==",
+      "dev": true
     },
     "npm-lifecycle": {
       "version": "2.1.0",
@@ -7071,20 +7088,12 @@
       }
     },
     "spdx-expression-validate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-expression-validate/-/spdx-expression-validate-1.0.2.tgz",
-      "integrity": "sha1-Wk5NdhbtHJuIFQNmtCF/dnwn6eM=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-validate/-/spdx-expression-validate-2.0.0.tgz",
+      "integrity": "sha512-b3wydZLM+Tc6CFvaRDBOF9d76oGIHNCLYFeHbftFXUWjnfZWganmDmvtM5sm1cRwJc/VDBMLyGGrsLFd1vOxbg==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "^1.0.0"
-      },
-      "dependencies": {
-        "spdx-expression-parse": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-          "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
-          "dev": true
-        }
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -7093,15 +7102,15 @@
       "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g=="
     },
     "spdx-ranges": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-ranges/-/spdx-ranges-2.0.0.tgz",
-      "integrity": "sha512-AUUXLfqkwD7GlzZkXv8ePPCpPjeVWI9xJCfysL8re/uKb6H10umMnC7bFRsHmLJan4fslUtekAgpHlSgLc/7mA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-ranges/-/spdx-ranges-2.1.0.tgz",
+      "integrity": "sha512-OOWghvosfmECc9edy/A9j7GabERmn8bJWHc0J1knVytQtO5Rw7VfxK6CDqmivJhfMJqWhWWUfffNNMPYvyvyQA==",
       "dev": true
     },
     "spdx-satisfies": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-satisfies/-/spdx-satisfies-4.0.0.tgz",
-      "integrity": "sha512-OcARj6U1OuVv98SVrRqgrR30sVocONtoPpnX8Xz4vXNrFVedqtbgkA+0KmQoXIQ2xjfltPPRVIMeNzKEFLWWKQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-satisfies/-/spdx-satisfies-4.0.1.tgz",
+      "integrity": "sha512-WVzZ/cXAzoNmjCWiEluEA3BjHp5tiUmmhn9MK+X0tBbR9sOqtC6UQwmgCNrAIZvNlMuBUYAaHYfb2oqlF9SwKA==",
       "dev": true,
       "requires": {
         "spdx-compare": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -269,7 +269,7 @@
   "devDependencies": {
     "deep-equal": "^1.0.1",
     "get-stream": "^4.1.0",
-    "licensee": "^5.0.0",
+    "licensee": "^6.1.0",
     "marked": "^0.6.0",
     "marked-man": "^0.2.1",
     "npm-registry-couchapp": "^2.7.1",


### PR DESCRIPTION
This PR upgrades the `licensee` license audit tool from 5.0.0 to 6.1.0, and enables its new corrections feature, which should save time manually whitelisting dependencies going forward.