### PR TITLE
npm-link: clarify usage of global prefix

### DIFF
--- a/docs/content/cli-commands/npm-link.md
+++ b/docs/content/cli-commands/npm-link.md
@@ -23,8 +23,8 @@ Package linking is a two-step process.
 
 First, `npm link` in a package folder will create a symlink in the global folder
 `{prefix}/lib/node_modules/<package>` that links to the package where the `npm
-link` command was executed. (see [`npm-config`](npm-config) for the value of `prefix`). It
-will also link any bins in the package to `{prefix}/bin/{name}`.
+link` command was executed. It will also link any bins in the package to `{prefix}/bin/{name}`.
+Note that `npm link` uses the global prefix (see `npm prefix -g` for its value).
 
 Next, in some other location, `npm link package-name` will create a
 symbolic link from globally-installed `package-name` to `node_modules/`


### PR DESCRIPTION
In wondered why npm link doesn't "install to" `npm prefix`.
I looked up the documentation for `npm prefix` and found
the important distinction between the local prefix, and the
global prefix.

This attempts to clarity that `npm link` always uses specifically
the global prefix.
