### PR TITLE
Fix error message for npm cache clean

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -65,7 +65,7 @@ cache.clean = clean
 function clean (args) {
   if (!args) args = []
   if (args.length) {
-    return BB.reject(new Error('npm cache clear does not accept arguments'))
+    return BB.reject(new Error('npm cache clean does not accept arguments'))
   }
   const cachePath = path.join(npm.cache, '_cacache')
   if (!npm.config.get('force')) {


### PR DESCRIPTION
This fixes an error message that erronously tells
the user that npm cache clear accepts no arguments
when the actual command is npm cache clean.