### PR TITLE
clean up flaky tests

### DIFF
--- a/test/common-tap.js
+++ b/test/common-tap.js
@@ -216,17 +216,15 @@ exports.readBinLink = function (path) {
 
 exports.skipIfWindows = function (why) {
   if (!isWindows) return
-  console.log('1..1')
   if (!why) why = 'this test not available on windows'
-  console.log('ok 1 # skip ' + why)
+  require('tap').plan(0, why)
   process.exit(0)
 }
 
 exports.pendIfWindows = function (why) {
   if (!isWindows) return
-  console.log('1..1')
   if (!why) why = 'this test is pending further changes on windows'
-  console.log('not ok 1 # todo ' + why)
+  require('tap').fail(' ', { todo: why, diagnostic: false })
   process.exit(0)
 }
 

--- a/test/tap/404-parent.js
+++ b/test/tap/404-parent.js
@@ -1,7 +1,6 @@
 var common = require('../common-tap.js')
 var test = require('tap').test
 var npm = require('../../')
-var osenv = require('osenv')
 var path = require('path')
 var fs = require('fs')
 var rimraf = require('rimraf')
@@ -10,18 +9,13 @@ var mr = require('npm-registry-mock')
 
 test('404-parent: if parent exists, specify parent in error message', function (t) {
   setup()
-  rimraf.sync(path.resolve(pkg, 'node_modules'))
-  performInstall(function (err) {
-    t.ok(err instanceof Error, 'error was returned')
-    t.equal(err.parent, '404-parent', "error's parent set")
-    t.end()
+  rimraf(path.resolve(pkg, 'node_modules'), () => {
+    performInstall(function (err) {
+      t.ok(err instanceof Error, 'error was returned')
+      t.equal(err.parent, '404-parent', "error's parent set")
+      t.end()
+    })
   })
-})
-
-test('cleanup', function (t) {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-  t.end()
 })
 
 function setup () {

--- a/test/tap/access.js
+++ b/test/tap/access.js
@@ -73,8 +73,7 @@ test('npm access public when no package passed and no package.json', function (t
   function (er, code, stdout, stderr) {
     t.ifError(er, 'npm access')
     t.match(stderr, /no package name passed to command and no package.json found/)
-    rimraf.sync(missing)
-    t.end()
+    rimraf(missing, t.end)
   })
 })
 
@@ -95,8 +94,7 @@ test('npm access public when no package passed and invalid package.json', functi
   function (er, code, stdout, stderr) {
     t.ifError(er, 'npm access')
     t.match(stderr, /Failed to parse json/)
-    rimraf.sync(invalid)
-    t.end()
+    rimraf(invalid, t.end)
   })
 })
 
@@ -405,8 +403,7 @@ test('npm access ls-packages with no package specified or package.json', functio
     function (er, code, stdout, stderr) {
       t.ifError(er, 'npm access ls-packages')
       t.same(JSON.parse(stdout), clientPackages)
-      rimraf.sync(missing)
-      t.end()
+      rimraf(missing, t.end)
     }
   )
 })
@@ -557,7 +554,6 @@ test('npm access blerg', function (t) {
 
 test('cleanup', function (t) {
   t.pass('cleaned up')
-  rimraf.sync(pkg)
   server.done()
   server.close()
   t.end()

--- a/test/tap/add-remote-git-file.js
+++ b/test/tap/add-remote-git-file.js
@@ -4,17 +4,16 @@ var fs = require('fs')
 var resolve = require('path').resolve
 var url = require('url')
 
-var osenv = require('osenv')
 var mkdirp = require('mkdirp')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var npm = require('../../lib/npm.js')
 var fetchPackageMetadata = require('../../lib/fetch-package-metadata.js')
 var common = require('../common-tap.js')
 
-var pkg = common.pkg
-var repo = common.pkg + '-repo'
+var pkg = resolve(common.pkg, 'package')
+var repo = resolve(common.pkg, 'repo')
+mkdirp.sync(pkg)
 
 var git
 var cloneURL = 'git+file://' + resolve(pkg, 'child.git')
@@ -25,7 +24,6 @@ var pjChild = JSON.stringify({
 }, null, 2) + '\n'
 
 test('setup', function (t) {
-  bootstrap()
   setup(function (er, r) {
     t.ifError(er, 'git started up successfully')
 
@@ -70,16 +68,6 @@ test('save install', function (t) {
   })
 })
 
-test('clean', function (t) {
-  cleanup()
-  t.end()
-})
-
-function bootstrap () {
-  cleanup()
-  mkdirp.sync(pkg)
-}
-
 function setup (cb) {
   mkdirp.sync(repo)
   fs.writeFileSync(resolve(repo, 'package.json'), pjChild)
@@ -94,10 +82,4 @@ function setup (cb) {
       )]
     }, cb)
   })
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(repo)
-  rimraf.sync(pkg)
 }

--- a/test/tap/add-remote-git-submodule.js
+++ b/test/tap/add-remote-git-submodule.js
@@ -1,7 +1,7 @@
 var fs = require('fs')
 var resolve = require('path').resolve
 
-var osenv = require('osenv')
+var cwd = process.cwd()
 var mkdirp = require('mkdirp')
 var rimraf = require('rimraf')
 var test = require('tap').test
@@ -9,8 +9,8 @@ var test = require('tap').test
 var npm = require('../../lib/npm.js')
 var common = require('../common-tap.js')
 
-var pkg = common.pkg
-var repos = pkg + '-repos'
+var pkg = resolve(common.pkg, 'package')
+var repos = resolve(common.pkg, 'repos')
 var subwt = resolve(repos, 'subwt')
 var topwt = resolve(repos, 'topwt')
 var suburl = 'git://localhost:' + common.gitPort + '/sub.git'
@@ -62,14 +62,13 @@ test('has file in submodule', function (t) {
 
 test('clean', function (t) {
   daemon.on('close', function () {
-    cleanup()
     t.end()
   })
   process.kill(daemonPID)
 })
 
 function bootstrap (t) {
-  process.chdir(osenv.tmpdir())
+  process.chdir(cwd)
   rimraf.sync(pkg)
   mkdirp.sync(pkg)
   process.chdir(pkg)
@@ -140,10 +139,4 @@ function setup (cb) {
       ]
     }, cb)
   })
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(repos)
-  rimraf.sync(pkg)
 }

--- a/test/tap/add-remote-git.js
+++ b/test/tap/add-remote-git.js
@@ -1,16 +1,14 @@
 var fs = require('fs')
 var resolve = require('path').resolve
 
-var osenv = require('osenv')
 var mkdirp = require('mkdirp')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var npm = require('../../lib/npm.js')
 var common = require('../common-tap.js')
 
-var pkg = common.pkg
-var repo = pkg + '-repo'
+var pkg = resolve(common.pkg, 'package')
+var repo = resolve(pkg, 'repo')
 
 var daemon
 var daemonPID
@@ -30,7 +28,8 @@ var pjChild = JSON.stringify({
 }, null, 2) + '\n'
 
 test('setup', function (t) {
-  bootstrap()
+  mkdirp.sync(pkg)
+  fs.writeFileSync(resolve(pkg, 'package.json'), pjParent)
   setup(function (er, r) {
     t.ifError(er, 'git started up successfully')
 
@@ -47,24 +46,14 @@ test('install from repo', function (t) {
   process.chdir(pkg)
   npm.commands.install('.', [], function (er) {
     t.ifError(er, 'npm installed via git')
-
     t.end()
   })
 })
 
 test('clean', function (t) {
-  daemon.on('close', function () {
-    cleanup()
-    t.end()
-  })
+  daemon.on('close', t.end)
   process.kill(daemonPID)
 })
-
-function bootstrap () {
-  cleanup()
-  mkdirp.sync(pkg)
-  fs.writeFileSync(resolve(pkg, 'package.json'), pjParent)
-}
 
 function setup (cb) {
   mkdirp.sync(repo)
@@ -112,10 +101,4 @@ function setup (cb) {
       ]
     }, cb)
   })
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(repo)
-  rimraf.sync(pkg)
 }

--- a/test/tap/all-package-metadata.js
+++ b/test/tap/all-package-metadata.js
@@ -26,8 +26,8 @@ function setup () {
   mkdirp.sync(cacheBase)
 }
 
-function cleanup () {
-  rimraf.sync(PKG_DIR)
+function cleanup (cb) {
+  rimraf(PKG_DIR, cb)
 }
 
 test('setup', function (t) {
@@ -88,8 +88,7 @@ test('allPackageMetadata full request', function (t) {
       }
     }, 'cache contents based on what was written')
     server.done()
-    cleanup()
-    t.end()
+    cleanup(t.end)
   })
 })
 
@@ -126,8 +125,7 @@ test('allPackageMetadata cache only', function (t) {
     t.ok(fileData, 'cache contents written to the right file')
     t.deepEquals(fileData, cacheContents, 'cacheContents written directly')
     server.done()
-    cleanup()
-    t.end()
+    cleanup(t.end)
   })
 })
 
@@ -188,8 +186,7 @@ test('createEntryStream merged stream', function (t) {
     t.ok(fileData, 'cache contents written to the right file')
     t.deepEquals(fileData, cacheContents, 'cache updated correctly')
     server.done()
-    cleanup()
-    t.end()
+    cleanup(t.end)
   })
 })
 
@@ -205,14 +202,11 @@ test('allPackageMetadata no sources', function (t) {
     t.ok(err, 'no sources, got an error')
     t.match(err.message, /No search sources available/, 'useful error message')
     server.done()
-    cleanup()
-    t.end()
+    cleanup(t.end)
   })
 })
 
 test('cleanup', function (t) {
-  cleanup()
   server.close()
-  t.pass('all done')
-  t.done()
+  cleanup(t.end)
 })

--- a/test/tap/bearer-token-check.js
+++ b/test/tap/bearer-token-check.js
@@ -4,9 +4,7 @@ var writeFileSync = require('graceful-fs').writeFileSync
 var fs = require('fs')
 var mkdirp = require('mkdirp')
 var http = require('http')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
-var test = require('tap').test
+const t = require('tap')
 
 var common = require('../common-tap.js')
 var toNerfDart = require('../../lib/config/nerf-dart.js')
@@ -38,14 +36,42 @@ server.on('request', (req, res) => {
   }
 })
 
-test('setup', function (t) {
-  server.listen(common.port, () => {
-    setup()
-    t.done()
-  })
+var contents = '@scoped:registry=' + common.registry + '\n' +
+               toNerfDart(common.registry) + ':_authToken=0xabad1dea\n'
+
+var json = {
+  name: 'test-package-install',
+  version: '1.0.0',
+  dependencies: {
+    '@scoped/underscore': '1.3.1'
+  }
+}
+
+var shrinkwrap = {
+  name: 'test-package-install',
+  version: '1.0.0',
+  dependencies: {
+    '@scoped/underscore': {
+      resolved: tarballURL,
+      version: '1.3.1'
+    }
+  }
+}
+
+t.teardown(() => server.close())
+
+t.test('setup', function (t) {
+  mkdirp.sync(modules)
+  writeFileSync(resolve(pkg, 'package.json'), JSON.stringify(json, null, 2) + '\n')
+  writeFileSync(outfile, contents)
+  writeFileSync(
+    resolve(pkg, 'npm-shrinkwrap.json'),
+    JSON.stringify(shrinkwrap, null, 2) + '\n'
+  )
+  server.listen(common.port, t.end)
 })
 
-test('authed npm install with tarball not on registry', function (t) {
+t.test('authed npm install with tarball not on registry', function (t) {
   common.npm(
     [
       'install',
@@ -81,48 +107,3 @@ test('authed npm install with tarball not on registry', function (t) {
     }
   )
 })
-
-test('cleanup', function (t) {
-  server.close(() => {
-    cleanup()
-    t.end()
-  })
-})
-
-var contents = '@scoped:registry=' + common.registry + '\n' +
-               toNerfDart(common.registry) + ':_authToken=0xabad1dea\n'
-
-var json = {
-  name: 'test-package-install',
-  version: '1.0.0',
-  dependencies: {
-    '@scoped/underscore': '1.3.1'
-  }
-}
-
-var shrinkwrap = {
-  name: 'test-package-install',
-  version: '1.0.0',
-  dependencies: {
-    '@scoped/underscore': {
-      resolved: tarballURL,
-      version: '1.3.1'
-    }
-  }
-}
-
-function setup () {
-  cleanup()
-  mkdirp.sync(modules)
-  writeFileSync(resolve(pkg, 'package.json'), JSON.stringify(json, null, 2) + '\n')
-  writeFileSync(outfile, contents)
-  writeFileSync(
-    resolve(pkg, 'npm-shrinkwrap.json'),
-    JSON.stringify(shrinkwrap, null, 2) + '\n'
-  )
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}

--- a/test/tap/bitbucket-https-url-with-creds-package.js
+++ b/test/tap/bitbucket-https-url-with-creds-package.js
@@ -5,10 +5,7 @@ const BB = require('bluebird')
 var fs = require('graceful-fs')
 var path = require('path')
 
-var mkdirp = require('mkdirp')
-var osenv = require('osenv')
 var requireInject = require('require-inject')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -64,22 +61,10 @@ test('bitbucket-https-url-with-creds-package', function (t) {
   })
 })
 
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
 function setup () {
-  cleanup()
-  mkdirp.sync(pkg)
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
     JSON.stringify(json, null, 2)
   )
   process.chdir(pkg)
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
 }

--- a/test/tap/bitbucket-https-url-with-creds.js
+++ b/test/tap/bitbucket-https-url-with-creds.js
@@ -6,9 +6,7 @@ var fs = require('graceful-fs')
 var path = require('path')
 
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
 var requireInject = require('require-inject')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -61,22 +59,11 @@ test('bitbucket-https-url-with-creds', function (t) {
   })
 })
 
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
 function setup () {
-  cleanup()
   mkdirp.sync(pkg)
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
     JSON.stringify(json, null, 2)
   )
   process.chdir(pkg)
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
 }

--- a/test/tap/bitbucket-shortcut-package.js
+++ b/test/tap/bitbucket-shortcut-package.js
@@ -6,9 +6,7 @@ var fs = require('graceful-fs')
 var path = require('path')
 
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
 var requireInject = require('require-inject')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -65,22 +63,11 @@ test('bitbucket-shortcut', function (t) {
   })
 })
 
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
 function setup () {
-  cleanup()
   mkdirp.sync(pkg)
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
     JSON.stringify(json, null, 2)
   )
   process.chdir(pkg)
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
 }

--- a/test/tap/bitbucket-shortcut.js
+++ b/test/tap/bitbucket-shortcut.js
@@ -6,9 +6,7 @@ var fs = require('graceful-fs')
 var path = require('path')
 
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
 var requireInject = require('require-inject')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -62,22 +60,11 @@ test('bitbucket-shortcut', function (t) {
   })
 })
 
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
 function setup () {
-  cleanup()
   mkdirp.sync(pkg)
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
     JSON.stringify(json, null, 2)
   )
   process.chdir(pkg)
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
 }

--- a/test/tap/build-already-built.js
+++ b/test/tap/build-already-built.js
@@ -2,8 +2,6 @@
 // message "already built" should not be error
 var test = require('tap').test
 var path = require('path')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var npmlog = require('npmlog')
 var mkdirp = require('mkdirp')
 var requireInject = require('require-inject')
@@ -12,13 +10,7 @@ var npm = require('../../lib/npm.js')
 
 const common = require('../common-tap.js')
 var PKG_DIR = common.pkg
