### PR TITLE
update npm init usage

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -17,7 +17,8 @@ init.usage = usage(
   'init',
   '\nnpm init [--force|-f|--yes|-y|--scope]' +
   '\nnpm init <@scope> (same as `npx <@scope>/create`)' +
-  '\nnpm init [<@scope>/]<name> (same as `npx [<@scope>/]create-<name>`)'
+  '\nnpm init [<@scope>/]<name> (same as `npx [<@scope>/]create-<name>`)' +
+  '\nnpm init <initializer>'
 )
 
 function init (args, cb) {


### PR DESCRIPTION
# What / Why

> Did not see support for initializer in `npm -h`

## References

* n/a
