### PR TITLE
chore(ci): add dirPacker to options

### DIFF
--- a/lib/ci.js
+++ b/lib/ci.js
@@ -4,6 +4,7 @@ const npm = require('./npm.js')
 const Installer = require('libcipm')
 const log = require('npmlog')
 const path = require('path')
+const pack = require('./pack.js')
 
 ci.usage = 'npm ci'
 
@@ -27,7 +28,8 @@ function ci (args, cb) {
     fmode: npm.modes.file,
     umask: npm.modes.umask,
     npmVersion: npm.version,
-    tmp: npm.tmp
+    tmp: npm.tmp,
+    dirPacker: pack.packGitDep
   }
 
   for (const key in npm.config.list[0]) {

--- a/node_modules/npm-lifecycle/CHANGELOG.md
+++ b/node_modules/npm-lifecycle/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="3.1.4"></a>
+## [3.1.4](https://github.com/npm/lifecycle/compare/v3.1.3...v3.1.4) (2019-09-18)
+
+
+### Bug Fixes
+
+* filter functions and undefined out of makeEnv ([10c0c08](https://github.com/npm/lifecycle/commit/10c0c08))
+
+
+
 <a name="3.1.3"></a>
 ## [3.1.3](https://github.com/npm/lifecycle/compare/v3.1.2...v3.1.3) (2019-08-12)
 

--- a/node_modules/npm-lifecycle/index.js
+++ b/node_modules/npm-lifecycle/index.js
@@ -458,11 +458,16 @@ function makeEnv (data, opts, prefix, env) {
       return
     }
     var value = opts.config[i]
-    if (value instanceof Stream || Array.isArray(value)) return
+    if (value instanceof Stream || Array.isArray(value) || typeof value === 'function') return
     if (i.match(/umask/)) value = umask.toString(value)
+
     if (!value) value = ''
     else if (typeof value === 'number') value = '' + value
     else if (typeof value !== 'string') value = JSON.stringify(value)
+
+    if (typeof value !== 'string') {
+      return
+    }
 
     value = value.indexOf('\n') !== -1
       ? JSON.stringify(value)

--- a/node_modules/npm-lifecycle/package.json
+++ b/node_modules/npm-lifecycle/package.json
@@ -1,19 +1,19 @@
 {
-  "_from": "npm-lifecycle@3.1.3",
-  "_id": "npm-lifecycle@3.1.3",
+  "_from": "npm-lifecycle@3.1.4",
+  "_id": "npm-lifecycle@3.1.4",
   "_inBundle": false,
-  "_integrity": "sha512-M0QmmqbEHBXxDrmc6X3+eKjW9+F7Edg1ENau92WkYw1sox6wojHzEZJIRm1ItljEiaigZlKL8mXni/4ylAy1Dg==",
+  "_integrity": "sha512-tgs1PaucZwkxECGKhC/stbEgFyc3TGh2TJcg2CDr6jbvQRdteHNhmMeljRzpe4wgFAXQADoy1cSqqi7mtiAa5A==",
   "_location": "/npm-lifecycle",
   "_phantomChildren": {},
   "_requested": {
     "type": "version",
     "registry": true,
-    "raw": "npm-lifecycle@3.1.3",
+    "raw": "npm-lifecycle@3.1.4",
     "name": "npm-lifecycle",
     "escapedName": "npm-lifecycle",
-    "rawSpec": "3.1.3",
+    "rawSpec": "3.1.4",
     "saveSpec": null,
-    "fetchSpec": "3.1.3"
+    "fetchSpec": "3.1.4"
   },
   "_requiredBy": [
     "#USER",
@@ -21,10 +21,10 @@
     "/libcipm",
     "/libnpm"
   ],
-  "_resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-3.1.3.tgz",
-  "_shasum": "09e9b0b6686e85fd53bab82364386222d97a3730",
-  "_spec": "npm-lifecycle@3.1.3",
-  "_where": "/Users/isaacs/dev/npm/cli",
+  "_resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-3.1.4.tgz",
+  "_shasum": "de6975c7d8df65f5150db110b57cce498b0b604c",
+  "_spec": "npm-lifecycle@3.1.4",
+  "_where": "/Users/claudiahdz/npm/cli",
   "author": {
     "name": "Mike Sherov"
   },
@@ -82,5 +82,5 @@
     "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
     "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
   },
-  "version": "3.1.3"
+  "version": "3.1.4"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3780,9 +3780,9 @@
       "dev": true
     },
     "npm-lifecycle": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-3.1.3.tgz",
-      "integrity": "sha512-M0QmmqbEHBXxDrmc6X3+eKjW9+F7Edg1ENau92WkYw1sox6wojHzEZJIRm1ItljEiaigZlKL8mXni/4ylAy1Dg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-3.1.4.tgz",
+      "integrity": "sha512-tgs1PaucZwkxECGKhC/stbEgFyc3TGh2TJcg2CDr6jbvQRdteHNhmMeljRzpe4wgFAXQADoy1cSqqi7mtiAa5A==",
       "requires": {
         "byline": "^5.0.0",
         "graceful-fs": "^4.1.15",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "npm-audit-report": "^1.3.2",
     "npm-cache-filename": "~1.0.2",
     "npm-install-checks": "~3.0.0",
-    "npm-lifecycle": "^3.1.3",
+    "npm-lifecycle": "^3.1.4",
     "npm-package-arg": "^6.1.1",
     "npm-packlist": "^1.4.4",
     "npm-pick-manifest": "^3.0.2",


### PR DESCRIPTION
## :pencil2: Changes
Adds dirPacker option for correct file extraction when installing and updates npm-lifecycle library to avoid bugs on scripts options handling.

## :link: References
See: https://github.com/npm/libcipm/pull/4
Fixes: https://npm.community/t/npm-6-11-2-npm-ci-not-copying-prepared-files/9718