-var fakePkg = 'foo'
-
-test('setup', function (t) {
-  cleanup()
-
-  t.end()
-})
+var fakePkg = path.resolve(PKG_DIR, 'foo')
 
 test("issue #6735 build 'already built' message", function (t) {
   npm.load({ loglevel: 'warn' }, function () {
@@ -66,14 +58,3 @@ test("issue #6735 build 'already built' message", function (t) {
     t.end()
   })
 })
-
-test('cleanup', function (t) {
-  cleanup()
-
-  t.end()
-})
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(PKG_DIR)
-}

--- a/test/tap/cache-eacces-error-message.js
+++ b/test/tap/cache-eacces-error-message.js
@@ -1,14 +1,11 @@
 const npm = require('../../lib/npm.js')
 const t = require('tap')
 
-if (process.platform === 'win32') {
-  t.plan(0, 'this is a unix-only thing')
-  process.exit(0)
-}
+const common = require('../common-tap.js')
+
+common.skipIfWindows('this is a unix-only thing')
 
 const errorMessage = require('../../lib/utils/error-message.js')
-
-const common = require('../common-tap.js')
 
 t.plan(1)
 

--- a/test/tap/check-cpu-reqs.js
+++ b/test/tap/check-cpu-reqs.js
@@ -2,9 +2,7 @@
 var path = require('path')
 var fs = require('fs')
 var test = require('tap').test
-var osenv = require('osenv')
 var mkdirp = require('mkdirp')
-var rimraf = require('rimraf')
 var common = require('../common-tap.js')
 
 var base = common.pkg
@@ -41,18 +39,7 @@ test('force install bad cpu', function (t) {
   })
 })
 
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(base)
-}
-
 function setup () {
-  cleanup()
   mkdirp.sync(path.resolve(installFrom, 'node_modules'))
   fs.writeFileSync(
     path.join(installFrom, 'package.json'),

--- a/test/tap/check-engine-reqs.js
+++ b/test/tap/check-engine-reqs.js
@@ -2,9 +2,7 @@
 var path = require('path')
 var fs = require('fs')
 var test = require('tap').test
-var osenv = require('osenv')
 var mkdirp = require('mkdirp')
-var rimraf = require('rimraf')
 var common = require('../common-tap.js')
 
 var base = common.pkg
@@ -54,18 +52,7 @@ test('warns on bad engine not strict', function (t) {
   })
 })
 
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(base)
-}
-
 function setup () {
-  cleanup()
   mkdirp.sync(path.resolve(installFrom, 'node_modules'))
   fs.writeFileSync(
     path.join(installFrom, 'package.json'),

--- a/test/tap/check-install-self.js
+++ b/test/tap/check-install-self.js
@@ -2,9 +2,7 @@
 var path = require('path')
 var fs = require('fs')
 var test = require('tap').test
-var osenv = require('osenv')
 var mkdirp = require('mkdirp')
-var rimraf = require('rimraf')
 var common = require('../common-tap.js')
 
 var base = common.pkg
@@ -43,18 +41,7 @@ test('force install self', function (t) {
   })
 })
 
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(base)
-}
-
 function setup () {
-  cleanup()
   mkdirp.sync(path.resolve(installFrom, 'node_modules'))
   fs.writeFileSync(
     path.join(installFrom, 'package.json'),

--- a/test/tap/check-os-reqs.js
+++ b/test/tap/check-os-reqs.js
@@ -2,9 +2,7 @@
 var path = require('path')
 var fs = require('fs')
 var test = require('tap').test
-var osenv = require('osenv')
 var mkdirp = require('mkdirp')
-var rimraf = require('rimraf')
 var common = require('../common-tap.js')
 
 var base = common.pkg
@@ -41,18 +39,7 @@ test('force install bad os', function (t) {
   })
 })
 
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(base)
-}
-
 function setup () {
-  cleanup()
   mkdirp.sync(path.resolve(installFrom, 'node_modules'))
   fs.writeFileSync(
     path.join(installFrom, 'package.json'),

--- a/test/tap/circular-dep.js
+++ b/test/tap/circular-dep.js
@@ -4,8 +4,6 @@ var existsSync = fs.existsSync || path.existsSync
 
 var mkdirp = require('mkdirp')
 var mr = require('npm-registry-mock')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -75,13 +73,11 @@ test('installing a package that depends on the current package', function (t) {
 })
 
 test('cleanup', function (t) {
-  cleanup()
   server.close()
   t.end()
 })
 
 function setup (cb) {
-  cleanup()
   mkdirp.sync(minimist)
   fs.writeFileSync(
     path.join(minimist, 'package.json'),
@@ -94,9 +90,4 @@ function setup (cb) {
     server = s
     cb()
   })
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
 }

--- a/test/tap/config-new-cafile.js
+++ b/test/tap/config-new-cafile.js
@@ -3,22 +3,17 @@ const common = require('../common-tap.js')
 var path = require('path')
 var fs = require('graceful-fs')
 var test = require('tap').test
-var mkdirp = require('mkdirp')
 var rimraf = require('rimraf')
-var osenv = require('osenv')
 var npmconf = require('../../lib/config/core.js')
 
 var dir = common.pkg
 var beep = path.resolve(dir, 'beep.pem')
 var npmrc = path.resolve(dir, 'npmrc')
 
-test('setup', function (t) {
-  bootstrap()
-  t.end()
-})
-
 test('can set new cafile when old is gone', function (t) {
   t.plan(5)
+  fs.writeFileSync(npmrc, '')
+  fs.writeFileSync(beep, '')
   npmconf.load({ userconfig: npmrc }, function (error, conf) {
     npmconf.loaded = false
     t.ifError(error)
@@ -40,19 +35,3 @@ test('can set new cafile when old is gone', function (t) {
     })
   })
 })
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function bootstrap () {
-  mkdirp.sync(dir)
-  fs.writeFileSync(npmrc, '')
-  fs.writeFileSync(beep, '')
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(dir)
-}

--- a/test/tap/correct-mkdir.js
+++ b/test/tap/correct-mkdir.js
@@ -5,11 +5,7 @@ var assert = require('assert')
 var requireInject = require('require-inject')
 const common = require('../common-tap.js')
 var cache_dir = common.pkg
-
-if (process.platform === 'win32') {
-  t.plan(0, 'windows does not use correct-mkdir behavior')
-  process.exit(0)
-}
+common.skipIfWindows('windows does not use correct-mkdir behavior')
 
 test('correct-mkdir: no race conditions', function (t) {
   var mock_fs = {}

--- a/test/tap/do-not-remove-other-bins.js
+++ b/test/tap/do-not-remove-other-bins.js
@@ -3,8 +3,6 @@ var fs = require('fs')
 var path = require('path')
 
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap')
@@ -41,7 +39,6 @@ var EXEC_OPTS = {
 }
 
 test('setup', function (t) {
-  cleanup()
   mkdirp.sync(path.join(installPath, 'node_modules'))
   mkdirp.sync(packageApath)
   fs.writeFileSync(
@@ -118,14 +115,3 @@ test('verify postremoval bins', function (t) {
   t.is(bin, path.join(installPath, 'node_modules', 'b'))
   t.end()
 })
-
-test('cleanup', function (t) {
-  cleanup()
-  t.pass('cleaned up')
-  t.end()
-})
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(base)
-}

--- a/test/tap/gist-short-shortcut-package.js
+++ b/test/tap/gist-short-shortcut-package.js
@@ -3,9 +3,7 @@ var fs = require('graceful-fs')
 var path = require('path')
 
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
 var requireInject = require('require-inject')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -63,22 +61,11 @@ test('gist-short-shortcut-package', function (t) {
   })
 })
 
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
 function setup () {
-  cleanup()
   mkdirp.sync(pkg)
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
     JSON.stringify(json, null, 2)
   )
   process.chdir(pkg)
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
 }

--- a/test/tap/gist-short-shortcut.js
+++ b/test/tap/gist-short-shortcut.js
@@ -3,9 +3,7 @@ var fs = require('graceful-fs')
 var path = require('path')
 
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
 var requireInject = require('require-inject')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -60,22 +58,11 @@ test('gist-shortcut', function (t) {
   })
 })
 
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
 function setup () {
-  cleanup()
   mkdirp.sync(pkg)
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
     JSON.stringify(json, null, 2)
   )
   process.chdir(pkg)
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
 }

--- a/test/tap/gist-shortcut-package.js
+++ b/test/tap/gist-shortcut-package.js
@@ -2,10 +2,7 @@
 var fs = require('graceful-fs')
 var path = require('path')
 
-var mkdirp = require('mkdirp')
-var osenv = require('osenv')
 var requireInject = require('require-inject')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -20,12 +17,8 @@ var json = {
   }
 }
 
-test('setup', function (t) {
-  setup()
-  t.end()
-})
-
 test('gist-shortcut-package', function (t) {
+  setup()
   var cloneUrls = [
     ['git://gist.github.com/deadbeef.git', 'GitHub gist shortcuts try git URLs first'],
     ['https://gist.github.com/deadbeef.git', 'GitHub gist shortcuts try HTTPS URLs second'],
@@ -63,22 +56,10 @@ test('gist-shortcut-package', function (t) {
   })
 })
 
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
 function setup () {
-  cleanup()
-  mkdirp.sync(pkg)
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
     JSON.stringify(json, null, 2)
   )
   process.chdir(pkg)
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
 }

--- a/test/tap/gist-shortcut.js
+++ b/test/tap/gist-shortcut.js
@@ -2,10 +2,7 @@
 var fs = require('graceful-fs')
 var path = require('path')
 
-var mkdirp = require('mkdirp')
-var osenv = require('osenv')
 var requireInject = require('require-inject')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -17,12 +14,12 @@ var json = {
   version: '0.0.0'
 }
 
-test('setup', function (t) {
-  setup()
-  t.end()
-})
-
 test('gist-shortcut', function (t) {
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    JSON.stringify(json, null, 2)
+  )
+  process.chdir(pkg)
   var cloneUrls = [
     ['git://gist.github.com/deadbeef.git', 'GitHub gist shortcuts try git URLs first'],
     ['https://gist.github.com/deadbeef.git', 'GitHub gist shortcuts try HTTPS URLs second'],
@@ -59,23 +56,3 @@ test('gist-shortcut', function (t) {
     })
   })
 })
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function setup () {
-  cleanup()
-  mkdirp.sync(pkg)
-  fs.writeFileSync(
-    path.join(pkg, 'package.json'),
-    JSON.stringify(json, null, 2)
-  )
-  process.chdir(pkg)
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}

--- a/test/tap/git-dependency-install-link.js
+++ b/test/tap/git-dependency-install-link.js
@@ -1,7 +1,6 @@
 var fs = require('fs')
 var resolve = require('path').resolve
 
-var osenv = require('osenv')
 var mkdirp = require('mkdirp')
 var rimraf = require('rimraf')
 var test = require('tap').test
@@ -11,9 +10,9 @@ var mr = require('npm-registry-mock')
 var npm = require('../../lib/npm.js')
 var common = require('../common-tap.js')
 
-var pkg = common.pkg
-var repo = pkg + '-repo'
-var prefix = pkg + '-prefix'
+var pkg = resolve(common.pkg, 'package')
+var repo = resolve(common.pkg, 'repo')
+var prefix = resolve(common.pkg, 'prefix')
 var cache = common.cache
 
 var daemon
@@ -42,8 +41,8 @@ var pjChild = JSON.stringify({
 }, null, 2) + '\n'
 
 test('setup', function (t) {
-  bootstrap()
-  setup(function (er, r) {
+  t.test('bootstrap', t => bootstrap(t.end))
+  t.test('setup', t => setup(function (er, r) {
     t.ifError(er, 'git started up successfully')
 
     if (!er) {
@@ -59,7 +58,8 @@ test('setup', function (t) {
 
       t.end()
     })
-  })
+  }))
+  t.end()
 })
 
 test('install from git repo [no --link]', function (t) {
@@ -103,20 +103,20 @@ test('install from git repo [with --link]', function (t) {
 
 test('clean', function (t) {
   mockRegistry.close()
-  daemon.on('close', function () {
-    cleanup()
-    t.end()
-  })
+  daemon.on('close', t.end)
   process.kill(daemonPID)
 })
 
-function bootstrap () {
-  rimraf.sync(repo)
-  rimraf.sync(pkg)
-  mkdirp.sync(pkg)
-  mkdirp.sync(cache)
+function bootstrap (cb) {
+  rimraf(repo, () => {
+    rimraf(pkg, () => {
+      mkdirp.sync(pkg)
+      mkdirp.sync(cache)
 
-  fs.writeFileSync(resolve(pkg, 'package.json'), pjParent)
+      fs.writeFileSync(resolve(pkg, 'package.json'), pjParent)
+      cb()
+    })
+  })
 }
 
 function setup (cb) {
@@ -169,11 +169,4 @@ function setup (cb) {
       ]
     }, cb)
   })
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(repo)
-  rimraf.sync(prefix)
-  rimraf.sync(pkg)
 }

--- a/test/tap/git-prepare.js
+++ b/test/tap/git-prepare.js
@@ -3,8 +3,6 @@
 const fs = require('fs')
 const path = require('path')
 
-const osenv = require('osenv')
-const rimraf = require('rimraf')
 const test = require('tap').test
 const mr = require('npm-registry-mock')
 
@@ -68,7 +66,7 @@ const fixture = new Tacks(Dir({
 }))
 
 test('setup', function (t) {
-  bootstrap()
+  fixture.create(testdir)
   setup(function (er, r) {
     t.ifError(er, 'git started up successfully')
 
@@ -115,16 +113,9 @@ test('install from git repo with prepare script', function (t) {
 
 test('clean', function (t) {
   mockRegistry.close()
-  daemon.on('close', function () {
-    cleanup()
-    t.end()
-  })
+  daemon.on('close', t.end)
   process.kill(daemonPID)
 })
-
-function bootstrap () {
-  fixture.create(testdir)
-}
 
 function setup (cb) {
   npm.load({
@@ -172,9 +163,4 @@ function setup (cb) {
       ]
     }, cb)
   })
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(testdir)
 }

--- a/test/tap/github-shortcut-package.js
+++ b/test/tap/github-shortcut-package.js
@@ -2,10 +2,7 @@
 var fs = require('graceful-fs')
 var path = require('path')
 
-var mkdirp = require('mkdirp')
-var osenv = require('osenv')
 var requireInject = require('require-inject')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -20,12 +17,12 @@ var json = {
   }
 }
 
-test('setup', function (t) {
-  setup()
-  t.end()
-})
-
 test('github-shortcut-package', function (t) {
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    JSON.stringify(json, null, 2)
+  )
+  process.chdir(pkg)
   var cloneUrls = [
     ['git://github.com/foo/private.git', 'GitHub shortcuts try git URLs first'],
     ['https://github.com/foo/private.git', 'GitHub shortcuts try HTTPS URLs second'],
@@ -62,23 +59,3 @@ test('github-shortcut-package', function (t) {
     })
   })
 })
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function setup () {
-  cleanup()
-  mkdirp.sync(pkg)
-  fs.writeFileSync(
-    path.join(pkg, 'package.json'),
-    JSON.stringify(json, null, 2)
-  )
-  process.chdir(pkg)
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}

--- a/test/tap/github-shortcut.js
+++ b/test/tap/github-shortcut.js
@@ -5,10 +5,7 @@ const BB = require('bluebird')
 const fs = require('graceful-fs')
 const path = require('path')
 
-const mkdirp = require('mkdirp')
-const osenv = require('osenv')
 const requireInject = require('require-inject')
-const rimraf = require('rimraf')
 const test = require('tap').test
 
 const common = require('../common-tap.js')
@@ -20,12 +17,12 @@ const json = {
   version: '0.0.0'
 }
 
-test('setup', function (t) {
-  setup()
-  t.end()
-})
-
 test('github-shortcut', function (t) {
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    JSON.stringify(json, null, 2)
+  )
+  process.chdir(pkg)
   const cloneUrls = [
     ['git://github.com/foo/private.git', 'GitHub shortcuts try git URLs first'],
     ['https://github.com/foo/private.git', 'GitHub shortcuts try HTTPS URLs second'],
@@ -62,23 +59,3 @@ test('github-shortcut', function (t) {
     })
   })
 })
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function setup () {
-  cleanup()
-  mkdirp.sync(pkg)
-  fs.writeFileSync(
-    path.join(pkg, 'package.json'),
-    JSON.stringify(json, null, 2)
-  )
-  process.chdir(pkg)
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}

--- a/test/tap/gitlab-shortcut-package.js
+++ b/test/tap/gitlab-shortcut-package.js
@@ -2,10 +2,7 @@
 var fs = require('graceful-fs')
 var path = require('path')
 
-var mkdirp = require('mkdirp')
-var osenv = require('osenv')
 var requireInject = require('require-inject')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -20,12 +17,12 @@ var json = {
   }
 }
 
-test('setup', function (t) {
-  setup()
-  t.end()
-})
-
 test('gitlab-shortcut-package', function (t) {
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    JSON.stringify(json, null, 2)
+  )
+  process.chdir(pkg)
   var cloneUrls = [
     ['https://gitlab.com/foo/private.git', 'GitLab shortcuts try HTTPS URLs second'],
     ['ssh://git@gitlab.com/foo/private.git', 'GitLab shortcuts try SSH first']
@@ -61,23 +58,3 @@ test('gitlab-shortcut-package', function (t) {
     })
   })
 })
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function setup () {
-  cleanup()
-  mkdirp.sync(pkg)
-  fs.writeFileSync(
-    path.join(pkg, 'package.json'),
-    JSON.stringify(json, null, 2)
-  )
-  process.chdir(pkg)
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}

--- a/test/tap/gitlab-shortcut.js
+++ b/test/tap/gitlab-shortcut.js
@@ -2,10 +2,7 @@
 var fs = require('graceful-fs')
 var path = require('path')
 
-var mkdirp = require('mkdirp')
-var osenv = require('osenv')
 var requireInject = require('require-inject')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -17,12 +14,12 @@ var json = {
   version: '0.0.0'
 }
 
-test('setup', function (t) {
-  setup()
-  t.end()
-})
-
 test('gitlab-shortcut', function (t) {
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    JSON.stringify(json, null, 2)
+  )
+  process.chdir(pkg)
   var cloneUrls = [
     ['https://gitlab.com/foo/private.git', 'GitLab shortcuts try HTTPS URLs second'],
     ['ssh://git@gitlab.com/foo/private.git', 'GitLab shortcuts try SSH first']
@@ -58,23 +55,3 @@ test('gitlab-shortcut', function (t) {
     })
   })
 })
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function setup () {
-  cleanup()
-  mkdirp.sync(pkg)
-  fs.writeFileSync(
-    path.join(pkg, 'package.json'),
-    JSON.stringify(json, null, 2)
-  )
-  process.chdir(pkg)
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}

--- a/test/tap/graceful-restart.js
+++ b/test/tap/graceful-restart.js
@@ -1,13 +1,7 @@
 var fs = require('fs')
 var resolve = require('path').resolve
-
-var osenv = require('osenv')
-var mkdirp = require('mkdirp')
-var rimraf = require('rimraf')
 var test = require('tap').test
-
 var common = require('../common-tap.js')
-
 var pkg = common.pkg
 
 var outGraceless = [
@@ -60,11 +54,6 @@ var pjGraceful = JSON.stringify({
   }
 }, null, 2) + '\n'
 
