### PR TITLE
Update references away from npm.community

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,10 +155,6 @@ When you find issues, please report them:
 Be sure to include *all* of the output from the npm command that didn't work
 as expected.  The `npm-debug.log` file is also helpful to provide.
 
-You can also find npm people in `#npm` on https://package.community/ or
-[on Twitter](https://twitter.com/npm_support).  Whoever responds will no
-doubt tell you to put the output in a gist or email.
-
 ## SEE ALSO
 
 * npm(1)


### PR DESCRIPTION
# What / Why
<!-- Describe the request in detail -->
Updated references from `npm.community` to `github.com/npm/cli/issues`.

> Details fully references in issue linked below.

---

**EDIT (scope change)**:
Just the README is updated with reference to `package.community`.



## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->
* Closes https://github.com/npm/cli/issues/698
* Scope Change: https://github.com/npm/cli/issues/698#issuecomment-575412013