### PR TITLE
fix: check `npm.config` before accessing its members

### DIFF
--- a/lib/utils/error-handler.js
+++ b/lib/utils/error-handler.js
@@ -36,7 +36,7 @@ process.on('timing', function (name, value) {
 process.on('exit', function (code) {
   process.emit('timeEnd', 'npm')
   log.disableProgress()
-  if (npm.config.loaded && npm.config.get('timing')) {
+  if (npm.config && npm.config.loaded && npm.config.get('timing')) {
     try {
       timings.logfile = getLogFile()
       cacheFile.append('_timing.json', JSON.stringify(timings) + '\n')
@@ -64,7 +64,7 @@ process.on('exit', function (code) {
       log.verbose('code', code)
     }
   }
-  if (npm.config.loaded && npm.config.get('timing') && !wroteLogFile) writeLogFile()
+  if (npm.config && npm.config.loaded && npm.config.get('timing') && !wroteLogFile) writeLogFile()
   if (wroteLogFile) {
     // just a line break
     if (log.levels[log.level] <= log.levels.error) console.error('')
@@ -79,7 +79,7 @@ process.on('exit', function (code) {
     wroteLogFile = false
   }
 
-  var doExit = npm.config.loaded && npm.config.get('_exit')
+  var doExit = npm.config && npm.config.loaded && npm.config.get('_exit')
   if (doExit) {
     // actually exit.
     if (exitCode === 0 && !itWorked) {
@@ -94,7 +94,7 @@ process.on('exit', function (code) {
 function exit (code, noLog) {
   exitCode = exitCode || process.exitCode || code
 
-  var doExit = npm.config.loaded ? npm.config.get('_exit') : true
+  var doExit = npm.config && npm.config.loaded ? npm.config.get('_exit') : true
   log.verbose('exit', [code, doExit])
   if (log.level === 'silent') noLog = true
 

--- a/lib/utils/error-message.js
+++ b/lib/utils/error-message.js
@@ -35,9 +35,9 @@ function errorMessage (er) {
     case 'EACCES':
     case 'EPERM':
       const isCachePath = typeof er.path === 'string' &&
-        er.path.startsWith(npm.config.get('cache'))
+        npm.config && er.path.startsWith(npm.config.get('cache'))
       const isCacheDest = typeof er.dest === 'string' &&
-        er.dest.startsWith(npm.config.get('cache'))
+        npm.config && er.dest.startsWith(npm.config.get('cache'))
 
       const isWindows = process.platform === 'win32'
 


### PR DESCRIPTION
## What / Why
Sometimes, `npm.config` can be missing entirely, but there are several
places where `npm.config.foo` is accessed blindly, resulting in these
kinds of errors and stack traces:

```
TypeError: Cannot read property 'get' of undefined
    at errorMessage (.../lib/utils/error-message.js:38:39)
    ...

TypeError: Cannot read property 'loaded' of undefined
    at exit (.../lib/utils/error-handler.js:97:27)
    ...
```

LBYL by checking `npm.config` first. Addresses a small part of #502.


## References
* Partially addresses: #502
