### PR TITLE
Fix WSH error message not being shown.

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -283,7 +283,7 @@
         ua = ua.replace(/\{arch\}/gi, process.arch)
 
         // continuous integration platforms
-        const ciName = process.env.GERRIT_PROJECT ? 'gerrit'
+        var ciName = process.env.GERRIT_PROJECT ? 'gerrit'
           : process.env.GITLAB_CI ? 'gitlab'
             : process.env.APPVEYOR ? 'appveyor'
               : process.env.CIRCLECI ? 'circle-ci'
@@ -304,7 +304,7 @@
                                     // Google Cloud Build - it sets almost nothing
                                       : process.env.BUILDER_OUTPUT ? 'builder'
                                         : false
-        const ci = ciName ? `ci/${ciName}` : ''
+        var ci = ciName ? ('ci/' + ciName) : ''
         ua = ua.replace(/\{ci\}/gi, ci)
 
         config.set('user-agent', ua.trim())


### PR DESCRIPTION
# What / Why
<!-- Describe the request in detail -->
> The use of `const` and literal strings prevent the WSH error message defined at the top of the file from getting shown. This is obviously a tragedy and must be fixed.

## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->
* n/a
