### PR TITLE
chore: ignore any nested .DS_Store file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ npm-debug.log
 /test/npm_cache*
 /node_modules/.cache
 .DS_Store
+**/.DS_Store


### PR DESCRIPTION
It looks like we need a more aggressive pattern matching in order to ignore nested `.DS_Store` files.