### PR TITLE
docs:correction to npm update -g behaviour

### DIFF
--- a/docs/content/cli-commands/npm-update.md
+++ b/docs/content/cli-commands/npm-update.md
@@ -122,7 +122,9 @@ version that satisfies `^0.4.0` (`>= 0.4.0 <0.5.0`)
 
 `npm update -g` will apply the `update` action to each globally installed
 package that is `outdated` -- that is, has a version that is different from
-`latest`.
+`wanted`.
+
+Note: Globally installed packages are treated as if they are installed with a caret semver range specified. So if you require to update to `latest` you may need to run `npm install -g [<pkg>...]`
 
 NOTE: If a package has been upgraded to a version newer than `latest`, it will
 be _downgraded_.


### PR DESCRIPTION
# What / Why
The docs state that running `npm update -g` will update globally installed packages to _latest_

![image](https://user-images.githubusercontent.com/26827682/73594772-4c93d380-4509-11ea-8c28-37f9cb6aa4f2.png)

The actual behaviour is to upgrading with an implicit caret range specified to the globally installed packages, this means that it will not always update to latest.

This PR updates the docs to make this clear.

## References
  * Closes #746 

