### PR TITLE
unsupported: add node v13

### DIFF
--- a/lib/utils/unsupported.js
+++ b/lib/utils/unsupported.js
@@ -6,7 +6,8 @@ var supportedNode = [
   {ver: '9', min: '9.0.0'},
   {ver: '10', min: '10.0.0'},
   {ver: '11', min: '11.0.0'},
-  {ver: '12', min: '12.0.0'}
+  {ver: '12', min: '12.0.0'},
+  {ver: '13', min: '13.0.0'}
 ]
 var knownBroken = '<6.0.0'
 


### PR DESCRIPTION
# What / Why
npm in node 13 says node 13 is unsupported.

I'll update npm in node after this is released; hopefully ASAP as node 13 released today.