### PR TITLE
outdated: fix rendering for global dependencies

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -149,7 +149,7 @@ function makePretty (p, opts) {
     has || 'MISSING',
     want,
     latest,
-    deppath
+    deppath || 'global'
   ]
   if (long) {
     columns[5] = type


### PR DESCRIPTION
Fixes: https://npm.community/t/npm-outdated-throw-an-error-cannot-read-property-length-of-undefined/5929