### PR TITLE
doc: fixed typo for Number.MAX_SAFE_INTEGER

### DIFF
--- a/doc/misc/semver.md
+++ b/doc/misc/semver.md
@@ -407,5 +407,5 @@ All surrounding text is simply ignored (`v3.4 replaces v3.3.1` becomes `3.4.0`).
 Only text which lacks digits will fail coercion (`version one` is not valid).
 The maximum  length for any semver component considered for coercion is 16 characters;
 longer components will be ignored (`10000000000000000.4.7.4` becomes `4.7.4`).
-The maximum value for any semver component is `Integer.MAX_SAFE_INTEGER || (2**53 - 1)`;
+The maximum value for any semver component is `Number.MAX_SAFE_INTEGER || (2**53 - 1)`;
 higher value components are invalid (`9999999999999999.4.7.4` is likely invalid).


### PR DESCRIPTION
Just replaced Integer.MAX_SAFE_INTEGER with Number.MAX_SAFE_INTEGER.