### PR TITLE
allow new majors of node to be automatically considered supported

### DIFF
--- a/lib/utils/unsupported.js
+++ b/lib/utils/unsupported.js
@@ -1,5 +1,6 @@
 'use strict'
 var semver = require('semver')
+var earliestSupportedNode = '9.3.0'
 var supportedNode = [
   {ver: '6', min: '6.0.0'},
   {ver: '8', min: '8.0.0'},
@@ -13,10 +14,11 @@ var knownBroken = '<6.2.0 || 9.0 - 9.2'
 
 var checkVersion = exports.checkVersion = function (version) {
   var versionNoPrerelease = version.replace(/-.*$/, '')
+  var isExplicitlySupportedNode = semver.satisfies(versionNoPrerelease, supportedNode.map(function (n) { return '^' + n.min }).join('||'))
   return {
     version: versionNoPrerelease,
     broken: semver.satisfies(versionNoPrerelease, knownBroken),
-    unsupported: !semver.satisfies(versionNoPrerelease, supportedNode.map(function (n) { return '^' + n.min }).join('||'))
+    unsupported: !isExplicitlySupportedNode || !semver.gte(versionNoPrerelease, earliestSupportedNode)
   }
 }
 


### PR DESCRIPTION
# What / Why

New major versions of node shouldn't be reported as "too old" or unsupported, in the absence of an explicit "known broken" declaration.

Per https://github.com/npm/cli/pull/696#discussion_r367574446