### PR TITLE
Fix typos across npm cli repository

### DIFF
--- a/lib/install/diff-trees.js
+++ b/lib/install/diff-trees.js
@@ -11,7 +11,7 @@ var moduleName = require('../utils/module-name.js')
 var isOnlyOptional = require('./is-only-optional.js')
 
 // we don't use get-requested because we're operating on files on disk, and
-// we don't want to extropolate from what _should_ be there.
+// we don't want to extrapolate from what _should_ be there.
 function pkgRequested (pkg) {
   return pkg._requested || (pkg._resolved && npa(pkg._resolved)) || (pkg._from && npa(pkg._from))
 }

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -121,7 +121,7 @@ function shrinkwrapDeps (deps, top, tree, seen) {
       if (isRegistry(requested)) {
         pkginfo.resolved = child.package._resolved
       }
-      // no integrity for git deps as integirty hashes are based on the
+      // no integrity for git deps as integrity hashes are based on the
       // tarball and we can't (yet) create consistent tarballs from a stable
       // source.
       if (requested.type !== 'git') {

--- a/test/tap/false-name.js
+++ b/test/tap/false-name.js
@@ -58,7 +58,7 @@ test('not every pkg.name can be required', function (t) {
       )
       t.ok(
         existsSync(path.join(pkg, 'node_modules', 'test-package')),
-        'test-pacakge subdep installed OK'
+        'test-package subdep installed OK'
       )
       t.end()
     }


### PR DESCRIPTION
:blue_heart: Fix typos across **npm cli repository**

### Fixed files :wrench: 

<details><summary>See all fixed files</summary>
<p>

```
cli/lib/install/diff-trees.js:14:20: "extropolate" is a misspelling of "extrapolate"
cli/lib/shrinkwrap.js:124:38: "integirty" is a misspelling of "integrity"
cli/test/tap/false-name.js:61:14: "pacakge" is a misspelling of "package"
```

</p>
</details>

**FYI:** I used [**Go Spellchecker**](https://github.com/liamzdenek/go-spellcheck) :smile_cat: