### PR TITLE
Release v6.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 6.14.1 (2020-02-26)
+
+* [`303e5c11e`](https://github.com/npm/cli/commit/303e5c11e7db34cf014107aecd2e81c821bfde8d)
+  `hosted-git-info@2.8.7`
+  Fixes a regression where scp-style git urls are passed to the WhatWG URL
+  parser, which does not handle them properly.
+  ([@isaacs](https://github.com/isaacs))
+
 ## 6.14.0 (2020-02-25)
 
 ### FEATURES

--- a/node_modules/hosted-git-info/CHANGELOG.md
+++ b/node_modules/hosted-git-info/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="2.8.7"></a>
+## [2.8.7](https://github.com/npm/hosted-git-info/compare/v2.8.6...v2.8.7) (2020-02-26)
+
+
+### Bug Fixes
+
+* Do not attempt to use url.URL when unavailable ([2d0bb66](https://github.com/npm/hosted-git-info/commit/2d0bb66)), closes [#61](https://github.com/npm/hosted-git-info/issues/61) [#62](https://github.com/npm/hosted-git-info/issues/62)
+* Do not pass scp-style URLs to the WhatWG url.URL ([f2cdfcf](https://github.com/npm/hosted-git-info/commit/f2cdfcf)), closes [#60](https://github.com/npm/hosted-git-info/issues/60)
+
+
+
 <a name="2.8.6"></a>
 ## [2.8.6](https://github.com/npm/hosted-git-info/compare/v2.8.5...v2.8.6) (2020-02-25)
 

--- a/node_modules/hosted-git-info/index.js
+++ b/node_modules/hosted-git-info/index.js
@@ -108,10 +108,25 @@ function parseGitUrl (giturl) {
   var matched = giturl.match(/^([^@]+)@([^:/]+):[/]?((?:[^/]+[/])?[^/]+?)(?:[.]git)?(#.*)?$/)
   if (!matched) {
     var legacy = url.parse(giturl)
-    if (legacy.auth) {
-      var whatwg = new url.URL(giturl)
-      legacy.auth = whatwg.username || ''
-      if (whatwg.password) legacy.auth += ':' + whatwg.password
+    // If we don't have url.URL, then sorry, this is just not fixable.
+    // This affects Node <= 6.12.
+    if (legacy.auth && typeof url.URL === 'function') {
+      // git urls can be in the form of scp-style/ssh-connect strings, like
+      // git+ssh://user@host.com:some/path, which the legacy url parser
+      // supports, but WhatWG url.URL class does not.  However, the legacy
+      // parser de-urlencodes the username and password, so something like
+      // https://user%3An%40me:p%40ss%3Aword@x.com/ becomes
+      // https://user:n@me:p@ss:word@x.com/ which is all kinds of wrong.
+      // Pull off just the auth and host, so we dont' get the confusing
+      // scp-style URL, then pass that to the WhatWG parser to get the
+      // auth properly escaped.
+      const authmatch = giturl.match(/[^@]+@[^:/]+/)
+      /* istanbul ignore else - this should be impossible */
+      if (authmatch) {
+        var whatwg = new url.URL(authmatch[0])
+        legacy.auth = whatwg.username || ''
+        if (whatwg.password) legacy.auth += ':' + whatwg.password
+      }
     }
     return legacy
   }

--- a/node_modules/hosted-git-info/package.json
+++ b/node_modules/hosted-git-info/package.json
@@ -1,19 +1,19 @@
 {
-  "_from": "hosted-git-info@2.8.6",
-  "_id": "hosted-git-info@2.8.6",
+  "_from": "hosted-git-info@2.8.7",
+  "_id": "hosted-git-info@2.8.7",
   "_inBundle": false,
-  "_integrity": "sha512-Kp6rShEsCHhF5dD3EWKdkgVA8ix90oSUJ0VY4g9goxxa0+f4lx63muTftn0mlJ/+8IESGWyKnP//V2D7S4ZbIQ==",
+  "_integrity": "sha512-ChkjQtKJ3GI6SsI4O5jwr8q8EPrWCnxuc4Tbx+vRI5x6mDOpjKKltNo1lRlszw3xwgTOSns1ZRBiMmmwpcvLxg==",
   "_location": "/hosted-git-info",
   "_phantomChildren": {},
   "_requested": {
     "type": "version",
     "registry": true,
-    "raw": "hosted-git-info@2.8.6",
+    "raw": "hosted-git-info@2.8.7",
     "name": "hosted-git-info",
     "escapedName": "hosted-git-info",
-    "rawSpec": "2.8.6",
+    "rawSpec": "2.8.7",
     "saveSpec": null,
-    "fetchSpec": "2.8.6"
+    "fetchSpec": "2.8.7"
   },
   "_requiredBy": [
     "#USER",
@@ -21,10 +21,10 @@
     "/normalize-package-data",
     "/npm-package-arg"
   ],
-  "_resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.6.tgz",
-  "_shasum": "3a6e6d0324c5371fc8c7ba7175e1e5d14578724d",
-  "_spec": "hosted-git-info@2.8.6",
-  "_where": "/Users/darcyclarke/Documents/Repos/npm/cli",
+  "_resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.7.tgz",
+  "_shasum": "4d2e0d5248e1cfabc984b0f6a6d75fe36e679511",
+  "_spec": "hosted-git-info@2.8.7",
+  "_where": "/Users/isaacs/dev/npm/cli",
   "author": {
     "name": "Rebecca Turner",
     "email": "me@re-becca.org",
@@ -62,11 +62,11 @@
   },
   "scripts": {
     "postrelease": "npm publish --tag=ancient-legacy-fixes && git push --follow-tags",
+    "posttest": "standard",
     "prerelease": "npm t",
-    "pretest": "standard",
     "release": "standard-version -s",
     "test": "tap -J --100 --no-esm test/*.js",
     "test:coverage": "tap --coverage-report=html -J --100 --no-esm test/*.js"
   },
-  "version": "2.8.6"
+  "version": "2.8.7"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "npm",
-  "version": "6.14.0",
+  "version": "6.14.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2479,9 +2479,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.6.tgz",
-      "integrity": "sha512-Kp6rShEsCHhF5dD3EWKdkgVA8ix90oSUJ0VY4g9goxxa0+f4lx63muTftn0mlJ/+8IESGWyKnP//V2D7S4ZbIQ=="
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.7.tgz",
+      "integrity": "sha512-ChkjQtKJ3GI6SsI4O5jwr8q8EPrWCnxuc4Tbx+vRI5x6mDOpjKKltNo1lRlszw3xwgTOSns1ZRBiMmmwpcvLxg=="
     },
     "http-cache-semantics": {
       "version": "3.8.1",
@@ -4036,7 +4036,7 @@
         },
         "find-up": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
@@ -4057,7 +4057,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
@@ -4082,7 +4082,7 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
@@ -4139,7 +4139,7 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.14.0",
+  "version": "6.14.1",
   "name": "npm",
   "description": "a package manager for JavaScript",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "glob": "^7.1.4",
     "graceful-fs": "^4.2.3",
     "has-unicode": "~2.0.1",
-    "hosted-git-info": "^2.8.6",
+    "hosted-git-info": "^2.8.7",
     "iferr": "^1.0.2",
     "infer-owner": "^1.0.4",
     "inflight": "~1.0.6",


### PR DESCRIPTION
## 6.14.1 (2020-02-26)

* [`303e5c11e`](https://github.com/npm/cli/commit/303e5c11e7db34cf014107aecd2e81c821bfde8d) `hosted-git-info@2.8.7` Fixes a regression where scp-style git urls are passed to the WhatWG URL parser, which does not handle them properly. ([@isaacs](https://github.com/isaacs))
