### PR TITLE
licensee@7.0.1

### DIFF
--- a/.licensee.json
+++ b/.licensee.json
@@ -1,7 +1,12 @@
 {
-  "license": "(MIT OR BSD-2-Clause OR BSD-3-Clause OR Apache-2.0 OR ISC OR Unlicense OR CC-BY-3.0 OR CC0-1.0 OR Artistic-2.0)",
+  "licenses": {
+    "spdx": [
+      "CC-BY-3.0"
+    ],
+    "blueOak": "bronze"
+  },
   "corrections": true,
-  "whitelist": {
+  "packages": {
     "config-chain": "1.1.12",
     "cyclist": "0.2.2",
     "json-schema": "0.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -130,6 +130,12 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@blueoak/list": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@blueoak/list/-/list-1.0.2.tgz",
+      "integrity": "sha512-KyqT0kkdxgbGys9mvo/1Mgdt/LGvUFPCZIK9pWPIfOM2mYzMDd/eVYy4sMP1YqvVI129k0alxRyM53H2MAs/Nw==",
+      "dev": true
+    },
     "@types/caseless": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.1.tgz",
@@ -2940,11 +2946,12 @@
       }
     },
     "licensee": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/licensee/-/licensee-6.1.0.tgz",
-      "integrity": "sha512-z0zTmZmHHXlbHMYYUQncutJ0u19SwaidkMdm4t37jvxuJL3HnxcESfzNfXRYnazi6VwGUUYheZcHw+U9mqYr7A==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/licensee/-/licensee-7.0.1.tgz",
+      "integrity": "sha512-iIF04YxU6i0oT/PTw0aTzIT5sVoSSfzNNR8aG4qiw9FmIU3VNDLpAu1T/zexRb/FePaKzWdvloTo7Ngn8XWExQ==",
       "dev": true,
       "requires": {
+        "@blueoak/list": "^1.0.2",
         "correct-license-metadata": "^1.0.1",
         "docopt": "^0.6.2",
         "fs-access": "^2.0.0",
@@ -2954,8 +2961,10 @@
         "run-parallel": "^1.1.9",
         "semver": "^5.6.0",
         "simple-concat": "^1.0.0",
+        "spdx-expression-parse": "^3.0.0",
         "spdx-expression-validate": "^2.0.0",
-        "spdx-satisfies": "^4.0.0"
+        "spdx-osi": "^3.0.0",
+        "spdx-whitelisted": "^1.0.0"
       }
     },
     "load-json-file": {
@@ -5724,20 +5733,25 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
       "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g=="
     },
+    "spdx-osi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-osi/-/spdx-osi-3.0.0.tgz",
+      "integrity": "sha512-7DZMaD/rNHWGf82qWOazBsLXQsaLsoJb9RRjhEUQr5o86kw3A1ErGzSdvaXl+KalZyKkkU5T2a5NjCCutAKQSw==",
+      "dev": true
+    },
     "spdx-ranges": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/spdx-ranges/-/spdx-ranges-2.1.0.tgz",
       "integrity": "sha512-OOWghvosfmECc9edy/A9j7GabERmn8bJWHc0J1knVytQtO5Rw7VfxK6CDqmivJhfMJqWhWWUfffNNMPYvyvyQA==",
       "dev": true
     },
-    "spdx-satisfies": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-satisfies/-/spdx-satisfies-4.0.1.tgz",
-      "integrity": "sha512-WVzZ/cXAzoNmjCWiEluEA3BjHp5tiUmmhn9MK+X0tBbR9sOqtC6UQwmgCNrAIZvNlMuBUYAaHYfb2oqlF9SwKA==",
+    "spdx-whitelisted": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-whitelisted/-/spdx-whitelisted-1.0.0.tgz",
+      "integrity": "sha512-X4FOpUCvZuo42MdB1zAZ/wdX4N0lLcWDozf2KYFVDgtLv8Lx+f31LOYLP2/FcwTzsPi64bS/VwKqklI4RBletg==",
       "dev": true,
       "requires": {
         "spdx-compare": "^1.0.0",
-        "spdx-expression-parse": "^3.0.0",
         "spdx-ranges": "^2.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -269,7 +269,7 @@
   "devDependencies": {
     "deep-equal": "^1.0.1",
     "get-stream": "^4.1.0",
-    "licensee": "^6.1.0",
+    "licensee": "^7.0.1",
     "marked": "^0.6.0",
     "marked-man": "^0.2.1",
     "npm-registry-couchapp": "^2.7.1",


### PR DESCRIPTION
This PR upgrades `licensee`, the license checking tool.  The new major version of `licensee` supports considerably streamlined configuration, which I've leveraged here.