### PR TITLE
fix: npm explore spawn shell correctly

### DIFF
--- a/lib/explore.js
+++ b/lib/explore.js
@@ -23,14 +23,13 @@ function explore (args, cb) {
   var opts = {cwd: cwd, stdio: 'inherit'}
 
   var shellArgs = []
-  if (args) {
+  if (args.length) {
     if (isWindows) {
       var execCmd = escapeExecPath(args.shift())
       var execArgs = [execCmd].concat(args.map(escapeArg))
       opts.windowsVerbatimArguments = true
       shellArgs = ['/d', '/s', '/c'].concat(execArgs)
     } else {
-      shellArgs.unshift('-c')
       shellArgs = ['-c', args.map(escapeArg).join(' ').trim()]
     }
   }


### PR DESCRIPTION
# What / Why
Fix `npm explore <packagename>` (with no additional arguments) shell spawning.

## References
  * Closes #783 
