### PR TITLE
fix undefined error caused by `npm outdated -g`

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -216,7 +216,7 @@ function makeJSON (list, opts) {
 function outdated_ (args, path, tree, parentHas, depth, opts, cb) {
   if (!tree.package) tree.package = {}
   if (path && moduleName(tree)) path += ' > ' + tree.package.name
-  if (!path && moduleName(tree)) path = tree.package.name
+  if (!path && moduleName(tree)) path = tree.package.name || ''
   if (depth > opts.depth) {
     return cb(null, [])
   }


### PR DESCRIPTION
Following error is shown when `npm outdated -g` is called:

```
npm ERR! Cannot read property 'length' of undefined
```

This patch fixes the problem by setting `path` to an empty string when `tree.package.name` is `undefined`.