-test('setup', function (t) {
-  bootstrap()
-  t.end()
-})
-
 test('graceless restart', function (t) {
   fs.writeFileSync(resolve(pkg, 'package.json'), pjGraceless)
   createChild(['run-script', 'restart'], function (err, code, out) {
@@ -84,20 +73,6 @@ test('graceful restart', function (t) {
     t.end()
   })
 })
-
-test('clean', function (t) {
-  cleanup()
-  t.end()
-})
-
-function bootstrap () {
-  mkdirp.sync(pkg)
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}
 
 function createChild (args, cb) {
   var env = {

--- a/test/tap/ignore-install-link.js
+++ b/test/tap/ignore-install-link.js
@@ -1,8 +1,5 @@
-if (process.platform === 'win32') {
-  require('tap').plan(0, 'symlinks are weird on windows, skip this test')
-  process.exit(0)
-}
 var common = require('../common-tap.js')
+common.skipIfWindows('symlinks are weird on windows')
 var test = require('tap').test
 var path = require('path')
 var fs = require('fs')

--- a/test/tap/init-interrupt.js
+++ b/test/tap/init-interrupt.js
@@ -2,21 +2,12 @@
 // if 'npm init' is interrupted with ^C, don't report
 // 'init written successfully'
 var test = require('tap').test
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var npmlog = require('npmlog')
 var requireInject = require('require-inject')
 
 var npm = require('../../lib/npm.js')
 
-const common = require('../common-tap.js')
-var PKG_DIR = common.pkg
-
-test('setup', function (t) {
-  cleanup()
-
-  t.end()
-})
+require('../common-tap.js')
 
 test('issue #6684 remove confusing message', function (t) {
   var initJsonMock = function (dir, input, config, cb) {
@@ -45,14 +36,3 @@ test('issue #6684 remove confusing message', function (t) {
     })
   })
 })
-
-test('cleanup', function (t) {
-  cleanup()
-
-  t.end()
-})
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(PKG_DIR)
-}

--- a/test/tap/install-at-locally.js
+++ b/test/tap/install-at-locally.js
@@ -2,7 +2,6 @@ var fs = require('graceful-fs')
 var path = require('path')
 
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
 var rimraf = require('rimraf')
 var test = require('tap').test
 
@@ -16,11 +15,6 @@ var json = {
   name: 'install-at-locally-mock',
   version: '0.0.0'
 }
-
-test('setup', function (t) {
-  cleanup()
-  t.end()
-})
 
 test('\'npm install ./package@1.2.3\' should install local pkg', function (t) {
   var target = './package@1.2.3'
@@ -46,18 +40,8 @@ test('\'npm install install/at/locally@./package@1.2.3\' should install local pk
   })
 })
 
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}
-
 function setup (target) {
-  cleanup()
+  rimraf.sync(pkg)
   var root = path.resolve(pkg, target)
   mkdirp.sync(root)
   fs.writeFileSync(
@@ -65,5 +49,4 @@ function setup (target) {
     JSON.stringify(json, null, 2)
   )
   mkdirp.sync(path.resolve(pkg, 'node_modules'))
-  process.chdir(pkg)
 }

--- a/test/tap/install-at-sub-path-locally.js
+++ b/test/tap/install-at-sub-path-locally.js
@@ -2,13 +2,11 @@ var fs = require('graceful-fs')
 var path = require('path')
 
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
 
-var pkg = common.pkg
+var pkg = path.resolve(common.pkg, 'package')
 
 var EXEC_OPTS = { cwd: pkg, stdio: [0, 1, 2] }
 
@@ -20,12 +18,17 @@ var json = {
 var target = '../package@1.2.3'
 
 test('setup', function (t) {
-  cleanup()
+  var root = path.resolve(pkg, target)
+  mkdirp.sync(root)
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify(json, null, 2)
+  )
+  mkdirp.sync(path.resolve(pkg, 'node_modules'))
   t.end()
 })
 
 test('\'npm install ../package@1.2.3\' should install local pkg from sub path', function (t) {
-  setup()
   common.npm(['install', '--loglevel=silent', target], EXEC_OPTS, function (err, code) {
     if (err) throw err
     var p = path.resolve(pkg, 'node_modules/install-at-sub-path-locally-mock/package.json')
@@ -44,26 +47,3 @@ test('\'running npm install ../package@1.2.3\' should not break on sub path re-i
     t.end()
   })
 })
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-  rimraf.sync(path.resolve(pkg, target))
-}
-
-function setup () {
-  cleanup()
-  var root = path.resolve(pkg, target)
-  mkdirp.sync(root)
-  fs.writeFileSync(
-    path.join(root, 'package.json'),
-    JSON.stringify(json, null, 2)
-  )
-  mkdirp.sync(path.resolve(pkg, 'node_modules'))
-  process.chdir(pkg)
-}

--- a/test/tap/install-bad-dep-format.js
+++ b/test/tap/install-bad-dep-format.js
@@ -2,8 +2,6 @@ var fs = require('graceful-fs')
 var path = require('path')
 
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -18,8 +16,13 @@ var json = {
 }
 
 test('invalid url format returns appropriate error', function (t) {
-  setup(json)
-  common.npm(['install'], {}, function (err, code, stdout, stderr) {
+  var pkgPath = path.resolve(common.pkg, json.name)
+  mkdirp.sync(pkgPath)
+  fs.writeFileSync(
+    path.join(pkgPath, 'package.json'),
+    JSON.stringify(json, null, 2)
+  )
+  common.npm(['install'], {cwd: pkgPath}, function (err, code, stdout, stderr) {
     t.ifError(err, 'install ran without error')
     t.equals(code, 1, 'install exited with code 1')
     t.match(stderr,
@@ -28,31 +31,3 @@ test('invalid url format returns appropriate error', function (t) {
     t.end()
   })
 })
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function setup (json) {
-  cleanup()
-  process.chdir(mkPkg(json))
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  var pkgs = [json]
-  pkgs.forEach(function (json) {
-    rimraf.sync(path.resolve(common.pkg, json.name))
-  })
-}
-
-function mkPkg (json) {
-  var pkgPath = path.resolve(common.pkg, json.name)
-  mkdirp.sync(pkgPath)
-  fs.writeFileSync(
-    path.join(pkgPath, 'package.json'),
-    JSON.stringify(json, null, 2)
-  )
-  return pkgPath
-}

--- a/test/tap/install-bad-man.js
+++ b/test/tap/install-bad-man.js
@@ -1,15 +1,13 @@
 var fs = require('fs')
 var resolve = require('path').resolve
 
-var osenv = require('osenv')
 var mkdirp = require('mkdirp')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
 
-var pkg = common.pkg
-var target = pkg + '-target'
+var pkg = resolve(common.pkg, 'package')
+var target = resolve(common.pkg, 'target')
 
 var EXEC_OPTS = {
   cwd: target
@@ -21,11 +19,17 @@ var json = {
   man: [ './install-bad-man.1.lol' ]
 }
 
-common.pendIfWindows('man pages do not get installed on Windows')
+common.skipIfWindows('man pages do not get installed on Windows')
 
 test('setup', function (t) {
-  setup()
-  t.pass('setup ran')
+  mkdirp.sync(pkg)
+  // make sure it installs locally
+  mkdirp.sync(resolve(target, 'node_modules'))
+  fs.writeFileSync(
+    resolve(pkg, 'package.json'),
+    JSON.stringify(json, null, 2) + '\n'
+  )
+  fs.writeFileSync(resolve(pkg, 'install-bad-man.1.lol'), 'lol\n')
   t.end()
 })
 
@@ -55,27 +59,3 @@ test("install from repo on 'OS X'", function (t) {
     }
   )
 })
-
-test('clean', function (t) {
-  cleanup()
-  t.pass('cleaned up')
-  t.end()
-})
-
-function setup () {
-  cleanup()
-  mkdirp.sync(pkg)
-  // make sure it installs locally
-  mkdirp.sync(resolve(target, 'node_modules'))
-  fs.writeFileSync(
-    resolve(pkg, 'package.json'),
-    JSON.stringify(json, null, 2) + '\n'
-  )
-  fs.writeFileSync(resolve(pkg, 'install-bad-man.1.lol'), 'lol\n')
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-  rimraf.sync(target)
-}

--- a/test/tap/install-cli-only-development.js
+++ b/test/tap/install-cli-only-development.js
@@ -3,9 +3,8 @@ var path = require('path')
 var existsSync = fs.existsSync || path.existsSync
 
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
 var rimraf = require('rimraf')
-var test = require('tap').test
+const t = require('tap')
 
 var common = require('../common-tap.js')
 
@@ -37,58 +36,7 @@ var devDependency = {
   version: '0.0.0'
 }
 
-test('setup', function (t) {
-  setup()
-  t.pass('setup ran')
-  t.end()
-})
-
-test('\'npm install --only=development\' should only install devDependencies', function (t) {
-  common.npm(['install', '--only=development'], EXEC_OPTS, function (err, code) {
-    t.ifError(err, 'install development successful')
-    t.equal(code, 0, 'npm install did not raise error code')
-    t.ok(
-      JSON.parse(fs.readFileSync(
-        path.resolve(pkg, 'node_modules/dev-dependency/package.json'), 'utf8')
-      ),
-      'devDependency was installed'
-    )
-    t.notOk(
-      existsSync(path.resolve(pkg, 'node_modules/dependency/package.json')),
-      'dependency was NOT installed'
-    )
-    t.end()
-  })
-})
-
-test('\'npm install --only=development\' should only install devDependencies regardless of npm.config.get(\'production\')', function (t) {
-  cleanup()
-  setup()
-
-  common.npm(['install', '--only=development', '--production'], EXEC_OPTS, function (err, code) {
-    t.ifError(err, 'install development successful')
-    t.equal(code, 0, 'npm install did not raise error code')
-    t.ok(
-      JSON.parse(fs.readFileSync(
-        path.resolve(pkg, 'node_modules/dev-dependency/package.json'), 'utf8')
-      ),
-      'devDependency was installed'
-    )
-    t.notOk(
-      existsSync(path.resolve(pkg, 'node_modules/dependency/package.json')),
-      'dependency was NOT installed'
-    )
-    t.end()
-  })
-})
-
-test('cleanup', function (t) {
-  cleanup()
-  t.pass('cleaned up')
-  t.end()
-})
-
-function setup () {
+t.test('setup', t => {
   mkdirp.sync(path.join(pkg, 'dependency'))
   fs.writeFileSync(
     path.join(pkg, 'dependency', 'package.json'),
@@ -106,10 +54,42 @@ function setup () {
     path.join(pkg, 'package.json'),
     JSON.stringify(json, null, 2)
   )
-  process.chdir(pkg)
-}
 
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}
+  t.end()
+})
+
+t.test('\'npm install --only=development\' should only install devDependencies', function (t) {
+  common.npm(['install', '--only=development'], EXEC_OPTS, function (err, code) {
+    t.ifError(err, 'install development successful')
+    t.equal(code, 0, 'npm install did not raise error code')
+    t.ok(
+      JSON.parse(fs.readFileSync(
+        path.resolve(pkg, 'node_modules/dev-dependency/package.json'), 'utf8')
+      ),
+      'devDependency was installed'
+    )
+    t.notOk(
+      existsSync(path.resolve(pkg, 'node_modules/dependency/package.json')),
+      'dependency was NOT installed'
+    )
+    rimraf(path.join(pkg, 'node_modules'), t.end)
+  })
+})
+
+t.test('\'npm install --only=development\' should only install devDependencies regardless of npm.config.get(\'production\')', function (t) {
+  common.npm(['install', '--only=development', '--production'], EXEC_OPTS, function (err, code) {
+    t.ifError(err, 'install development successful')
+    t.equal(code, 0, 'npm install did not raise error code')
+    t.ok(
+      JSON.parse(fs.readFileSync(
+        path.resolve(pkg, 'node_modules/dev-dependency/package.json'), 'utf8')
+      ),
+      'devDependency was installed'
+    )
+    t.notOk(
+      existsSync(path.resolve(pkg, 'node_modules/dependency/package.json')),
+      'dependency was NOT installed'
+    )
+    rimraf(path.join(pkg, 'node_modules'), t.end)
+  })
+})

--- a/test/tap/install-cli-only-production.js
+++ b/test/tap/install-cli-only-production.js
@@ -3,8 +3,6 @@ var path = require('path')
 var existsSync = fs.existsSync || path.existsSync
 
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -59,7 +57,6 @@ test('setup', function (t) {
     JSON.stringify(json, null, 2)
   )
 
-  process.chdir(pkg)
   t.end()
 })
 
@@ -81,10 +78,4 @@ test('\'npm install --only=production\' should only install dependencies', funct
     )
     t.end()
   })
-})
-
-test('cleanup', function (t) {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-  t.end()
 })

--- a/test/tap/install-cli-only-shrinkwrap.js
+++ b/test/tap/install-cli-only-shrinkwrap.js
@@ -3,7 +3,6 @@ var path = require('path')
 var existsSync = fs.existsSync || path.existsSync
 
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
 var rimraf = require('rimraf')
 var test = require('tap').test
 
@@ -55,61 +54,6 @@ var devDependency = {
 }
 
 test('setup', function (t) {
-  cleanup()
-  setup()
-  t.pass('setup ran')
-  t.end()
-})
-
-test('\'npm install --only=development\' should only install devDependencies', function (t) {
-  common.npm(['install', '--only=development'], EXEC_OPTS, function (err, code, stderr, stdout) {
-    if (err) throw err
-    t.comment(stdout.trim())
-    t.comment(stderr.trim())
-    t.is(code, 0, 'npm install did not raise error code')
-    t.ok(
-      existsSync(
-        path.resolve(pkg, 'node_modules/dev-dependency/package.json')
-      ),
-      'devDependency was installed'
-    )
-    t.notOk(
-      existsSync(path.resolve(pkg, 'node_modules/dependency/package.json')),
-      'dependency was NOT installed'
-    )
-    t.end()
-  })
-})
-
-test('\'npm install --only=production\' should only install dependencies', function (t) {
-  cleanup()
-  setup()
-  common.npm(['install', '--only=production'], EXEC_OPTS, function (err, code, stdout, stderr) {
-    if (err) throw err
-    t.comment(stdout.trim())
-    t.comment(stderr.trim())
-    t.is(code, 0, 'npm install did not raise error code')
-    t.ok(
-      existsSync(
-        path.resolve(pkg, 'node_modules/dependency/package.json')
-      ),
-      'dependency was installed'
-    )
-    t.notOk(
-      existsSync(path.resolve(pkg, 'node_modules/dev-dependency/package.json')),
-      'devDependency was NOT installed'
-    )
-    t.end()
-  })
-})
-
-test('cleanup', function (t) {
-  cleanup()
-  t.pass('cleaned up')
-  t.end()
-})
-
-function setup () {
   mkdirp.sync(path.join(pkg, 'dependency'))
   fs.writeFileSync(
     path.join(pkg, 'dependency', 'package.json'),
@@ -131,10 +75,45 @@ function setup () {
     path.join(pkg, 'npm-shrinkwrap.json'),
     JSON.stringify(shrinkwrap, null, 2)
   )
-  process.chdir(pkg)
-}
+  t.end()
+})
 
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}
+test('\'npm install --only=development\' should only install devDependencies', function (t) {
+  common.npm(['install', '--only=development'], EXEC_OPTS, function (err, code, stderr, stdout) {
+    if (err) throw err
+    t.comment(stdout.trim())
+    t.comment(stderr.trim())
+    t.is(code, 0, 'npm install did not raise error code')
+    t.ok(
+      existsSync(
+        path.resolve(pkg, 'node_modules/dev-dependency/package.json')
+      ),
+      'devDependency was installed'
+    )
+    t.notOk(
+      existsSync(path.resolve(pkg, 'node_modules/dependency/package.json')),
+      'dependency was NOT installed'
+    )
+    rimraf(path.join(pkg, 'node_modules'), t.end)
+  })
+})
+
+test('\'npm install --only=production\' should only install dependencies', function (t) {
+  common.npm(['install', '--only=production'], EXEC_OPTS, function (err, code, stdout, stderr) {
+    if (err) throw err
+    t.comment(stdout.trim())
+    t.comment(stderr.trim())
+    t.is(code, 0, 'npm install did not raise error code')
+    t.ok(
+      existsSync(
+        path.resolve(pkg, 'node_modules/dependency/package.json')
+      ),
+      'dependency was installed'
+    )
+    t.notOk(
+      existsSync(path.resolve(pkg, 'node_modules/dev-dependency/package.json')),
+      'devDependency was NOT installed'
+    )
+    rimraf(path.join(pkg, 'node_modules'), t.end)
+  })
+})

--- a/test/tap/install-cli-production-nosave.js
+++ b/test/tap/install-cli-production-nosave.js
@@ -3,12 +3,9 @@ var path = require('path')
 
 var mkdirp = require('mkdirp')
 var mr = require('npm-registry-mock')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
-var test = require('tap').test
+var t = require('tap')
 
 var common = require('../common-tap.js')
-var server
 
 var pkg = common.pkg
 
@@ -21,16 +18,20 @@ var PACKAGE_JSON1 = {
   }
 }
 
-test('setup', function (t) {
-  setup()
+t.test('setup', function (t) {
+  mkdirp.sync(path.resolve(pkg, 'node_modules'))
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    JSON.stringify(PACKAGE_JSON1, null, 2)
+  )
   mr({ port: common.port }, function (er, s) {
     t.ifError(er, 'started mock registry')
-    server = s
+    t.parent.teardown(() => s.close())
     t.end()
   })
 })
 
-test('install --production <module> without --save exits successfully', function (t) {
+t.test('install --production <module> without --save exits successfully', function (t) {
   common.npm(
     [
       '--registry', common.registry,
@@ -45,25 +46,3 @@ test('install --production <module> without --save exits successfully', function
     }
   )
 })
-
-test('cleanup', function (t) {
-  server.close()
-  cleanup()
-  t.end()
-})
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}
-
-function setup () {
-  cleanup()
-  mkdirp.sync(path.resolve(pkg, 'node_modules'))
-  fs.writeFileSync(
-    path.join(pkg, 'package.json'),
-    JSON.stringify(PACKAGE_JSON1, null, 2)
-  )
-
-  process.chdir(pkg)
-}

--- a/test/tap/install-cli-production.js
+++ b/test/tap/install-cli-production.js
@@ -3,8 +3,6 @@ var path = require('path')
 var existsSync = fs.existsSync || path.existsSync
 
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -59,7 +57,6 @@ test('setup', function (t) {
     JSON.stringify(json, null, 2)
   )
 
-  process.chdir(pkg)
   t.end()
 })
 
@@ -79,10 +76,4 @@ test('\'npm install --production\' should only install dependencies', function (
     )
     t.end()
   })
-})
-
-test('cleanup', function (t) {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-  t.end()
 })

--- a/test/tap/install-cli-unicode.js
+++ b/test/tap/install-cli-unicode.js
@@ -1,14 +1,10 @@
 var fs = require('graceful-fs')
 var path = require('path')
 
-var mkdirp = require('mkdirp')
 var mr = require('npm-registry-mock')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
-var server
 
 var pkg = common.pkg
 
@@ -28,15 +24,13 @@ var json = {
 }
 
 test('setup', function (t) {
-  rimraf.sync(pkg)
-  mkdirp.sync(pkg)
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
     JSON.stringify(json, null, 2)
   )
 
   mr({ port: common.port }, function (er, s) {
-    server = s
+    t.parent.teardown(() => s.close())
     t.end()
   })
 })
@@ -60,12 +54,4 @@ test('does not use unicode with --unicode false', function (t) {
       t.end()
     }
   )
-})
-
-test('cleanup', function (t) {
-  server.close()
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-
-  t.end()
 })

--- a/test/tap/install-duplicate-deps-warning.js
+++ b/test/tap/install-duplicate-deps-warning.js
@@ -1,10 +1,7 @@
 var fs = require('graceful-fs')
 var path = require('path')
 
-var mkdirp = require('mkdirp')
 var mr = require('npm-registry-mock')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -21,21 +18,16 @@ var json = {
   }
 }
 
-test('setup', function (t) {
+test('npm install with duplicate dependencies, different versions', function (t) {
+  t.plan(1)
   t.comment('test for https://github.com/npm/npm/issues/6725')
-  cleanup()
-  mkdirp.sync(pkg)
+
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
     JSON.stringify(json, null, 2)
   )
   process.chdir(pkg)
-  console.dir(pkg)
-  t.end()
-})
 
-test('npm install with duplicate dependencies, different versions', function (t) {
-  t.plan(1)
   mr({ port: common.port }, function (er, s) {
     var opts = {
       cache: common.cache,
@@ -57,13 +49,3 @@ test('npm install with duplicate dependencies, different versions', function (t)
     })
   })
 })
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}

--- a/test/tap/install-from-local-multipath.js
+++ b/test/tap/install-from-local-multipath.js
@@ -2,8 +2,6 @@ var fs = require('graceful-fs')
 var path = require('path')
 
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap')
@@ -115,7 +113,6 @@ var child2Lock = {
 }
 
 test('setup', function (t) {
-  rimraf.sync(pkg)
   mkdirp.sync(pkg)
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
@@ -173,10 +170,4 @@ test('\'npm install\' should install local packages', function (t) {
       t.end()
     }
   )
-})
-
-test('cleanup', function (t) {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(root)
-  t.end()
 })

--- a/test/tap/install-from-local.js
+++ b/test/tap/install-from-local.js
@@ -2,8 +2,6 @@ var fs = require('graceful-fs')
 var path = require('path')
 
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap')
@@ -37,7 +35,6 @@ var localDevDependency = {
 }
 
 test('setup', function (t) {
-  rimraf.sync(pkg)
   mkdirp.sync(pkg)
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
@@ -89,10 +86,4 @@ test('\'npm install\' should install local packages', function (t) {
       t.end()
     }
   )
-})
-
-test('cleanup', function (t) {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(root)
-  t.end()
 })

--- a/test/tap/install-man.js
+++ b/test/tap/install-man.js
@@ -1,15 +1,13 @@
 var fs = require('fs')
 var resolve = require('path').resolve
 
-var osenv = require('osenv')
 var mkdirp = require('mkdirp')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
 
-var pkg = common.pkg
-var target = pkg + '-target'
+var pkg = resolve(common.pkg, 'package')
+var target = resolve(common.pkg, 'target')
 
 common.pendIfWindows('man pages do not get installed on Windows')
 
@@ -24,8 +22,14 @@ var json = {
 }
 
 test('setup', function (t) {
-  setup()
-  t.pass('setup ran')
+  mkdirp.sync(pkg)
+  // make sure it installs locally
+  mkdirp.sync(resolve(target, 'node_modules'))
+  fs.writeFileSync(
+    resolve(pkg, 'package.json'),
+    JSON.stringify(json, null, 2) + '\n'
+  )
+  fs.writeFileSync(resolve(pkg, 'install-man.1'), 'THIS IS A MANPAGE\n')
   t.end()
 })
 
@@ -51,27 +55,3 @@ test('install man page', function (t) {
     }
   )
 })
-
-test('clean', function (t) {
-  cleanup()
-  t.pass('cleaned up')
-  t.end()
-})
-
-function setup () {
-  cleanup()
-  mkdirp.sync(pkg)
-  // make sure it installs locally
-  mkdirp.sync(resolve(target, 'node_modules'))
-  fs.writeFileSync(
-    resolve(pkg, 'package.json'),
-    JSON.stringify(json, null, 2) + '\n'
-  )
-  fs.writeFileSync(resolve(pkg, 'install-man.1'), 'THIS IS A MANPAGE\n')
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-  rimraf.sync(target)
-}

