### PR TITLE
Use Actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    - name: Run sudo tests on Linux
-      if: matrix.os == 'ubuntu-latest'
-      run: sudo PATH=$PATH $(which node) . run tap -- "test/tap/*.js" --coverage  --timeout 600
+    # - name: Run sudo tests on Linux
+    #   if: matrix.os == 'ubuntu-latest'
+    #   run: sudo PATH=$PATH $(which node) . run tap -- "test/tap/*.js" --coverage  --timeout 600
 
       # Run the installer script
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: Node CI
+
+on: [push]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x]
+        os: [ubuntu-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      # Checkout the npm/cli repo
+    - uses: actions/checkout@v1
+
+      # Installs the specific version of Node.js
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+      # Run the installer script
+    - run: node . install
+
+      # Run the tests
+    - run: node . run tap -- \"test/tap/*.js\" -t600 -Rclassic -c
+      env:
+        DEPLOY_VERSION: testing
+        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_OPTIONAL_TOKEN }}
+
+      # Run the linter
+    - run: npx standard
+
+      # Validate licenses
+    - run: node . run licenses

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,9 @@ jobs:
         DEPLOY_VERSION: testing
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_OPTIONAL_TOKEN }}
 
-    - name: Run sudo tests on Linux
-      if: matrix.os == 'ubuntu-latest'
-      run: sudo PATH=$PATH $(which node) . run tap -- "test/tap/*.js" --coverage  --timeout 600
+    # - name: Run sudo tests on Linux
+    #   if: matrix.os == 'ubuntu-latest'
+    #   run: sudo PATH=$PATH $(which node) . run tap -- "test/tap/*.js" --coverage  --timeout 600
 
     - name: Lint
       run: npx standard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    # - name: Run sudo tests on Linux
-    #   if: matrix.os == 'ubuntu-latest'
-    #   run: sudo PATH=$PATH $(which node) . run tap -- "test/tap/*.js" --coverage  --timeout 600
-
       # Run the installer script
     - name: Install dependencies
       run: node . install
@@ -35,6 +31,10 @@ jobs:
       env:
         DEPLOY_VERSION: testing
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_OPTIONAL_TOKEN }}
+
+    - name: Run sudo tests on Linux
+      if: matrix.os == 'ubuntu-latest'
+      run: sudo PATH=$PATH $(which node) . run tap -- "test/tap/*.js" --coverage  --timeout 600
 
     - name: Lint
       run: npx standard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
         node-version: ${{ matrix.node-version }}
 
     - name: Run sudo tests on Linux
-      if: ${{ matrix.os }} === ubuntu-latest
-      run: sudo PATH=$PATH $(which node) . run tap -- \"test/tap/*.js\" --coverage  --timeout 600
+      if: matrix.os === "ubuntu-latest"
+      run: sudo PATH=$PATH $(which node) . run tap -- "test/tap/*.js" --coverage  --timeout 600
 
       # Run the installer script
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,17 +21,23 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
+    - name: Run sudo tests on Linux
+      if: ${{ matrix.os }} === ubuntu-latest
+      run: sudo PATH=$PATH $(which node) . run tap -- \"test/tap/*.js\" --coverage  --timeout 600
+
       # Run the installer script
-    - run: node . install
+    - name: Install dependencies
+      run: node . install
 
       # Run the tests
-    - run: node . run tap -- \"test/tap/*.js\" -t600 -Rclassic -c
+    - name: Run Tap tests
+      run: node . run tap -- "test/tap/*.js" -t600 -Rclassic -c
       env:
         DEPLOY_VERSION: testing
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_OPTIONAL_TOKEN }}
 
-      # Run the linter
-    - run: npx standard
+    - name: Lint
+      run: npx standard
 
-      # Validate licenses
-    - run: node . run licenses
+    - name: Validate licenses
+      run: node . run licenses

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
 
     - name: Run sudo tests on Linux
-      if: matrix.os === "ubuntu-latest"
+      if: matrix.os == 'ubuntu-latest'
       run: sudo PATH=$PATH $(which node) . run tap -- "test/tap/*.js" --coverage  --timeout 600
 
       # Run the installer script


### PR DESCRIPTION
# What / Why

Hello! I was chatting with @mikemimik about using Actions for CI, so here's a spike for it. I've done my best to convert the `.travis.yml` file over to a GitHub Actions' `.github/workflows/ci.yml` file.

For the most part I was able to directly map everything that was being done in Travis except the Slack notification. If that's a blocker, we could perhaps create a separate Actions => Slack action that works with the id like Travis.

As for why - I saw that a Travis build was pending for around 40 minutes. That's my whole reasoning 😁 ~You can take a look at the timings here in this PR~ Actions won't show the statuses on this PR because they ran on my fork - you can 👀 them here: https://github.com/JasonEtco/cli/actions.

This workflow runs the full test suite against Node 8,10 and 12, and against Linux (`ubuntu-latest`) and Windows.

The Travis and Appveyor files can be removed, but I figured y'all can try this out before removing the others if you decide you want to.

Let me know if I can clarify anything 👍 