### PR TITLE
fix root-ownership race conditions in meta-test

### DIFF
--- a/test/tap/meta-test-flaky-root-ownership-test.js
+++ b/test/tap/meta-test-flaky-root-ownership-test.js
@@ -1,0 +1,20 @@
+const t = require('tap')
+if (!process.getuid || process.getuid() !== 0 || !process.env.SUDO_UID || !process.env.SUDO_GID) {
+  t.pass('this test only runs in sudo mode')
+  t.end()
+  process.exit(0)
+}
+
+const common = require('../common-tap.js')
+const fs = require('fs')
+const mkdirp = require('mkdirp')
+mkdirp.sync(common.cache + '/root/owned')
+fs.writeFileSync(common.cache + '/root/owned/file.txt', 'should be chowned')
+const chown = require('chownr')
+
+// this will fire after t.teardown() but before process.on('exit')
+setTimeout(() => {
+  chown.sync(common.cache, +process.env.SUDO_UID, +process.env.SUDO_GID)
+}, 100)
+
+t.pass('this is fine')


### PR DESCRIPTION
Currently all of our tests verify on teardown that there are no
root-owned files in the cache.

However, owing to some race conditions and slippery stream event
deferral behavior that won't be fixed until v7, occasionally cacache's
chown doesn't get processed until _after_ the promise resolves and the
test ends.

As a result, sometimes this check occurs before the chown has happened,
resulting in flaky hard-to-reproduce failures.

The somewhat-kludgey solution here is to move the ownership check from
t.teardown to process.on('exit').  In npm v7, we should move it back to
t.teardown, because we should never have a test that resolves in such a
way as to leave the cache in an invalid state.