### PR TITLE
Fix figgyPudding error in `npm token`

### DIFF
--- a/lib/token.js
+++ b/lib/token.js
@@ -118,9 +118,10 @@ function config () {
     })
   } else {
     conf = conf.concat({ auth: {} })
-    conf.auth = {}
   }
-  if (conf.otp) conf.auth.otp = conf.otp
+  if (conf.otp) {
+    conf = conf.concat({ auth: { otp: conf.otp } })
+  }
   return conf
 }
 


### PR DESCRIPTION
It seems that a couple of lines were missed when token.js was [changed to use figgyPudding](https://github.com/npm/cli/commit/4cf850d2be118abce72b3cf533f13512e9844ad1#diff-398ed3b014436a5204583323ea29320b), which [causes an error](https://npm.community/t/npm-token-err-figgypudding-options-cannot-be-modified-use-concat-instead/10288) when trying to run that command in certain circumstances.  This patch fixes that error.

Tested locally by applying the patch to npm 6.11.3.