### PR TITLE
docs: fix header parsing that was breaking misc config manpage

### DIFF
--- a/scripts/docs-build.js
+++ b/scripts/docs-build.js
@@ -15,7 +15,7 @@ fs.readFile(src, 'utf8', function (err, data) {
   }
 
   var result = data.replace(/@VERSION@/g, npm.version)
-    .replace(/---([\s\S]+)---/g, '')
+    .replace(/^---([\s\S]+?)---/g, '')
     .replace(/\[([^\]]+)\]\(\/cli-commands\/([^)]+)\)/g, replacer)
     .replace(/\[([^\]]+)\]\(\/configuring-npm\/([^)]+)\)/g, replacer)
     .replace(/\[([^\]]+)\]\(\/using-npm\/([^)]+)\)/g, replacer)


### PR DESCRIPTION
Tiny fix to the header parsing that was breaking `npm help 7 config`.