### PR TITLE
Fix error on `pkg.name[0]` when name is empty

### DIFF
--- a/lib/unbuild.js
+++ b/lib/unbuild.js
@@ -58,7 +58,7 @@ function rmStuff (pkg, folder, cb) {
   // if it's global, and folder is in {prefix}/node_modules,
   // then bins are in {prefix}/bin
   // otherwise, then bins are in folder/../.bin
-  var parent = pkg.name[0] === '@' ? path.dirname(path.dirname(folder)) : path.dirname(folder)
+  var parent = pkg.name && pkg.name[0] === '@' ? path.dirname(path.dirname(folder)) : path.dirname(folder)
   var gnm = npm.dir
   // gnm might be an absolute path, parent might be relative
   // this checks they're the same directory regardless


### PR DESCRIPTION
>TypeError: Cannot read property '0' of undefined
>     at rmStuff (C:\Program Files\nodejs\node_modules\npm\lib\unbuild.js:61:24)

Closes npm/npm#17858
Closes npm/npm#18042
Closes https://npm.community/t/issue-npm-dedupe-crash-with-typeerror-cannot-read-property-0-of-undefined/644/3