### PR TITLE
Fix: Always return JSON for `outdated --json` command

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -101,7 +101,7 @@ function outdated (args, silent, cb) {
         return aa[0].path.localeCompare(bb[0].path) ||
           aa[1].localeCompare(bb[1])
       })
-      if (er || silent || list.length === 0) return cb(er, list)
+      if (er || silent) return cb(er, list)
       if (opts.json) {
         output(makeJSON(list, opts))
       } else if (opts.parseable) {


### PR DESCRIPTION
Return JSON when no outdated packages are found.
https://npm.community/t/npm-outdated-json-not-always-json/5953