### PR TITLE
chore: fixes nodejs tests

### DIFF
--- a/lib/utils/unsupported.js
+++ b/lib/utils/unsupported.js
@@ -7,7 +7,8 @@ var supportedNode = [
   {ver: '10', min: '10.0.0'},
   {ver: '11', min: '11.0.0'},
   {ver: '12', min: '12.0.0'},
-  {ver: '13', min: '13.0.0'}
+  {ver: '13', min: '13.0.0'},
+  {ver: '14', min: '14.0.0'}
 ]
 var knownBroken = '<6.2.0 || 9.0 - 9.2'
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -12,6 +12,8 @@ node ./bin/npm-cli.js pack --loglevel error >/dev/null
 mv *.tgz release
 cd release
 tar xzf *.tgz
+cp ../.npmrc package/
+cp -r ../tap-snapshots package/
 cp -r ../test package/
 
 mkdir node_modules

--- a/test/tap/ci.js
+++ b/test/tap/ci.js
@@ -15,7 +15,10 @@ const File = Tacks.File
 const cacheDir = common.cache
 const testDir = common.pkg
 
-const EXEC_OPTS = { cwd: testDir }
+const EXEC_OPTS = {
+  cwd: testDir,
+  nodeExecPath: process.execPath
+}
 
 const PKG = {
   name: 'top',

--- a/test/tap/prepare.js
+++ b/test/tap/prepare.js
@@ -55,7 +55,11 @@ test('test', function (t) {
   common.npm([
     'pack',
     '--loglevel', 'warn'
-  ], { cwd: pkg, env: env }, function (err, code, stdout, stderr) {
+  ], {
+    cwd: pkg,
+    env: env,
+    nodeExecPath: process.execPath
+  }, function (err, code, stdout, stderr) {
     t.equal(code, 0, 'pack finished successfully')
     t.ifErr(err, 'pack finished successfully')
 

--- a/test/tap/prepublish-only.js
+++ b/test/tap/prepublish-only.js
@@ -98,7 +98,8 @@ test('test', function (t) {
   common.npm(
     [
       'publish',
-      '--loglevel', 'warn'
+      '--loglevel', 'warn',
+      '--scripts-prepend-node-path'
     ],
     {
       cwd: pkg,

--- a/test/tap/publish-scoped.js
+++ b/test/tap/publish-scoped.js
@@ -46,7 +46,7 @@ test('npm publish should honor scoping', function (t) {
 
   fs.writeFileSync(configFile, configuration.join('\n') + '\n')
 
-  common.npm(['publish'], {'cwd': pkg}, function (err, code, stdout, stderr) {
+  common.npm(['publish'], {'cwd': pkg, nodeExecPath: process.execPath}, function (err, code, stdout, stderr) {
     if (err) throw err
     t.is(code, 0, 'published without error')
     server.done()

--- a/test/tap/publish.js
+++ b/test/tap/publish.js
@@ -52,7 +52,10 @@ test('basic npm publish', (t) => {
       `--//localhost:${server.port}/:username=username`,
       `--//localhost:${server.port}/:_password=` + Buffer.from('password').toString('base64'),
       `--//localhost:${server.port}/:email=` + 'ogd@aoaioxxysz.net'
-    ], {'cwd': testDir})
+    ], {
+      'cwd': testDir,
+      nodeExecPath: process.execPath
+    })
       .spread((code, stdout, stderr) => {
         t.comment(stdout)
         t.comment(stderr)

--- a/test/tap/umask-lifecycle.js
+++ b/test/tap/umask-lifecycle.js
@@ -40,12 +40,13 @@ test('setup', function (t) {
 })
 
 test('umask script', function (t) {
-  common.npm(['run', 'umask'], {
+  common.npm(['run', 'umask', '--scripts-prepend-node-path'], {
     cwd: pkg,
     env: {
       PATH: process.env.PATH,
       Path: process.env.Path,
-      'npm_config_loglevel': 'warn'
+      'npm_config_loglevel': 'warn',
+      nodeExecPath: process.execPath
     }
   }, function (er, code, sout, serr) {
     t.equal(sout, expected)

--- a/test/tap/version-no-package.js
+++ b/test/tap/version-no-package.js
@@ -7,7 +7,7 @@ test('npm version in a prefix with no package.json', function (t) {
   process.chdir(pkg)
   common.npm(
     ['version', '--json', '--prefix', pkg],
-    { cwd: pkg },
+    { cwd: pkg, nodeExecPath: process.execPath },
     function (er, code, stdout, stderr) {
       t.ifError(er, "npm version doesn't care that there's no package.json")
       t.notOk(code, 'npm version ran without barfing')


### PR DESCRIPTION
- Fixes ability to run tests using an arbitrary node bin
  - Most tests were failing due to mismatching versions of node (local compiled version vs system version)
- Fixes `make test-npm` in nodejs repo
  - Added `tap-snapshots` folder (fixes snapshot-dependent tests)
  - Added required `.npmrc` root file (fixes broken config tests)
- Added v14 to supported matrix

Fixes npm/statusboard#45