### PR TITLE
Fixed 'See Also' section references in npm-update doc

### DIFF
--- a/docs/content/cli-commands/npm-update.md
+++ b/docs/content/cli-commands/npm-update.md
@@ -132,9 +132,9 @@ be _downgraded_.
 
 ### See Also
 
-* [npm install](/cli-commands/install)
-* [npm outdated](/cli-commands/outdated)
-* [npm shrinkwrap](/cli-commands/shrinkwrap)
+* [npm install](/cli-commands/npm-install)
+* [npm outdated](/cli-commands/npm-outdated)
+* [npm shrinkwrap](/cli-commands/npm-shrinkwrap)
 * [npm registry](/using-npm/registry)
 * [npm folders](/configuring-npm/folders)
-* [npm ls](/cli-commands/ls)
+* [npm ls](/cli-commands/npm-ls)


### PR DESCRIPTION
# What / Why
<!-- Describe the request in detail -->
> https://docs.npmjs.com/cli-commands/update.html most of links in the See Also section are 404.

## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->
* n/a
