### PR TITLE
test: fix git configs for git 2.23 and above

### DIFF
--- a/test/common-tap.js
+++ b/test/common-tap.js
@@ -193,7 +193,8 @@ exports.makeGitRepo = function (params, cb) {
     git.chainableExec(['config', 'user.name', user], opts),
     git.chainableExec(['config', 'user.email', email], opts),
     // don't time out tests waiting for a gpg passphrase or 2fa
-    git.chainableExec(['config', 'commit.gpgsign', 'false'], opts),
+    git.chainableExec(['config', 'commit.gpgSign', 'false'], opts),
+    git.chainableExec(['config', 'tag.gpgSign', 'false'], opts),
     git.chainableExec(['config', 'tag.forceSignAnnotated', 'false'], opts),
     git.chainableExec(['add'].concat(added), opts),
     git.chainableExec(['commit', '-m', message], opts)


### PR DESCRIPTION
Config values are now case-sensitive, so `commit.gpgsign=false` was
doing nothing.

# What / Why
<!-- Describe the request in detail -->
> n/a

## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->
* n/a
