### PR TITLE
Use GitHub-specific syntax for `repository` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,7 @@
   },
   "homepage": "https://docs.npmjs.com/",
   "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/npm/cli"
-  },
+  "repository": "npm/cli",
   "bugs": {
     "url": "https://npm.community/c/bugs"
   },


### PR DESCRIPTION
This is a minor change, but wouldn't it be a good way to lead other npm packages by example? This seems to be a version completely equal to the longer one by npm documentation, but way more preferred by GitHub projects.