### PR TITLE
Support "collective" property as fallback fo "funding"

### DIFF
--- a/lib/utils/funding.js
+++ b/lib/utils/funding.js
@@ -70,7 +70,8 @@ function getFundingInfo (idealTree, opts) {
     // within top levels takes precedence over nested ones
     return (Object.keys(deps)).map((key) => {
       const dep = deps[key]
-      const { name, funding, version } = dep
+      const { name, version } = dep
+      const funding = dep.funding || dep.collective;
 
       const fundingItem = {}
 


### PR DESCRIPTION
Following up on a comment I shared here: https://github.com/npm/cli/pull/273#pullrequestreview-311628205

There are many packages using the `collective` property today to expose their Open Collective URL. Would be great to support that when `funding` is not found. While we wait for maintainers to add it. 

The syntax of `collective` is similar to the one of `funding`, making the implementation uncomplicated.

It's also nice that this allow anyone to test the new `npm fund` feature and see results today, while in the current state it's giving (at least for me) only empty results for all the projects I tested.