### PR TITLE
docs: fix gatsby's `pathPrefix`

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  pathPrefix: `${__dirname}/public`,
+  pathPrefix: './public',
   siteMetadata: {
     title: 'npm cli documentation',
     description: 'Documentation for the npm cli.',


### PR DESCRIPTION
It needs to be a relative path.

# What / Why
<!-- Describe the request in detail -->
> n/a

## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->
* n/a
