### PR TITLE
fix: resolve circular dependency in pack.js

### DIFF
--- a/lib/pack.js
+++ b/lib/pack.js
@@ -4,6 +4,9 @@
 // Packs the specified package into a .tgz file, which can then
 // be installed.
 
+// Set this early to avoid issues with circular dependencies.
+module.exports = pack
+
 const BB = require('bluebird')
 
 const byteSize = require('byte-size')
@@ -37,7 +40,6 @@ pack.usage = 'npm pack [[<@scope>/]<pkg>...] [--dry-run]'
 // if it can be installed, it can be packed.
 pack.completion = install.completion
 
-module.exports = pack
 function pack (args, silent, cb) {
   const cwd = process.cwd()
   if (typeof cb !== 'function') {


### PR DESCRIPTION
`lib/pack.js` and `lib/config/figgy-config.js` load each other,
making `figgy-config.js` grab the original `module.exports` value
and not the intended one. In particular, this always sets the
`dirPacker` value to `undefined` in the config generation step.

Fix this by setting `module.exports` early.

Refs: https://github.com/nodejs/node/pull/29935