### PR TITLE
Update package.json.md

### DIFF
--- a/doc/files/package.json.md
+++ b/doc/files/package.json.md
@@ -219,7 +219,8 @@ Conversely, some files are always ignored:
 * `node_modules`
 * `config.gypi`
 * `*.orig`
-* `package-lock.json` (use shrinkwrap instead)
+
+`package-lock.json` is ignored by default, unless explicitly included (e.g. with `"*"`). Use shrinkwrap instead.
 
 ## main
 


### PR DESCRIPTION
Makes it clear that package-lock.json can be included with glob wildcards, and that this behaviour differs from other excluded globs.