--- a/test/tap/install-package-json-order.js
+++ b/test/tap/install-package-json-order.js
@@ -1,6 +1,5 @@
 var test = require('tap').test
 var path = require('path')
-var rimraf = require('rimraf')
 var mkdirp = require('mkdirp')
 var spawn = require('child_process').spawn
 var npm = require.resolve('../../bin/npm-cli.js')
@@ -9,20 +8,26 @@ const common = require('../common-tap.js')
 var pkg = common.pkg
 var workdir = path.join(pkg, 'workdir')
 var tmp = path.join(pkg, 'tmp')
-var cache = common.cache
 var fs = require('fs')
-var osenv = require('osenv')
 
 test('package.json sorting after install', function (t) {
   var packageJson = path.resolve(pkg, 'package.json')
   var installedPackage = path.resolve(workdir,
     'node_modules/install-package-json-order/package.json')
 
-  cleanup()
-  mkdirp.sync(cache)
   mkdirp.sync(tmp)
   mkdirp.sync(workdir)
-  setup()
+
+  fs.writeFileSync(path.resolve(pkg, 'package.json'), JSON.stringify({
+    'name': 'install-package-json-order',
+    'version': '0.0.0',
+    'array': [ 'one', 'two', 'three' ]
+  }, null, 2), 'utf8')
+
+  fs.writeFileSync(path.resolve(workdir, 'package.json'), JSON.stringify({
+    'name': 'install-package-json-order-work',
+    'version': '0.0.0'
+  }, null, 2), 'utf8')
 
   var before = JSON.parse(fs.readFileSync(packageJson).toString())
   var child = spawn(node, [npm, 'install', pkg], { cwd: workdir })
@@ -35,29 +40,3 @@ test('package.json sorting after install', function (t) {
     t.end()
   })
 })
-
-test('cleanup', function (t) {
-  cleanup()
-  t.pass('cleaned up')
-  t.end()
-})
-
-function setup () {
-  mkdirp.sync(pkg)
-
-  fs.writeFileSync(path.resolve(pkg, 'package.json'), JSON.stringify({
-    'name': 'install-package-json-order',
-    'version': '0.0.0',
-    'array': [ 'one', 'two', 'three' ]
-  }, null, 2), 'utf8')
-  fs.writeFileSync(path.resolve(workdir, 'package.json'), JSON.stringify({
-    'name': 'install-package-json-order-work',
-    'version': '0.0.0'
-  }, null, 2), 'utf8')
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(cache)
-  rimraf.sync(pkg)
-}

--- a/test/tap/install-property-conflicts.js
+++ b/test/tap/install-property-conflicts.js
@@ -1,9 +1,7 @@
 var fs = require('fs')
 var resolve = require('path').resolve
 
-var osenv = require('osenv')
 var mkdirp = require('mkdirp')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -22,8 +20,12 @@ var json = {
 }
 
 test('setup', function (t) {
-  setup()
-  t.pass('setup ran')
+  // make sure it installs locally
+  mkdirp.sync(resolve(target, 'node_modules'))
+  fs.writeFileSync(
+    resolve(pkg, 'package.json'),
+    JSON.stringify(json, null, 2) + '\n'
+  )
   t.end()
 })
 
@@ -49,26 +51,3 @@ test('install package with a `type` property', function (t) {
     }
   )
 })
-
-test('clean', function (t) {
-  cleanup()
-  t.pass('cleaned up')
-  t.end()
-})
-
-function setup () {
-  cleanup()
-  mkdirp.sync(pkg)
-  // make sure it installs locally
-  mkdirp.sync(resolve(target, 'node_modules'))
-  fs.writeFileSync(
-    resolve(pkg, 'package.json'),
-    JSON.stringify(json, null, 2) + '\n'
-  )
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-  rimraf.sync(target)
-}

--- a/test/tap/install-save-exact.js
+++ b/test/tap/install-save-exact.js
@@ -3,12 +3,10 @@ var path = require('path')
 
 var mkdirp = require('mkdirp')
 var mr = require('npm-registry-mock')
-var osenv = require('osenv')
 var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
-var server
 
 var pkg = common.pkg
 
@@ -20,95 +18,65 @@ var json = {
   description: 'fixture'
 }
 
