### PR TITLE
CI: add `fail-fast: false`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on: [push]
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         node-version: [8.x, 10.x, 12.x]
         os: [ubuntu-latest, windows-latest]


### PR DESCRIPTION
This will allow all builds to run even if one fails

Matches the Travis CI behavior