### PR TITLE
Use env to find bash

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # set configurations that will be "sticky" on this system,
 # surviving npm self-updates.

--- a/scripts/clean-old.sh
+++ b/scripts/clean-old.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # look for old 0.x cruft, and get rid of it.
 # Should already be sitting in the npm folder.

--- a/scripts/dep-update
+++ b/scripts/dep-update
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 node . install --save $1@$2 &&\
 node scripts/gen-dev-ignores.js &&\
 git add node_modules package.json package-lock.json &&\

--- a/scripts/dev-dep-update
+++ b/scripts/dev-dep-update
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 node . install --save --save-dev $1@$2 &&\
 node scripts/gen-dev-ignores.js &&\
 git add package.json package-lock.json &&\

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # script for creating a zip and tarball for inclusion in node
 

--- a/scripts/relocate.sh
+++ b/scripts/relocate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Change the cli shebang to point at the specified node
 # Useful for when the program is moved around after install.


### PR DESCRIPTION
On BSD platforms, there is a clear seperation between the OS and third party packages. Here, bash is a third party package so it won't be installed to /bin.

FreeBSD:	/usr/local/bin/bash
NetBSD:		/usr/pkg/bin/bash
OpenBSD:	/usr/ports/bin/bash

As such, we need to use /usr/bin/env to launch these scripts.

BTW, I couldn't find any document of the tools required to build npm, but bash should probably be listed there somewhere.