### PR TITLE
npm checks only node.exe and not node on local dir

### DIFF
--- a/bin/npm
+++ b/bin/npm
@@ -9,6 +9,9 @@ esac
 
 NODE_EXE="$basedir/node.exe"
 if ! [ -x "$NODE_EXE" ]; then
+  NODE_EXE="$basedir/node"
+fi
+if ! [ -x "$NODE_EXE" ]; then
   NODE_EXE=node
 fi
 


### PR DESCRIPTION
Npm find local node.exe on windows, but relies on global node installation on linux. Added a test to check for a local installation of node before relying on the system wide installation.