### PR TITLE
Correcting isntall

### DIFF
--- a/lib/config/cmd-list.js
+++ b/lib/config/cmd-list.js
@@ -28,7 +28,7 @@ var affordances = {
   'verison': 'version',
   'ic': 'ci',
   'innit': 'init',
-  'isntall': 'install',
+  'install': 'install',
   'install-clean': 'ci',
   'isntall-clean': 'ci',
   'dist-tags': 'dist-tag',

--- a/lib/config/cmd-list.js
+++ b/lib/config/cmd-list.js
@@ -30,7 +30,6 @@ var affordances = {
   'innit': 'init',
   'install': 'install',
   'install-clean': 'ci',
-  'isntall-clean': 'ci',
   'dist-tags': 'dist-tag',
   'apihelp': 'help',
   'find-dupes': 'dedupe',

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -92,7 +92,7 @@
   var commandCache = {}
   var aliasNames = Object.keys(aliases)
 
-  var littleGuys = [ 'isntall', 'verison' ]
+  var littleGuys = [ 'install', 'verison' ]
   var fullList = cmdList.concat(aliasNames).filter(function (c) {
     return plumbing.indexOf(c) === -1
   })


### PR DESCRIPTION
# Correcting a typo for the install command

When using the command 'npm install --help', I noticed that in the description 'aliases: i, isntall, add', install is written isntall. I imagine that this is some type of typo, so looking at the code, I made some changes that I believe can help. Thank you.