### PR TITLE
Bug Fix: Add spec to dist-tag remove function

### DIFF
--- a/lib/dist-tag.js
+++ b/lib/dist-tag.js
@@ -119,7 +119,8 @@ function remove (spec, tag, opts) {
     delete tags[tag]
     const url = `/-/package/${spec.escapedName}/dist-tags/${encodeURIComponent(tag)}`
     const reqOpts = opts.concat({
-      method: 'DELETE'
+      method: 'DELETE',
+      spec
     })
     return otplease(reqOpts, reqOpts => regFetch(url, reqOpts)).then(() => {
       output(`-${tag}: ${spec.name}@${version}`)


### PR DESCRIPTION
The `rm` command in `dist-tag` switches to the default registry when using a private registry. Here's an example using `npm dist-tag rm @scope/package_name@1.0.1 tagName --verbose`:

 `
```
npm verb dist-tag del cutesie from @root/package101
npm http fetch GET 200 http://localhost:3001/api/v4/packages/npm/-/package/@root%2fpackage101/dist-tags 8052ms
npm http fetch DELETE 401 https://registry.npmjs.org/-/package/@root%2fpackage101/dist-tags/cutesie 141ms
npm verb stack Error: 401 Unauthorized - DELETE https://registry.npmjs.org/-/package/@root%2fpackage101/dist-tags/cutesie
```

In `index.js`, the `opts` in the `regFetch` evaluates to `undefined`:

```
function regFetch (uri, opts) {
  opts = config(opts)
  const registry = (
    (opts.spec && pickRegistry(opts.spec, opts)) ||
    opts.registry <-- opts.registry is the default NPM registry

```
Adding spec as the second argument in the `remove` function fixed the error and reached my private registry