### PR TITLE
docs(package-lock): Added package-lock resolved example

### DIFF
--- a/doc/spec/package-lock.md
+++ b/doc/spec/package-lock.md
@@ -75,6 +75,24 @@ this resource.
   URL.  If the tarball URL isn't on the same server as the registry URL then
   this is a complete URL.
 
+  eg, Given a `package-lock.json` file containing:
+
+  ```
+  "resolved": "https://registry.npmjs.org/example/-/example-1.0.0.tgz"
+  ```
+
+  and a registry source configuring a custom value:
+
+  ```
+  npm install --registry https://registry.example.com
+  ```
+
+  the package will be eventually fetched from the custom-defined registry:
+
+  ```
+  https://registry.example.com/example/-/example-1.0.0.tgz
+  ```
+
 #### link *(new)*
 
 If this module was symlinked in development but had semver in the

--- a/doc/spec/package-lock.md
+++ b/doc/spec/package-lock.md
@@ -87,7 +87,7 @@ this resource.
   npm install --registry https://registry.example.com
   ```
 
-  the package will be eventually fetched from the custom-defined registry:
+  the package will be fetched from the custom-defined registry:
 
   ```
   https://registry.example.com/example/-/example-1.0.0.tgz


### PR DESCRIPTION
## :pencil2: Changes
Added a concrete example on how the url from the `resolved` field of a `package-lock.json` file will be used along with the configured `registry` value in order to build the URL for that package.

## :link: References
See: https://github.com/npm/npm-registry-fetch/issues/7

