### PR TITLE
Check save-prefix satisfies requested install version range

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -318,7 +318,18 @@ function computeVersionSpec (tree, child) {
     if (semver.valid(version, true) &&
         semver.gte(version, '0.1.0', true) &&
         !npm.config.get('save-exact')) {
-      rangeDescriptor = npm.config.get('save-prefix')
+      if (requested.type === 'range') {
+        // add save-prefix '^' or '~' only when the future candidates satisfies the
+        // requested range version spec
+        var futureVersion = semver.maxSatisfying([semver.inc(version, 'major'),
+          semver.inc(version, 'minor'), semver.inc(version, 'patch')],
+        npm.config.get('save-prefix') + version)
+        if (semver.satisfies(futureVersion, requested.fetchSpec)) {
+          rangeDescriptor = npm.config.get('save-prefix')
+        }
+      } else {
+        rangeDescriptor = npm.config.get('save-prefix')
+      }
     }
     if (requested.type === 'alias') {
       rangeDescriptor = `npm:${requested.subSpec.name}@${rangeDescriptor}`


### PR DESCRIPTION
The [bug report](https://npm.community/t/npm-install-typescript-3-1-1-3-3-save-dev-produces-incompatible-version-in-package-json/7005) is also opened in npm community.

In short, the recent Angular Compiler requires older typescript packages and asks users to run `npm install typescript@">=3.1.1 <3.3"`

However, after running the install command, package.json will be update to `typescript@^3.2.4`, which will still pull incompatible version, eg.'typescript@3.3.0' in other build machine. So I add some checks in **computeVersionSpec** to ensure adding the save-prefix `^` or `~` only when it satisfies requested **version range**.