### PR TITLE
Added ARM64 platform check 

### DIFF
--- a/test/tap/legacy-platform-all.js
+++ b/test/tap/legacy-platform-all.js
@@ -33,6 +33,7 @@ var fixture = new Tacks(
       ],
       cpu: [
         'arm',
+        'arm64',
         'mips',
         'ia32',
         'x64',


### PR DESCRIPTION
I have added the arm64 architecture check in the legacy-platform-all.js test file.
