### PR TITLE
Fix: Return a value for `view` when in silent mode

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -185,6 +185,7 @@ function fetchAndRead (nv, args, silent, opts, cb) {
     }
 
     if (silent) {
+      return retval
     } else if (error) {
       throw error
     } else if (


### PR DESCRIPTION
When querying `npm.commands.view` with `silent` mode, instead of returning `undefined` we should return the result.

```javascript
const npm = require('npm')

const silent = true

npm.load({ global: true }, () => {
  npm.commands.view(['npm'], silent, (err, result) => {
    if (err != null) throw err
    console.dir({ result }) // currently prints "{ result: undefined }"
  })
})
```