### PR TITLE
chore: fix netlify publish path config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [build]
   base = "docs"
   command = "npm run build"
-  publish = "docs/public"
+  publish = "public"


### PR DESCRIPTION
Fix incorrect publish path on Netlify config file. Netlify was incorrectly looking for `docs/docs/public` instead of `docs/public`.