### PR TITLE
fix: relativize file links when inflating shrinkwrap

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -203,6 +203,7 @@ function removeObsoleteDep (child, log) {
   })
 }
 
+exports.packageRelativePath = packageRelativePath
 function packageRelativePath (tree) {
   if (!tree) return ''
   var requested = tree.package._requested || {}

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -74,7 +74,10 @@ function doesChildVersionMatch (child, requested, requestor) {
     var childReq = child.package._requested
     if (childReq) {
       if (childReq.rawSpec === requested.rawSpec) return true
-      if (childReq.type === requested.type && childReq.saveSpec === requested.saveSpec) return true
+      if (childReq.type === requested.type) {
+        if (childReq.saveSpec === requested.saveSpec) return true
+        if (childReq.fetchSpec === requested.fetchSpec) return true
+      }
     }
     // If _requested didn't exist OR if it didn't match then we'll try using
     // _from. We pass it through npa to normalize the specifier.

--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -570,7 +570,7 @@ function addDependency (name, versionSpec, tree, log, done) {
   try {
     var req = childDependencySpecifier(tree, name, versionSpec)
     if (tree.swRequires && tree.swRequires[name]) {
-      var swReq = childDependencySpecifier(tree, name, tree.swRequires[name], tree.package._where)
+      var swReq = childDependencySpecifier(tree, name, tree.swRequires[name])
     }
   } catch (err) {
     return done(err)

--- a/lib/install/get-requested.js
+++ b/lib/install/get-requested.js
@@ -7,6 +7,8 @@ module.exports = function (child, reqBy) {
   if (!reqBy) reqBy = child.requiredBy[0]
   const deps = reqBy.package.dependencies || {}
   const devDeps = reqBy.package.devDependencies || {}
+  const optDeps = reqBy.package.optionalDependencies || {}
   const name = moduleName(child)
-  return npa.resolve(name, deps[name] || devDeps[name], reqBy.realpath)
+  const spec = deps[name] || devDeps[name] || optDeps[name]
+  return npa.resolve(name, spec, reqBy.realpath)
 }

--- a/lib/install/get-requested.js
+++ b/lib/install/get-requested.js
@@ -1,7 +1,7 @@
 'use strict'
 const npa = require('npm-package-arg')
 const moduleName = require('../utils/module-name.js')
-
+const packageRelativePath = require('./deps').packageRelativePath
 module.exports = function (child, reqBy) {
   if (!child.requiredBy.length) return
   if (!reqBy) reqBy = child.requiredBy[0]
@@ -10,5 +10,6 @@ module.exports = function (child, reqBy) {
   const optDeps = reqBy.package.optionalDependencies || {}
   const name = moduleName(child)
   const spec = deps[name] || devDeps[name] || optDeps[name]
-  return npa.resolve(name, spec, reqBy.realpath)
+  const where = packageRelativePath(reqBy)
+  return npa.resolve(name, spec, where)
 }

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -110,12 +110,11 @@ function inflatableChild (onDiskChild, name, topPath, tree, sw, requested, opts)
     sw.version = regTarball
   }
   if (sw.requires) {
-    Object.keys(sw.requires).forEach(_ => {
-      sw.requires[_] = (
-        tarballToVersion(_, sw.requires[_]) ||
-        relativizeLink(_, sw.requires[_], topPath, requested) ||
-        sw.requires[_]
-      )
+    Object.keys(sw.requires).forEach(name => {
+      const spec = sw.requires[name]
+      sw.requires[name] = tarballToVersion(name, spec) ||
+        relativizeLink(name, spec, topPath, requested) ||
+        spec
     })
   }
   const modernLink = requested.type === 'directory' && !sw.from

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -89,12 +89,12 @@ function tarballToVersion (name, tb) {
   return match[2] || match[1]
 }
 
-function relativizeLink( name , spec, topPath, requested) {
+function relativizeLink (name, spec, topPath, requested) {
   if (!spec.startsWith('file:')) {
-    return;
+    return
   }
-  const relativized = path.relative(requested.fetchSpec, path.resolve(topPath, spec.slice(5)));
-  return 'file:' + relativized;
+  const relativized = path.relative(requested.fetchSpec, path.resolve(topPath, spec.slice(5)))
+  return 'file:' + relativized
 }
 
 function inflatableChild (onDiskChild, name, topPath, tree, sw, requested, opts) {
@@ -115,8 +115,8 @@ function inflatableChild (onDiskChild, name, topPath, tree, sw, requested, opts)
         tarballToVersion(_, sw.requires[_]) ||
         relativizeLink(_, sw.requires[_], topPath, requested) ||
         sw.requires[_]
-      );
-    });
+      )
+    })
   }
   const modernLink = requested.type === 'directory' && !sw.from
   if (hasModernMeta(onDiskChild) && childIsEquivalent(sw, requested, onDiskChild)) {

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -89,11 +89,21 @@ function tarballToVersion (name, tb) {
   return match[2] || match[1]
 }
 
-function relativizeLink (name, spec, topPath, requested) {
+function relativizeLink (name, spec, topPath, sw, requested) {
   if (!spec.startsWith('file:')) {
     return
   }
-  const relativized = path.relative(requested.fetchSpec, path.resolve(topPath, spec.slice(5)))
+
+  let requestedPath
+  if (requested.type === 'directory') {
+    requestedPath = requested.fetchSpec
+  } else if (requested.type === 'file') {
+    requestedPath = path.dirname(requested.fetchSpec)
+  } else {
+    requestedPath = sw.resolved
+  }
+
+  const relativized = path.relative(requestedPath, path.resolve(topPath, spec.slice(5)))
   return 'file:' + relativized
 }
 
@@ -113,7 +123,7 @@ function inflatableChild (onDiskChild, name, topPath, tree, sw, requested, opts)
     Object.keys(sw.requires).forEach(name => {
       const spec = sw.requires[name]
       sw.requires[name] = tarballToVersion(name, spec) ||
-        relativizeLink(name, spec, topPath, requested) ||
+        relativizeLink(name, spec, topPath, sw, requested) ||
         spec
     })
   }

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -89,6 +89,14 @@ function tarballToVersion (name, tb) {
   return match[2] || match[1]
 }
 
+function relativizeLink( name , spec, topPath, requested) {
+  if (!spec.startsWith('file:')) {
+    return;
+  }
+  const relativized = path.relative(requested.fetchSpec, path.resolve(topPath, spec.slice(5)));
+  return 'file:' + relativized;
+}
+
 function inflatableChild (onDiskChild, name, topPath, tree, sw, requested, opts) {
   validate('OSSOOOO|ZSSOOOO', arguments)
   const usesIntegrity = (
@@ -101,7 +109,15 @@ function inflatableChild (onDiskChild, name, topPath, tree, sw, requested, opts)
     sw.resolved = sw.version
     sw.version = regTarball
   }
-  if (sw.requires) Object.keys(sw.requires).map(_ => { sw.requires[_] = tarballToVersion(_, sw.requires[_]) || sw.requires[_] })
+  if (sw.requires) {
+    Object.keys(sw.requires).forEach(_ => {
+      sw.requires[_] = (
+        tarballToVersion(_, sw.requires[_]) ||
+        relativizeLink(_, sw.requires[_], topPath, requested) ||
+        sw.requires[_]
+      );
+    });
+  }
   const modernLink = requested.type === 'directory' && !sw.from
   if (hasModernMeta(onDiskChild) && childIsEquivalent(sw, requested, onDiskChild)) {
     // The version on disk matches the shrinkwrap entry.

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -89,18 +89,14 @@ function tarballToVersion (name, tb) {
   return match[2] || match[1]
 }
 
-function relativizeLink (name, spec, topPath, sw, requested) {
+function relativizeLink (name, spec, topPath, requested) {
   if (!spec.startsWith('file:')) {
     return
   }
 
-  let requestedPath
-  if (requested.type === 'directory') {
-    requestedPath = requested.fetchSpec
-  } else if (requested.type === 'file') {
-    requestedPath = path.dirname(requested.fetchSpec)
-  } else {
-    requestedPath = sw.resolved
+  let requestedPath = requested.fetchSpec
+  if (requested.type === 'file') {
+    requestedPath = path.dirname(requestedPath)
   }
 
   const relativized = path.relative(requestedPath, path.resolve(topPath, spec.slice(5)))
@@ -123,7 +119,7 @@ function inflatableChild (onDiskChild, name, topPath, tree, sw, requested, opts)
     Object.keys(sw.requires).forEach(name => {
       const spec = sw.requires[name]
       sw.requires[name] = tarballToVersion(name, spec) ||
-        relativizeLink(name, spec, topPath, sw, requested) ||
+        relativizeLink(name, spec, topPath, requested) ||
         spec
     })
   }

--- a/test/tap/install-dep-classification.js
+++ b/test/tap/install-dep-classification.js
@@ -126,7 +126,7 @@ test('optional dependency identification', function (t) {
           optional: true
         },
         example: {
-          version: '1.0.0',
+          version: 'file:../example-1.0.0.tgz',
           optional: true
         }
       }
@@ -150,7 +150,7 @@ test('development dependency identification', function (t) {
           dev: true
         },
         example: {
-          version: '1.0.0',
+          version: 'file:../example-1.0.0.tgz',
           dev: true
         }
       }
@@ -173,7 +173,7 @@ test('default dependency identification', function (t) {
           optional: true
         },
         example: {
-          version: '1.0.0',
+          version: 'file:../example-1.0.0.tgz',
           optional: true
         }
       }


### PR DESCRIPTION
Fixes #750.

When reading a package tree from disk and `package.json` files, `file:*` dependencies have paths relative to the current package directory. But when reading from shrinkwap file, the shrinkwrap file stores paths relative to the top package's path.

Both data are used to populate a `tree.package.dependencies` field. For the shrinkwrap, it happens [here](https://github.com/npm/cli/blob/f533d61eb27c484fae84571fbea8bc1d83acb42b/lib/install/inflate-shrinkwrap.js#L160). But such `dependencies` have wrong path. They need to be relativized after reading from the shrinkwrap.

The bug manifests when `computeMetadata` goes through `tree.package.dependencies` and tries to find a matching package in the tree that satisfies each dependency. But because the `file:` paths are wrong, the matching package is not found, although it is present in the tree. The package's `requiredBy` array remains empty and it's removed by `pruneIdealTree`. The result is a broken `node_modules` tree with missing links.