### PR TITLE
fix: on uninstall package, *.ps1 not delete

### DIFF
--- a/lib/unbuild.js
+++ b/lib/unbuild.js
@@ -78,8 +78,11 @@ function rmBins (pkg, folder, parent, top, cb) {
   const binRoot = top ? npm.bin : path.resolve(parent, '.bin')
   asyncMap(Object.keys(pkg.bin), function (b, cb) {
     if (process.platform === 'win32') {
-      chain([ [gentlyRm, path.resolve(binRoot, b) + '.cmd', true, folder],
-        [gentlyRm, path.resolve(binRoot, b), true, folder] ], cb)
+      chain([
+        [gentlyRm, path.resolve(binRoot, b) + '.ps1', true, folder],
+        [gentlyRm, path.resolve(binRoot, b) + '.cmd', true, folder],
+        [gentlyRm, path.resolve(binRoot, b), true, folder]
+      ], cb)
     } else {
       gentlyRm(path.resolve(binRoot, b), true, folder, cb)
     }


### PR DESCRIPTION
On npm@6.11.0 and cmd-shim@3.0.0, add proper support for PowerShell.
but when uninstall package, npm not delete it(*.ps1)
this PR fix it

#### why test failed or not run
Because read-cmd-shim not supper extract path from powershell files
I create a PR to fix this issue, but there is currently not merge
Please see the PR https://github.com/npm/read-cmd-shim/pull/6