### PR TITLE
**WIP** install: correctly exclude dev dependencies when using global and shrinkwrap

### DIFF
--- a/lib/install/is-only-dev.js
+++ b/lib/install/is-only-dev.js
@@ -5,13 +5,15 @@ const moduleName = require('../utils/module-name.js')
 const isDevDep = require('./is-dev-dep.js')
 const isProdDep = require('./is-prod-dep.js')
 
-// Returns true if the module `node` is only required direcctly as a dev
+// Returns true if the module `node` is only required directly as a dev
 // dependency of the top level or transitively _from_ top level dev
 // dependencies.
 // Dual mode modules (that are both dev AND prod) should return false.
 function isOnlyDev (node, seen) {
   if (!seen) seen = new Set()
-  return node.requiredBy.length && node.requiredBy.every(andIsOnlyDev(moduleName(node), seen))
+  const isRequired = node.requiredBy.length > 0
+  const isTranstiveDependency = isRequired && node.requiredBy.every(andIsOnlyDev(moduleName(node), seen))
+  return isTranstiveDependency || !isRequired
 }
 
 // There is a known limitation with this implementation: If a dependency is


### PR DESCRIPTION
See report at https://npm.community/t/devdependencies-are-installed-if-global-flag-used-and-shrinkwrap-file-is-present/9019

Signed-off-by: Gergely Imreh <imrehg@gmail.com>