### PR TITLE
Revert "windows: Add preliminary WSL support for npm and npx"

### DIFF
--- a/bin/npm
+++ b/bin/npm
@@ -8,10 +8,6 @@ case `uname` in
 esac
 
 NODE_EXE="$basedir/node.exe"
-if [ -x "$NODE_EXE" ] && [ -f "/bin/wslpath" ]; then # run the corresponding command prompt when Node for Windows is executed within WSL
-  cmd.exe /c `wslpath -w "$basedir/npm.cmd"` "$@"
-  exit $?
-fi
 if ! [ -x "$NODE_EXE" ]; then
   NODE_EXE="$basedir/node"
 fi

--- a/bin/npx
+++ b/bin/npx
@@ -8,10 +8,6 @@ case `uname` in
 esac
 
 NODE_EXE="$basedir/node.exe"
-if [ -x "$NODE_EXE" ] && [ -f "/bin/wslpath" ]; then # run the corresponding command prompt when Node for Windows is executed within WSL
-  cmd.exe /c `wslpath -w "$basedir/npx.cmd"` "$@"
-  exit $?
-fi
 if ! [ -x "$NODE_EXE" ]; then
   NODE_EXE=node
 fi


### PR DESCRIPTION
This reverts commit 3471d5200217bfa612b1a262e36c9c043a52eb09.

# What / Why
From my understanding, this change enables npm to detect that it is running inside of WSL, and instead of running the Linux version of npm, it will run the Windows installed version of npm. Would you be able to revert this change?

The reasoning behind this is that this could cause performance and compatibility issues for npm. Users in WSL would be expecting to use the Linux version of npm, and instead routing the command to target the Windows version of npm could cause unexpected problems. 

I'm happy to dive into more detail on the reasons why, and thank you for thinking about WSL when you made this change! :)
