### PR TITLE
Fix cache location for `npm ci`

### DIFF
--- a/lib/ci.js
+++ b/lib/ci.js
@@ -33,7 +33,7 @@ function ci (args, cb) {
   }
 
   for (const key in npm.config.list[0]) {
-    if (key !== 'log') {
+    if (!['log', 'cache'].includes(key)) {
       opts[key] = npm.config.list[0][key]
     }
   }


### PR DESCRIPTION
When you set `<cache>` directory in npm config, `npm ci` has been using `<cache>` for storing the cache instead of `<cache>/_cacache`