### PR TITLE
Building any npm package in OE/Yocto env run into error:

### DIFF
--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -74,7 +74,9 @@ function quotemeta (str) {
 }
 
 function tarballToVersion (name, tb) {
-  const registry = quotemeta(npm.config.get('registry'))
+  var x = npm.config.get('registry');
+  if ( x === null) x = '';
+  const registry = quotemeta(x)
     .replace(/https?:/, 'https?:')
     .replace(/([^/])$/, '$1/')
   let matchRegTarball

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -75,7 +75,7 @@ function quotemeta (str) {
 
 function tarballToVersion (name, tb) {
   var x = npm.config.get('registry')
-  if (x === null) x = '';
+  if (x === null) x = ''
   const registry = quotemeta(x)
     .replace(/https?:/, 'https?:')
     .replace(/([^/])$/, '$1/')

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -74,8 +74,8 @@ function quotemeta (str) {
 }
 
 function tarballToVersion (name, tb) {
-  var x = npm.config.get('registry');
-  if ( x === null) x = '';
+  var x = npm.config.get('registry')
+  if (x === null) x = '';
   const registry = quotemeta(x)
     .replace(/https?:/, 'https?:')
     .replace(/([^/])$/, '$1/')


### PR DESCRIPTION
| npm ERR! Cannot read property 'replace' of null

, case registry may not exist in the restricted env.