### PR TITLE
Don't override user specified depth in outdated

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -91,7 +91,7 @@ function outdated (args, silent, cb) {
   var dir = path.resolve(npm.dir, '..')
 
   // default depth for `outdated` is 0 (cf. `ls`)
-  if (opts.depth) opts = opts.concat({depth: 0})
+  if (opts.depth === Infinity) opts = opts.concat({depth: 0})
 
   readPackageTree(dir, andComputeMetadata(function (er, tree) {
     if (!tree) return cb(er)


### PR DESCRIPTION
Restores ability to update packages using `--depth` as suggested by `npm audit`.

i.e `npm update eslint-utils --depth 2`.

----

[I've restored the previous conditional check, which was against `Infinity`](https://github.com/npm/cli/commit/084741913c4fdb396e589abf3440b4be3aa0b67e#diff-3d20499d58f14c6f1edfe93d8ba8a8a2L74-R94); however I've never worked in `npm/cli` before, so don't know if that value still holds water :) 

How it is currently means the `npm update <package> --depth <depth>` commands suggested by `npm audit` won't work, as any `depth` value is clobbered to `0` if it's anything but, resulting in empty output.

[This is the related community bug report](https://npm.community/t/npm-update-depth-command-no-longer-working-correctly-v6-9-0/7571).

-----

Since this was included in v6.6.0 onwards, it effects all versions of Node from `11.10.0` onwards, as well as `10.16.0+`