### PR TITLE
outdated: fix special 'remote' deps

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -366,6 +366,8 @@ function shouldUpdate (args, tree, dep, has, req, depth, pkgpath, opts, cb, type
     return doIt('git', 'git')
   } else if (parsed.type === 'file') {
     return updateLocalDeps()
+  } else if (parsed.type === 'remote') {
+    return doIt('remote', 'remote')
   } else {
     return packument(parsed, opts.concat({
       'prefer-online': true

--- a/test/tap/outdated-remote.js
+++ b/test/tap/outdated-remote.js
@@ -3,7 +3,6 @@ const path = require('path')
 const test = require('tap').test
 const Tacks = require('tacks')
 const File = Tacks.File
-const Symlink = Tacks.Symlink
 const Dir = Tacks.Dir
 const common = require('../common-tap.js')
 

--- a/test/tap/outdated-remote.js
+++ b/test/tap/outdated-remote.js
@@ -1,0 +1,96 @@
+'use strict'
+const path = require('path')
+const test = require('tap').test
+const Tacks = require('tacks')
+const File = Tacks.File
+const Symlink = Tacks.Symlink
+const Dir = Tacks.Dir
+const common = require('../common-tap.js')
+
+const basedir = path.join(__dirname, path.basename(__filename, '.js'))
+const testdir = path.join(basedir, 'testdir')
+const cachedir = path.join(basedir, 'cache')
+const globaldir = path.join(basedir, 'global')
+const tmpdir = path.join(basedir, 'tmp')
+
+const conf = {
+  cwd: testdir,
+  env: common.newEnv().extend({
+    npm_config_cache: cachedir,
+    npm_config_tmp: tmpdir,
+    npm_config_prefix: globaldir,
+    npm_config_registry: common.registry,
+    npm_config_loglevel: 'warn'
+  })
+}
+
+const fixture = new Tacks(Dir({
+  cache: Dir(),
+  global: Dir(),
+  tmp: Dir(),
+  testdir: Dir({
+    node_modules: Dir({
+      'foo-http': Dir({
+        'package.json': File({
+          name: 'foo-http',
+          version: '1.0.0'
+        })
+      }),
+      'foo-https': Dir({
+        'package.json': File({
+          name: 'foo-https',
+          version: '1.0.0'
+        })
+      })
+    }),
+    'package.json': File({
+      name: 'outdated-remote',
+      version: '1.0.0',
+      dependencies: {
+        'foo-http': 'http://example.com/foo.tar.gz',
+        'foo-https': 'https://example.com/foo.tar.gz'
+      }
+    })
+  })
+}))
+
+function setup () {
+  cleanup()
+  fixture.create(basedir)
+}
+
+function cleanup () {
+  fixture.remove(basedir)
+}
+
+test('setup', t => {
+  setup()
+  return common.fakeRegistry.listen()
+})
+
+test('discovers new versions in outdated', t => {
+  return common.npm(['outdated', '--json'], conf).then(([code, stdout, stderr]) => {
+    t.is(code, 1, 'npm outdated completed successfully')
+    t.comment(stdout.trim())
+    t.comment(stderr.trim())
+    const data = JSON.parse(stdout)
+    t.same(data['foo-http'], {
+      current: '1.0.0',
+      wanted: 'remote',
+      latest: 'remote',
+      location: ''
+    })
+    t.same(data['foo-https'], {
+      current: '1.0.0',
+      wanted: 'remote',
+      latest: 'remote',
+      location: ''
+    })
+  })
+})
+
+test('cleanup', t => {
+  common.fakeRegistry.close()
+  cleanup()
+  t.done()
+})


### PR DESCRIPTION
Add a special case for 'remote' deps (tarballs). Before b7b54f2d18e2d8d65ec67c850b21ae9f01c60e7e the package names were just looked up in the registry instead. The errors caused by that were hidden by `npm-pick-manifest` not returning the `ETARGET` error that `outdated` expects.

See https://npm.community/t/6187