### PR TITLE
Windows: Add preliminary WSL support for npm and npx

### DIFF
--- a/bin/npm
+++ b/bin/npm
@@ -2,12 +2,16 @@
 (set -o igncr) 2>/dev/null && set -o igncr; # cygwin encoding fix
 
 basedir=`dirname "$0"`
+isexe=0
 
 case `uname` in
     *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
 esac
 
 NODE_EXE="$basedir/node.exe"
+if [ -x "$NODE_EXE" ]; then
+  isexe=1
+fi
 if ! [ -x "$NODE_EXE" ]; then
   NODE_EXE="$basedir/node"
 fi
@@ -33,5 +37,9 @@ case `uname` in
     fi
     ;;
 esac
+
+if [ isexe==1 ] && [ -f "/bin/wslpath" ]; then # normalize path back to Windows path
+  NPM_CLI_JS=`wslpath -w "$NPM_CLI_JS"`
+fi
 
 "$NODE_EXE" "$NPM_CLI_JS" "$@"

--- a/bin/npm
+++ b/bin/npm
@@ -38,8 +38,9 @@ case `uname` in
     ;;
 esac
 
-if [ isexe==1 ] && [ -f "/bin/wslpath" ]; then # normalize path back to Windows path
-  NPM_CLI_JS=`wslpath -w "$NPM_CLI_JS"`
+if [ isexe==1 ] && [ -f "/bin/wslpath" ]; then # run the corresponding command prompt when Node for Windows is executed within WSL
+  cmd.exe /c `wslpath -w "$basedir/npm.cmd"` "$@"
+  return
 fi
 
 "$NODE_EXE" "$NPM_CLI_JS" "$@"

--- a/bin/npm
+++ b/bin/npm
@@ -2,15 +2,15 @@
 (set -o igncr) 2>/dev/null && set -o igncr; # cygwin encoding fix
 
 basedir=`dirname "$0"`
-isexe=0
 
 case `uname` in
     *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
 esac
 
 NODE_EXE="$basedir/node.exe"
-if [ -x "$NODE_EXE" ]; then
-  isexe=1
+if [ -x "$NODE_EXE" ] && [ -f "/bin/wslpath" ]; then # run the corresponding command prompt when Node for Windows is executed within WSL
+  cmd.exe /c `wslpath -w "$basedir/npm.cmd"` "$@"
+  exit $?
 fi
 if ! [ -x "$NODE_EXE" ]; then
   NODE_EXE="$basedir/node"
@@ -37,10 +37,5 @@ case `uname` in
     fi
     ;;
 esac
-
-if [ isexe==1 ] && [ -f "/bin/wslpath" ]; then # run the corresponding command prompt when Node for Windows is executed within WSL
-  cmd.exe /c `wslpath -w "$basedir/npm.cmd"` "$@"
-  return
-fi
 
 "$NODE_EXE" "$NPM_CLI_JS" "$@"

--- a/bin/npx
+++ b/bin/npx
@@ -36,8 +36,9 @@ case `uname` in
     ;;
 esac
 
-if [ isexe==1 ] && [ -f "/bin/wslpath" ]; then # normalize path back to Windows path
-  NPX_CLI_JS=`wslpath -w "$NPX_CLI_JS"`
+if [ isexe==1 ] && [ -f "/bin/wslpath" ]; then # run the corresponding cmd instead
+  cmd.exe /c `wslpath -w "$basedir/npx.cmd"` "$@"
+  return
 fi
 
 "$NODE_EXE" "$NPX_CLI_JS" "$@"

--- a/bin/npx
+++ b/bin/npx
@@ -2,15 +2,15 @@
 (set -o igncr) 2>/dev/null && set -o igncr; # cygwin encoding fix
 
 basedir=`dirname "$0"`
-isexe=0
 
 case `uname` in
     *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
 esac
 
 NODE_EXE="$basedir/node.exe"
-if [ -x "$NODE_EXE" ]; then
-  isexe=1
+if [ -x "$NODE_EXE" ] && [ -f "/bin/wslpath" ]; then # run the corresponding command prompt when Node for Windows is executed within WSL
+  cmd.exe /c `wslpath -w "$basedir/npx.cmd"` "$@"
+  exit $?
 fi
 if ! [ -x "$NODE_EXE" ]; then
   NODE_EXE=node
@@ -35,10 +35,5 @@ case `uname` in
     fi
     ;;
 esac
-
-if [ isexe==1 ] && [ -f "/bin/wslpath" ]; then # run the corresponding cmd instead
-  cmd.exe /c `wslpath -w "$basedir/npx.cmd"` "$@"
-  return
-fi
 
 "$NODE_EXE" "$NPX_CLI_JS" "$@"

--- a/bin/npx
+++ b/bin/npx
@@ -2,12 +2,16 @@
 (set -o igncr) 2>/dev/null && set -o igncr; # cygwin encoding fix
 
 basedir=`dirname "$0"`
+isexe=0
 
 case `uname` in
     *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
 esac
 
 NODE_EXE="$basedir/node.exe"
+if [ -x "$NODE_EXE" ]; then
+  isexe=1
+fi
 if ! [ -x "$NODE_EXE" ]; then
   NODE_EXE=node
 fi
@@ -31,5 +35,9 @@ case `uname` in
     fi
     ;;
 esac
+
+if [ isexe==1 ] && [ -f "/bin/wslpath" ]; then # normalize path back to Windows path
+  NPM_CLI_JS=`wslpath -w "$NPM_CLI_JS"`
+fi
 
 "$NODE_EXE" "$NPX_CLI_JS" "$@"

--- a/bin/npx
+++ b/bin/npx
@@ -37,7 +37,7 @@ case `uname` in
 esac
 
 if [ isexe==1 ] && [ -f "/bin/wslpath" ]; then # normalize path back to Windows path
-  NPM_CLI_JS=`wslpath -w "$NPM_CLI_JS"`
+  NPX_CLI_JS=`wslpath -w "$NPX_CLI_JS"`
 fi
 
 "$NODE_EXE" "$NPX_CLI_JS" "$@"


### PR DESCRIPTION
This pull request would make it possible to run `npm` and `npx` installed with Node on Windows within Windows Subsystem for Linux.

It is required, however, that the end of line characters of `npm` and `npx` be `\n` for the fix to take effect, which might be worth a separate issue or pull request.