### PR TITLE
Tidy code for excluding readme from npm view

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -168,12 +168,12 @@ function fetchAndRead (nv, args, silent, opts, cb) {
 
     Object.keys(versions).forEach(function (v) {
       if (semver.satisfies(v, version, true)) {
-        args.forEach(function (args) {
-          // remove readme unless we asked for it
-          if (args.indexOf('readme') !== -1) {
-            delete versions[v].readme
-          }
-          results.push(showFields(data, versions[v], args))
+        // remove readme unless we asked for it
+        if (args.indexOf('readme') !== -1) {
+          delete versions[v].readme
+        }
+        args.forEach(function (arg) {
+          results.push(showFields(data, versions[v], arg))
         })
       }
     })


### PR DESCRIPTION
This worked but was very confusing because it was shadowing the
'args' variable with the version in the iterator function iterating
through itself, so the 'args' passed to `showFields` was the single
arg, not the array of args.

Moreover, it was performing the `indexOf` test on each individual
arg, so doing `indexOf` on the string rather than the array, which
still worked, but was somewhat confusing and probably not the
intention. Instead, check once outside of the loop to see if args
contains 'readme'.

test this please ✅