-test('setup', function (t) {
-  setup()
+test('mock registry', function (t) {
   mr({ port: common.port }, function (er, s) {
-    server = s
+    t.parent.teardown(() => s.close())
     t.end()
   })
 })
 
+const setup = t => {
+  t.test('destroy', t => rimraf(pkg, t.end))
+  t.test('create', t => {
+    mkdirp.sync(path.resolve(pkg, 'node_modules'))
+    fs.writeFileSync(
+      path.join(pkg, 'package.json'),
+      JSON.stringify(json, null, 2)
+    )
+    t.end()
+  })
+  t.end()
+}
+
+const check = (savearg, deptype) => t => {
+  common.npm(
+    [
+      '--loglevel', 'silent',
+      '--registry', common.registry,
+      savearg,
+      '--save-exact',
+      'install', 'underscore@1.3.1'
+    ],
+    EXEC_OPTS,
+    function (err, code) {
+      t.ifError(err, 'npm ran without issue')
+      t.notOk(code, 'npm install exited without raising an error code')
+
+      var p = path.resolve(pkg, 'node_modules/underscore/package.json')
+      t.ok(JSON.parse(fs.readFileSync(p)))
+
+      p = path.resolve(pkg, 'package.json')
+      var pkgJson = JSON.parse(fs.readFileSync(p, 'utf8'))
+
+      t.same(
+        pkgJson[deptype],
+        { 'underscore': '1.3.1' },
+        'underscore dependency should specify exactly 1.3.1'
+      )
+
+      t.end()
+    }
+  )
+}
+
 test('\'npm install --save --save-exact\' should install local pkg', function (t) {
-  common.npm(
-    [
-      '--loglevel', 'silent',
-      '--registry', common.registry,
-      '--save',
-      '--save-exact',
-      'install', 'underscore@1.3.1'
-    ],
-    EXEC_OPTS,
-    function (err, code) {
-      t.ifError(err, 'npm ran without issue')
-      t.notOk(code, 'npm install exited without raising an error code')
-
-      var p = path.resolve(pkg, 'node_modules/underscore/package.json')
-      t.ok(JSON.parse(fs.readFileSync(p)))
-
-      p = path.resolve(pkg, 'package.json')
-      var pkgJson = JSON.parse(fs.readFileSync(p, 'utf8'))
-
-      t.same(
-        pkgJson.dependencies,
-        { 'underscore': '1.3.1' },
-        'underscore dependency should specify exactly 1.3.1'
-      )
-
-      t.end()
-    }
-  )
-})
-
-test('\'npm install --save-dev --save-exact\' should install local pkg', function (t) {
-  setup()
-
-  common.npm(
-    [
-      '--loglevel', 'silent',
-      '--registry', common.registry,
-      '--save-dev',
-      '--save-exact',
-      'install', 'underscore@1.3.1'
-    ],
-    EXEC_OPTS,
-    function (err, code) {
-      t.ifError(err, 'npm ran without issue')
-      t.notOk(code, 'npm install exited without raising an error code')
-
-      var p = path.resolve(pkg, 'node_modules/underscore/package.json')
-      t.ok(JSON.parse(fs.readFileSync(p)))
-
-      p = path.resolve(pkg, 'package.json')
-      var pkgJson = JSON.parse(fs.readFileSync(p, 'utf8'))
-
-      t.same(
-        pkgJson.devDependencies,
-        { 'underscore': '1.3.1' },
-        'underscore dependency should specify exactly 1.3.1'
-      )
-
-      t.end()
-    }
-  )
-})
-
-test('cleanup', function (t) {
-  server.close()
-  cleanup()
+  t.test('setup', setup)
+  t.test('check', check('--save', 'dependencies'))
   t.end()
 })
 
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}
-
-function setup () {
-  cleanup()
-  mkdirp.sync(path.resolve(pkg, 'node_modules'))
-  fs.writeFileSync(
-    path.join(pkg, 'package.json'),
-    JSON.stringify(json, null, 2)
-  )
-  process.chdir(pkg)
-}
+test('\'npm install --save-dev --save-exact\' should install local pkg', function (t) {
+  t.test('setup', setup)
+  t.test('check', check('--save-dev', 'devDependencies'))
+  t.end()
+})

--- a/test/tap/install-save-local.js
+++ b/test/tap/install-save-local.js
@@ -2,7 +2,6 @@ var fs = require('graceful-fs')
 var path = require('path')
 
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
 var rimraf = require('rimraf')
 var test = require('tap').test
 
@@ -28,146 +27,7 @@ var localDevDependency = {
   version: '0.0.0'
 }
 
-test('setup', function (t) {
-  setup()
-  t.end()
-})
-
-test('\'npm install --save ../local/path\' should save to package.json', function (t) {
-  common.npm(
-    [
-      '--loglevel', 'silent',
-      '--save',
-      'install', '../package-local-dependency'
-    ],
-    EXEC_OPTS,
-    function (err, code) {
-      t.ifError(err, 'npm install ran without issue')
-      t.notOk(code, 'npm install exited with code 0')
-
-      var dependencyPackageJson = path.join(
-        pkg, 'node_modules', 'package-local-dependency', 'package.json'
-      )
-      t.ok(JSON.parse(fs.readFileSync(dependencyPackageJson, 'utf8')))
-
-      var pkgJson = JSON.parse(fs.readFileSync(pkg + '/package.json', 'utf8'))
-      t.is(Object.keys(pkgJson.dependencies).length, 1, 'only one dep')
-      t.ok(
-        /file:.*?[/]package-local-dependency$/.test(pkgJson.dependencies['package-local-dependency']),
-        'local package saved correctly'
-      )
-      t.end()
-    }
-  )
-})
-
-test('\'npm install --save local/path\' should save to package.json', function (t) {
-  setup()
-  common.npm(
-    [
-      '--loglevel', 'silent',
-      '--save',
-      'install', 'package-local-dependency/'
-    ],
-    EXEC_OPTS,
-    function (err, code) {
-      t.ifError(err, 'npm install ran without issue')
-      t.notOk(code, 'npm install exited with code 0')
-
-      var dependencyPackageJson = path.join(
-        pkg, 'node_modules', 'package-local-dependency', 'package.json'
-      )
-      t.ok(JSON.parse(fs.readFileSync(dependencyPackageJson, 'utf8')))
-
-      var pkgJson = JSON.parse(fs.readFileSync(pkg + '/package.json', 'utf8'))
-      t.is(Object.keys(pkgJson.dependencies).length, 1, 'only one dep')
-      t.ok(
-        /file:package-local-dependency$/.test(pkgJson.dependencies['package-local-dependency']),
-        'local package saved correctly'
-      )
-      t.end()
-    }
-  )
-})
-
-test('\'npm install --save-dev ../local/path\' should save to package.json', function (t) {
-  setup()
-  common.npm(
-    [
-      '--loglevel', 'silent',
-      '--save-dev',
-      'install', '../package-local-dev-dependency'
-    ],
-    EXEC_OPTS,
-    function (err, code) {
-      t.ifError(err, 'npm install ran without issue')
-      t.notOk(code, 'npm install exited with code 0')
-
-      var dependencyPackageJson = path.resolve(
-        pkg, 'node_modules', 'package-local-dev-dependency', 'package.json'
-      )
-      t.ok(JSON.parse(fs.readFileSync(dependencyPackageJson, 'utf8')))
-
-      var pkgJson = JSON.parse(fs.readFileSync(pkg + '/package.json', 'utf8'))
-      t.is(Object.keys(pkgJson.devDependencies).length, 1, 'only one dep')
-      t.ok(
-        /file:.*?[/\\]package-local-dev-dependency$/.test(pkgJson.devDependencies['package-local-dev-dependency']),
-        'local package saved correctly'
-      )
-
-      t.end()
-    }
-  )
-})
-test('\'npm install --save-dev local/path\' should save to package.json', function (t) {
-  setup()
-  common.npm(
-    [
-      '--loglevel', 'silent',
-      '--save-dev',
-      'install', 'package-local-dev-dependency/'
-    ],
-    EXEC_OPTS,
-    function (err, code) {
-      t.ifError(err, 'npm install ran without issue')
-      t.notOk(code, 'npm install exited with code 0')
-
-      var dependencyPackageJson = path.resolve(
-        pkg, 'node_modules', 'package-local-dev-dependency', 'package.json'
-      )
-      t.ok(JSON.parse(fs.readFileSync(dependencyPackageJson, 'utf8')))
-
-      var pkgJson = JSON.parse(fs.readFileSync(pkg + '/package.json', 'utf8'))
-      t.is(Object.keys(pkgJson.devDependencies).length, 1, 'only one dep')
-      t.ok(
-        /file:package-local-dev-dependency$/.test(pkgJson.devDependencies['package-local-dev-dependency']),
-        'local package saved correctly'
-      )
-
-      t.end()
-    }
-  )
-})
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  process.chdir(__dirname)
-  rimraf.sync(root)
-}
-
-function setup () {
-  cleanup()
-  mkdirp.sync(pkg)
-  fs.writeFileSync(
-    path.join(pkg, 'package.json'),
-    JSON.stringify(json, null, 2)
-  )
-
+test('setup deps in root', t => {
   mkdirp.sync(path.join(root, 'package-local-dependency'))
   fs.writeFileSync(
     path.join(root, 'package-local-dependency', 'package.json'),
@@ -180,16 +40,142 @@ function setup () {
     JSON.stringify(localDevDependency, null, 2)
   )
 
-  mkdirp.sync(path.join(pkg, 'package-local-dependency'))
-  fs.writeFileSync(
-    path.join(pkg, 'package-local-dependency', 'package.json'),
-    JSON.stringify(localDependency, null, 2)
-  )
+  t.end()
+})
 
-  mkdirp.sync(path.join(pkg, 'package-local-dev-dependency'))
-  fs.writeFileSync(
-    path.join(pkg, 'package-local-dev-dependency', 'package.json'),
-    JSON.stringify(localDevDependency, null, 2)
-  )
-  process.chdir(pkg)
+test('\'npm install --save ../local/path\' should save to package.json', function (t) {
+  t.plan(2)
+  t.test('setup', setup)
+  t.test('run test', t => common.npm(
+    [
+      '--loglevel', 'silent',
+      '--save',
+      'install', '../package-local-dependency'
+    ],
+    EXEC_OPTS
+  ).then(([code]) => {
+    t.equal(code, 0, 'npm install exited with code 0')
+
+    var dependencyPackageJson = path.join(
+      pkg, 'node_modules', 'package-local-dependency', 'package.json'
+    )
+    t.ok(JSON.parse(fs.readFileSync(dependencyPackageJson, 'utf8')))
+
+    var pkgJson = JSON.parse(fs.readFileSync(pkg + '/package.json', 'utf8'))
+    t.is(Object.keys(pkgJson.dependencies).length, 1, 'only one dep')
+    t.ok(
+      /file:.*?[/]package-local-dependency$/.test(pkgJson.dependencies['package-local-dependency']),
+      'local package saved correctly'
+    )
+  }))
+})
+
+test('\'npm install --save local/path\' should save to package.json', function (t) {
+  t.plan(2)
+  t.test('setup', setup)
+  t.test('run test', t => common.npm(
+    [
+      '--loglevel', 'silent',
+      '--save',
+      'install', 'package-local-dependency/'
+    ],
+    EXEC_OPTS
+  ).then(([code, out, err]) => {
+    t.equal(code, 0, 'npm install exited with code 0')
+
+    var dependencyPackageJson = path.join(
+      pkg, 'node_modules', 'package-local-dependency', 'package.json'
+    )
+    t.ok(JSON.parse(fs.readFileSync(dependencyPackageJson, 'utf8')))
+
+    var pkgJson = JSON.parse(fs.readFileSync(pkg + '/package.json', 'utf8'))
+    t.is(Object.keys(pkgJson.dependencies).length, 1, 'only one dep')
+    t.ok(
+      /file:package-local-dependency$/.test(pkgJson.dependencies['package-local-dependency']),
+      'local package saved correctly'
+    )
+  }))
+})
+
+test('\'npm install --save-dev ../local/path\' should save to package.json', function (t) {
+  t.plan(2)
+  t.test('setup', setup)
+  t.test('run test', t => common.npm(
+    [
+      '--loglevel', 'silent',
+      '--save-dev',
+      'install', '../package-local-dev-dependency'
+    ],
+    EXEC_OPTS
+  ).then(([code]) => {
+    t.equal(code, 0, 'npm install exited with code 0')
+
+    var dependencyPackageJson = path.resolve(
+      pkg, 'node_modules', 'package-local-dev-dependency', 'package.json'
+    )
+    t.ok(JSON.parse(fs.readFileSync(dependencyPackageJson, 'utf8')))
+
+    var pkgJson = JSON.parse(fs.readFileSync(pkg + '/package.json', 'utf8'))
+    t.is(Object.keys(pkgJson.devDependencies).length, 1, 'only one dep')
+    t.ok(
+      /file:.*?[/\\]package-local-dev-dependency$/.test(pkgJson.devDependencies['package-local-dev-dependency']),
+      'local package saved correctly'
+    )
+
+    t.end()
+  }))
+})
+
+test('\'npm install --save-dev local/path\' should save to package.json', function (t) {
+  t.plan(2)
+  t.test('setup', setup)
+  t.test('run test', t => common.npm(
+    [
+      '--loglevel', 'silent',
+      '--save-dev',
+      'install', 'package-local-dev-dependency/'
+    ],
+    EXEC_OPTS
+  ).then(([code]) => {
+    t.equal(code, 0, 'npm install exited with code 0')
+
+    var dependencyPackageJson = path.resolve(
+      pkg, 'node_modules', 'package-local-dev-dependency', 'package.json'
+    )
+    t.ok(JSON.parse(fs.readFileSync(dependencyPackageJson, 'utf8')))
+
+    var pkgJson = JSON.parse(fs.readFileSync(pkg + '/package.json', 'utf8'))
+    t.is(Object.keys(pkgJson.devDependencies).length, 1, 'only one dep')
+    t.ok(
+      /file:package-local-dev-dependency$/.test(pkgJson.devDependencies['package-local-dev-dependency']),
+      'local package saved correctly'
+    )
+
+    t.end()
+  }))
+})
+
+function setup (t) {
+  t.test('destroy', t => rimraf(pkg, t.end))
+  t.test('create', t => {
+    mkdirp.sync(pkg)
+    fs.writeFileSync(
+      path.join(pkg, 'package.json'),
+      JSON.stringify(json, null, 2)
+    )
+
+    mkdirp.sync(path.join(pkg, 'package-local-dependency'))
+    fs.writeFileSync(
+      path.join(pkg, 'package-local-dependency', 'package.json'),
+      JSON.stringify(localDependency, null, 2)
+    )
+
+    mkdirp.sync(path.join(pkg, 'package-local-dev-dependency'))
+    fs.writeFileSync(
+      path.join(pkg, 'package-local-dev-dependency', 'package.json'),
+      JSON.stringify(localDevDependency, null, 2)
+    )
+    t.end()
+  })
+  t.end()
 }

--- a/test/tap/install-save-prefix.js
+++ b/test/tap/install-save-prefix.js
@@ -1,14 +1,11 @@
 var fs = require('fs')
 var path = require('path')
 
-var mkdirp = require('mkdirp')
 var mr = require('npm-registry-mock')
-var osenv = require('osenv')
 var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
-var server
 
 var pkg = common.pkg
 
@@ -19,17 +16,18 @@ var json = {
   version: '0.0.1'
 }
 
-test('setup', function (t) {
-  setup()
+test('start mock reg', function (t) {
   mr({ port: common.port }, function (er, s) {
     t.ifError(er, 'started mock registry')
-    server = s
+    t.parent.teardown(() => s.close())
     t.end()
   })
 })
 
 test('install --save with \'^\' save prefix should accept minor updates', function (t) {
-  common.npm(
+  t.plan(2)
+  t.test('setup', setup)
+  t.test('run test', t => common.npm(
     [
       '--registry', common.registry,
       '--loglevel', 'silent',
@@ -37,31 +35,30 @@ test('install --save with \'^\' save prefix should accept minor updates', functi
       '--save',
       'install', 'underscore@latest'
     ],
-    EXEC_OPTS,
-    function (err, code) {
-      t.ifError(err, 'npm install ran without issue')
-      t.notOk(code, 'npm install exited with code 0')
+    EXEC_OPTS
+  ).then(([code]) => {
+    console.error('back from install!', code)
+    t.equal(code, 0, 'npm install exited with code 0')
 
-      var p = path.join(pkg, 'node_modules', 'underscore', 'package.json')
-      t.ok(JSON.parse(fs.readFileSync(p)))
+    var p = path.join(pkg, 'node_modules', 'underscore', 'package.json')
+    t.ok(JSON.parse(fs.readFileSync(p)))
 
-      var pkgJson = JSON.parse(fs.readFileSync(
-        path.join(pkg, 'package.json'),
-        'utf8'
-      ))
-      t.deepEqual(
-        pkgJson.dependencies,
-        { 'underscore': '^1.5.1' },
-        'got expected save prefix and version of 1.5.1'
-      )
-      t.end()
-    }
-  )
+    var pkgJson = JSON.parse(fs.readFileSync(
+      path.join(pkg, 'package.json'),
+      'utf8'
+    ))
+    t.deepEqual(
+      pkgJson.dependencies,
+      { 'underscore': '^1.5.1' },
+      'got expected save prefix and version of 1.5.1'
+    )
+  }))
 })
 
 test('install --save-dev with \'^\' save prefix should accept minor dev updates', function (t) {
-  setup()
-  common.npm(
+  t.plan(2)
+  t.test('setup', setup)
+  t.test('run test', t => common.npm(
     [
       '--registry', common.registry,
       '--loglevel', 'silent',
@@ -69,31 +66,30 @@ test('install --save-dev with \'^\' save prefix should accept minor dev updates'
       '--save-dev',
       'install', 'underscore@1.3.1'
     ],
-    EXEC_OPTS,
-    function (err, code) {
-      t.ifError(err, 'npm install ran without issue')
-      t.notOk(code, 'npm install exited with code 0')
+    EXEC_OPTS
+  ).then(([code]) => {
+    t.equal(code, 0, 'npm install exited with code 0')
 
-      var p = path.join(pkg, 'node_modules', 'underscore', 'package.json')
-      t.ok(JSON.parse(fs.readFileSync(p)))
+    var p = path.join(pkg, 'node_modules', 'underscore', 'package.json')
+    t.ok(JSON.parse(fs.readFileSync(p)))
 
-      var pkgJson = JSON.parse(fs.readFileSync(
-        path.join(pkg, 'package.json'),
-        'utf8'
-      ))
-      t.deepEqual(
-        pkgJson.devDependencies,
-        { 'underscore': '^1.3.1' },
-        'got expected save prefix and version of 1.3.1'
-      )
-      t.end()
-    }
-  )
+    var pkgJson = JSON.parse(fs.readFileSync(
+      path.join(pkg, 'package.json'),
+      'utf8'
+    ))
+    t.deepEqual(
+      pkgJson.devDependencies,
+      { 'underscore': '^1.3.1' },
+      'got expected save prefix and version of 1.3.1'
+    )
+    t.end()
+  }))
 })
 
 test('install --save with \'~\' save prefix should accept patch updates', function (t) {
-  setup()
-  common.npm(
+  t.plan(2)
+  t.test('setup', setup)
+  t.test('run test', t => common.npm(
     [
       '--registry', common.registry,
       '--loglevel', 'silent',
@@ -101,31 +97,29 @@ test('install --save with \'~\' save prefix should accept patch updates', functi
       '--save',
       'install', 'underscore@1.3.1'
     ],
-    EXEC_OPTS,
-    function (err, code) {
-      t.ifError(err, 'npm install ran without issue')
-      t.notOk(code, 'npm install exited with code 0')
+    EXEC_OPTS
+  ).then(([code]) => {
+    t.equal(code, 0, 'npm install exited with code 0')
 
-      var p = path.join(pkg, 'node_modules', 'underscore', 'package.json')
-      t.ok(JSON.parse(fs.readFileSync(p)))
+    var p = path.join(pkg, 'node_modules', 'underscore', 'package.json')
+    t.ok(JSON.parse(fs.readFileSync(p)))
 
-      var pkgJson = JSON.parse(fs.readFileSync(
-        path.join(pkg, 'package.json'),
-        'utf8'
-      ))
-      t.deepEqual(
-        pkgJson.dependencies,
-        { 'underscore': '~1.3.1' },
-        'got expected save prefix and version of 1.3.1'
-      )
-      t.end()
-    }
-  )
+    var pkgJson = JSON.parse(fs.readFileSync(
+      path.join(pkg, 'package.json'),
+      'utf8'
+    ))
+    t.deepEqual(
+      pkgJson.dependencies,
+      { 'underscore': '~1.3.1' },
+      'got expected save prefix and version of 1.3.1'
+    )
+  }))
 })
 
 test('install --save-dev with \'~\' save prefix should accept patch updates', function (t) {
-  setup()
-  common.npm(
+  t.plan(2)
+  t.test('setup', setup)
+  t.test('run test', t => common.npm(
     [
       '--registry', common.registry,
       '--loglevel', 'silent',
@@ -133,46 +127,38 @@ test('install --save-dev with \'~\' save prefix should accept patch updates', fu
       '--save-dev',
       'install', 'underscore@1.3.1'
     ],
-    EXEC_OPTS,
-    function (err, code) {
-      t.ifError(err, 'npm install ran without issue')
-      t.notOk(code, 'npm install exited with code 0')
+    EXEC_OPTS
+  ).then(([code]) => {
+    t.notOk(code, 'npm install exited with code 0')
 
-      var p = path.join(pkg, 'node_modules', 'underscore', 'package.json')
-      t.ok(JSON.parse(fs.readFileSync(p)))
+    var p = path.join(pkg, 'node_modules', 'underscore', 'package.json')
+    t.ok(JSON.parse(fs.readFileSync(p)))
 
-      var pkgJson = JSON.parse(fs.readFileSync(
-        path.join(pkg, 'package.json'),
-        'utf8'
-      ))
-      t.deepEqual(
-        pkgJson.devDependencies,
-        { 'underscore': '~1.3.1' },
-        'got expected save prefix and version of 1.3.1'
-      )
-      t.end()
-    }
-  )
+    var pkgJson = JSON.parse(fs.readFileSync(
+      path.join(pkg, 'package.json'),
+      'utf8'
+    ))
+    t.deepEqual(
+      pkgJson.devDependencies,
+      { 'underscore': '~1.3.1' },
+      'got expected save prefix and version of 1.3.1'
+    )
+  }))
 })
 
-test('cleanup', function (t) {
-  server.close()
-  cleanup()
+function setup (t) {
+  t.test('destroy', t => {
+    t.plan(2)
+    rimraf(path.resolve(pkg, 'node_modules'), () => t.pass('node_modules'))
+    rimraf(path.resolve(pkg, 'pacakage-lock.json'), () => t.pass('lock file'))
+  })
+  t.test('create', t => {
+    fs.writeFileSync(
+      path.join(pkg, 'package.json'),
+      JSON.stringify(json, null, 2)
+    )
+    t.end()
+  })
+
   t.end()
-})
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}
-
-function setup () {
-  cleanup()
-  mkdirp.sync(path.resolve(pkg, 'node_modules'))
-  fs.writeFileSync(
-    path.join(pkg, 'package.json'),
-    JSON.stringify(json, null, 2)
-  )
-
-  process.chdir(pkg)
 }

--- a/test/tap/install-scoped-already-installed.js
+++ b/test/tap/install-scoped-already-installed.js
@@ -3,8 +3,6 @@ var path = require('path')
 var existsSync = fs.existsSync || path.existsSync
 
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap')
@@ -37,7 +35,6 @@ var scopedDependency = {
 }
 
 test('setup', function (t) {
-  rimraf.sync(root)
   mkdirp.sync(pkg)
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
@@ -56,7 +53,6 @@ test('setup', function (t) {
     JSON.stringify(scopedDependency, null, 2)
   )
 
-  process.chdir(pkg)
   t.end()
 })
 
@@ -116,12 +112,6 @@ test('installing already installed local scoped package', function (t) {
       )
     }
   )
-})
-
-test('cleanup', function (t) {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(root)
-  t.end()
 })
 
 function contains (list, element) {

--- a/test/tap/install-scoped-link.js
+++ b/test/tap/install-scoped-link.js
@@ -4,16 +4,15 @@ var path = require('path')
 var existsSync = fs.existsSync || path.existsSync
 
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var escapeExecPath = require('../../lib/utils/escape-exec-path')
 
 var common = require('../common-tap.js')
 
-var pkg = common.pkg
-var work = pkg + '-TEST'
+var resolve = require('path').resolve
+var pkg = resolve(common.pkg, 'package')
+var work = resolve(common.pkg, 'TEST')
 var modules = path.join(work, 'node_modules')
 
 var EXEC_OPTS = { cwd: work }
@@ -29,7 +28,6 @@ var json = {
 }
 
 test('setup', function (t) {
-  cleanup()
   mkdirp.sync(pkg)
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
@@ -73,14 +71,3 @@ test('installing package with links', function (t) {
     }
   )
 })
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(work)
-  rimraf.sync(pkg)
-}

--- a/test/tap/install-scoped-with-peer-dependency.js
+++ b/test/tap/install-scoped-with-peer-dependency.js
@@ -2,15 +2,13 @@ var fs = require('fs')
 var path = require('path')
 
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
 var pkg = common.pkg
 var local = path.join(pkg, 'package')
 
-var EXEC_OPTS = { }
+var EXEC_OPTS = { cwd: pkg }
 
 var json = {
   name: '@scope/package',
@@ -21,8 +19,12 @@ var json = {
 }
 
 test('setup', function (t) {
-  setup()
-
+  mkdirp.sync(local)
+  mkdirp.sync(path.resolve(pkg, 'node_modules'))
+  fs.writeFileSync(
+    path.join(local, 'package.json'),
+    JSON.stringify(json, null, 2)
+  )
   t.end()
 })
 
@@ -36,24 +38,3 @@ test('it should install peerDependencies in same tree level as the parent packag
     t.end()
   })
 })
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function setup () {
-  cleanup()
-  mkdirp.sync(local)
-  mkdirp.sync(path.resolve(pkg, 'node_modules'))
-  fs.writeFileSync(
-    path.join(local, 'package.json'),
-    JSON.stringify(json, null, 2)
-  )
-  process.chdir(pkg)
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}

--- a/test/tap/install-test-cli-without-package-lock.js
+++ b/test/tap/install-test-cli-without-package-lock.js
@@ -2,8 +2,6 @@ var fs = require('graceful-fs')
 var path = require('path')
 
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -28,8 +26,23 @@ var dependency = {
 }
 
 test('setup', function (t) {
-  setup()
-  t.pass('setup ran')
+  mkdirp.sync(path.join(pkg, 'dependency'))
+  fs.writeFileSync(
+    path.join(pkg, 'dependency', 'package.json'),
+    JSON.stringify(dependency, null, 2)
+  )
+
+  mkdirp.sync(path.join(pkg, 'node_modules'))
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    JSON.stringify(json, null, 2)
+  )
+
+  // Disable package-lock
+  fs.writeFileSync(
+    path.join(pkg, '.npmrc'),
+    'package-lock=false\n'
+  )
   t.end()
 })
 
@@ -49,35 +62,3 @@ test('\'npm install-test\' should not generate package-lock.json.*', function (t
     t.end()
   })
 })
-
-test('cleanup', function (t) {
-  cleanup()
-  t.pass('cleaned up')
-  t.end()
-})
-
-function setup () {
-  mkdirp.sync(path.join(pkg, 'dependency'))
-  fs.writeFileSync(
-    path.join(pkg, 'dependency', 'package.json'),
-    JSON.stringify(dependency, null, 2)
-  )
-
-  mkdirp.sync(path.join(pkg, 'node_modules'))
-  fs.writeFileSync(
-    path.join(pkg, 'package.json'),
-    JSON.stringify(json, null, 2)
-  )
-
-  // Disable package-lock
-  fs.writeFileSync(
-    path.join(pkg, '.npmrc'),
-    'package-lock=false\n'
-  )
-  process.chdir(pkg)
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}

--- a/test/tap/install-with-dev-dep-duplicate.js
+++ b/test/tap/install-with-dev-dep-duplicate.js
@@ -1,10 +1,7 @@
 var fs = require('graceful-fs')
 var path = require('path')
 
-var mkdirp = require('mkdirp')
 var mr = require('npm-registry-mock')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -42,13 +39,19 @@ test('prefers version from dependencies over devDependencies', function (t) {
 
   mr({ port: common.port }, function (er, s) {
     setup(function (err) {
-      if (err) return t.fail(err)
+      if (err) {
+        throw err
+      }
 
       npm.install('.', function (err) {
-        if (err) return t.fail(err)
+        if (err) {
+          throw err
+        }
 
         npm.commands.ls([], true, function (err, _, results) {
-          if (err) return t.fail(err)
+          if (err) {
+            throw err
+          }
 
           // these contain full paths so we can't do an exact match
           // with them
@@ -63,14 +66,7 @@ test('prefers version from dependencies over devDependencies', function (t) {
   })
 })
 
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
 function setup (cb) {
-  cleanup()
-  mkdirp.sync(pkg)
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
     JSON.stringify(json, null, 2)
@@ -82,9 +78,4 @@ function setup (cb) {
     registry: common.registry
   }
   npm.load(opts, cb)
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
 }

--- a/test/tap/it.js
+++ b/test/tap/it.js
@@ -2,9 +2,7 @@ var join = require('path').join
 var statSync = require('graceful-fs').statSync
 var writeFileSync = require('graceful-fs').writeFileSync
 
-var mkdirp = require('mkdirp')
 var mr = require('npm-registry-mock')
-var osenv = require('osenv')
 var rimraf = require('rimraf')
 var test = require('tap').test
 
@@ -23,55 +21,45 @@ var json = {
   }
 }
 
-var server
-
 test('run up the mock registry', function (t) {
   mr({ port: common.port }, function (err, s) {
     if (err) throw err
-    server = s
+    t.parent.teardown(() => s.close())
     t.end()
   })
 })
 
+const check = args => t =>
+  common.npm(args.concat('--registry=' + common.registry), { cwd: pkg })
+    .then(([code, stdout, stderr]) => {
+      t.equal(code, 0, 'command ran without error')
+      t.ok(statSync(installed), 'package was installed')
+      t.equal(require(installed).version, '1.5.1', 'underscore got installed as expected')
+      t.match(stdout, /hax/, 'found expected test output')
+      t.notOk(stderr, 'stderr should be empty')
+    })
+
 test('npm install-test', function (t) {
-  setup()
-  common.npm(['install-test', '--no-shrinkwrap', '--registry=' + common.registry], { cwd: pkg }, function (err, code, stdout, stderr) {
-    if (err) throw err
-    t.equal(code, 0, 'command ran without error')
-    t.ok(statSync(installed), 'package was installed')
-    t.equal(require(installed).version, '1.5.1', 'underscore got installed as expected')
-    t.match(stdout, /hax/, 'found expected test output')
-    t.notOk(stderr, 'stderr should be empty')
-    t.end()
-  })
+  t.plan(2)
+  t.test('setup', setup)
+  t.test('check', check(['install-test', '--no-shrinkwrap']))
 })
 
 test('npm it (the form most people will use)', function (t) {
-  setup()
-  common.npm(['it', '--registry=' + common.registry], { cwd: pkg }, function (err, code, stdout, stderr) {
-    if (err) throw err
-    t.equal(code, 0, 'command ran without error')
-    t.ok(statSync(installed), 'package was installed')
-    t.equal(require(installed).version, '1.5.1', 'underscore got installed as expected')
-    t.match(stdout, /hax/, 'found expected test output')
-    t.notOk(stderr, 'stderr should be empty')
+  t.plan(2)
+  t.test('setup', setup)
+  t.test('check', check(['it']))
+})
+
+function setup (t) {
+  t.test('destroy', t => {
+    t.plan(2)
+    rimraf(join(pkg, 'node_modules'), () => t.pass('node_modules'))
+    rimraf(join(pkg, 'package-lock.json'), () => t.pass('lock file'))
+  })
+  t.test('create', t => {
+    writeFileSync(join(pkg, 'package.json'), JSON.stringify(json, null, 2))
     t.end()
   })
-})
-
-test('cleanup', function (t) {
-  process.chdir(osenv.tmpdir())
-  server.close()
-  cleanup()
   t.end()
-})
-
-function cleanup () {
-  rimraf.sync(pkg)
-}
-
-function setup () {
-  cleanup()
-  mkdirp.sync(pkg)
-  writeFileSync(join(pkg, 'package.json'), JSON.stringify(json, null, 2))
 }

--- a/test/tap/lifecycle-INIT_CWD.js
+++ b/test/tap/lifecycle-INIT_CWD.js
@@ -2,8 +2,6 @@ var fs = require('fs')
 var path = require('path')
 
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -20,39 +18,19 @@ var json = {
 }
 
 test('setup', function (t) {
-  cleanup()
-  mkdirp.sync(pkg)
   mkdirp.sync(subdir)
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
     JSON.stringify(json, null, 2)
   )
-
-  process.chdir(subdir)
   t.end()
 })
 
-test('make sure the env.INIT_CWD is correct', function (t) {
-  common.npm(['run-script', 'initcwd'], {
-    cwd: subdir
-  }, function (er, code, stdout) {
-    if (er) throw er
-    t.equal(code, 0, 'exit code')
-    stdout = stdout.trim().split(/\r|\n/).pop()
-    var actual = stdout
-
-    t.equal(actual, subdir)
-    t.end()
-  })
-})
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(subdir)
-  rimraf.sync(pkg)
-}
+test('make sure the env.INIT_CWD is correct', t =>
+  common.npm(['run-script', 'initcwd'], { cwd: subdir })
+    .then(([code, stdout, stderr]) => {
+      t.equal(code, 0, 'exit code')
+      stdout = stdout.trim().split(/\r|\n/).pop()
+      var actual = stdout
+      t.equal(actual, subdir)
+    }))

--- a/test/tap/lifecycle-order.js
+++ b/test/tap/lifecycle-order.js
@@ -1,13 +1,7 @@
 var fs = require('graceful-fs')
 var path = require('path')
-
-var mkdirp = require('mkdirp')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
-
 var common = require('../common-tap.js')
-
 var pkg = common.pkg
 
 var json = {
@@ -21,37 +15,19 @@ var json = {
 }
 
 test('setup', function (t) {
-  cleanup()
-  mkdirp.sync(pkg)
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
     JSON.stringify(json, null, 2)
   )
-
-  process.chdir(pkg)
   t.end()
 })
 
-test('lifecycle scripts execute in the proper order', function (t) {
-  common.npm('install', {cwd: pkg}, function (err, code, stdout, stderr) {
-    if (err) throw err
+test('lifecycle scripts execute in the proper order', t =>
+  common.npm('install', {cwd: pkg}).then(([code, stdout, stderr]) => {
     t.is(code, 0, 'no error')
 
     // All three files should exist
     t.ok(fs.existsSync(path.join(pkg, 'preinstall-step')), 'preinstall ok')
     t.ok(fs.existsSync(path.join(pkg, 'install-step')), 'install ok')
     t.ok(fs.existsSync(path.join(pkg, 'postinstall-step')), 'postinstall ok')
-
-    t.end()
-  })
-})
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}
+  }))

--- a/test/tap/link.js
+++ b/test/tap/link.js
@@ -1,7 +1,5 @@
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
 var path = require('path')
-var rimraf = require('rimraf')
 var test = require('tap').test
 var lstatSync = require('fs').lstatSync
 var writeFileSync = require('fs').writeFileSync
@@ -72,7 +70,28 @@ var insideInstallJSON = {
 }
 
 test('setup', function (t) {
-  setup()
+  mkdirp.sync(linkRoot)
+  mkdirp.sync(link)
+  writeFileSync(
+    path.join(link, 'package.json'),
+    JSON.stringify(readJSON, null, 2)
+  )
+  mkdirp.sync(linkScoped)
+  writeFileSync(
+    path.join(linkScoped, 'package.json'),
+    JSON.stringify(readScopedJSON, null, 2)
+  )
+  mkdirp.sync(linkInstall)
+  writeFileSync(
+    path.join(linkInstall, 'package.json'),
+    JSON.stringify(installJSON, null, 2)
+  )
+  mkdirp.sync(linkInside)
+  writeFileSync(
+    path.join(linkInside, 'package.json'),
+    JSON.stringify(insideInstallJSON, null, 2)
+  )
+  writeFileSync(configPath, config)
   common.npm(['ls', '-g', '--depth=0'], OPTS, function (err, c, out) {
     t.ifError(err)
     t.equal(c, 0, 'set up ok')
@@ -173,50 +192,14 @@ test('ls the linked packages', function (t) {
 })
 
 test('cleanup', function (t) {
-  process.chdir(osenv.tmpdir())
+  process.chdir(common.pkg)
   common.npm(['rm', 'foo'], OPTS, function (err, code) {
     t.ifError(err, 'npm removed the linked package without error')
     t.equal(code, 0, 'cleanup foo in local ok')
     common.npm(['rm', '-g', 'foo'], OPTS, function (err, code) {
       t.ifError(err, 'npm removed the global package without error')
       t.equal(code, 0, 'cleanup foo in global ok')
-
-      cleanup()
       t.end()
     })
   })
 })
-
-function cleanup () {
-  rimraf.sync(linkRoot)
-  rimraf.sync(link)
-  rimraf.sync(linkScoped)
-  rimraf.sync(linkInstall)
-  rimraf.sync(linkInside)
-}
-
-function setup () {
-  cleanup()
-  mkdirp.sync(linkRoot)
-  mkdirp.sync(link)
-  writeFileSync(
-    path.join(link, 'package.json'),
-    JSON.stringify(readJSON, null, 2)
-  )
-  mkdirp.sync(linkScoped)
-  writeFileSync(
-    path.join(linkScoped, 'package.json'),
-    JSON.stringify(readScopedJSON, null, 2)
-  )
-  mkdirp.sync(linkInstall)
-  writeFileSync(
-    path.join(linkInstall, 'package.json'),
-    JSON.stringify(installJSON, null, 2)
-  )
-  mkdirp.sync(linkInside)
-  writeFileSync(
-    path.join(linkInside, 'package.json'),
-    JSON.stringify(insideInstallJSON, null, 2)
-  )
-  writeFileSync(configPath, config)
-}

--- a/test/tap/locker.js
+++ b/test/tap/locker.js
@@ -2,8 +2,6 @@ var test = require('tap').test
 var path = require('path')
 var fs = require('graceful-fs')
 var crypto = require('crypto')
-var rimraf = require('rimraf')
-var osenv = require('osenv')
 var mkdirp = require('mkdirp')
 var npm = require('../../')
 var locker = require('../../lib/utils/locker.js')
@@ -16,13 +14,7 @@ var cache = path.join(pkg, '/cache')
 var tmp = path.join(pkg, '/tmp')
 var nm = path.join(pkg, '/node_modules')
 
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}
-
 test('setup', function (t) {
-  cleanup()
   mkdirp.sync(cache)
   mkdirp.sync(tmp)
   t.end()
@@ -82,9 +74,4 @@ test('unlocking out of order errors out', function (t) {
       t.end()
     })
   })
-})
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
 })

--- a/test/tap/ls-depth-cli.js
+++ b/test/tap/ls-depth-cli.js
@@ -1,11 +1,8 @@
 var fs = require('graceful-fs')
 var path = require('path')
 
-var mkdirp = require('mkdirp')
 var Bluebird = require('bluebird')
 var mr = Bluebird.promisify(require('npm-registry-mock'))
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap')
@@ -29,8 +26,6 @@ var json = {
 }
 
 test('setup', function (t) {
-  cleanup()
-  mkdirp.sync(pkg)
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
     JSON.stringify(json, null, 2)
@@ -199,13 +194,3 @@ test('npm ls --depth=1 --parseable --long', function (t) {
     }
   )
 })
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}

--- a/test/tap/ls-depth-unmet.js
+++ b/test/tap/ls-depth-unmet.js
@@ -1,10 +1,7 @@
 var fs = require('graceful-fs')
 var path = require('path')
 
-var mkdirp = require('mkdirp')
 var mr = require('npm-registry-mock')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap')
@@ -25,8 +22,6 @@ var json = {
 }
 
 test('setup', function (t) {
-  cleanup()
-  mkdirp.sync(pkg)
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
     JSON.stringify(json, null, 2)
@@ -160,13 +155,3 @@ test('npm ls --depth=Infinity', function (t) {
     }
   )
 })
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}

--- a/test/tap/ls-env.js
+++ b/test/tap/ls-env.js
@@ -1,10 +1,7 @@
 var fs = require('graceful-fs')
 var path = require('path')
 
-var mkdirp = require('mkdirp')
 var mr = require('npm-registry-mock')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap')
@@ -22,8 +19,6 @@ var json = {
 }
 
 test('setup', function (t) {
-  cleanup()
-  mkdirp.sync(pkg)
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
     JSON.stringify(json, null, 2)
@@ -123,13 +118,3 @@ test('npm ls --only=prod', function (t) {
     t.end()
   })
 })
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}

--- a/test/tap/ls-production-and-dev.js
+++ b/test/tap/ls-production-and-dev.js
@@ -1,10 +1,7 @@
 var fs = require('graceful-fs')
 var path = require('path')
 
-var mkdirp = require('mkdirp')
 var mr = require('npm-registry-mock')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap')
@@ -27,8 +24,6 @@ var json = {
 }
 
 test('setup', function (t) {
-  cleanup()
-  mkdirp.sync(pkg)
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
     JSON.stringify(json, null, 2)
@@ -160,13 +155,3 @@ test('npm ls --only=prod', function (t) {
     t.end()
   })
 })
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}

--- a/test/tap/no-global-warns.js
+++ b/test/tap/no-global-warns.js
@@ -2,8 +2,6 @@
 var path = require('path')
 var test = require('tap').test
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var writeFileSync = require('fs').writeFileSync
 var common = require('../common-tap.js')
 
@@ -38,7 +36,13 @@ var installJSON = {
 }
 
 test('setup', function (t) {
-  setup()
+  mkdirp.sync(mockGlobal)
+  mkdirp.sync(toInstall)
+  writeFileSync(
+    path.join(toInstall, 'package.json'),
+    JSON.stringify(installJSON, null, 2)
+  )
+  writeFileSync(configPath, config)
   t.end()
 })
 
@@ -59,24 +63,3 @@ test('no-global-warns', function (t) {
       t.end()
     })
 })
