### PR TITLE
chore(docs): update unpublish docs with both commands, removing policy info from cli docs, and added reference to unpublish policy docs

### DIFF
--- a/docs/content/cli-commands/npm-unpublish.md
+++ b/docs/content/cli-commands/npm-unpublish.md
@@ -10,19 +10,21 @@ description: Remove a package from the registry
 
 ### Synopsis
 
+#### Unpublishing a single version of a package
+
 ```bash
-npm unpublish [<@scope>/]<pkg>[@<version>]
+npm unpublish <package-name>@<version>
+```
+
+#### Unpublishing an entire package
+
+```bash
+npm unpublish <package-name> -f
 ```
 
 ### Warning
 
-**It is generally considered bad behavior to remove versions of a library
-that others are depending on!**
-
-Consider using the `deprecate` command
-instead, if your intent is to encourage users to upgrade.
-
-There is plenty of room on the registry.
+Consider using the `deprecate` command instead, if your intent is to encourage users to upgrade, or if you no longer want to maintain a package.
 
 ### Description
 
@@ -34,16 +36,10 @@ the root package entry is removed from the registry entirely.
 
 Even if a package version is unpublished, that specific name and
 version combination can never be reused. In order to publish the
-package again, a new version number must be used. Additionally,
-new versions of packages with every version unpublished may not
-be republished until 24 hours have passed.
+package again, a new version number must be used. If you unpublish the entire package, you may not publish any new versions of that package until 24 hours have passed.
 
-With the default registry (`registry.npmjs.org`), unpublish is
-only allowed with versions published in the last 72 hours. If you
-are trying to unpublish a version published longer ago than that,
-contact support@npmjs.com.
+To learn more about how unpublish is treated on the npm registry, see our <a href="https://www.npmjs.com/policies/unpublish" target="_blank" rel="noopener noreferrer"> unpublish policies</a>. 
 
-The scope is optional and follows the usual rules for [`scope`](/using-npm/scope).
 
 ### See Also
 

--- a/docs/content/cli-commands/npm-unpublish.md
+++ b/docs/content/cli-commands/npm-unpublish.md
@@ -13,13 +13,13 @@ description: Remove a package from the registry
 #### Unpublishing a single version of a package
 
 ```bash
-npm unpublish <package-name>@<version>
+npm unpublish [<@scope>/]<pkg>@<version>
 ```
 
 #### Unpublishing an entire package
 
 ```bash
-npm unpublish <package-name> -f
+npm unpublish [<@scope>/]<pkg> --force
 ```
 
 ### Warning

--- a/lib/unpublish.js
+++ b/lib/unpublish.js
@@ -20,7 +20,11 @@ const readJson = BB.promisify(require('read-package-json'))
 const usage = require('./utils/usage.js')
 const whoami = BB.promisify(require('./whoami.js'))
 
-unpublish.usage = usage('npm unpublish [<@scope>/]<pkg>[@<version>]')
+unpublish.usage = usage(
+    'unpublish',
+    '\nnpm unpublish [<@scope>/]<pkg>@<version>' +
+    '\nnpm unpublish [<@scope>/]<pkg> --force'
+)
 
 function UsageError () {
   throw Object.assign(new Error(`Usage: ${unpublish.usage}`), {

--- a/lib/unpublish.js
+++ b/lib/unpublish.js
@@ -21,8 +21,8 @@ const usage = require('./utils/usage.js')
 const whoami = BB.promisify(require('./whoami.js'))
 
 unpublish.usage = usage(
-    'unpublish',
-    '\nnpm unpublish [<@scope>/]<pkg>@<version>' +
+  'unpublish',
+  '\nnpm unpublish [<@scope>/]<pkg>@<version>' +
     '\nnpm unpublish [<@scope>/]<pkg> --force'
 )
 
@@ -79,7 +79,7 @@ function unpublish (args, cb) {
         'Refusing to delete entire project.\n' +
         'Run with --force to do this.\n' +
         unpublish.usage
-      ), {code: 'EUSAGE'})
+      ), { code: 'EUSAGE' })
     }
     if (!spec || path.resolve(spec.name) === npm.localPrefix) {
       // if there's a package.json in the current folder, then


### PR DESCRIPTION
- Updating docs unpublish docs to with examples of both unpublish commands
- Removing policy info from cli docs to centralize policy in policy docs
- Added reference to unpublish policy docs 