### PR TITLE
Replace condescending line with a helpful message.

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -224,7 +224,7 @@
       loadErr = er
       if (er) return cb_(er)
       if (npm.config.get('force')) {
-        log.warn('using --force', 'I sure hope you know what you are doing.')
+        log.warn('using --force', 'Warning: Using --force is discouraged. Consider an alternative approach.')
       }
       npm.config.loaded = true
       loaded = true


### PR DESCRIPTION
The current warning is not an actual help message, is not suggesting any actions, and it's quite condescending.

# What / Why
<!-- Describe the request in detail -->
> This PR changes a warning about using `--force-` which is not currently providing any help into something more meaningful so users can take a different action.

## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->
* There is no issue associated to it. 
