### PR TITLE
npm version --no-git-tag-version --verbose should not log git error

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -256,7 +256,7 @@ function checkGit (localData, cb) {
   statGitFolder(function (er) {
     var doGit = !er && npm.config.get('git-tag-version')
     if (!doGit) {
-      if (er) log.verbose('version', 'error checking for .git', er)
+      if (er && npm.config.get('git-tag-version')) log.verbose('version', 'error checking for .git', er)
       log.verbose('version', 'not tagging in git')
       return cb(null, false)
     }


### PR DESCRIPTION
When npm version is run with both the `--no-git-tag-version` and `--verbose` flags, it logs an error if it cannot find a `.git` folder in the current folder. This error is very annoying for our automated build tooling and seems not relevant in the case that I don't want to update git.

Example of the error:
```
npm verb version Error: ENOENT: no such file or directory, stat 'C:\some-git-repo\dist\some-folder\.git'
npm verb version  error checking for .git { [Error: ENOENT: no such file or directory, stat 'C:\some-git-repo\dist\some-folder\.git']
npm verb version   stack:
npm verb version    'Error: ENOENT: no such file or directory, stat \'C:\\some-git-repo\\dist\\some-folder\\.git\'',
npm verb version   errno: -4058,
npm verb version   code: 'ENOENT',
npm verb version   syscall: 'stat',
npm verb version   path: 'C:\\some-git-repo\\dist\\some-folder\\.git' }
npm verb version not tagging in git
```

Expected output:
```
npm verb version not tagging in git
``` 

This PR just prevents the error from being logged. Of course another option would be to skip the statGitFolder altogether...