### PR TITLE
Gracefully handle "Cannot read property .match of undefined"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,7 +123,7 @@ We often want to know if the bug we've fixed for the feature we've added has any
 1. Make a pull-request against this repository
 2. Add the following comment to the pull-request: "`test this please ✅`"
 
-This will trigger the [benmark suite](https://github.com/npm/benchmarks) to run against your pull-request, and when it's finished running it will post a comment on your pull-request just like bellow. You'll be able to see the results from the suite inline in your pull-request.
+This will trigger the [benchmark suite](https://github.com/npm/benchmarks) to run against your pull-request, and when it's finished running it will post a comment on your pull-request just like below. You'll be able to see the results from the suite inline in your pull-request.
 
 > You'll notice that the bot-user will also add a 🚀 reaction to your comment to
 let you know that it's sent the request to start the benchmark suite.
@@ -186,7 +186,6 @@ You'll need a few things installed in order to update and test the CLI project d
 
 > Package vendoring is commonly referred to as the case where dependent packages are stored in the same place as your project. That usually means you dependencies are checked into your source management system, such as Git.
 
-The CLI project vendors it's dependencies in the `node_modules/` folder. Meaning all the dependencies that the CLI project uses are contained withing the project itself. This is represented by the `bundledDependencies` section in the root level `package.json` file. The main reason for this is because the `npm` CLI project is distributed with the NodeJS runtime and needs to work out of the box, which means all dependencies need to be available after the runtime is installed.
+The CLI project vendors its dependencies in the `node_modules/` folder. Meaning all the dependencies that the CLI project uses are contained within the project itself. This is represented by the `bundledDependencies` section in the root level `package.json` file. The main reason for this is because the `npm` CLI project is distributed with the NodeJS runtime and needs to work out of the box, which means all dependencies need to be available after the runtime is installed.
 
 There are a couple scripts created to help manage this process in the `scripts/` folder.
-

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -7,7 +7,6 @@ const childPath = require('../utils/child-path.js')
 const createChild = require('./node.js').create
 let fetchPackageMetadata
 const inflateBundled = require('./inflate-bundled.js')
-const errorHandler = require('../utils/error-handler.js')
 const moduleName = require('../utils/module-name.js')
 const normalizePackageData = require('normalize-package-data')
 const npm = require('../npm.js')
@@ -58,7 +57,7 @@ function inflateShrinkwrap (topPath, tree, swdeps, opts) {
       let message = `Object for dependency "${name}" is empty.\n`
       message += 'Something went wrong. Regenerate the package-lock.json with "npm install".\n'
       message += 'If using a shrinkwrap, regenerate with "npm shrinkwrap".'
-      return Promise.reject(errorHandler(message))
+      return Promise.reject(new Error(message))
     }
 
     return inflatableChild(

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -54,12 +54,12 @@ function inflateShrinkwrap (topPath, tree, swdeps, opts) {
     const dependencies = sw.dependencies || {}
     const requested = realizeShrinkwrapSpecifier(name, sw, topPath)
 
-    // if (Object.keys(sw).length === 0) {
-    //   let message = `Object for dependency "${name}" is empty.\n`
-    //   message += 'Something went wrong. Regenerate the package-lock.json with "npm install".\n'
-    //   message += 'If using a shrinkwrap, regenerate with "npm shrinkwrap".'
-    //   return errorHandler(message)
-    // }
+    if (Object.keys(sw).length === 0) {
+      let message = `Object for dependency "${name}" is empty.\n`
+      message += 'Something went wrong. Regenerate the package-lock.json with "npm install".\n'
+      message += 'If using a shrinkwrap, regenerate with "npm shrinkwrap".'
+      return errorHandler(message)
+    }
 
     return inflatableChild(
       onDisk[name], name, topPath, tree, sw, requested, opts

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -7,6 +7,7 @@ const childPath = require('../utils/child-path.js')
 const createChild = require('./node.js').create
 let fetchPackageMetadata
 const inflateBundled = require('./inflate-bundled.js')
+const errorHandler = require('../utils/error-handler.js')
 const moduleName = require('../utils/module-name.js')
 const normalizePackageData = require('normalize-package-data')
 const npm = require('../npm.js')
@@ -52,6 +53,14 @@ function inflateShrinkwrap (topPath, tree, swdeps, opts) {
     const sw = swdeps[name]
     const dependencies = sw.dependencies || {}
     const requested = realizeShrinkwrapSpecifier(name, sw, topPath)
+
+    // if (Object.keys(sw).length === 0) {
+    //   let message = `Object for dependency "${name}" is empty.\n`
+    //   message += 'Something went wrong. Regenerate the package-lock.json with "npm install".\n'
+    //   message += 'If using a shrinkwrap, regenerate with "npm shrinkwrap".'
+    //   return errorHandler(message)
+    // }
+
     return inflatableChild(
       onDisk[name], name, topPath, tree, sw, requested, opts
     ).then((child) => {

--- a/lib/install/inflate-shrinkwrap.js
+++ b/lib/install/inflate-shrinkwrap.js
@@ -58,7 +58,7 @@ function inflateShrinkwrap (topPath, tree, swdeps, opts) {
       let message = `Object for dependency "${name}" is empty.\n`
       message += 'Something went wrong. Regenerate the package-lock.json with "npm install".\n'
       message += 'If using a shrinkwrap, regenerate with "npm shrinkwrap".'
-      return errorHandler(message)
+      return Promise.reject(errorHandler(message))
     }
 
     return inflatableChild(

--- a/test/tap/lockfile-empty-dep-value.js
+++ b/test/tap/lockfile-empty-dep-value.js
@@ -1,0 +1,68 @@
+'use strict'
+
+const common = require('../common-tap.js')
+const path = require('path')
+const test = require('tap').test
+
+const Tacks = require('tacks')
+const File = Tacks.File
+const Dir = Tacks.Dir
+
+const basedir = common.pkg
+const testdir = path.join(basedir, 'testdir')
+
+const fixture = new Tacks(Dir({
+  cache: Dir(),
+  global: Dir(),
+  tmp: Dir(),
+  testdir: Dir({
+    'package-lock.json': File({
+      name: 'http-locks',
+      version: '1.0.0',
+      lockfileVersion: 1,
+      requires: true,
+      dependencies: {
+        minimist: {}
+      }
+    }),
+    'package.json': File({
+      name: 'http-locks',
+      version: '1.0.0',
+      dependencies: {
+        minimist: common.registry + '/minimist/-/minimist-0.0.5.tgz'
+      }
+    })
+  })
+}))
+
+function setup () {
+  cleanup()
+  fixture.create(basedir)
+}
+
+function cleanup () {
+  fixture.remove(basedir)
+}
+
+test('setup', function (t) {
+  setup()
+  t.done()
+})
+
+test('raises error to regenerate the lock file', function (t) {
+  common.npm(['install'], {cwd: testdir}, function (err, code, stdout, stderr) {
+    if (err) throw err
+    t.match(
+      stderr,
+      'npm ERR! Something went wrong. Regenerate the package-lock.json with "npm install".',
+      'returns message to regenerate package-lock'
+    )
+
+    t.done()
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.done()
+})

--- a/test/tap/shrinkwrap-empty-dep-value.js
+++ b/test/tap/shrinkwrap-empty-dep-value.js
@@ -1,0 +1,66 @@
+'use strict'
+
+const common = require('../common-tap.js')
+const path = require('path')
+const test = require('tap').test
+
+const Tacks = require('tacks')
+const File = Tacks.File
+const Dir = Tacks.Dir
+
+const basedir = common.pkg
+const testdir = path.join(basedir, 'testdir')
+
+const fixture = new Tacks(Dir({
+  cache: Dir(),
+  global: Dir(),
+  tmp: Dir(),
+  testdir: Dir({
+    'npm-shrinkwrap.json': File({
+      name: 'http-locks',
+      version: '0.0.0',
+      dependencies: {
+        minimist: {}
+      }
+    }),
+    'package.json': File({
+      name: 'http-locks',
+      version: '1.0.0',
+      dependencies: {
+        minimist: common.registry + '/minimist/-/minimist-0.0.5.tgz'
+      }
+    })
+  })
+}))
+
+function setup () {
+  cleanup()
+  fixture.create(basedir)
+}
+
+function cleanup () {
+  fixture.remove(basedir)
+}
+
+test('setup', function (t) {
+  setup()
+  t.done()
+})
+
+test('raises error to regenerate the shrinkwrap', function (t) {
+  common.npm(['install'], {cwd: testdir}, function (err, code, stdout, stderr) {
+    if (err) throw err
+    t.match(
+      stderr,
+      'npm ERR! If using a shrinkwrap, regenerate with "npm shrinkwrap".',
+      'returns message to regenerate shrinkwrap'
+    )
+
+    t.done()
+  })
+})
+
+test('cleanup', function (t) {
+  cleanup()
+  t.done()
+})


### PR DESCRIPTION
# What / Why
There's a bug in which an npm command will raise an error `Cannot read property .match on undefined` and exit the script with an error. There are a few open issues:
- https://github.com/npm/cli/issues/973 (occurs with `npm install`)
- https://github.com/npm/cli/issues/961 (occurs with `npm install`)
- https://github.com/npm/cli/issues/703 (occurs with `npm audit fix`)
- https://github.com/npm/cli/issues/403 (occurs with `npm uninstall --save-dev`)

I've run into this with `npm prune`, but I was unable to reproduce it while looking into it. This doesn't fix the root of the issue, which it appears that empty parameters are being generated in the lock file something like this:

```
"package-a": {
  "dependencies": {
    "package-b": {}
  }
}
```

And causing an undefined error here: https://github.com/npm/cli/blob/latest/lib/install/inflate-shrinkwrap.js#L87

Because there is no `"version"` key that is passed in here: https://github.com/npm/cli/blob/latest/lib/install/inflate-shrinkwrap.js#L99 (which is returning an `undefined`).

## Solution
This catches a dependency if it's empty and displays an error message to the user to regenerate the package-lock.json or npm-shrinkwrap.json.

## TODO
- ~write tests~
- split out the messaging based on the lockfile type if requested

## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->
* n/a
