### PR TITLE
install: improve isOnly(Dev,Optional)

### DIFF
--- a/lib/install/is-only-dev.js
+++ b/lib/install/is-only-dev.js
@@ -28,9 +28,10 @@ function andIsOnlyDev (name, seen) {
       return isDev && !isProd
     } else {
       if (seen.has(req)) return true
-      seen = new Set(seen)
       seen.add(req)
-      return isOnlyDev(req, seen)
+      const result = isOnlyDev(req, seen)
+      seen.delete(req)
+      return result
     }
   }
 }

--- a/lib/install/is-only-optional.js
+++ b/lib/install/is-only-optional.js
@@ -11,11 +11,12 @@ function isOptional (node, seen) {
   if (seen.has(node) || node.requiredBy.length === 0) {
     return false
   }
-  seen = new Set(seen)
   seen.add(node)
   const swOptional = node.fromShrinkwrap && node.package._optional
-  return node.requiredBy.every(function (req) {
+  const result = node.requiredBy.every(function (req) {
     if (req.fakeChild && swOptional) return true
     return isOptDep(req, moduleName(node)) || isOptional(req, seen)
   })
+  seen.delete(node)
+  return result
 }


### PR DESCRIPTION
Instead of creating a new set each time a new node gets visited, so that 
its siblings do not have it in `seen`, just remove the node from the 
original set right after all child nodes are visited.

See #76