### PR TITLE
fix(cmd): correct `udpate` to `update`

### DIFF
--- a/lib/config/cmd-list.js
+++ b/lib/config/cmd-list.js
@@ -35,7 +35,7 @@ var affordances = {
   'apihelp': 'help',
   'find-dupes': 'dedupe',
   'upgrade': 'update',
-  'udpate': 'update',
+  'update': 'update',
   'login': 'adduser',
   'add-user': 'adduser',
   'author': 'owner',


### PR DESCRIPTION
```
$ npm update --help
npm update [-g] [<pkg>...]

aliases: up, upgrade, udpate
```

`udpate` should be `update`