### PR TITLE
feat: add new forbidden 403 error code

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -421,7 +421,7 @@ function shouldUpdate (args, tree, dep, has, req, depth, pkgpath, opts, cb, type
       var l = pickManifest(d, 'latest')
       var m = pickManifest(d, req)
     } catch (er) {
-      if (er.code === 'ETARGET') {
+      if (er.code === 'ETARGET' || er.code === 'E403') {
         return skip(er)
       } else {
         return skip()

--- a/lib/utils/error-message.js
+++ b/lib/utils/error-message.js
@@ -313,6 +313,19 @@ function errorMessage (er) {
       detail.push(['notarget', msg.join('\n')])
       break
 
+    case 'E403':
+      short.push(['403', er.message])
+      msg = [
+        'In most cases you or one of your dependencies are requesting',
+        'a package version that is forbidden by your security policy',
+        'please contact your npme admin.'
+      ]
+      if (er.parent) {
+        msg.push("\nIt was specified as a dependency of '" + er.parent + "'\n")
+      }
+      detail.push(['403', msg.join('\n')])
+      break
+
     case 'ENOTSUP':
       if (er.required) {
         short.push(['notsup', er.message])


### PR DESCRIPTION
## :pencil2: Changes
This PR introduces a new `E403` error code in the case that a forbidden package was requested and blocked by the security proxy.

## :link: References
See: https://github.com/npm/npm-pick-manifest/pull/1