### PR TITLE
Travis CI: The sudo: tag is deprecated in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: true
 # need to declare the language as well as the matrix below
 language: node_js
 


### PR DESCRIPTION
__sudo: required__ no longer is.