### PR TITLE
Correct command line usage messages

### DIFF
--- a/doc/cli/npm-access.md
+++ b/doc/cli/npm-access.md
@@ -6,7 +6,7 @@ npm-access(1) -- Set access level on published packages
     npm access public [<package>]
     npm access restricted [<package>]
 
-    npm access grant <read-only|read-write> <scope:team> [<package>]
+    npm access grant read-only|read-write <scope:team> [<package>]
     npm access revoke <scope:team> [<package>]
 
     npm access 2fa-required [<package>]

--- a/doc/cli/npm-adduser.md
+++ b/doc/cli/npm-adduser.md
@@ -3,7 +3,7 @@ npm-adduser(1) -- Add a registry user account
 
 ## SYNOPSIS
 
-    npm adduser [--registry=url] [--scope=@orgname] [--always-auth] [--auth-type=legacy]
+    npm adduser [--registry=<url>] [--scope=@<orgname>] [--always-auth] [--auth-type=legacy]
 
     aliases: login, add-user
 

--- a/doc/cli/npm-hook.md
+++ b/doc/cli/npm-hook.md
@@ -5,7 +5,7 @@ npm-hook(1) -- Manage registry hooks
 
     npm hook ls [pkg]
     npm hook add <entity> <url> <secret>
-    npm hook update <id> <url> [secret]
+    npm hook update <id> <url> [<secret>]
     npm hook rm <id>
 
 ## EXAMPLE

--- a/doc/cli/npm-publish.md
+++ b/doc/cli/npm-publish.md
@@ -4,7 +4,7 @@ npm-publish(1) -- Publish a package
 
 ## SYNOPSIS
 
-    npm publish [<tarball>|<folder>] [--tag <tag>] [--access <public|restricted>] [--otp otpcode] [--dry-run]
+    npm publish [<tarball>|<folder>] [--tag <tag>] [--access public|restricted] [--otp otpcode] [--dry-run]
 
     Publishes '.' if no argument supplied
     Sets tag 'latest' if no --tag specified
@@ -35,7 +35,7 @@ specifying a different default registry or using a `npm-scope(7)` in the name
   and `npm install` installs the `latest` tag. See `npm-dist-tag(1)` for
   details about tags.
 
-* `[--access <public|restricted>]`
+* `[--access public|restricted]`
   Tells the registry whether this package should be published as public or
   restricted. Only applies to scoped packages, which default to `restricted`.
   If you don't have a paid account, you must publish with `--access public`

--- a/doc/cli/npm-search.md
+++ b/doc/cli/npm-search.md
@@ -3,7 +3,7 @@ npm-search(1) -- Search for packages
 
 ## SYNOPSIS
 
-    npm search [-l|--long] [--json] [--parseable] [--no-description] [search terms ...]
+    npm search [-l|--long] [--json] [--parseable] [--no-description] [<search terms> ...]
 
     aliases: s, se, find
 

--- a/doc/cli/npm-token.md
+++ b/doc/cli/npm-token.md
@@ -5,7 +5,7 @@ npm-token(1) -- Manage your authentication tokens
 
     npm token list [--json|--parseable]
     npm token create [--read-only] [--cidr=1.1.1.1/24,2.2.2.2/16]
-    npm token revoke <id|token>
+    npm token revoke <id>|<token>
 
 ## DESCRIPTION
 

