### PR TITLE
Enable production flag for npm audit.

### DIFF
--- a/lib/audit.js
+++ b/lib/audit.js
@@ -39,7 +39,7 @@ module.exports = auditCmd
 const usage = require('./utils/usage')
 auditCmd.usage = usage(
   'audit',
-  '\nnpm audit [--json]' +
+  '\nnpm audit [--json] [--production]' +
   '\nnpm audit fix ' +
   '[--force|--package-lock-only|--dry-run|--production|--only=(dev|prod)]'
 )
@@ -175,7 +175,7 @@ function auditCmd (args, cb) {
     const requires = Object.assign(
       {},
       (pkgJson && pkgJson.dependencies) || {},
-      (pkgJson && pkgJson.devDependencies) || {}
+      (!opts.production && pkgJson && pkgJson.devDependencies) || {}
     )
     return lockVerify(npm.prefix).then((result) => {
       if (result.status) return audit.generate(sw, requires)

--- a/test/tap/audit.js
+++ b/test/tap/audit.js
@@ -263,6 +263,209 @@ test('exits with non-zero exit code for vulnerabilities at the `audit-level` fla
   })
 })
 
+test('exits with zero exit code for vulnerabilities in devDependencies when running with production flag', t => {
+  const fixture = new Tacks(new Dir({
+    'package.json': new File({
+      name: 'foo',
+      version: '1.0.0',
+      dependencies: {
+        gooddep: '1.0.0'
+      },
+      devDependencies: {
+        baddep: '1.0.0'
+      }
+    })
+  }))
+  fixture.create(testDir)
+  return tmock(t).then(srv => {
+    srv.filteringRequestBody(req => 'ok')
+    srv.post('/-/npm/v1/security/audits/quick', 'ok').reply(200, 'yeah')
+    srv.get('/gooddep').twice().reply(200, {
+      name: 'gooddep',
+      'dist-tags': {
+        'latest': '1.2.3'
+      },
+      versions: {
+        '1.0.0': {
+          name: 'gooddep',
+          version: '1.0.0',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
+          }
+        },
+        '1.2.3': {
+          name: 'gooddep',
+          version: '1.2.3',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
+          }
+        }
+      }
+    })
+    srv.get('/baddep').twice().reply(200, {
+      name: 'baddep',
+      'dist-tags': {
+        'latest': '1.2.3'
+      },
+      versions: {
+        '1.0.0': {
+          name: 'baddep',
+          version: '1.0.0',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
+          }
+        },
+        '1.2.3': {
+          name: 'baddep',
+          version: '1.2.3',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
+          }
+        }
+      }
+    })
+    return common.npm([
+      'install',
+      '--audit',
+      '--json',
+      '--production',
+      '--package-lock-only',
+      '--registry', common.registry,
+      '--cache', path.join(testDir, 'npm-cache')
+    ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+      srv.filteringRequestBody(req => 'ok')
+      srv.post('/-/npm/v1/security/audits', 'ok').reply(200, {
+        actions: [],
+        metadata: {
+          vulnerabilities: {}
+        }
+      })
+     return common.npm([
+        'audit',
+        '--json',
+        '--production',
+        '--registry', common.registry,
+        '--cache', path.join(testDir, 'npm-cache')
+      ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+        t.equal(code, 0, 'exited OK')
+      })
+    })
+  })
+})
+
+test('exits with non-zero exit code for vulnerabilities in dependencies when running with production flag', t => {
+  const fixture = new Tacks(new Dir({
+    'package.json': new File({
+      name: 'foo',
+      version: '1.0.0',
+      dependencies: {
+        baddep: '1.0.0'
+      },
+      devDependencies: {
+        gooddep: '1.0.0'
+      }
+    })
+  }))
+  fixture.create(testDir)
+  return tmock(t).then(srv => {
+    srv.filteringRequestBody(req => 'ok')
+    srv.post('/-/npm/v1/security/audits/quick', 'ok').reply(200, 'yeah')
+    srv.get('/baddep').twice().reply(200, {
+      name: 'baddep',
+      'dist-tags': {
+        'latest': '1.2.3'
+      },
+      versions: {
+        '1.0.0': {
+          name: 'baddep',
+          version: '1.0.0',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
+          }
+        },
+        '1.2.3': {
+          name: 'baddep',
+          version: '1.2.3',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
+          }
+        }
+      }
+    })
+    srv.get('/gooddep').twice().reply(200, {
+      name: 'gooddep',
+      'dist-tags': {
+        'latest': '1.2.3'
+      },
+      versions: {
+        '1.0.0': {
+          name: 'gooddep',
+          version: '1.0.0',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
+          }
+        },
+        '1.2.3': {
+          name: 'gooddep',
+          version: '1.2.3',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
+          }
+        }
+      }
+    })
+    return common.npm([
+      'install',
+      '--audit',
+      '--json',
+      '--production',
+      '--package-lock-only',
+      '--registry', common.registry,
+      '--cache', path.join(testDir, 'npm-cache')
+    ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+      srv.filteringRequestBody(req => 'ok')
+      srv.post('/-/npm/v1/security/audits', 'ok').reply(200, {
+        actions: [{
+          action: 'update',
+          module: 'baddep',
+          target: '1.2.3',
+          resolves: [{path: 'baddep'}]
+        }],
+        metadata: {
+          vulnerabilities: {
+            low: 1
+          }
+        }
+      })
+     return common.npm([
+        'audit',
+        '--json',
+        '--production',
+        '--registry', common.registry,
+        '--cache', path.join(testDir, 'npm-cache')
+      ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+        t.equal(code, 1, 'exited OK')
+      })
+    })
+  })
+})
+
 test('cleanup', t => {
   return rimraf(testDir)
 })

--- a/test/tap/audit.js
+++ b/test/tap/audit.js
@@ -348,7 +348,7 @@ test('exits with zero exit code for vulnerabilities in devDependencies when runn
           vulnerabilities: {}
         }
       })
-     return common.npm([
+      return common.npm([
         'audit',
         '--json',
         '--production',
@@ -453,7 +453,7 @@ test('exits with non-zero exit code for vulnerabilities in dependencies when run
           }
         }
       })
-     return common.npm([
+      return common.npm([
         'audit',
         '--json',
         '--production',


### PR DESCRIPTION
Summary of changes:
This PR enables using the existing `--production` flag when running `npm audit`. Using this flag will ignore dev dependencies when assigning the `requires` constant that is passed to `audit.generate`.  

Reason for changes:
Currently there is no way to ignore dev dependencies when running an audit.  Being able to do so is desirable when an audit is part of a CI process.