### PR TITLE
version: update lock before lifecycle

### DIFF
--- a/doc/cli/npm-version.md
+++ b/doc/cli/npm-version.md
@@ -53,11 +53,12 @@ The exact order of execution is as follows:
   1. Check to make sure the git working directory is clean before we get started.
      Your scripts may add files to the commit in future steps.
      This step is skipped if the `--force` flag is set.
-  2. Run the `preversion` script. These scripts have access to the old `version` in package.json.
+  2. Run the `preversion` script. These scripts have access to the old `version` in `package.json`.
      A typical use would be running your full test suite before deploying.
      Any files you want added to the commit should be explicitly added using `git add`.
   3. Bump `version` in `package.json` as requested (`patch`, `minor`, `major`, etc).
-  4. Run the `version` script. These scripts have access to the new `version` in package.json
+     Also updates `npm-shrinkwrap.json` or `package-lock.json` if present.
+  4. Run the `version` script. These scripts have access to the new `version` in `package.json`
      (so they can incorporate it into file headers in generated files for example).
      Again, scripts should explicitly add generated files to the commit using `git add`.
   5. Commit and tag.

--- a/lib/version.js
+++ b/lib/version.js
@@ -106,6 +106,7 @@ function persistVersion (newVersion, silent, data, localData, cb_) {
     !localData.hasGit && [checkGit, localData],
     [lifecycle, lifecycleData, 'preversion', where],
     [updatePackage, newVersion, silent],
+    [updateShrinkwrap, newVersion, localData],
     [lifecycle, lifecycleData, 'version', where],
     [commit, localData, newVersion],
     [lifecycle, lifecycleData, 'postversion', where]
@@ -144,12 +145,8 @@ function updatePackage (newVersion, silent, cb_) {
 }
 
 function commit (localData, newVersion, cb) {
-  updateShrinkwrap(newVersion, function (er, hasShrinkwrap, hasLock) {
-    if (er || !localData.hasGit) return cb(er)
-    localData.hasShrinkwrap = hasShrinkwrap
-    localData.hasPackageLock = hasLock
-    _commit(newVersion, localData, cb)
-  })
+  if (!localData.hasGit) return cb()
+  _commit(newVersion, localData, cb)
 }
 
 const SHRINKWRAP = 'npm-shrinkwrap.json'
@@ -161,7 +158,7 @@ function readLockfile (name) {
   ).catch({code: 'ENOENT'}, () => null)
 }
 
-function updateShrinkwrap (newVersion, cb) {
+function updateShrinkwrap (newVersion, localData, cb) {
   BB.join(
     readLockfile(SHRINKWRAP),
     readLockfile(PKGLOCK),
@@ -187,7 +184,9 @@ function updateShrinkwrap (newVersion, cb) {
           log.error('version', `Failed to update version in ${file}`)
           return cb(err)
         } else {
-          return cb(null, !!shrinkwrap, !!lockfile)
+          localData.hasShrinkwrap = !!shrinkwrap
+          localData.hasPackageLock = !!lockfile
+          return cb(null)
         }
       })
     }


### PR DESCRIPTION
Update version information in lock files before the main `version` 
lifecycle script is run.

See https://npm.community/t/5135

---

Should probably include tests but that seems to require refactoring that particular test setup ~~and I don't feel like doing that right now~~ and I though, let's discuss the changes first.

Also, I couldn't run the existing tests because they failed when run as a bunch but passed while run individually. Then they edited this very commit (?!), so I'm just going to let Travis-CI handle this.