### PR TITLE
docs: mention --no-optional in package-json

### DIFF
--- a/docs/content/configuring-npm/package-json.md
+++ b/docs/content/configuring-npm/package-json.md
@@ -740,7 +740,8 @@ If a dependency can be used, but you would like npm to proceed if it cannot be
 found or fails to install, then you may put it in the `optionalDependencies`
 object.  This is a map of package name to version or url, just like the
 `dependencies` object.  The difference is that build failures do not cause
-installation to fail.
+installation to fail.  Running `npm install --no-optional` will prevent these
+dependencies from being installed.
 
 It is still your program's responsibility to handle the lack of the
 dependency.  For example, something like this:


### PR DESCRIPTION
# What / Why
<!-- Describe the request in detail -->

Reference `npm install --no-optional` in the `optionalDependencies` section of `/docs/content/configuring-npm/package-json.md`

## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->

Closes #614
