### PR TITLE
npm init help wrong command

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -63,7 +63,7 @@ function init (args, cb) {
       'This utility will walk you through creating a package.json file.',
       'It only covers the most common items, and tries to guess sensible defaults.',
       '',
-      'See `npm help json` for definitive documentation on these fields',
+      'See `npm help init` for definitive documentation on these fields',
       'and exactly what they do.',
       '',
       'Use `npm install <pkg>` afterwards to install a package and',


### PR DESCRIPTION
# What / Why
<!-- Describe the request in detail -->
> on running `npm help json` it prints `No results for "json"`

## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->
* Closes #1161 