### PR TITLE
fix(fund): support funding string shorthand

### DIFF
--- a/lib/utils/funding.js
+++ b/lib/utils/funding.js
@@ -8,12 +8,10 @@ exports.validFundingUrl = validFundingUrl
 // Is the value of a `funding` property of a `package.json`
 // a valid type+url for `npm fund` to display?
 function validFundingUrl (funding) {
-  if (!funding || !funding.url) {
-    return false
-  }
+  if (!funding) return false
 
   try {
-    var parsed = new URL(funding.url)
+    var parsed = new URL(funding.url || funding)
   } catch (error) {
     return false
   }
@@ -62,6 +60,14 @@ function getFundingInfo (idealTree, opts) {
     )
   }
 
+  function retrieveFunding (funding) {
+    return typeof funding === 'string'
+      ? {
+        url: funding
+      }
+      : funding
+  }
+
   function getFundingDependencies (tree) {
     const deps = tree && tree.dependencies
     if (!deps) return empty()
@@ -82,7 +88,7 @@ function getFundingInfo (idealTree, opts) {
       }
 
       if (funding && validFundingUrl(funding)) {
-        fundingItem.funding = funding
+        fundingItem.funding = retrieveFunding(funding)
         length++
       }
 
@@ -134,7 +140,7 @@ function getFundingInfo (idealTree, opts) {
     }
 
     if (idealTree && idealTree.funding) {
-      result.funding = idealTree.funding
+      result.funding = retrieveFunding(idealTree.funding)
     }
 
     result.dependencies =

--- a/test/tap/fund.js
+++ b/test/tap/fund.js
@@ -92,9 +92,7 @@ const fixture = new Tacks(Dir({
             node_modules: Dir({
               'sub-bar': getFixturePackage({
                 name: 'sub-bar',
-                funding: {
-                  url: 'https://example.com/sponsor'
-                }
+                funding: 'https://example.com/sponsor'
               })
             })
           })

--- a/test/tap/utils.funding.js
+++ b/test/tap/utils.funding.js
@@ -35,6 +35,28 @@ test('single item missing funding', (t) => {
   t.end()
 })
 
+test('funding object missing url', (t) => {
+  t.deepEqual(
+    getFundingInfo({ name: 'project',
+      dependencies: {
+        'single-item': {
+          name: 'single-item',
+          version: '1.0.0',
+          funding: {
+            type: 'Foo'
+          }
+        }
+      }}),
+    {
+      name: 'project',
+      dependencies: {},
+      length: 0
+    },
+    'should return empty list'
+  )
+  t.end()
+})
+
 test('use path if name is missing', (t) => {
   t.deepEqual(
     getFundingInfo({ name: undefined,
@@ -82,6 +104,51 @@ test('single item tree', (t) => {
       length: 1
     },
     'should return list with a single item'
+  )
+  t.end()
+})
+
+test('top-level funding info', (t) => {
+  t.deepEqual(
+    getFundingInfo({ name: 'project',
+      funding: 'http://example.com'
+    }),
+    {
+      name: 'project',
+      funding: {
+        url: 'http://example.com'
+      },
+      dependencies: {},
+      length: 0
+    },
+    'should return top-level item with normalized funding info'
+  )
+  t.end()
+})
+
+test('use string shorthand', (t) => {
+  t.deepEqual(
+    getFundingInfo({ name: 'project',
+      dependencies: {
+        'single-item': {
+          name: 'single-item',
+          version: '1.0.0',
+          funding: 'http://example.com'
+        }
+      }}),
+    {
+      name: 'project',
+      dependencies: {
+        'single-item': {
+          version: '1.0.0',
+          funding: {
+            url: 'http://example.com'
+          }
+        }
+      },
+      length: 1
+    },
+    'should return item with normalized funding info'
   )
   t.end()
 })


### PR DESCRIPTION
## Overview

In the approved RFC it was documented that `npm fund` should also support a shorthand version of the `funding` property using only a string instead of an object.

## :pencil2: Changes
- Fixes `funding` behavior to normalize a string argument into valid info
- Add tests to make sure everything works as expected


## :link: References
- Approved RFC: https://github.com/npm/rfcs/blob/2d2f00457ab19b3003eb6ac5ab3d250259fd5a81/accepted/0017-add-funding-support.md
- User land request: https://github.com/sindresorhus/ky/pull/192

## :mag: Testing

**Manual testing:**
In a folder with a given `package.json`:

```json
{
  "name": "foo",
  "version": "1.0.0",
  "funding": "http://example.com"
}
```

Running `npm fund` should output:

```sh
$ npm fund
foo@1.0.0
└── url: http://example.com
```

✅ This change has unit test coverage
✅ This change has integration test coverage

## :fire: Rollback

> If we observe something wrong with this change in production, how should we respond?

This can be reverted at any time