### PR TITLE
version: using 'allow-same-version', git commit --allow-empty and git tag -f

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -286,27 +286,32 @@ function checkGit (localData, cb) {
 
 module.exports.buildCommitArgs = buildCommitArgs
 function buildCommitArgs (args) {
-  args = args || [ 'commit' ]
-  if (!npm.config.get('commit-hooks')) args.push('--no-verify')
-  if (npm.config.get('allow-same-version')) args.push('--allow-empty')
-  return args
+  const add = []
+  args = args || []
+  if (args[0] === 'commit') args.shift()
+  if (!npm.config.get('commit-hooks')) add.push('-n')
+  if (npm.config.get('allow-same-version')) add.push('--allow-empty')
+  return ['commit', ...add, ...args]
+}
+
+module.exports.buildTagFlags = buildTagFlags
+function buildTagFlags () {
+  return '-'.concat(
+    npm.config.get('sign-git-tag') ? 's' : '',
+    npm.config.get('allow-same-version') ? 'f' : '',
+    'm'
+  )
 }
 
 function _commit (version, localData, cb) {
   const options = { env: process.env }
   const message = npm.config.get('message').replace(/%s/g, version)
-  const signTag = npm.config.get('sign-git-tag')
   const signCommit = npm.config.get('sign-git-commit')
-  const commitArgs = [
-    ...buildCommitArgs(['commit']),
+  const commitArgs = buildCommitArgs([
+    'commit',
     ...(signCommit ? ['-S', '-m'] : ['-m']),
     message
-  ]
-  const flagForTag = '-'.concat(
-    signTag ? 's' : '',
-    npm.config.get('allow-same-version') ? 'f' : '',
-    'm'
-  )
+  ])
 
   stagePackageFiles(localData, options).then(() => {
     return git.exec(commitArgs, options)
@@ -314,7 +319,7 @@ function _commit (version, localData, cb) {
     if (!localData.existingTag) {
       return git.exec([
         'tag', npm.config.get('tag-version-prefix') + version,
-        flagForTag, message
+        buildTagFlags(), message
       ], options)
     }
   }).nodeify(cb)

--- a/lib/version.js
+++ b/lib/version.js
@@ -287,7 +287,8 @@ function checkGit (localData, cb) {
 module.exports.buildCommitArgs = buildCommitArgs
 function buildCommitArgs (args) {
   args = args || [ 'commit' ]
-  if (!npm.config.get('commit-hooks')) args.push('-n')
+  if (!npm.config.get('commit-hooks')) args.push('--no-verify')
+  if (npm.config.get('allow-same-version')) args.push('--allow-empty')
   return args
 }
 
@@ -296,12 +297,16 @@ function _commit (version, localData, cb) {
   const message = npm.config.get('message').replace(/%s/g, version)
   const signTag = npm.config.get('sign-git-tag')
   const signCommit = npm.config.get('sign-git-commit')
-  const commitArgs = buildCommitArgs([
-    'commit',
+  const commitArgs = [
+    ...buildCommitArgs(['commit']),
     ...(signCommit ? ['-S', '-m'] : ['-m']),
     message
-  ])
-  const flagForTag = signTag ? '-sm' : '-m'
+  ]
+  const flagForTag = '-'.concat(
+    signTag ? 's' : '',
+    npm.config.get('allow-same-version') ? 'f' : '',
+    'm'
+  )
 
   stagePackageFiles(localData, options).then(() => {
     return git.exec(commitArgs, options)

--- a/test/tap/version-allow-same-version.js
+++ b/test/tap/version-allow-same-version.js
@@ -22,6 +22,21 @@ t.test('setup', t => {
 
 t.test('without --allow-same-version', t => {
   npm.config.set('allow-same-version', false)
+
+  const version = require('../../lib/version')
+
+  const commit1 = version.buildCommitArgs()
+  const commit2 = version.buildCommitArgs([ 'commit' ])
+  const commit3 = version.buildCommitArgs([ 'commit', '-m', 'some commit message' ])
+
+  t.same(commit1, [ 'commit' ])
+  t.same(commit2, [ 'commit' ])
+  t.same(commit3, [ 'commit', '-m', 'some commit message' ])
+
+  const tag = version.buildTagFlags()
+
+  t.same(tag, '-m')
+
   npm.commands.version(['0.0.1'], function (err) {
     t.isa(err, Error, 'got an error')
     t.like(err.message, /Version not changed/)
@@ -31,6 +46,21 @@ t.test('without --allow-same-version', t => {
 
 t.test('with --allow-same-version', t => {
   npm.config.set('allow-same-version', true)
+
+  const version = require('../../lib/version')
+
+  const commit1 = version.buildCommitArgs()
+  const commit2 = version.buildCommitArgs([ 'commit' ])
+  const commit3 = version.buildCommitArgs([ 'commit', '-m', 'some commit message' ])
+
+  t.same(commit1, [ 'commit', '--allow-empty' ])
+  t.same(commit2, [ 'commit', '--allow-empty' ])
+  t.same(commit3, [ 'commit', '--allow-empty', '-m', 'some commit message' ])
+
+  const tag = version.buildTagFlags()
+
+  t.same(tag, '-fm')
+
   npm.commands.version(['0.0.1'], function (err) {
     if (err) {
       throw err

--- a/test/tap/version-commit-hooks.js
+++ b/test/tap/version-commit-hooks.js
@@ -33,7 +33,7 @@ test('npm version <semver> with commit-hooks disabled', function (t) {
 
     t.same(args1, [ 'commit', '-n' ])
     t.same(args2, [ 'commit', '-n' ])
-    t.same(args3, [ 'commit', '-m', 'some commit message', '-n' ])
+    t.same(args3, [ 'commit', '-n', '-m', 'some commit message' ])
     t.end()
   })
 })


### PR DESCRIPTION
# What / Why
When running `npm version "x.x.x" --allow-same-version`, it often is the case that `git commit` will fail because there are no changes to commit, _and_ that `git tag vx.x.x` will fail because the tag already exists.

The changes here are exactly these to prevent failure only when the option `allow-same-version` is activated.
