### PR TITLE
feat: adding tests and updating docs to reflect changes in registry teams API. The default developers team can no longer be removed

### DIFF
--- a/docs/content/cli-commands/npm-team.md
+++ b/docs/content/cli-commands/npm-team.md
@@ -29,12 +29,11 @@ handle permissions for packages.
 
 Teams must always be fully qualified with the organization/scope they belong to
 when operating on them, separated by a colon (`:`). That is, if you have a
-`developers` team on a `foo` organization, you must always refer to that team as
-`foo:developers` in these commands.
+`wombats` team in a `wisdom` organization, you must always refer to that team as
+`wisdom:wombats` in these commands.
 
 * create / destroy:
-  Create a new team, or destroy an existing one.
-
+  Create a new team, or destroy an existing one. Note: You cannot remove the `developers` team, <a href="https://docs.npmjs.com/about-developers-team" target="_blank">learn more.</a>
 * add / rm:
   Add a user to an existing team, or remove a user from a team they belong to.
 

--- a/test/tap/team.js
+++ b/test/tap/team.js
@@ -88,6 +88,29 @@ test('team destroy', function (t) {
   })
 })
 
+test('team destroy is not allowed for the default developers team', (t) => {
+  const teamData = {
+    name: 'developers',
+    scope_id: 1234,
+    created: '2015-07-23T18:07:49.959Z',
+    updated: '2015-07-23T18:07:49.959Z',
+    deleted: '2015-07-23T18:27:27.178Z'
+  }
+  server.delete('/-/team/myorg/' + teamData.name).reply(405, teamData)
+  common.npm([
+    'team', 'destroy', 'myorg:' + teamData.name,
+    '--registry', common.registry,
+    '--loglevel', 'silent',
+    '--json'
+  ], {}, function (err, code, stdout, stderr) {
+    t.ifError(err, 'npm team')
+    t.equal(code, 1, 'exited with code 1')
+    t.equal(stderr, '', 'no error output')
+    t.match(JSON.parse(stdout), {error: {code: 'E405'}})
+    t.end()
+  })
+})
+
 test('team add', function (t) {
   var user = 'zkat'
   server.put('/-/team/myorg/myteam/user', JSON.stringify({


### PR DESCRIPTION
# What / Why
The registry teams API has been updated to no longer allow the removal of the default developers team. This is PR updates the docs page for the `npm teams` cmd and also adds a test to document the expected behavior and HTTP response. 

## References
* n/a