-
-test('cleanup', function (t) {
-  process.chdir(osenv.tmpdir())
-  cleanup()
-  t.end()
-})
-
-function cleanup () {
-  rimraf.sync(base)
-}
-
-function setup () {
-  cleanup()
-  mkdirp.sync(mockGlobal)
-  mkdirp.sync(toInstall)
-  writeFileSync(
-    path.join(toInstall, 'package.json'),
-    JSON.stringify(installJSON, null, 2)
-  )
-  writeFileSync(configPath, config)
-}

--- a/test/tap/no-scan-full-global-dir.js
+++ b/test/tap/no-scan-full-global-dir.js
@@ -3,7 +3,6 @@ var fs = require('fs')
 var path = require('path')
 var test = require('tap').test
 var requireInject = require('require-inject')
-var osenv = require('osenv')
 var npm = require('../../lib/npm.js')
 
 // XXX update this when rpt's realpath.js is extracted out
@@ -24,8 +23,6 @@ Object.keys(packages).forEach(function (name) {
   dirs[path.join(packages[name].path, 'node_modules')] = packages[name].children || []
   files[path.join(packages[name].path, 'package.json')] = packages[name].package
 })
-
-process.chdir(osenv.tmpdir())
 
 var mockReaddir = function (name, cb) {
   if (dirs[name]) return cb(null, dirs[name])

--- a/test/tap/outdated-depth.js
+++ b/test/tap/outdated-depth.js
@@ -1,10 +1,7 @@
 var fs = require('graceful-fs')
 var path = require('path')
 
-var mkdirp = require('mkdirp')
 var mr = require('npm-registry-mock')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var npm = require('../../')
@@ -22,8 +19,6 @@ var json = {
 }
 
 test('setup', function (t) {
-  cleanup()
-  mkdirp.sync(pkg)
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
     JSON.stringify(json, null, 2)
@@ -79,13 +74,3 @@ test('outdated depth zero', function (t) {
     )
   })
 })
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}

--- a/test/tap/peer-deps.js
+++ b/test/tap/peer-deps.js
@@ -1,10 +1,7 @@
 var fs = require('graceful-fs')
 var path = require('path')
 
-var mkdirp = require('mkdirp')
 var mr = require('npm-registry-mock')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -21,6 +18,17 @@ var json = {
   dependencies: {
     'npm-test-peer-deps': '*'
   }
+}
+
+function setup (cb) {
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    JSON.stringify(json, null, 2)
+  )
+  process.chdir(pkg)
+
+  var opts = { cache: common.cache, registry: common.registry }
+  npm.load(opts, cb)
 }
 
 test('installs the peer dependency directory structure', function (t) {
@@ -42,26 +50,3 @@ test('installs the peer dependency directory structure', function (t) {
     })
   })
 })
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function setup (cb) {
-  cleanup()
-  mkdirp.sync(pkg)
-  fs.writeFileSync(
-    path.join(pkg, 'package.json'),
-    JSON.stringify(json, null, 2)
-  )
-  process.chdir(pkg)
-
-  var opts = { cache: common.cache, registry: common.registry }
-  npm.load(opts, cb)
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}

--- a/test/tap/publish-config.js
+++ b/test/tap/publish-config.js
@@ -3,7 +3,6 @@
 const common = require('../common-tap.js')
 const test = require('tap').test
 const fs = require('fs')
-const osenv = require('osenv')
 const pkg = common.pkg
 
 fs.writeFileSync(pkg + '/package.json', JSON.stringify({
@@ -58,7 +57,7 @@ test(function (t) {
         HOME: process.env.HOME,
         Path: process.env.PATH,
         PATH: process.env.PATH,
-        USERPROFILE: osenv.home()
+        USERPROFILE: process.env.USERPROFILE
       }
     }, function (err, code, stdout, stderr) {
       t.comment(stdout)

--- a/test/tap/publish-invalid-semver-tag.js
+++ b/test/tap/publish-invalid-semver-tag.js
@@ -2,54 +2,52 @@ var common = require('../common-tap.js')
 var test = require('tap').test
 var npm = require('../../lib/npm.js')
 var mkdirp = require('mkdirp')
-var rimraf = require('rimraf')
 var path = require('path')
 var fs = require('fs')
 var mr = require('npm-registry-mock')
 
-var osenv = require('osenv')
-
 var PKG_DIR = common.pkg
-var CACHE_DIR = common.cache
+let cacheIteration = 0
+let CACHE_DIR
 
 var DEFAULT_PKG = {
   'name': 'examples',
   'version': '1.2.3'
 }
 
-var mockServer
-
-const chownr = require('chownr')
-const fixOwner = (
-  process.getuid && process.getuid() === 0 &&
-  process.env.SUDO_UID && process.env.SUDO_GID
-) ? (path) => chownr.sync(path, +process.env.SUDO_UID, +process.env.SUDO_GID)
-  : () => {}
-
+const isRoot = process.getuid && process.getuid() === 0
+const sudoUID = isRoot ? +process.env.SUDO_UID : null
+const sudoGID = isRoot ? +process.env.SUDO_GID : null
+const { chownSync } = require('fs')
 function resetPackage (options) {
-  rimraf.sync(CACHE_DIR)
+  CACHE_DIR = path.resolve(common.cache, '' + cacheIteration++)
   mkdirp.sync(CACHE_DIR)
-  fixOwner(CACHE_DIR)
+  npm.config.set('cache', CACHE_DIR)
+
+  if (isRoot && sudoUID && sudoGID) {
+    chownSync(CACHE_DIR, sudoUID, sudoGID)
+  }
 
   fs.writeFileSync(path.resolve(PKG_DIR, 'package.json'), DEFAULT_PKG)
 }
 
 test('setup', function (t) {
-  process.chdir(osenv.tmpdir())
   mkdirp.sync(PKG_DIR)
   process.chdir(PKG_DIR)
 
-  resetPackage({})
-
   mr({ port: common.port }, function (er, server) {
+    if (er) {
+      throw er
+    }
+    t.parent.teardown(() => server.close())
     npm.load({
-      cache: CACHE_DIR,
+      cache: common.cache,
       registry: common.registry,
       cwd: PKG_DIR
     }, function (err) {
-      t.ifError(err, 'started server')
-      mockServer = server
-
+      if (err) {
+        throw err
+      }
       t.end()
     })
   })
@@ -75,13 +73,4 @@ test('attempt publish with semver-like version', function (t) {
     t.same(err.message, 'Tag name must not be a valid SemVer range: 1.2.3')
     t.end()
   })
-})
-
-test('cleanup', function (t) {
-  mockServer.close()
-
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(PKG_DIR)
-
-  t.end()
 })

--- a/test/tap/scripts-whitespace-windows.js
+++ b/test/tap/scripts-whitespace-windows.js
@@ -2,8 +2,6 @@ var fs = require('graceful-fs')
 var path = require('path')
 
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap')
@@ -43,7 +41,6 @@ if (process.argv.length === 8)
 */ }.toString().split('\n').slice(1, -1).join('\n')
 
 test('setup', function (t) {
-  cleanup()
   mkdirp.sync(tmp)
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
@@ -89,13 +86,3 @@ test('test', function (t) {
     t.end()
   })
 })
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}

--- a/test/tap/shrinkwrap-dev-dependency.js
+++ b/test/tap/shrinkwrap-dev-dependency.js
@@ -1,10 +1,7 @@
 var fs = require('fs')
 var path = require('path')
 
-var mkdirp = require('mkdirp')
 var mr = require('npm-registry-mock')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -46,26 +43,11 @@ var json = {
   }
 }
 
-function setup () {
-  cleanup()
-  mkdirp.sync(pkg)
-  fs.writeFileSync(path.join(pkg, 'package.json'), JSON.stringify(json, null, 2))
-  process.chdir(pkg)
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}
-
-test('setup', function (t) {
-  setup()
-  t.end()
-})
-
 test("shrinkwrap doesn't strip out the dependency", function (t) {
   t.plan(3)
-  setup()
+
+  fs.writeFileSync(path.join(pkg, 'package.json'), JSON.stringify(json, null, 2))
+  process.chdir(pkg)
 
   mr({port: common.port}, function (er, s) {
     common.npm(opts.concat(['install', '.']), {stdio: [0, 'pipe', 2]}, function (err, code) {
@@ -85,9 +67,4 @@ test("shrinkwrap doesn't strip out the dependency", function (t) {
       })
     })
   })
-})
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
 })

--- a/test/tap/shrinkwrap-empty-deps.js
+++ b/test/tap/shrinkwrap-empty-deps.js
@@ -2,11 +2,8 @@
 
 const common = require('../common-tap.js')
 const fs = require('fs')
-const mkdirp = require('mkdirp')
 const mr = require('npm-registry-mock')
-const osenv = require('osenv')
 const path = require('path')
-const rimraf = require('rimraf')
 const test = require('tap').test
 
 const pkg = common.pkg
@@ -22,8 +19,6 @@ const json = {
 }
 
 test('setup', function (t) {
-  cleanup()
-  mkdirp.sync(pkg)
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
     JSON.stringify(json, null, 2)
@@ -61,14 +56,3 @@ test('returns a list of removed items', function (t) {
     )
   })
 })
-
-test('cleanup', function (t) {
-  cleanup()
-
-  t.end()
-})
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}

--- a/test/tap/shrinkwrap-extra-metadata.js
+++ b/test/tap/shrinkwrap-extra-metadata.js
@@ -2,12 +2,9 @@
 
 const common = require('../common-tap.js')
 const fs = require('fs')
-const mkdirp = require('mkdirp')
 const mr = require('npm-registry-mock')
 const npm = require('../../lib/npm.js')
-const osenv = require('osenv')
 const path = require('path')
-const rimraf = require('rimraf')
 const test = require('tap').test
 
 const pkg = common.pkg
