### PR TITLE
chore(docs): Fixed example typo & code style in npm-scripts.md

### DIFF
--- a/docs/content/using-npm/scripts.md
+++ b/docs/content/using-npm/scripts.md
@@ -145,9 +145,15 @@ suites, then those executables will be added to the `PATH` for
 executing the scripts.  So, if your package.json has this:
 
 ```json
-{ "name" : "foo"
-, "dependencies" : { "bar" : "0.1.x" }
-, "scripts": { "start" : "bar ./test" } }
+{ 
+  "name" : "foo", 
+  "dependencies" : { 
+    "bar" : "0.1.x" 
+  }, 
+  "scripts": { 
+    "start" : "bar ./test" 
+  } 
+}
 ```
 
 then you could run `npm start` to execute the `bar` script, which is
@@ -176,9 +182,15 @@ there is a config param of `<name>[@<version>]:<key>`.  For example,
 if the package.json has this:
 
 ```json
-{ "name" : "foo"
-, "config" : { "port" : "8080" }
-, "scripts" : { "start" : "node server.js" } }
+{ 
+  "name" : "foo", 
+  "config" : { 
+    "port" : "8080" 
+  }, 
+  "scripts" : { 
+    "start" : "node server.js" 
+  } 
+}
 ```
 
 and the server.js is this:
@@ -213,10 +225,11 @@ process.env.npm_package_scripts_install === "foo.js"
 For example, if your package.json contains this:
 
 ```json
-{ "scripts" :
-  { "install" : "scripts/install.js"
-  , "postinstall" : "scripts/postinstall.js"
-  , "uninstall" : "scripts/uninstall.js"
+{ 
+  "scripts" : { 
+    "install" : "scripts/install.js", 
+    "postinstall" : "scripts/install.js", 
+    "uninstall" : "scripts/uninstall.js"
   }
 }
 ```
@@ -232,10 +245,11 @@ If you want to run a make command, you can do so.  This works just
 fine:
 
 ```json
-{ "scripts" :
-  { "preinstall" : "./configure"
-  , "install" : "make && make install"
-  , "test" : "make test"
+{ 
+  "scripts" : { 
+    "preinstall" : "./configure", 
+    "install" : "make && make install", 
+    "test" : "make test"
   }
 }
 ```


### PR DESCRIPTION
# Fixed example typo & code style in npm-scripts.md
First of all, thanks for your works.  
When I read npm docs about [using npm/scripts](https://github.com/npm/cli/blob/latest/docs/content/using-npm/scripts.md#examples), I find a typo in the "Examples" section.
the scripts code example is as follows:

```
{ 
    "scripts" : { 
        "install" : "scripts/install.js", 
        "postinstall" : "scripts/postinstall.js", 
        "uninstall" : "scripts/uninstall.js"
    }
}
```
Considering the context：

> then scripts/install.js will be called for the install and post-install stages of the lifecycle, and scripts/uninstall.js will be called when the package is uninstalled. Since scripts/install.js is running for two different phases, it would be wise in this case to look at the npm_lifecycle_event environment variable.

I think the postinstall script command should be "scripts/install.js", and the [official website documentation](https://docs.npmjs.com/using-npm/scripts.html#examples) also verified my idea.

By the way also beautify the code style of the JSON example :P 
