### PR TITLE
unsupported: npm v6.10.0 breaks on node v6.0, v6.1, v9.0 - v9.2

### DIFF
--- a/lib/utils/unsupported.js
+++ b/lib/utils/unsupported.js
@@ -9,7 +9,7 @@ var supportedNode = [
   {ver: '12', min: '12.0.0'},
   {ver: '13', min: '13.0.0'}
 ]
-var knownBroken = '<6.0.0'
+var knownBroken = '<6.2.0 || 9.0 - 9.2'
 
 var checkVersion = exports.checkVersion = function (version) {
   var versionNoPrerelease = version.replace(/-.*$/, '')


### PR DESCRIPTION
https://github.com/nvm-sh/nvm/commit/100861d529d26a4022ee4ac6dc5d8df86a3a6f65

npm v6.10 caused npm to no longer work on node v6.0, v6.1, v9.0, v9.1, and v9.2.

This PR isn't to debate semver adherence, though, I just want to update the "unsupported" logic to be correct :-)

I'd also like to update the `supportedNode` list, but it'd need a "max" to be supported, or instead of "min" a semver range, and that seemed like a bigger change.