### PR TITLE
Fixed "publish --force" not correctly publishing for already published packages

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -150,7 +150,7 @@ function upload (pkg, isRetry, cached, opts) {
           )).finally(() => {
             // ignore errors.  Use the force.  Reach out with your feelings.
             return otplease(opts, opts => {
-              return upload(pkg, true, tarball, opts)
+              return upload(pkg, true, cached, opts)
             }).catch(() => {
               // but if it fails again, then report the first error.
               throw err


### PR DESCRIPTION
Currently "publish --force" does not work correctly when the deployed package is already in the registry. This is a regression from v10 where this worked correctly. The following error is thrown in line 138 of publish.js:

> TypeError [ERR_INVALID_ARG_VALUE]: The argument 'path' must be a string or Uint8Array without null bytes. Received <Buffer 1f 8b 08 00 4d 45 ea 5d 04 00 ed 19 f9 af d2 30 d8 9f 4d fc 1f 2a 1a 07 ca 36 f0 8a 22 a0 c6 db 78 45 3c e3 95 b9 75 50 ...
>     at readFile (fs.js:295:10)
>     at go$readFile (C:\Program Files\nodejs\node_modules\npm\node_modules\graceful-fs\graceful-fs.js:110:14)
>     at readFile (C:\Program Files\nodejs\node_modules\npm\node_modules\graceful-fs\graceful-fs.js:107:12)
>     at tryCatcher (C:\Program Files\nodejs\node_modules\npm\node_modules\bluebird\js\release\util.js:16:23)
>     at ret (eval at makeNodePromisifiedEval (C:\Program Files\nodejs\node_modules\npm\node_modules\bluebird\js\release\promisify.js:184:12), <anonymous>:14:23)
>     at upload (C:\Program Files\nodejs\node_modules\npm\lib\publish.js:138:12)
>     at C:\Program Files\nodejs\node_modules\npm\lib\publish.js:156:22
>     at C:\Program Files\nodejs\node_modules\npm\lib\utils\otplease.js:16:12
>     at tryCatcher (C:\Program Files\nodejs\node_modules\npm\node_modules\bluebird\js\release\util.js:16:23)
>     at Function.Promise.attempt.Promise.try (C:\Program Files\nodejs\node_modules\npm\node_modules\bluebird\js\release\method.js:39:29)
>     at otplease (C:\Program Files\nodejs\node_modules\npm\lib\utils\otplease.js:14:16)
>     at C:\Program Files\nodejs\node_modules\npm\lib\publish.js:154:20
>     at PassThroughHandlerContext.finallyHandler (C:\Program Files\nodejs\node_modules\npm\node_modules\bluebird\js\release\finally.js:56:23)
>     at PassThroughHandlerContext.tryCatcher (C:\Program Files\nodejs\node_modules\npm\node_modules\bluebird\js\release\util.js:16:23)
>     at Promise._settlePromiseFromHandler (C:\Program Files\nodejs\node_modules\npm\node_modules\bluebird\js\release\promise.js:517:31)
>     at Promise._settlePromise (C:\Program Files\nodejs\node_modules\npm\node_modules\bluebird\js\release\promise.js:574:18) {
>   code: 'ERR_INVALID_ARG_VALUE'
> }

The BB.promisify(require('graceful-fs').readFile) throws an error when used with an input buffer which is used in line 156 of publish.js. Using the file path again (PR) fixes the problem and is the same behavior as in v10.

# What / Why
<!-- Describe the request in detail -->
> * It is no longer possible to publish already published packages with the --force option.

## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->
