### PR TITLE
access: grant is ok with non-scoped

### DIFF
--- a/lib/access.js
+++ b/lib/access.js
@@ -112,7 +112,7 @@ access.grant = ([perms, scopeteam, pkg], opts) => {
     }
     return modifyPackage(pkg, opts, (pkgName, opts) => {
       return libaccess.grant(pkgName, scopeteam, perms, opts)
-    })
+    }, false)
   })
 }
 

--- a/test/tap/access.js
+++ b/test/tap/access.js
@@ -217,6 +217,33 @@ test('npm access grant read-write', function (t) {
   )
 })
 
+test('npm access grant read-write on unscoped package', function (t) {
+  server.filteringRequestBody((body) => {
+    const data = JSON.parse(body)
+    t.deepEqual(data, {
+      permissions: 'read-write',
+      package: 'another'
+    }, 'got the right body')
+    return true
+  })
+  server.put('/-/team/myorg/myteam/package', true).reply(201)
+  common.npm(
+    [
+      'access',
+      'grant', 'read-write',
+      'myorg:myteam',
+      'another',
+      '--registry', common.registry
+    ],
+    { cwd: pkg },
+    function (er, code, stdout, stderr) {
+      t.ifError(er, 'npm access grant')
+      t.equal(code, 0, 'exited with Error')
+      t.end()
+    }
+  )
+})
+
 test('npm access grant others', function (t) {
   common.npm(
     [


### PR DESCRIPTION
# What / Why
<!-- Describe the request in detail -->
Same as #151, this PR fixes the regression in npm@6.6.0 where `npm access grant` stopped working on unscoped packages.

## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->
* Related to #151 
