### PR TITLE
fix(unpublish): add space after hyphen

### DIFF
--- a/lib/unpublish.js
+++ b/lib/unpublish.js
@@ -99,7 +99,7 @@ function unpublish (args, cb) {
   }).then(
     ret => {
       if (!opts.silent && opts.loglevel !== 'silent') {
-        output(`-${spec.name}${
+        output(`- ${spec.name}${
           spec.type === 'version' ? `@${spec.rawSpec}` : ''
         }`)
       }


### PR DESCRIPTION
This PR will
- add a space after `-` to the unpublish message, [just like `publish` has](https://github.com/npm/cli/blob/656bce7dd0f9753a273912e803261ed246593924/lib/publish.js#L67).