--- a/lib/access.js
+++ b/lib/access.js
@@ -20,7 +20,7 @@ access.usage = usage(
   'npm access',
   'npm access public [<package>]\n' +
   'npm access restricted [<package>]\n' +
-  'npm access grant <read-only|read-write> <scope:team> [<package>]\n' +
+  'npm access grant read-only|read-write <scope:team> [<package>]\n' +
   'npm access revoke <scope:team> [<package>]\n' +
   'npm access 2fa-required [<package>]\n' +
   'npm access 2fa-not-required [<package>]\n' +

--- a/lib/adduser.js
+++ b/lib/adduser.js
@@ -11,7 +11,7 @@ try {
 
 adduser.usage = usage(
   'adduser',
-  'npm adduser [--registry=url] [--scope=@orgname] [--auth-type=legacy] [--always-auth]'
+  'npm adduser [--registry=<url>] [--scope=@<orgname>] [--auth-type=legacy] [--always-auth]'
 )
 
 function adduser (args, cb) {

--- a/lib/hook.js
+++ b/lib/hook.js
@@ -13,7 +13,7 @@ const validate = require('aproba')
 
 hook.usage = [
   'npm hook add <pkg> <url> <secret> [--type=<type>]',
-  'npm hook ls [pkg]',
+  'npm hook ls [<pkg>]',
   'npm hook rm <id>',
   'npm hook update <id> <url> <secret>'
 ].join('\n')

--- a/lib/install-ci-test.js
+++ b/lib/install-ci-test.js
@@ -10,7 +10,7 @@ var usage = require('./utils/usage')
 
 installTest.usage = usage(
   'install-ci-test',
-  '\nnpm install-ci-test [args]' +
+  '\nnpm install-ci-test [<args>]' +
   '\nSame args as `npm ci`'
 )
 

--- a/lib/install-test.js
+++ b/lib/install-test.js
@@ -10,7 +10,7 @@ var usage = require('./utils/usage')
 
 installTest.usage = usage(
   'install-test',
-  '\nnpm install-test [args]' +
+  '\nnpm install-test [<args>]' +
   '\nSame args as `npm install`'
 )
 

--- a/lib/org.js
+++ b/lib/org.js
@@ -12,9 +12,9 @@ module.exports = org
 org.subcommands = ['set', 'rm', 'ls']
 
 org.usage =
-  'npm org set orgname username [developer | admin | owner]\n' +
-  'npm org rm orgname username\n' +
-  'npm org ls orgname [<username>]'
+  'npm org set <orgname> <username> [developer | admin | owner]\n' +
+  'npm org rm <orgname> <username>\n' +
+  'npm org ls <orgname> [<username>]'
 
 const OrgConfig = figgyPudding({
   json: {},

--- a/lib/ping.js
+++ b/lib/ping.js
@@ -14,7 +14,7 @@ const PingConfig = figgyPudding({
 
 module.exports = ping
 
-ping.usage = 'npm ping\nping registry'
+ping.usage = 'npm ping\nping --registry <registry>'
 
 function ping (args, silent, cb) {
   if (typeof cb !== 'function') {

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -20,7 +20,7 @@ const readJson = BB.promisify(require('read-package-json'))
 const semver = require('semver')
 const statAsync = BB.promisify(require('graceful-fs').stat)
 
-publish.usage = 'npm publish [<tarball>|<folder>] [--tag <tag>] [--access <public|restricted>] [--dry-run]' +
+publish.usage = 'npm publish [<tarball>|<folder>] [--tag <tag>] [--access public|restricted] [--dry-run]' +
                 "\n\nPublishes '.' if no argument supplied" +
                 '\n\nSets tag `latest` if no --tag specified'
 

--- a/lib/search.js
+++ b/lib/search.js
@@ -15,7 +15,7 @@ const usage = require('./utils/usage')
 
 search.usage = usage(
   'search',
-  'npm search [--long] [search terms ...]'
+  'npm search [--long] [<search terms> ...]'
 )
 
 search.completion = function (opts, cb) {

--- a/lib/token.js
+++ b/lib/token.js
@@ -22,7 +22,7 @@ token._validateCIDRList = validateCIDRList
 token.usage =
   'npm token list\n' +
   'npm token revoke <tokenKey>\n' +
-  'npm token create [--read-only] [--cidr=list]\n'
+  'npm token create [--read-only] [--cidr=<list>]\n'
 
 token.subcommands = ['list', 'revoke', 'create']
 

--- a/lib/view.js
+++ b/lib/view.js
@@ -32,7 +32,7 @@ const ViewConfig = figgyPudding({
 
 view.usage = usage(
   'view',
-  'npm view [<@scope>/]<pkg>[@<version>] [<field>[.subfield]...]'
+  'npm view [<@scope>/]<pkg>[@<version>] [<field>[.<subfield>]...]'
 )
 
 view.completion = function (opts, cb) {


### PR DESCRIPTION
`<>` should not be used for words that intent to use 'as is'.

Also fixed the on-line usage string of subcommand `npm ping`.