### PR TITLE
shrinkwrap: no need to read package.json when read shrinkwrap

### DIFF
--- a/lib/install/read-shrinkwrap.js
+++ b/lib/install/read-shrinkwrap.js
@@ -18,7 +18,7 @@ function readShrinkwrap (child, next) {
   BB.join(
     maybeReadFile('npm-shrinkwrap.json', child),
     // Don't read non-root lockfiles
-    child.isTop && maybeReadFile('package-lock.json', child)
+    child.isTop && maybeReadFile('package-lock.json', child),
     (shrinkwrap, lockfile) => {
       if (shrinkwrap && lockfile) {
         log.warn('read-shrinkwrap', 'Ignoring package-lock.json because there is already an npm-shrinkwrap.json. Please use only one of the two.')

--- a/lib/install/read-shrinkwrap.js
+++ b/lib/install/read-shrinkwrap.js
@@ -20,7 +20,7 @@ function readShrinkwrap (child, next) {
     // Don't read non-root lockfiles
     child.isTop && maybeReadFile('package-lock.json', child),
     child.isTop && maybeReadFile('package.json', child),
-    (shrinkwrap, lockfile, pkgJson) => {
+    (shrinkwrap, lockfile) => {
       if (shrinkwrap && lockfile) {
         log.warn('read-shrinkwrap', 'Ignoring package-lock.json because there is already an npm-shrinkwrap.json. Please use only one of the two.')
       }
@@ -31,7 +31,7 @@ function readShrinkwrap (child, next) {
       }
       child.package._shrinkwrap = parsed
     }
-  ).then(() => next(), next)
+  ).then(next, next)
 }
 
 function maybeReadFile (name, child) {

--- a/lib/install/read-shrinkwrap.js
+++ b/lib/install/read-shrinkwrap.js
@@ -18,8 +18,7 @@ function readShrinkwrap (child, next) {
   BB.join(
     maybeReadFile('npm-shrinkwrap.json', child),
     // Don't read non-root lockfiles
-    child.isTop && maybeReadFile('package-lock.json', child),
-    child.isTop && maybeReadFile('package.json', child),
+    child.isTop && maybeReadFile('package-lock.json', child)
     (shrinkwrap, lockfile) => {
       if (shrinkwrap && lockfile) {
         log.warn('read-shrinkwrap', 'Ignoring package-lock.json because there is already an npm-shrinkwrap.json. Please use only one of the two.')
@@ -31,7 +30,7 @@ function readShrinkwrap (child, next) {
       }
       child.package._shrinkwrap = parsed
     }
-  ).then(next, next)
+  ).then(() => next(), next)
 }
 
 function maybeReadFile (name, child) {


### PR DESCRIPTION
The PR includes a simple change that removes the unnecessary operation when readShrinkwrap.
This change will optimize performance when `npm install`.