### PR TITLE
Feature/benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,49 @@
+---
+name: Benchmark Suite
+
+on:
+  push:
+    branches:
+      - "latest"
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  build:
+    name: Trigger Benchmarks
+
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the npm/cli repo
+      - uses: actions/checkout@v1.1.0
+
+      # Installs the specific version of nodejs
+      - name: Use nodejs 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+
+      # Trigger Webhook
+      - name: Trigger Webhook
+        env:
+          DISPATCH_REPO: "benchmarks"
+          DISPATCH_OWNER: "npm"
+        run: |
+          curl \
+            -s \
+            -X POST https://api.github.com/repos/${DISPATCH_OWNER}/${DISPATCH_REPO}/dispatches \
+            -H "Accept: application/vnd.github.everest-preview+json" \
+            -H "Authorization: token ${{ secrets.NPM_DEPLOY_USER_PAT }}" \
+            -d \
+            '
+            {
+              "event_type": "${{ github.event_name }}",
+              "client_payload": {
+                "pr_id": "${{ github.event.pull_request.number }}",
+                "repo": "${{ github.event.repository.name }}",
+                "owner": "${{ github.event.repository.owner.login }}",
+                "commit_sha": "${{ github.event.after }}"
+              }
+            }'


### PR DESCRIPTION
# What / Why
<!-- Describe the request in detail -->
We want benchmarking to run on the current state of the repo. This is done by sending a dispatch event to the https://github.com/npm/benchmark repository. It has a set of actions which will run all the benchmarked scenarios and then report back to the pull-request with some results. Those results are specifically from the `ubuntu-latest`/`node@12.x` matrix run.

## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->
* Epic: https://github.com/npm/statusboard/issues/3
