### PR TITLE
Support listing out npm cache

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -52,6 +52,9 @@ function cache (args, cb) {
     case 'verify': case 'check':
       result = verify()
       break
+    case 'list': case 'ls':
+      result = list()
+      break
     default: return cb('Usage: ' + cache.usage)
   }
   if (!result || !result.then) {
@@ -133,5 +136,24 @@ function unpack (pkg, ver, unpackTarget, dmode, fmode, uid, gid) {
   return unbuild([unpackTarget], true).then(() => {
     const opts = npmConfig({dmode, fmode, uid, gid, offline: true})
     return pacote.extract(npa.resolve(pkg, ver), unpackTarget, opts)
+  })
+}
+
+cache.list = list
+function list () {
+  const cache = path.join(npm.config.get('cache'), '_cacache')
+  let prefix = cache
+  if (prefix.indexOf(process.env.HOME) === 0) {
+    prefix = '~' + prefix.substr(process.env.HOME.length)
+  }
+
+  return cacache.ls(cache).then((data) => {
+    for (var key in data) {
+      output(key)
+      output('  url = ' + data[key].metadata.url)
+      output('  path = ' + data[key].path)
+      output('  size = ' + data[key].size)
+      output('  time = ' + data[key].time)
+    }
   })
 }

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -22,18 +22,21 @@ cache.usage = 'npm cache add <tarball file>' +
               '\nnpm cache add <git url>' +
               '\nnpm cache add <name>@<version>' +
               '\nnpm cache clean' +
+              '\nnpm cache list [--json]' +
               '\nnpm cache verify'
 
 cache.completion = function (opts, cb) {
   var argv = opts.conf.argv.remain
   if (argv.length === 2) {
-    return cb(null, ['add', 'clean'])
+    return cb(null, ['add', 'clean', 'list', 'verify'])
   }
 
   // TODO - eventually...
   switch (argv[2]) {
     case 'clean':
     case 'add':
+    case 'list':
+    case 'verify':
       return cb(null, [])
   }
 }
@@ -53,6 +56,7 @@ function cache (args, cb) {
       result = verify()
       break
     case 'list': case 'ls':
+
       result = list()
       break
     default: return cb('Usage: ' + cache.usage)
@@ -141,19 +145,46 @@ function unpack (pkg, ver, unpackTarget, dmode, fmode, uid, gid) {
 
 cache.list = list
 function list () {
+  const json = npm.config.get('json')
   const cache = path.join(npm.config.get('cache'), '_cacache')
-  let prefix = cache
-  if (prefix.indexOf(process.env.HOME) === 0) {
-    prefix = '~' + prefix.substr(process.env.HOME.length)
+  let writer
+  if (json) {
+    writer = {
+      item: undefined,
+      handleElement: function (item) {
+        if (this.item === undefined) {
+          output('[')
+        } else {
+          output('  ' + JSON.stringify(this.item) + ',')
+        }
+        this.item = item
+      },
+      done: function () {
+        if (this.item === undefined) {
+          output(JSON.stringify([]))
+        } else {
+          output('  ' + JSON.stringify(this.item))
+          output(']')
+        }
+      }
+    }
+  } else {
+    writer = {
+      handleElement: function (item) {
+        output(item.key)
+        output('  url = ' + (item.metadata === undefined ? 'undefined' : item.metadata.url))
+        output('  path = ' + item.path)
+        output('  size = ' + item.size)
+        output('  time = ' + item.time)
+      },
+      done: () => {}
+    }
   }
 
-  return cacache.ls(cache).then((data) => {
-    for (var key in data) {
-      output(key)
-      output('  url = ' + data[key].metadata.url)
-      output('  path = ' + data[key].path)
-      output('  size = ' + data[key].size)
-      output('  time = ' + data[key].time)
-    }
+  return new BB((resolve, reject) => {
+    const stream = cacache.ls.stream(cache)
+    stream.on('data', (item) => writer.handleElement(item))
+    stream.on('error', error => { reject(error) })
+    stream.on('end', () => { writer.done(); resolve('done') })
   })
 }

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -56,7 +56,6 @@ function cache (args, cb) {
       result = verify()
       break
     case 'list': case 'ls':
-
       result = list()
       break
     default: return cb('Usage: ' + cache.usage)


### PR DESCRIPTION
The [documentation for npm-cache](https://docs.npmjs.com/cli/npm-cache) says it can list the contents of the cache folder:

> Used to add, list, or clean the npm cache folder.

The `list` functionality isn't actually present, but is supported by [`cacache`](https://www.npmjs.com/package/cacache#ls).

This PR adds a `list` (or `ls`) subcommand to `npm cache` that outputs the contents of the cache in the following format:

```
$ npm cache list
...
make-fetch-happen:request-cache:https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz
  url = https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz
  path = /Users/jtolar/.npm/_cacache/content-v2/sha1/45/26/92cb711d5f79dc7f85e440ce41b9f244d221
  size = 1752
  time = 1556301242419
make-fetch-happen:request-cache:https://registry.npmjs.org/ultron
  url = https://registry.npmjs.org/ultron
  path = /Users/jtolar/.npm/_cacache/content-v2/sha512/bb/79/1e224496f3bcf5cc6d503ca512a9ff44625ee82e436a7fb24dfde1591a56068846ef7ed2c6fe3f7f233afd74c2d672a4c18e711595d1b2fe64c81f54e9d0
  size = 2101
  time = 1556301242411
...
```

If a different output format would be preferable, I'm happy to change this PR.