### PR TITLE
Do not pretty-print package-lock.json to prevent corrupting git lines count history

### DIFF
--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -387,6 +387,20 @@ Makes various commands more forceful.
 * skips cache when requesting from the registry.
 * prevents checks against clobbering non-npm files.
 
+### format-package-lock
+
+* Default: false
+* Type: Boolean
+
+Format `package-lock.json` as a human readable file.
+
+### format-shrinkwrap
+
+* Default: false
+* Type: Boolean
+
+Format `npm-shrinkwrap.json` as a human readable file.
+
 ### fetch-retries
 
 * Default: 2

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -141,6 +141,8 @@ Object.defineProperty(exports, 'defaults', {get: function () {
     editor: osenv.editor(),
     'engine-strict': false,
     force: false,
+    'format-package-lock': false,
+    'format-shrinkwrap': false,
 
     'fetch-retries': 2,
     'fetch-retry-factor': 10,
@@ -282,6 +284,8 @@ exports.types = {
   editor: String,
   'engine-strict': Boolean,
   force: Boolean,
+  'format-package-lock': Boolean,
+  'format-shrinkwrap': Boolean,
   'fetch-retries': Number,
   'fetch-retry-factor': Number,
   'fetch-retry-mintimeout': Number,

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -270,11 +270,25 @@ function checkPackageFile (dir, name) {
   return readFile(
     file, 'utf8'
   ).then((data) => {
+    let indent
+    let newline
+    if (name === PKGLOCK && npm.config.get('format-package-lock') === false) {
+      indent = 0
+      newline = 0
+    }
+    else if (name === SHRINKWRAP && npm.config.get('format-shrinkwrap') === false) {
+      indent = 0
+      newline = 0
+    }
+    else {
+      indent = detectIndent(data).indent
+      newline = detectNewline(data)
+    }
     return {
       path: file,
       raw: data,
-      indent: detectIndent(data).indent,
-      newline: detectNewline(data)
+      indent,
+      newline
     }
   }).catch({code: 'ENOENT'}, () => {})
 }


### PR DESCRIPTION
Because package-lock.json is not a human readable file, there is no need to pretty-print it.
Since this file created automatically and required by guidelines to include into git history it is severely corrupting git commitment statistics due to a terrific count of lines added by it.