### PR TITLE
Implements peerDependenciesMeta

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -711,6 +711,12 @@ function resolveWithNewModule (pkg, tree, log, next) {
   })
 }
 
+var isOptionalPeerDep = exports.isOptionalPeerDep = function (tree, pkgname) {
+  if (!tree.package.peerDependenciesMeta) return
+  if (!tree.package.peerDependenciesMeta[pkgname]) return
+  return !!tree.package.peerDependenciesMeta[pkgname].optional
+}
+
 var validatePeerDeps = exports.validatePeerDeps = function (tree, onInvalid) {
   if (!tree.package.peerDependencies) return
   Object.keys(tree.package.peerDependencies).forEach(function (pkgname) {
@@ -719,7 +725,7 @@ var validatePeerDeps = exports.validatePeerDeps = function (tree, onInvalid) {
       var spec = npa.resolve(pkgname, version)
     } catch (e) {}
     var match = spec && findRequirement(tree.parent || tree, pkgname, spec)
-    if (!match) onInvalid(tree, pkgname, version)
+    if (!match && !isOptionalPeerDep(tree, pkgname)) onInvalid(tree, pkgname, version)
   })
 }
 


### PR DESCRIPTION
This diff implements the `peerDependenciesMeta` field specified in the [following rfc](https://github.com/yarnpkg/rfcs/blob/master/accepted/0000-optional-peer-dependencies.md).

## What is it?

This field provides a way to package authors to disable the peer dependency warnings for packages that may be needed for some integrations, but only affect a subset of the users and aren't worth printing a warning to all.

## Why implement it this way?

The rfc can be read for more details on why this syntax and not another; it's worth noting that both Yarn and pnpm (cc @zkochan) have been supporting this field for about half a year now.

## Why is it important?

With npm still being roughly half the Javascript ecosystem, some maintainers are found omitting to declare their peer dependencies altogether just to avoid the peer dependency warning to their users. It generates invalid dependency trees that may work in the best cases, but break when an unrelated package is added to the dependency tree and changes the way the hoisting works.

## Why is it broken not to list peer dependencies?

<details>
<summary>It's convoluted, click to expand 🙂</summary>

Proof by example; imagine the following setup:

- `A` depends on `B@*`, and has an **unlisted** peer dependency on `X`
- your app depends on `A` and `X@1`
- `B@1` depends on nothing

In this situation, we get the following tree:

```
. - A - B@1
  \
    X@1
```

The package `A` is able to access `X@1` (assuming a `node_modules` install), everything is ok. Now let's say that `B` gets a new release, `B@2`, which includes a dependency on `X@2`:

```
. - A - B@2 - X@2
  \
    X@1
```

But because of the hoisting, and because there is no conflict doing this, `X` will be moved from `B` to its parent folder. We'll now get the following:

```
. - A - B@2
  \   \ 
    X   X@2
```

Because of this hoisting, when `A` makes a require call to obtain `X`, it will no longer get the `X@1` provided by its parent. Instead it will get `X@2` provided by its child, breaking the original contract in a very subtle way.

If `X` had been listed as peer dependency of `A`, even optional, then the package manager would have been able to detect that hoisting `X` into `A` would have caused a conflict, and this problem would have been avoided.

</details>

## Where are the tests?

This diff was manually tested by patching my local npm and trying it out. I also don't see how it could have any adverse effect, although I'm not familiar with the codebase.

Regarding automated tests, given that the fixtures are stored in a separate repository I figured you might want to integrate them yourself - although I can do it if you prefer. From a cursory glance, the relevant files to modify are:

- https://github.com/npm/cli/blob/latest/test/tap/peer-deps.js
  This is a trap, this file should not be modified 😃 It's just the test that matters.

- https://github.com/npm/npm-registry-mock/blob/master/fixtures/npm-test-peer-deps.json
  An optional unmet peer dependency should be added.