### PR TITLE
Fix regression in lockfile repair for sub-dependencies

### DIFF
--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -141,6 +141,7 @@ function isGit (sw) {
 }
 
 function makeFakeChild (name, topPath, tree, sw, requested) {
+  const isDirectory = requested.type === 'directory'
   const from = sw.from || requested.raw
   const pkg = {
     name: name,
@@ -167,16 +168,16 @@ function makeFakeChild (name, topPath, tree, sw, requested) {
   }
   const child = createChild({
     package: pkg,
-    loaded: true,
+    loaded: isDirectory,
     parent: tree,
     children: [],
     fromShrinkwrap: requested,
     fakeChild: sw,
     fromBundle: sw.bundled ? tree.fromBundle || tree : null,
     path: childPath(tree.path, pkg),
-    realpath: requested.type === 'directory' ? requested.fetchSpec : childPath(tree.realpath, pkg),
+    realpath: isDirectory ? requested.fetchSpec : childPath(tree.realpath, pkg),
     location: (tree.location === '/' ? '' : tree.location + '/') + pkg.name,
-    isLink: requested.type === 'directory',
+    isLink: isDirectory,
     isInLink: tree.isLink || tree.isInLink,
     swRequires: sw.requires
   })

--- a/test/tap/install-test-cli-with-broken-package-lock.js
+++ b/test/tap/install-test-cli-with-broken-package-lock.js
@@ -1,0 +1,118 @@
+var fs = require('graceful-fs')
+var path = require('path')
+
+var mkdirp = require('mkdirp')
+var osenv = require('osenv')
+var rimraf = require('rimraf')
+var test = require('tap').test
+
+var common = require('../common-tap.js')
+
+var pkg = common.pkg
+
+var EXEC_OPTS = { cwd: pkg }
+
+var json = {
+  name: 'install-test-cli-with-broken-package-lock',
+  description: 'fixture',
+  version: '0.0.0',
+  dependencies: {
+    optimist: '0.6.0'
+  }
+}
+
+var brokenLockfile = {
+  name: 'install-test-cli-with-broken-package-lock',
+  version: '0.0.0',
+  lockfileVersion: 1,
+  requires: true,
+  dependencies: {
+    optimist: {
+      version: '0.6.0',
+      resolved: 'https://registry.npmjs.org/optimist/-/optimist-0.6.0.tgz',
+      integrity: 'sha1-aUJIJvNAX3nxQub8PZrljU27kgA=',
+      requires: {
+        minimist: '~0.0.1',
+        wordwrap: '~0.0.2'
+      }
+    },
+    wordwrap: {
+      version: '0.0.3',
+      resolved: 'https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz',
+      integrity: 'sha1-o9XabNXAvAAI03I0u68b7WMFkQc='
+    }
+  }
+}
+
+var expected = {
+  name: 'install-test-cli-with-broken-package-lock',
+  version: '0.0.0',
+  lockfileVersion: 1,
+  requires: true,
+  dependencies: {
+    minimist: {
+      version: '0.0.10',
+      resolved: 'https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz',
+      integrity: 'sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8='
+    },
+    optimist: {
+      version: '0.6.0',
+      resolved: 'https://registry.npmjs.org/optimist/-/optimist-0.6.0.tgz',
+      integrity: 'sha1-aUJIJvNAX3nxQub8PZrljU27kgA=',
+      requires: {
+        minimist: '~0.0.1',
+        wordwrap: '~0.0.2'
+      }
+    },
+    wordwrap: {
+      version: '0.0.3',
+      resolved: 'https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz',
+      integrity: 'sha1-o9XabNXAvAAI03I0u68b7WMFkQc='
+    }
+  }
+}
+
+test('setup', function (t) {
+  setup()
+  t.end()
+})
+
+test('\'npm install-test\' should repair package-lock.json', function (t) {
+  common.npm(['install-test'], EXEC_OPTS, function (err, code, stderr, stdout) {
+    if (err) throw err
+    t.comment(stdout.trim())
+    t.comment(stderr.trim())
+    t.is(code, 0, 'npm install did not raise error code')
+    var lockfile = JSON.parse(fs.readFileSync(path.join(pkg, 'package-lock.json')))
+    t.same(
+      lockfile,
+      expected,
+      'package-lock.json should be repaired'
+    )
+    t.end()
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.end()
+})
+
+function setup () {
+  cleanup()
+  mkdirp.sync(pkg)
+  fs.writeFileSync(
+    path.join(pkg, 'package.json'),
+    JSON.stringify(json, null, 2)
+  )
+  fs.writeFileSync(
+    path.join(pkg, 'package-lock.json'),
+    JSON.stringify(brokenLockfile, null, 2)
+  )
+  process.chdir(pkg)
+}
+
+function cleanup () {
+  process.chdir(osenv.tmpdir())
+  rimraf.sync(pkg)
+}


### PR DESCRIPTION
This fixes a regression where lockfiles with missing sub-dependencies
are no longer repaired. The regression was introduced in this commit:
1fafb51513466cd793866b576dfea9a8963a3335 which in turn was bringing back
the change from this commit 24acc9fc89d99d87cc66206c6c6f7cdc82fbf763.

Changing `loaded` has caused a lot of churn so not sure if this will cause further regressions, but looks like each regression was tested.

I also couldn't get the mock registry to work as the test would just hang indefinitely when trying to initialise it with `mr({ port: common.port }, function (er, s) {...`. Would love any help refactoring the current tests to use the mock registry/how to set it up locally.