### PR TITLE
Release 6.13.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 6.13.6 (2020-01-09)
+
+### DEPENDENCIES
+
+* [`6dba897a1`](https://github.com/npm/cli/commit/6dba897a1e2d56388fb6df0c814b0bb85af366b4)
+  `pacote@9.5.12`:
+    * [`d2f4176`](https://github.com/npm/pacote/commit/d2f4176b6af393d7e29de27e9b638dbcbab9a0c7)
+      fix(git): Do not drop uid/gid when executing in root-owned directory
+      ([@isaacs](https://github.com/isaacs))
+
 ## 6.13.5 (2020-01-09)
 
 ### BUG FIXES

--- a/node_modules/pacote/CHANGELOG.md
+++ b/node_modules/pacote/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="9.5.12"></a>
+## [9.5.12](https://github.com/npm/pacote/compare/v9.5.11...v9.5.12) (2020-01-06)
+
+
+### Bug Fixes
+
+* **git:** Do not drop uid/gid when executing in root-owned directory ([d2f4176](https://github.com/npm/pacote/commit/d2f4176))
+
+
+
 <a name="9.5.11"></a>
 ## [9.5.11](https://github.com/npm/pacote/compare/v9.5.10...v9.5.11) (2019-12-09)
 

--- a/node_modules/pacote/lib/util/git.js
+++ b/node_modules/pacote/lib/util/git.js
@@ -16,6 +16,7 @@ const promiseRetry = require('promise-retry')
 const uniqueFilename = require('unique-filename')
 const which = BB.promisify(require('which'))
 const semver = require('semver')
+const inferOwner = require('infer-owner')
 
 const GOOD_ENV_VARS = new Set([
   'GIT_ASKPASS',
@@ -181,10 +182,24 @@ function revs (repo, opts) {
   })
 }
 
+// infer the owner from the cwd git is operating in, if not the
+// process cwd, but only if we're root.
+// See: https://github.com/npm/cli/issues/624
+module.exports._cwdOwner = cwdOwner
+function cwdOwner (gitOpts, opts) {
+  const isRoot = process.getuid && process.getuid() === 0
+  if (!isRoot || !gitOpts.cwd) { return Promise.resolve() }
+
+  return BB.resolve(inferOwner(gitOpts.cwd).then(owner => {
+    gitOpts.uid = owner.uid
+    gitOpts.gid = owner.gid
+  }))
+}
+
 module.exports._exec = execGit
 function execGit (gitArgs, gitOpts, opts) {
   opts = optCheck(opts)
-  return checkGit(opts).then(gitPath => {
+  return BB.resolve(cwdOwner(gitOpts, opts).then(() => checkGit(opts).then(gitPath => {
     return promiseRetry((retry, number) => {
       if (number !== 1) {
         opts.log.silly('pacote', 'Retrying git command: ' + gitArgs.join(' ') + ' attempt # ' + number)
@@ -202,13 +217,13 @@ function execGit (gitArgs, gitOpts, opts) {
       maxTimeout: opts['fetch-retry-maxtimeout'],
       minTimeout: opts['fetch-retry-mintimeout']
     })
-  })
+  })))
 }
 
 module.exports._spawn = spawnGit
 function spawnGit (gitArgs, gitOpts, opts) {
   opts = optCheck(opts)
-  return checkGit(opts).then(gitPath => {
+  return BB.resolve(cwdOwner(gitOpts, opts).then(() => checkGit(opts).then(gitPath => {
     return promiseRetry((retry, number) => {
       if (number !== 1) {
         opts.log.silly('pacote', 'Retrying git command: ' + gitArgs.join(' ') + ' attempt # ' + number)
@@ -231,7 +246,7 @@ function spawnGit (gitArgs, gitOpts, opts) {
         return stdout
       })
     }, opts.retry)
-  })
+  })))
 }
 
 module.exports._mkOpts = mkOpts

--- a/node_modules/pacote/package.json
+++ b/node_modules/pacote/package.json
@@ -1,8 +1,8 @@
 {
-  "_from": "pacote@9.5.11",
-  "_id": "pacote@9.5.11",
+  "_from": "pacote@9.5.12",
+  "_id": "pacote@9.5.12",
   "_inBundle": false,
-  "_integrity": "sha512-DMDPvFKCjCg6zMS4IfzZyvT57O/bX8XGG00eEoy4K/S4Wj+qiN8KbnmKpsTvfS6OL9r5TAicxMKWbj1yV2Yh4g==",
+  "_integrity": "sha512-BUIj/4kKbwWg4RtnBncXPJd15piFSVNpTzY0rysSr3VnMowTYgkGKcaHrbReepAkjTr8lH2CVWRi58Spg2CicQ==",
   "_location": "/pacote",
   "_phantomChildren": {
     "safe-buffer": "5.1.2",
@@ -11,12 +11,12 @@
   "_requested": {
     "type": "version",
     "registry": true,
-    "raw": "pacote@9.5.11",
+    "raw": "pacote@9.5.12",
     "name": "pacote",
     "escapedName": "pacote",
-    "rawSpec": "9.5.11",
+    "rawSpec": "9.5.12",
     "saveSpec": null,
-    "fetchSpec": "9.5.11"
+    "fetchSpec": "9.5.12"
   },
   "_requiredBy": [
     "#USER",
@@ -24,10 +24,10 @@
     "/libcipm",
     "/libnpm"
   ],
-  "_resolved": "https://registry.npmjs.org/pacote/-/pacote-9.5.11.tgz",
-  "_shasum": "524152077cb392c47b1fbe198aa28f778bef7ee1",
-  "_spec": "pacote@9.5.11",
-  "_where": "/Users/isaacs/dev/npm/cli",
+  "_resolved": "https://registry.npmjs.org/pacote/-/pacote-9.5.12.tgz",
+  "_shasum": "1e11dd7a8d736bcc36b375a9804d41bb0377bf66",
+  "_spec": "pacote@9.5.12",
+  "_where": "/Users/ruyadorno/Documents/workspace/cli",
   "author": {
     "name": "Kat Marchán",
     "email": "kzm@sykosomatic.org"
@@ -123,5 +123,5 @@
     "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
     "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
   },
-  "version": "9.5.11"
+  "version": "9.5.12"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4424,9 +4424,9 @@
       }
     },
     "pacote": {
-      "version": "9.5.11",
-      "resolved": "https://registry.npmjs.org/pacote/-/pacote-9.5.11.tgz",
-      "integrity": "sha512-DMDPvFKCjCg6zMS4IfzZyvT57O/bX8XGG00eEoy4K/S4Wj+qiN8KbnmKpsTvfS6OL9r5TAicxMKWbj1yV2Yh4g==",
+      "version": "9.5.12",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-9.5.12.tgz",
+      "integrity": "sha512-BUIj/4kKbwWg4RtnBncXPJd15piFSVNpTzY0rysSr3VnMowTYgkGKcaHrbReepAkjTr8lH2CVWRi58Spg2CicQ==",
       "requires": {
         "bluebird": "^3.5.3",
         "cacache": "^12.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "npm",
-  "version": "6.13.5",
+  "version": "6.13.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.13.5",
+  "version": "6.13.6",
   "name": "npm",
   "description": "a package manager for JavaScript",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "once": "~1.4.0",
     "opener": "^1.5.1",
     "osenv": "^0.1.5",
-    "pacote": "^9.5.11",
+    "pacote": "^9.5.12",
     "path-is-inside": "~1.0.2",
     "promise-inflight": "~1.0.1",
     "qrcode-terminal": "^0.12.0",


### PR DESCRIPTION
## 6.13.6 (2020-01-09)

### DEPENDENCIES

* [`6dba897a1`](https://github.com/npm/cli/commit/6dba897a1e2d56388fb6df0c814b0bb85af366b4) `pacote@9.5.12`:
    * [`d2f4176`](https://github.com/npm/pacote/commit/d2f4176b6af393d7e29de27e9b638dbcbab9a0c7) fix(git): Do not drop uid/gid when executing in root-owned directory ([@isaacs](https://github.com/isaacs))

Fix: npm/cli#624
Fix: npm/cli#642
Fix: npm/cli#514