### PR TITLE
docs(npm-scripts): highlight scripts in list

### DIFF
--- a/doc/misc/npm-scripts.md
+++ b/doc/misc/npm-scripts.md
@@ -6,47 +6,47 @@ npm-scripts(7) -- How npm handles the "scripts" field
 npm supports the "scripts" property of the package.json file, for the
 following scripts:
 
-* prepublish:
+* **prepublish**:
   Run BEFORE the package is packed and published, as well as on local `npm
   install` without any arguments. (See below)
-* prepare:
+* **prepare**:
   Run both BEFORE the package is packed and published, on local `npm
   install` without any arguments, and when installing git dependencies (See
   below). This is run AFTER `prepublish`, but BEFORE `prepublishOnly`.
-* prepublishOnly:
+* **prepublishOnly**:
   Run BEFORE the package is prepared and packed, ONLY on `npm publish`. (See
   below.)
-* prepack:
+* **prepack**:
   run BEFORE a tarball is packed (on `npm pack`, `npm publish`, and when
   installing git dependencies)
-* postpack:
+* **postpack**:
   Run AFTER the tarball has been generated and moved to its final destination.
-* publish, postpublish:
+* **publish**, **postpublish**:
   Run AFTER the package is published.
-* preinstall:
+* **preinstall**:
   Run BEFORE the package is installed
-* install, postinstall:
+* **install**, **postinstall**:
   Run AFTER the package is installed.
-* preuninstall, uninstall:
+* **preuninstall**, **uninstall**:
   Run BEFORE the package is uninstalled.
-* postuninstall:
+* **postuninstall**:
   Run AFTER the package is uninstalled.
-* preversion:
+* **preversion**:
   Run BEFORE bumping the package version.
-* version:
+* **version**:
   Run AFTER bumping the package version, but BEFORE commit.
-* postversion:
+* **postversion**:
   Run AFTER bumping the package version, and AFTER commit.
-* pretest, test, posttest:
+* **pretest**, **test**, **posttest**:
   Run by the `npm test` command.
-* prestop, stop, poststop:
+* **prestop**, **stop**, **poststop**:
   Run by the `npm stop` command.
-* prestart, start, poststart:
+* **prestart**, **start**, **poststart**:
   Run by the `npm start` command.
-* prerestart, restart, postrestart:
+* **prerestart**, **restart**, **postrestart**:
   Run by the `npm restart` command. Note: `npm restart` will run the
   stop and start scripts if no `restart` script is provided.
-* preshrinkwrap, shrinkwrap, postshrinkwrap:
+* **preshrinkwrap**, **shrinkwrap**, **postshrinkwrap**:
   Run by the `npm shrinkwrap` command.
 
 Additionally, arbitrary scripts can be executed by running `npm


### PR DESCRIPTION
# What / Why

Reading [the docs](https://docs.npmjs.com/misc/scripts) I noticed that I have problems to mentally absorb the content because the mentioned scripts are not highlighted an so visually blend in to the surrounding text. This is not only a rendering issue because there is no syntax in the markdown to highlight this "sub-headers". I choose to use "bold" here other options would be "italic" or headings. I choose to use "bold".

This might be a useful change, especially for people with a reading-comprehension disability.

## References

The "problematic" change was introduced with 3ef3ff05d0bdc515b9624e4a9c9d1801b6aaf6b6