@@ -19,8 +16,6 @@ const json = {
 }
 
 test('setup', function (t) {
-  cleanup()
-  mkdirp.sync(pkg)
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
     JSON.stringify(json, null, 2)
@@ -32,6 +27,7 @@ test('setup', function (t) {
 
 test('adds additional metadata fields from the pkglock spec', function (t) {
   mr({ port: common.port }, function (er, s) {
+    t.teardown(() => s.close())
     common.npm(
       [
         '--registry', common.registry,
@@ -56,21 +52,9 @@ test('adds additional metadata fields from the pkglock spec', function (t) {
             'shrinkwrap wrote the expected metadata fields'
           )
 
-          s.close()
           t.end()
         })
       }
     )
   })
 })
-
-test('cleanup', function (t) {
-  cleanup()
-
-  t.end()
-})
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}

--- a/test/tap/shrinkwrap-global-auth.js
+++ b/test/tap/shrinkwrap-global-auth.js
@@ -6,8 +6,6 @@ var writeFileSync = require('graceful-fs').writeFileSync
 
 var mkdirp = require('mkdirp')
 var mr = require('npm-registry-mock')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var ssri = require('ssri')
 var test = require('tap').test
 
@@ -22,7 +20,30 @@ var tarballURL = common.registry + tarballPath
 var tarball = path.resolve(__dirname, '../fixtures/scoped-underscore-1.3.1.tgz')
 var tarballIntegrity = ssri.fromData(fs.readFileSync(tarball)).toString()
 
-var server
+var contents = 'registry=' + common.registry + '\n' +
+               '_authToken=0xabad1dea\n' +
+               '\'always-auth\'=true\n'
+
+var json = {
+  name: 'test-package-install',
+  version: '1.0.0',
+  dependencies: {
+    '@scoped/underscore': '1.0.0'
+  }
+}
+
+var shrinkwrap = {
+  name: 'test-package-install',
+  version: '1.0.0',
+  lockfileVersion: 1,
+  dependencies: {
+    '@scoped/underscore': {
+      resolved: tarballURL,
+      integrity: tarballIntegrity,
+      version: '1.3.1'
+    }
+  }
+}
 
 function mocks (server) {
   var auth = 'Bearer 0xabad1dea'
@@ -34,10 +55,16 @@ function mocks (server) {
 }
 
 test('setup', function (t) {
+  mkdirp.sync(modules)
+  writeFileSync(path.resolve(pkg, 'package.json'), JSON.stringify(json, null, 2) + '\n')
+  writeFileSync(outfile, contents)
+  writeFileSync(
+    path.resolve(pkg, 'npm-shrinkwrap.json'),
+    JSON.stringify(shrinkwrap, null, 2) + '\n'
+  )
   mr({ port: common.port, plugin: mocks }, function (er, s) {
-    server = s
+    t.parent.teardown(() => s.close())
     t.ok(s, 'set up mock registry')
-    setup()
     t.end()
   })
 })
@@ -68,50 +95,3 @@ test('authed npm install with shrinkwrapped global package', function (t) {
     }
   )
 })
-
-test('cleanup', function (t) {
-  server.close()
-  cleanup()
-  t.end()
-})
-
-var contents = 'registry=' + common.registry + '\n' +
-               '_authToken=0xabad1dea\n' +
-               '\'always-auth\'=true\n'
-
-var json = {
-  name: 'test-package-install',
-  version: '1.0.0',
-  dependencies: {
-    '@scoped/underscore': '1.0.0'
-  }
-}
-
-var shrinkwrap = {
-  name: 'test-package-install',
-  version: '1.0.0',
-  lockfileVersion: 1,
-  dependencies: {
-    '@scoped/underscore': {
-      resolved: tarballURL,
-      integrity: tarballIntegrity,
-      version: '1.3.1'
-    }
-  }
-}
-
-function setup () {
-  cleanup()
-  mkdirp.sync(modules)
-  writeFileSync(path.resolve(pkg, 'package.json'), JSON.stringify(json, null, 2) + '\n')
-  writeFileSync(outfile, contents)
-  writeFileSync(
-    path.resolve(pkg, 'npm-shrinkwrap.json'),
-    JSON.stringify(shrinkwrap, null, 2) + '\n'
-  )
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}

--- a/test/tap/shrinkwrap-lifecycle.js
+++ b/test/tap/shrinkwrap-lifecycle.js
@@ -1,16 +1,10 @@
 var fs = require('graceful-fs')
 var path = require('path')
-
-var mkdirp = require('mkdirp')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
-
 var common = require('../common-tap.js')
 var pkg = common.pkg
 
 test('npm shrinkwrap execution order', function (t) {
-  setup()
   fs.writeFileSync(path.resolve(pkg, 'package.json'), JSON.stringify({
     author: 'Simen Bekkhus',
     name: 'shrinkwrap-lifecycle',
@@ -22,7 +16,7 @@ test('npm shrinkwrap execution order', function (t) {
       postshrinkwrap: 'echo this happens third'
     }
   }), 'utf8')
-  common.npm(['shrinkwrap', '--loglevel=error'], [], function (err, code, stdout, stderr) {
+  common.npm(['shrinkwrap', '--loglevel=error'], { cwd: pkg }, function (err, code, stdout, stderr) {
     if (err) throw err
 
     t.comment(stdout)
@@ -41,14 +35,3 @@ test('npm shrinkwrap execution order', function (t) {
     t.end()
   })
 })
-
-test('cleanup', function (t) {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-  t.end()
-})
-
-function setup () {
-  mkdirp.sync(pkg)
-  process.chdir(pkg)
-}

--- a/test/tap/shrinkwrap-optional-dependency.js
+++ b/test/tap/shrinkwrap-optional-dependency.js
@@ -3,8 +3,6 @@ var path = require('path')
 
 var mkdirp = require('mkdirp')
 var mr = require('npm-registry-mock')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -22,17 +20,17 @@ test('shrinkwrap does not fail on missing optional dependency', function (t) {
   }
 
   mr({port: common.port, mocks: mocks}, function (er, s) {
-    function fail (err) {
-      s.close() // Close on failure to allow node to exit
-      t.fail(err)
-    }
-
+    t.parent.teardown(() => s.close())
     setup(function (err) {
-      if (err) return fail(err)
+      if (err) {
+        throw err
+      }
 
       // Install without the optional dependency
       npm.install('.', function (err) {
-        if (err) return fail(err)
+        if (err) {
+          throw err
+        }
 
         // Pretend the optional dependency was specified, but somehow failed to load:
         json.optionalDependencies = {
@@ -41,7 +39,9 @@ test('shrinkwrap does not fail on missing optional dependency', function (t) {
         writePackage()
 
         npm.commands.shrinkwrap([], true, function (err, results) {
-          if (err) return fail(err)
+          if (err) {
+            throw err
+          }
 
           t.deepEqual(results.dependencies, desired.dependencies)
           s.close()
@@ -50,11 +50,6 @@ test('shrinkwrap does not fail on missing optional dependency', function (t) {
       })
     })
   })
-})
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
 })
 
 var desired = {
@@ -83,19 +78,14 @@ function writePackage () {
 }
 
 function setup (cb) {
-  cleanup()
   mkdirp.sync(pkg)
   writePackage()
   process.chdir(pkg)
 
   var opts = {
     cache: common.cache,
-    registry: common.registry
+    registry: common.registry,
+    cwd: pkg
   }
   npm.load(opts, cb)
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
 }

--- a/test/tap/shrinkwrap-prod-dependency-also.js
+++ b/test/tap/shrinkwrap-prod-dependency-also.js
@@ -1,10 +1,7 @@
 var fs = require('fs')
 var path = require('path')
 
-var mkdirp = require('mkdirp')
 var mr = require('npm-registry-mock')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -20,49 +17,6 @@ function reportOutput (t, fh, out) {
   var prefix = fh + '> '
   t.comment(prefix + trimmed.split(/\n/).join('\n' + prefix))
 }
-
-var server
-test("shrinkwrap --also=development doesn't strip out prod dependencies", function (t) {
-  t.plan(4)
-
-  mr({port: common.port}, function (er, s) {
-    server = s
-    setup()
-    common.npm(['install', '.'].concat(opts), {cwd: pkg}, function (err, code, stdout, stderr) {
-      if (err) return t.fail(err)
-      t.is(code, 0, 'install')
-      reportOutput(t, 'out', stdout)
-      reportOutput(t, 'err', stderr)
-      common.npm(['shrinkwrap', '--also=development'].concat(opts), {cwd: pkg}, function (err, code, stdout, stderr) {
-        if (err) return t.fail(err)
-        var ok = t.is(code, 0, 'shrinkwrap')
-        reportOutput(t, 'out', stdout)
-        reportOutput(t, 'err', stderr)
-        if (ok) {
-          try {
-            var results = JSON.parse(fs.readFileSync(path.join(pkg, 'npm-shrinkwrap.json')))
-            t.pass('read shrinkwrap')
-          } catch (ex) {
-            t.ifError(ex, 'read shrinkwrap')
-          }
-        }
-        t.deepEqual(
-          results.dependencies,
-          desired.dependencies,
-          'results have dev dep'
-        )
-        s.done()
-        t.end()
-      })
-    })
-  })
-})
-
-test('cleanup', function (t) {
-  server.close()
-  cleanup()
-  t.end()
-})
 
 var desired = {
   name: 'npm-test-shrinkwrap-prod-dependency',
@@ -94,13 +48,38 @@ var json = {
   }
 }
 
-function setup (opts) {
-  cleanup()
-  mkdirp.sync(pkg)
-  fs.writeFileSync(path.join(pkg, 'package.json'), JSON.stringify(json, null, 2))
-}
+test("shrinkwrap --also=development doesn't strip out prod dependencies", function (t) {
+  t.plan(4)
 
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}
+  mr({port: common.port}, function (er, s) {
+    t.parent.teardown(() => s.close())
+    fs.writeFileSync(path.join(pkg, 'package.json'), JSON.stringify(json, null, 2))
+    common.npm(['install', '.'].concat(opts), {cwd: pkg}, function (err, code, stdout, stderr) {
+      if (err) return t.fail(err)
+      t.is(code, 0, 'install')
+      reportOutput(t, 'out', stdout)
+      reportOutput(t, 'err', stderr)
+      common.npm(['shrinkwrap', '--also=development'].concat(opts), {cwd: pkg}, function (err, code, stdout, stderr) {
+        if (err) return t.fail(err)
+        var ok = t.is(code, 0, 'shrinkwrap')
+        reportOutput(t, 'out', stdout)
+        reportOutput(t, 'err', stderr)
+        if (ok) {
+          try {
+            var results = JSON.parse(fs.readFileSync(path.join(pkg, 'npm-shrinkwrap.json')))
+            t.pass('read shrinkwrap')
+          } catch (ex) {
+            t.ifError(ex, 'read shrinkwrap')
+          }
+        }
+        t.deepEqual(
+          results.dependencies,
+          desired.dependencies,
+          'results have dev dep'
+        )
+        s.done()
+        t.end()
+      })
+    })
+  })
+})

--- a/test/tap/shrinkwrap-prod-dependency.js
+++ b/test/tap/shrinkwrap-prod-dependency.js
@@ -3,42 +3,12 @@ var path = require('path')
 
 var mkdirp = require('mkdirp')
 var mr = require('npm-registry-mock')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var npm = require('../../')
 
 var common = require('../common-tap.js')
 var pkg = common.pkg
-
-test("shrinkwrap --dev doesn't strip out prod dependencies", function (t) {
-  t.plan(1)
-
-  mr({port: common.port}, function (er, s) {
-    setup({}, function (err) {
-      if (err) return t.fail(err)
-
-      npm.install('.', function (err) {
-        if (err) return t.fail(err)
-
-        npm.config.set('dev', true)
-        npm.commands.shrinkwrap([], true, function (err, results) {
-          if (err) return t.fail(err)
-
-          t.deepEqual(results.dependencies, desired.dependencies)
-          s.close()
-          t.end()
-        })
-      })
-    })
-  })
-})
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
 
 var desired = {
   name: 'npm-test-shrinkwrap-prod-dependency',
@@ -70,8 +40,7 @@ var json = {
   }
 }
 
-function setup (opts, cb) {
-  cleanup()
+test('setup', function (t) {
   mkdirp.sync(pkg)
   fs.writeFileSync(path.join(pkg, 'package.json'), JSON.stringify(json, null, 2))
   process.chdir(pkg)
@@ -81,14 +50,27 @@ function setup (opts, cb) {
     registry: common.registry
   }
 
-  for (var key in opts) {
-    allOpts[key] = opts[key]
-  }
+  npm.load(allOpts, t.end)
+})
 
-  npm.load(allOpts, cb)
-}
+test('mock registry', t => {
+  mr({port: common.port}, function (er, s) {
+    t.parent.teardown(() => s.close())
+    t.end()
+  })
+})
 
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}
+test("shrinkwrap --dev doesn't strip out prod dependencies", t => {
+  t.plan(1)
+  npm.install('.', function (err) {
+    if (err) return t.fail(err)
+
+    npm.config.set('dev', true)
+    npm.commands.shrinkwrap([], true, function (err, results) {
+      if (err) return t.fail(err)
+
+      t.deepEqual(results.dependencies, desired.dependencies)
+      t.end()
+    })
+  })
+})

--- a/test/tap/shrinkwrap-save-dev-with-existing-deps.js
+++ b/test/tap/shrinkwrap-save-dev-with-existing-deps.js
@@ -1,12 +1,8 @@
 /* eslint-disable camelcase */
 var fs = require('fs')
 var path = require('path')
-
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
-
 var common = require('../common-tap.js')
 
 var base = common.pkg
@@ -74,7 +70,6 @@ function writeJson (filename, obj) {
 }
 
 test('setup', function (t) {
-  cleanup()
   writeJson(installme_pkg, installme_pkg_json)
   writeJson(example_pkg, example_pkg_json)
   writeJson(example_shrinkwrap, example_shrinkwrap_json)
@@ -95,13 +90,3 @@ test('install --save-dev leaves prod deps alone', function (t) {
     t.end()
   })
 })
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(base)
-}

--- a/test/tap/shrinkwrap-save-with-existing-dev-deps.js
+++ b/test/tap/shrinkwrap-save-with-existing-dev-deps.js
@@ -3,8 +3,6 @@ var fs = require('fs')
 var path = require('path')
 
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -63,7 +61,6 @@ function writeJson (filename, obj) {
 }
 
 test('setup', function (t) {
-  cleanup()
   writeJson(installme_pkg, installme_pkg_json)
   writeJson(example_pkg, example_pkg_json)
   writeJson(example_shrinkwrap, example_shrinkwrap_json)
@@ -71,24 +68,12 @@ test('setup', function (t) {
   t.end()
 })
 
-test('install --save leaves dev deps alone', function (t) {
-  common.npm(['install', '--save', 'file://' + installme], EXEC_OPTS, function (er, code, stdout, stderr) {
-    t.ifError(er, "spawn didn't catch fire")
-    t.is(code, 0, 'install completed ok')
-    t.is(stderr, '', 'install completed without error output')
-    var shrinkwrap = JSON.parse(fs.readFileSync(example_shrinkwrap))
-    t.ok(shrinkwrap.dependencies.installed, "save new install didn't remove dev dep")
-    t.ok(shrinkwrap.dependencies.installme, 'save new install DID add new dep')
-    t.end()
-  })
-})
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(base)
-}
+test('install --save leaves dev deps alone', t =>
+  common.npm(['install', '--save', 'file://' + installme], EXEC_OPTS)
+    .then(([code, stdout, stderr]) => {
+      t.is(code, 0, 'install completed ok')
+      t.is(stderr, '', 'install completed without error output')
+      var shrinkwrap = JSON.parse(fs.readFileSync(example_shrinkwrap))
+      t.ok(shrinkwrap.dependencies.installed, "save new install didn't remove dev dep")
+      t.ok(shrinkwrap.dependencies.installme, 'save new install DID add new dep')
+    }))

--- a/test/tap/startstop.js
+++ b/test/tap/startstop.js
@@ -2,8 +2,6 @@ var fs = require('graceful-fs')
 var path = require('path')
 
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap')
@@ -33,7 +31,6 @@ function testOutput (t, command, er, code, stdout, stderr) {
 }
 
 test('setup', function (t) {
-  cleanup()
   mkdirp.sync(pkg)
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
@@ -62,13 +59,3 @@ test('npm restart', function (t) {
     t.end()
   })
 })
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}

--- a/test/tap/symlink-cycle.js
+++ b/test/tap/symlink-cycle.js
@@ -3,8 +3,6 @@ var fs = require('fs')
 var path = require('path')
 var test = require('tap').test
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var writeFileSync = require('fs').writeFileSync
 var common = require('../common-tap.js')
 
@@ -27,7 +25,12 @@ var cycleJSON = {
 }
 
 test('setup', function (t) {
-  setup()
+  mkdirp.sync(path.join(cycle, 'node_modules'))
+  writeFileSync(
+    path.join(cycle, 'package.json'),
+    JSON.stringify(cycleJSON, null, 2)
+  )
+  fs.symlinkSync(cycle, path.join(cycle, 'node_modules', 'cycle'), 'junction')
   t.end()
 })
 
@@ -39,23 +42,3 @@ test('ls', function (t) {
     t.end()
   })
 })
-
-test('cleanup', function (t) {
-  process.chdir(osenv.tmpdir())
-  cleanup()
-  t.end()
-})
-
-function cleanup () {
-  rimraf.sync(base)
-}
-
-function setup () {
-  cleanup()
-  mkdirp.sync(path.join(cycle, 'node_modules'))
-  writeFileSync(
-    path.join(cycle, 'package.json'),
-    JSON.stringify(cycleJSON, null, 2)
-  )
-  fs.symlinkSync(cycle, path.join(cycle, 'node_modules', 'cycle'), 'junction')
-}

--- a/test/tap/uninstall-package.js
+++ b/test/tap/uninstall-package.js
@@ -1,10 +1,7 @@
 var fs = require('graceful-fs')
 var path = require('path')
 
-var mkdirp = require('mkdirp')
 var mr = require('npm-registry-mock')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -24,14 +21,10 @@ var json = {
 }
 
 test('setup', function (t) {
-  cleanup()
-  mkdirp.sync(pkg)
-  process.chdir(pkg)
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
     JSON.stringify(json, null, 2)
   )
-
   t.end()
 })
 
@@ -90,13 +83,3 @@ test('does not fail if installed package lacks a name somehow', function (t) {
     }
   )
 })
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}

--- a/test/tap/unpack-foreign-tarball.js
+++ b/test/tap/unpack-foreign-tarball.js
@@ -1,9 +1,8 @@
 var fs = require('graceful-fs')
 var path = require('path')
 
-var test = require('tap').test
+var t = require('tap')
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
 var rimraf = require('rimraf')
 
 var common = require('../common-tap.js')
@@ -24,64 +23,62 @@ var EXEC_OPTS = {
   cwd: pkg
 }
 
-function verify (t, files, err, code) {
+function verify (t, files, code) {
   if (code) {
-    t.fail('exited with failure: ' + code)
-    return t.end()
+    return t.fail('exited with failure: ' + code)
   }
   var actual = fs.readdirSync(target).sort()
   var expect = files.concat(['.npmignore', 'package.json']).sort()
   t.same(actual, expect)
-  t.end()
 }
 
-test('setup', function (t) {
-  setup()
-  t.comment('test for https://github.com/npm/npm/issues/5658')
-  t.end()
-})
+t.comment('test for https://github.com/npm/npm/issues/5658')
 
-test('npmignore only', function (t) {
+t.test('npmignore only', function (t) {
+  t.test('setup', setup)
   var file = path.resolve(fixtures, 'npmignore.tgz')
-  common.npm(['install', file], EXEC_OPTS, verify.bind(null, t, ['foo']))
+  return t.test('test', t => common.npm(['install', file], EXEC_OPTS)
+    .then(([code]) => verify(t, ['foo'], code)))
 })
 
-test('gitignore only', function (t) {
-  setup()
+t.test('gitignore only', function (t) {
+  t.test('setup', setup)
   var file = path.resolve(fixtures, 'gitignore.tgz')
-  common.npm(['install', file], EXEC_OPTS, verify.bind(null, t, ['foo']))
+  return t.test('test', t => common.npm(['install', file], EXEC_OPTS)
+    .then(([code]) => verify(t, ['foo'], code)))
 })
 
-test('gitignore and npmignore', function (t) {
-  setup()
+t.test('gitignore and npmignore', function (t) {
+  t.test('setup', setup)
   var file = path.resolve(fixtures, 'gitignore-and-npmignore.tgz')
-  common.npm(['install', file], EXEC_OPTS, verify.bind(null, t, ['foo', 'bar']))
+  return t.test('test', t => common.npm(['install', file], EXEC_OPTS)
+    .then(([code]) => verify(t, ['foo', 'bar'], code)))
 })
 
-test('gitignore and npmignore, not gzipped 1/2', function (t) {
-  setup()
+t.test('gitignore and npmignore, not gzipped 1/2', function (t) {
+  t.test('setup', setup)
   var file = path.resolve(fixtures, 'gitignore-and-npmignore.tar')
-  common.npm(['install', file], EXEC_OPTS, verify.bind(null, t, ['foo', 'bar']))
+  return t.test('test', t => common.npm(['install', file], EXEC_OPTS)
+    .then(([code]) => verify(t, ['foo', 'bar'], code)))
 })
 
-test('gitignore and npmignore, not gzipped 2/2', function (t) {
-  setup()
+t.test('gitignore and npmignore, not gzipped 2/2', function (t) {
+  t.test('setup', setup)
   var file = path.resolve(fixtures, 'gitignore-and-npmignore-2.tar')
-  common.npm(['install', file], EXEC_OPTS, verify.bind(null, t, ['foo', 'bar']))
+  return t.test('test', t => common.npm(['install', file], EXEC_OPTS)
+    .then(([code]) => verify(t, ['foo', 'bar'], code)))
 })
 
-test('cleanup', function (t) {
-  cleanup()
+function setup (t) {
+  t.test('destroy', t => {
+    t.plan(2)
+    t.test('node_modules', t => rimraf(nm, t.end))
+    t.test('tmp', t => rimraf(tmp, t.end))
+  })
+  t.test('create', t => {
+    mkdirp.sync(nm)
+    mkdirp.sync(tmp)
+    t.end()
+  })
   t.end()
-})
-
-function setup () {
-  cleanup()
-  mkdirp.sync(nm)
-  mkdirp.sync(tmp)
-}
-
-function cleanup () {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
 }

--- a/test/tap/unpublish-config.js
+++ b/test/tap/unpublish-config.js
@@ -2,9 +2,6 @@ var fs = require('graceful-fs')
 var http = require('http')
 var path = require('path')
 
-var mkdirp = require('mkdirp')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap.js')
@@ -18,8 +15,6 @@ var json = {
 }
 
 test('setup', function (t) {
-  mkdirp.sync(pkg)
-
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
     JSON.stringify(json), 'utf8'
@@ -63,7 +58,7 @@ test('cursory test of unpublishing with config', function (t) {
           HOME: process.env.HOME,
           Path: process.env.PATH,
           PATH: process.env.PATH,
-          USERPROFILE: osenv.home()
+          USERPROFILE: process.env.USERPROFILE
         }
       },
       function (err, code) {
@@ -72,10 +67,4 @@ test('cursory test of unpublishing with config', function (t) {
       }
     )
   })
-})
-
-test('cleanup', function (t) {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-  t.end()
 })

--- a/test/tap/update-examples.js
+++ b/test/tap/update-examples.js
@@ -1,11 +1,7 @@
 var common = require('../common-tap.js')
 var test = require('tap').test
 var mkdirp = require('mkdirp')
-var rimraf = require('rimraf')
 var mr = require('npm-registry-mock')
-
-var osenv = require('osenv')
-
 var requireInject = require('require-inject')
 
 var PKG_DIR = common.pkg
@@ -64,7 +60,6 @@ var registryMocks = {
 }
 
 // ** dynamic mocks, cloned from templates and modified **
-var mockServer
 var mockDepJson = clone(DEP_PKG)
 var mockInstalled = clone(INSTALLED)
 var mockParentJson = clone(DEFAULT_PKG)
@@ -83,17 +78,20 @@ function extend (a, b) {
   return a
 }
 
-const chownr = require('chownr')
-const fixOwner = (
-  process.getuid && process.getuid() === 0 &&
-  process.env.SUDO_UID && process.env.SUDO_GID
-) ? (path) => chownr.sync(path, +process.env.SUDO_UID, +process.env.SUDO_GID)
-  : () => {}
-
+const path = require('path')
+let cacheIteration = 0
+const isRoot = process.getuid && process.getuid() === 0
+const sudoUID = isRoot ? +process.env.SUDO_UID : null
+const sudoGID = isRoot ? +process.env.SUDO_GID : null
+const { chownSync } = require('fs')
 function resetPackage (options) {
-  rimraf.sync(CACHE_DIR)
+  CACHE_DIR = path.resolve(common.cache, '' + cacheIteration++)
+  npm.config.set('cache', CACHE_DIR)
   mkdirp.sync(CACHE_DIR)
-  fixOwner(CACHE_DIR)
+
+  if (isRoot && sudoUID && sudoGID) {
+    chownSync(CACHE_DIR, sudoUID, sudoGID)
+  }
 
   installAskedFor = undefined
 
@@ -145,20 +143,18 @@ var npm = requireInject.installGlobally('../../lib/npm.js', {
 
 test('setup', function (t) {
   t.plan(5)
-  process.chdir(osenv.tmpdir())
-  mkdirp.sync(PKG_DIR)
   process.chdir(PKG_DIR)
   t.pass('made ' + PKG_DIR)
 
-  resetPackage({})
-
   mr({ port: common.port, mocks: registryMocks }, function (er, server) {
     t.pass('mock registry active')
-    npm.load({ cache: CACHE_DIR,
+    npm.load({
+      cache: CACHE_DIR,
       registry: common.registry,
-      cwd: PKG_DIR }, function (err) {
+      cwd: PKG_DIR
+    }, function (err) {
       t.ifError(err, 'started server')
-      mockServer = server
+      t.parent.teardown(() => server.close())
 
       t.pass('npm.load complete')
 
@@ -222,13 +218,4 @@ test('update old caret dependency with newer', function (t) {
     t.equal(installAskedFor, 'dep1@0.4.1', 'should want to install dep@0.4.1')
     t.end()
   })
-})
-
-test('cleanup', function (t) {
-  mockServer.close()
-
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(PKG_DIR)
-
-  t.end()
 })

--- a/test/tap/url-dependencies.js
+++ b/test/tap/url-dependencies.js
@@ -1,14 +1,10 @@
 var fs = require('graceful-fs')
 var path = require('path')
 
-var mkdirp = require('mkdirp')
 var mr = require('npm-registry-mock')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var common = require('../common-tap')
-var server
 
 var pkg = common.pkg
 
@@ -27,87 +23,39 @@ var mockRoutes = {
   }
 }
 
+const tarballWasFetched = output => output.includes(
+  `GET 200 ${common.registry}/underscore/-/underscore-1.3.1.tgz`)
+
+const performInstall = () => common.npm(['install'], {
+  cwd: pkg,
+  env: {
+    npm_config_registry: common.registry,
+    npm_config_cache_lock_stale: 1000,
+    npm_config_cache_lock_wait: 1000,
+    npm_config_loglevel: 'http',
+    HOME: process.env.HOME,
+    Path: process.env.PATH,
+    PATH: process.env.PATH
+  }
+})
+
 test('setup', function (t) {
-  mr({ port: common.port, mocks: mockRoutes }, function (er, s) {
-    server = s
-    t.end()
-  })
-})
-
-test('url-dependencies: download first time', function (t) {
-  setup()
-
-  performInstall(t, function (output) {
-    if (!tarballWasFetched(output)) {
-      t.fail('Tarball was not fetched')
-    } else {
-      t.pass('Tarball was fetched')
-    }
-    t.end()
-  })
-})
-
-test('url-dependencies: do not download subsequent times', function (t) {
-  setup()
-
-  performInstall(t, function () {
-    performInstall(t, function (output) {
-      if (tarballWasFetched(output)) {
-        t.fail('Tarball was fetched second time around')
-      } else {
-        t.pass('Tarball was not fetched')
-      }
-      t.end()
-    })
-  })
-})
-
-test('cleanup', function (t) {
-  server.close()
-  cleanup()
-  t.end()
-})
-
-function cleanup () {
-  // windows fix for locked files
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(path.resolve(pkg))
-}
-
-function setup () {
-  cleanup()
-  mkdirp.sync(pkg)
   fs.writeFileSync(
     path.join(pkg, 'package.json'),
     JSON.stringify(json, null, 2)
   )
-}
-
-function tarballWasFetched (output) {
-  return output.indexOf(
-    'GET 200 ' +
-      common.registry +
-      '/underscore/-/underscore-1.3.1.tgz'
-  ) > -1
-}
-
-function performInstall (t, cb) {
-  var opts = {
-    cwd: pkg,
-    env: {
-      npm_config_registry: common.registry,
-      npm_config_cache_lock_stale: 1000,
-      npm_config_cache_lock_wait: 1000,
-      npm_config_loglevel: 'http',
-      HOME: process.env.HOME,
-      Path: process.env.PATH,
-      PATH: process.env.PATH
-    }
-  }
-  common.npm(['install'], opts, function (err, code, stdout, stderr) {
-    t.ifError(err, 'install success')
-    t.notOk(code, 'npm install exited with code 0')
-
-    cb(stderr)
+  mr({ port: common.port, mocks: mockRoutes }, function (er, s) {
+    t.parent.teardown(() => s.close())
+    t.end()
   })
-}
+})
+
+test('url-dependencies: download first time', t =>
+  performInstall().then(([code, _, output]) => {
+    t.equal(code, 0, 'exited successfully')
+    t.ok(tarballWasFetched(output), 'download first time')
+  })
+    .then(() => performInstall()).then(([code, _, output]) => {
+      t.equal(code, 0, 'exited successfully')
+      t.notOk(tarballWasFetched(output), 'do not download second time')
+    }))

--- a/test/tap/version-allow-same-version.js
+++ b/test/tap/version-allow-same-version.js
@@ -1,65 +1,40 @@
-var fs = require('graceful-fs')
-var path = require('path')
+const fs = require('graceful-fs')
+const path = require('path')
+const t = require('tap')
+const common = require('../common-tap.js')
+const npm = require('../../')
+const pkg = common.pkg
+const cache = common.cache
+const npmrc = path.resolve(pkg, './.npmrc')
+const configContents = 'sign-git-tag=false\n'
 
-var mkdirp = require('mkdirp')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
-var test = require('tap').test
-
-var common = require('../common-tap.js')
-var npm = require('../../')
-var pkg = common.pkg
-var cache = common.cache
-var npmrc = path.resolve(pkg, './.npmrc')
-var configContents = 'sign-git-tag=false\n'
-
-test('npm version <semver> with same version without --allow-same-version', function (t) {
-  setup()
-  fs.writeFileSync(path.resolve(pkg, 'package.json'), JSON.stringify({
-    author: 'Lucas Theisen',
-    name: 'version-allow-same-version',
-    version: '0.0.1',
-    description: 'Test for npm version without --allow-same-version'
-  }), 'utf8')
-  npm.load({cache: cache, 'allow-same-version': false, registry: common.registry}, function () {
-    var version = require('../../lib/version')
-    version(['0.0.1'], function (err) {
-      t.ok(err)
-      t.like(err.message, /Version not changed/)
-      t.end()
-    })
-  })
-})
-test('npm version <semver> with same version with --allow-same-version', function (t) {
-  setup()
-  fs.writeFileSync(path.resolve(pkg, 'package.json'), JSON.stringify({
-    author: 'Lucas Theisen',
-    name: 'version-allow-same-version',
-    version: '0.0.1',
-    description: 'Test for npm version without --allow-same-version'
-  }), 'utf8')
-  npm.load({cache: cache, 'allow-same-version': true, registry: common.registry}, function () {
-    var version = require('../../lib/version')
-    version(['0.0.1'],
-      function (err) { t.ok(!err) },
-      function () { t.end() })
-  })
-})
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function cleanup () {
-  // windows fix for locked files
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}
-
-function setup () {
-  mkdirp.sync(pkg)
-  mkdirp.sync(path.join(pkg, 'node_modules'))
-  mkdirp.sync(cache)
-  fs.writeFileSync(npmrc, configContents, 'ascii')
+t.test('setup', t => {
   process.chdir(pkg)
-}
+  fs.writeFileSync(npmrc, configContents, 'ascii')
+  fs.writeFileSync(path.resolve(pkg, 'package.json'), JSON.stringify({
+    author: 'Lucas Theisen',
+    name: 'version-allow-same-version',
+    version: '0.0.1',
+    description: 'Test for npm version without --allow-same-version'
+  }), 'utf8')
+  npm.load({cache: cache, 'allow-same-version': false, registry: common.registry}, t.end)
+})
+
+t.test('without --allow-same-version', t => {
+  npm.config.set('allow-same-version', false)
+  npm.commands.version(['0.0.1'], function (err) {
+    t.isa(err, Error, 'got an error')
+    t.like(err.message, /Version not changed/)
+    t.end()
+  })
+})
+
+t.test('with --allow-same-version', t => {
+  npm.config.set('allow-same-version', true)
+  npm.commands.version(['0.0.1'], function (err) {
+    if (err) {
+      throw err
+    }
+    t.end()
+  })
+})

--- a/test/tap/version-commit-hooks.js
+++ b/test/tap/version-commit-hooks.js
@@ -1,10 +1,7 @@
-var fs = require('graceful-fs')
-var path = require('path')
-var osenv = require('osenv')
-var mkdirp = require('mkdirp')
-var rimraf = require('rimraf')
+const fs = require('graceful-fs')
+const path = require('path')
 const common = require('../common-tap.js')
-var pkg = common.pkg
+const pkg = common.pkg
 
 var test = require('tap').test
 var npm = require('../../')
@@ -12,7 +9,6 @@ var npm = require('../../')
 delete process.env['npm_config_commit_hooks']
 
 test('npm version <semver> with commit-hooks disabled in .npmrc', function (t) {
-  mkdirp.sync(pkg)
   var npmrc = path.resolve(pkg, '.npmrc')
   fs.writeFileSync(npmrc, 'commit-hooks=false\n', 'ascii')
   process.chdir(pkg)
@@ -56,10 +52,4 @@ test('npm version <semver> with commit-hooks enabled (default)', function (t) {
     t.same(args3, [ 'commit', '-m', 'some commit message' ])
     t.end()
   })
-})
-
-test('cleanup', function (t) {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-  t.end()
 })

--- a/test/tap/version-consistent-newlines.js
+++ b/test/tap/version-consistent-newlines.js
@@ -3,11 +3,9 @@
 const common = require('../common-tap.js')
 const test = require('tap').test
 const npm = require('../../')
-const osenv = require('osenv')
 const path = require('path')
 const fs = require('fs')
 const mkdirp = require('mkdirp')
-const rimraf = require('rimraf')
 const requireInject = require('require-inject')
 
 const pkg = common.pkg
@@ -66,16 +64,7 @@ test('npm version does not alter the line endings in package.json (CRLF)', funct
   })
 })
 
-test('cleanup', function (t) {
-  process.chdir(osenv.tmpdir())
-
-  rimraf.sync(pkg)
-  t.end()
-})
-
 function setup (lineEnding) {
-  mkdirp.sync(pkg)
-  mkdirp.sync(cache)
   mkdirp.sync(gitDir)
   fs.writeFileSync(
     path.resolve(pkg, 'package.json'),

--- a/test/tap/version-sub-directory.js
+++ b/test/tap/version-sub-directory.js
@@ -3,8 +3,6 @@ var fs = require('fs')
 var path = require('path')
 
 var mkdirp = require('mkdirp')
-var osenv = require('osenv')
-var rimraf = require('rimraf')
 var test = require('tap').test
 
 var npm = require('../../lib/npm.js')
@@ -17,7 +15,9 @@ var cache = common.cache
 var json = { name: 'cat', version: '0.1.2' }
 
 test('npm version <semver> from a subdirectory', function (t) {
-  setup()
+  mkdirp.sync(subDirectory)
+  process.chdir(subDirectory)
+  fs.writeFileSync(packagePath, JSON.stringify(json), 'utf8')
   npmLoad()
 
   function npmLoad () {
@@ -54,22 +54,3 @@ test('npm version <semver> from a subdirectory', function (t) {
     t.end()
   }
 })
-
-test('cleanup', function (t) {
-  cleanup()
-  t.end()
-})
-
-function cleanup () {
-  // windows fix for locked files
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(pkg)
-}
-
-function setup () {
-  cleanup()
-  mkdirp.sync(cache)
-  mkdirp.sync(subDirectory)
-  process.chdir(subDirectory)
-  fs.writeFileSync(packagePath, JSON.stringify(json), 'utf8')
-}

--- a/test/tap/view.js
+++ b/test/tap/view.js
@@ -1,10 +1,14 @@
 var common = require('../common-tap.js')
-var test = require('tap').test
+const t = require('tap')
+var test = t.test
 var osenv = require('osenv')
 var path = require('path')
 var fs = require('fs')
 var rimraf = require('rimraf')
 var mkdirp = require('mkdirp')
+
+// this test has to use a tmpdir so that it's outside of
+// the current package context of npm.
 var tmp = osenv.tmpdir()
 var t1dir = path.resolve(tmp, 'view-local-no-pkg')
 var t2dir = path.resolve(tmp, 'view-local-notmine')
@@ -12,6 +16,15 @@ var t3dir = path.resolve(tmp, 'view-local-mine')
 var mr = require('npm-registry-mock')
 
 var server
+
+t.teardown(() => {
+  rimraf.sync(t1dir)
+  rimraf.sync(t2dir)
+  rimraf.sync(t3dir)
+  if (server) {
+    server.close()
+  }
+})
 
 test('setup', function (t) {
   mkdirp.sync(t1dir)
@@ -46,7 +59,6 @@ function plugin (server) {
 }
 
 test('npm view . in global mode', function (t) {
-  process.chdir(t1dir)
   common.npm([
     'view',
     '.',
@@ -61,7 +73,6 @@ test('npm view . in global mode', function (t) {
 })
 
 test('npm view --global', function (t) {
-  process.chdir(t1dir)
   common.npm([
     'view',
     '--registry=' + common.registry,
@@ -75,7 +86,6 @@ test('npm view --global', function (t) {
 })
 
 test('npm view . with no package.json', function (t) {
-  process.chdir(t1dir)
   common.npm([
     'view',
     '.',
@@ -89,7 +99,6 @@ test('npm view . with no package.json', function (t) {
 })
 
 test('npm view . with no published package', function (t) {
-  process.chdir(t3dir)
   common.npm([
     'view',
     '.',
@@ -103,7 +112,6 @@ test('npm view . with no published package', function (t) {
 })
 
 test('npm view .', function (t) {
-  process.chdir(t2dir)
   common.npm([
     'view',
     '.',
@@ -117,7 +125,6 @@ test('npm view .', function (t) {
 })
 
 test('npm view . select fields', function (t) {
-  process.chdir(t2dir)
   common.npm([
     'view',
     '.',
@@ -132,7 +139,6 @@ test('npm view . select fields', function (t) {
 })
 
 test('npm view .@<version>', function (t) {
-  process.chdir(t2dir)
   common.npm([
     'view',
     '.@0.0.0',
@@ -147,7 +153,6 @@ test('npm view .@<version>', function (t) {
 })
 
 test('npm view .@<version> version --json', function (t) {
-  process.chdir(t2dir)
   common.npm([
     'view',
     '.@0.0.0',
@@ -163,7 +168,6 @@ test('npm view .@<version> version --json', function (t) {
 })
 
 test('npm view . --json author name version', function (t) {
-  process.chdir(t2dir)
   common.npm([
     'view',
     '.',
@@ -186,7 +190,6 @@ test('npm view . --json author name version', function (t) {
 })
 
 test('npm view .@<version> --json author name version', function (t) {
-  process.chdir(t2dir)
   common.npm([
     'view',
     '.@0.0.0',
@@ -375,14 +378,4 @@ test('npm view with valid but non existent package name', function (t) {
 
     t.end()
   })
-})
-
-test('cleanup', function (t) {
-  process.chdir(osenv.tmpdir())
-  rimraf.sync(t1dir)
-  rimraf.sync(t2dir)
-  rimraf.sync(t3dir)
-  t.pass('cleaned up')
-  server.close()
-  t.end()
 })


### PR DESCRIPTION
1. Get rid of a lot of usage of `osenv.tmpdir` in tests.
2. Remove unnecessary creation/deletion of `common.pkg`
3. Reduce `rimraf.sync` wherever possible (often collides with `common-tap.js`'s rimraf on windows)
4. Use common test utilities wherever possible.
5. DRY tests with test templates where it makes sense.