### PR TITLE
Revert "prune: Fix bug where prune --production would remove dev deps…

### DIFF
--- a/lib/prune.js
+++ b/lib/prune.js
@@ -65,4 +65,3 @@ Pruner.prototype.loadAllDepsIntoIdealTree = function (cb) {
 
 Pruner.prototype.runPreinstallTopLevelLifecycles = function (cb) { cb() }
 Pruner.prototype.runPostinstallTopLevelLifecycles = function (cb) { cb() }
-Pruner.prototype.saveToDependencies = function (cb) { cb() }


### PR DESCRIPTION
… from the lock file"

This change broke the ability to (easily) create a shrinkwrap file that does not include devDeps.  The current behavior of a package published with a shrinkwrap file that includes devDeps is that the devDeps get installed when the package is installed globally (not what you would typically want ever).  The only way around this was to `prune --prod` during prepack to generate a shrinkwrap without devDeps and publish with that (prior to this change going out).  See people here discussing that workaround: ([here](https://npm.community/t/devdependencies-installed-when-package-has-shrinkwrap-file/2244) [here](https://stackoverflow.com/a/47739968/1287889))

After this change, `prune --prod` no longer modifies the shrinkwrap file to remove devDeps.   Reverting this commit restores the old behavior. 

The situation is already looking like a hack but here are two alternative ideas: 

- Perhaps the commit in question IS correct, but a shrinkwrapped package should not install devDeps when installed as a dependency or global package (this seems the most correct and implied behavior described in https://docs.npmjs.com/files/shrinkwrap.json).  This is not the current behavior now though.
- Perhaps running `npm shrinkwrap --prod` should remove the devDeps from the lock file (without pruning node_modules so its faster and can be restored by shrink-wrapping without the flag).  The goal isn't to prune node_modules, its to get my shrinkwrap file right. 

I would propose we revert this change in the meantime so that this avenue isn’t broken, until the primary issue is resolved.

This reverts commit cec5be5427f7f5106a905de8630e1243e9b36ef4.


### workaround for those interested

- During prepack: `npm prune --prod && rm npm-shrinkwrap.json && npm shrinkwrap` Generates the shrinkwrap without devDeps
- During postpack: `git checkout -- npm-shrinkwrap.json && npm i` restores devDeps and reinstalls what was removed during the prune.