### PR TITLE
Warn in a nicer tone

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -224,7 +224,7 @@
       loadErr = er
       if (er) return cb_(er)
       if (npm.config.get('force')) {
-        log.warn('using --force', 'I sure hope you know what you are doing.')
+        log.warn('using --force', 'I hope you know what you are doing.')
       }
       npm.config.loaded = true
       loaded = true


### PR DESCRIPTION
# What / Why
<!-- Describe the request in detail -->

Every time I need to clear the cache I feel like NPM is talking down to me.

- The tone ("I sure hope you know what you are doing") seems to indicate a severe consequence and that I might actually not know what I'm doing
- If the idea of this message is to remind someone to think before using `--force` then it's too late, this message is shown after the fact

Removing the word "sure" I think we can keep the same message but tone it down enough that it doesn't feel insulting.

## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->
* n/a
