### PR TITLE
Handle unhandledRejections, help with cache eacces

### DIFF
--- a/bin/npm-cli.js
+++ b/bin/npm-cli.js
@@ -62,6 +62,7 @@
   log.info('using', 'node@%s', process.version)
 
   process.on('uncaughtException', errorHandler)
+  process.on('unhandledRejection', errorHandler)
 
   if (conf.usage && npm.command !== 'help') {
     npm.argv.unshift(npm.command)

--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -187,11 +187,12 @@ function errorHandler (er) {
   log.verbose('npm ', 'v' + npm.version)
 
   ;[
+    'code',
+    'syscall',
     'file',
     'path',
-    'code',
-    'errno',
-    'syscall'
+    'dest',
+    'errno'
   ].forEach(function (k) {
     var v = er[k]
     if (v) log.error(k, v)

--- a/test/tap/cache-eacces-error-message.js
+++ b/test/tap/cache-eacces-error-message.js
@@ -1,0 +1,38 @@
+const npm = require('../../lib/npm.js')
+const t = require('tap')
+
+if (process.platform === 'win32') {
+  t.plan(0, 'this is a unix-only thing')
+  process.exit(0)
+}
+
+const errorMessage = require('../../lib/utils/error-message.js')
+
+const common = require('../common-tap.js')
+
+t.plan(1)
+
+npm.load({ cache: common.cache }, () => {
+  npm.config.set('cache', common.cache)
+  const er = new Error('access is e, i am afraid')
+  er.code = 'EACCES'
+  er.errno = -13
+  er.path = common.cache + '/src'
+  er.dest = common.cache + '/to'
+
+  t.match(errorMessage(er), {
+    summary: [
+      [
+        '',
+        new RegExp('\n' +
+          'Your cache folder contains root-owned files, due to a bug in\n' +
+          'previous versions of npm which has since been addressed.\n' +
+          '\n' +
+          'To permanently fix this problem, please run:\n' +
+          '  sudo chown -R [0-9]+:[0-9]+ ".*npm_cache_cache-eacces-error-message"'
+        )
+      ]
+    ],
+    detail: []
+  }, 'get the helpful error message')
+})


### PR DESCRIPTION
Suggested by @godmar in
https://npm.community/t/npm-err-cb-never-called-permission-denied/9167/5

Incidentally, this turned up that we're catching uncaughtExceptions in
the main npm functions, but not unhandledRejections!

Tracing this through, it seems like node-fetch-npm's use of cacache is
particularly brittle.  Any throw that comes from cacache is not caught
properly, since node-fetch-npm is all streams and callbacks.  The naive
approach (just adding a catch and failing the callback) doesn't work,
because then make-fetch-happen and npm-registry-fetch interpret the
failure as an invalid response, when actually it was a local cache
error.

So, a bit more love and polish is definitely still needed in the
guts of npm's fetching and caching code paths.  In the meantime, though,
handling any unhandledRejection at the top level prevents at least the
worst and most useless type of error message.