### PR TITLE
makefile: fix docs target typo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,11 +129,11 @@ publish: gitclean ls-ok link docs-clean docs
 	git push origin --tags &&\
 	node bin/npm-cli.js publish --tag=$(PUBLISHTAG)
 
-release: gitclean ls-ok markedclean marked-manclean docs-clean doc
+release: gitclean ls-ok markedclean marked-manclean docs-clean docs
 	node bin/npm-cli.js prune --production --no-save
 	@bash scripts/release.sh
 
 sandwich:
 	@[ $$(whoami) = "root" ] && (echo "ok"; echo "ham" > sandwich) || (echo "make it yourself" && exit 13)
 
-.PHONY: all latest install dev link doc clean uninstall test man docs-clean docclean release ls-ok realclean
+.PHONY: all latest install dev link docs clean uninstall test man docs-clean docclean release ls-ok realclean


### PR DESCRIPTION
A few references to the `doc` target were not updated to `docs` in
https://github.com/npm/cli/pull/274 and resulted in `make release`
not building the docs.

# What / Why
<!-- Describe the request in detail -->
The instructions for [maintaining npm in Node.js](https://github.com/nodejs/node/blob/master/doc/guides/maintaining-npm.md) run `make release`.

https://github.com/npm/cli/pull/274 replaced the `doc` target with `docs` but didn't update the dependencies for the `release` target which meant the docs are not built.

## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->
* Closes https://github.com/nodejs/node/issues/30719
