### PR TITLE
Respects the save options for `npm --link`

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -330,13 +330,25 @@ Installer.prototype.run = function (_cb) {
       [this, this.finishTracker, 'runTopLevelLifecycles']
     )
     if (getSaveType()) {
+      if (this.link) {
+        // if we specified "link", we had removed obsolete deps from the ideal tree...
+        // ...so, reload the deps so we can respect the save options
+        postInstallSteps.push(
+          [this, this.loadAllDepsIntoIdealTree]
+        )
+      } else {
+        postInstallSteps.push(
+          // this is necessary as we don't fill in `dependencies` and `devDependencies` in deps loaded from shrinkwrap
+          // until after we extract them
+          [this, (next) => { computeMetadata(this.idealTree); next() }],
+          [this, this.pruneIdealTree],
+          [this, this.debugLogicalTree, 'saveTree', 'idealTree'],
+        )
+      }
+
       postInstallSteps.push(
-        // this is necessary as we don't fill in `dependencies` and `devDependencies` in deps loaded from shrinkwrap
-        // until after we extract them
-        [this, (next) => { computeMetadata(this.idealTree); next() }],
-        [this, this.pruneIdealTree],
-        [this, this.debugLogicalTree, 'saveTree', 'idealTree'],
-        [this, this.saveToDependencies])
+        [this, this.saveToDependencies]
+      )
     }
   }
   postInstallSteps.push(
@@ -514,7 +526,7 @@ Installer.prototype.computeLinked = function (cb) {
     isLinkable(pkg, function (install, link) {
       if (install) linkTodoList.push(['global-install', pkg])
       if (link) linkTodoList.push(['global-link', pkg])
-      if (!save && (install || link)) removeObsoleteDep(pkg) // TBD
+      if (install || link) removeObsoleteDep(pkg, log)
       next()
     })
   }, function () {

--- a/lib/install.js
+++ b/lib/install.js
@@ -501,9 +501,11 @@ Installer.prototype.computeLinked = function (cb) {
   if (!this.link || this.global) return cb()
   var linkTodoList = []
   var self = this
+  const save = npm.config.get('save')
   asyncMap(this.differences, function (action, next) {
     var cmd = action[0]
     var pkg = action[1]
+    
     if (cmd !== 'add' && cmd !== 'update') return next()
     var isReqByTop = pkg.requiredBy.filter(function (mod) { return mod.isTop }).length
     var isReqByUser = pkg.userRequired
@@ -512,7 +514,7 @@ Installer.prototype.computeLinked = function (cb) {
     isLinkable(pkg, function (install, link) {
       if (install) linkTodoList.push(['global-install', pkg])
       if (link) linkTodoList.push(['global-link', pkg])
-      if (install || link) removeObsoleteDep(pkg)
+      if (!save && (install || link)) removeObsoleteDep(pkg) // TBD
       next()
     })
   }, function () {
@@ -520,18 +522,6 @@ Installer.prototype.computeLinked = function (cb) {
     self.differences.length = 0
     Array.prototype.push.apply(self.differences, linkTodoList)
     diffTrees(self.currentTree, self.idealTree, self.differences, log.newGroup('d2'), cb)
-  })
-}
-
-function isLinkable (pkg, cb) {
-  var globalPackage = path.resolve(npm.globalPrefix, 'lib', 'node_modules', moduleName(pkg))
-  var globalPackageJson = path.resolve(globalPackage, 'package.json')
-  fs.stat(globalPackage, function (er) {
-    if (er) return cb(true, true)
-    fs.readFile(globalPackageJson, function (er, data) {
-      var json = parseJSON.noExceptions(data)
-      cb(false, json && json.version === pkg.package.version)
-    })
   })
 }
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -336,17 +336,14 @@ Installer.prototype.run = function (_cb) {
         postInstallSteps.push(
           [this, this.loadAllDepsIntoIdealTree]
         )
-      } else {
-        postInstallSteps.push(
-          // this is necessary as we don't fill in `dependencies` and `devDependencies` in deps loaded from shrinkwrap
-          // until after we extract them
-          [this, (next) => { computeMetadata(this.idealTree); next() }],
-          [this, this.pruneIdealTree],
-          [this, this.debugLogicalTree, 'saveTree', 'idealTree'],
-        )
-      }
-
+      } 
+      
       postInstallSteps.push(
+        // this is necessary as we don't fill in `dependencies` and `devDependencies` in deps loaded from shrinkwrap
+        // until after we extract them
+        [this, (next) => { computeMetadata(this.idealTree); next() }],
+        [this, this.pruneIdealTree],
+        [this, this.debugLogicalTree, 'saveTree', 'idealTree'],
         [this, this.saveToDependencies]
       )
     }

--- a/lib/install.js
+++ b/lib/install.js
@@ -336,8 +336,8 @@ Installer.prototype.run = function (_cb) {
         postInstallSteps.push(
           [this, this.loadAllDepsIntoIdealTree]
         )
-      } 
-      
+      }
+
       postInstallSteps.push(
         // this is necessary as we don't fill in `dependencies` and `devDependencies` in deps loaded from shrinkwrap
         // until after we extract them

--- a/lib/install.js
+++ b/lib/install.js
@@ -513,11 +513,9 @@ Installer.prototype.computeLinked = function (cb) {
   if (!this.link || this.global) return cb()
   var linkTodoList = []
   var self = this
-  const save = npm.config.get('save')
   asyncMap(this.differences, function (action, next) {
     var cmd = action[0]
     var pkg = action[1]
-    
     if (cmd !== 'add' && cmd !== 'update') return next()
     var isReqByTop = pkg.requiredBy.filter(function (mod) { return mod.isTop }).length
     var isReqByUser = pkg.userRequired
@@ -534,6 +532,18 @@ Installer.prototype.computeLinked = function (cb) {
     self.differences.length = 0
     Array.prototype.push.apply(self.differences, linkTodoList)
     diffTrees(self.currentTree, self.idealTree, self.differences, log.newGroup('d2'), cb)
+  })
+}
+
+function isLinkable (pkg, cb) {
+  var globalPackage = path.resolve(npm.globalPrefix, 'lib', 'node_modules', moduleName(pkg))
+  var globalPackageJson = path.resolve(globalPackage, 'package.json')
+  fs.stat(globalPackage, function (er) {
+    if (er) return cb(true, true)
+    fs.readFile(globalPackageJson, function (er, data) {
+      var json = parseJSON.noExceptions(data)
+      cb(false, json && json.version === pkg.package.version)
+    })
   })
 }
 


### PR DESCRIPTION
# What / Why
<!-- Describe the request in detail -->
I really love `npm install --link`. However, it wasn't respecting my save options. When I develop locally, I prefer to install to the global folder and then just link to that. However, when I push to CI/CD systems, it's easier for those systems to simply "npm install" and just consume whatever deps are listed in the package.json. Other times, I have a scaffolded project, where it will consistently use the same deps; for example a Vue project with linters and test framework. It's super easy for me to re-use those package.json files and run `npm install --link` to install link to the deps in the new project.

What this change does is it respects the save options so that after install linking, the package.json gets updated. I think it's become a convention to save deps by default, so, in order to not save, the "--no-save" options must be used. 

What's missing from this pull request: updated tests. Since that could be somewhat of a lift for me, I wanted to first get feedback on the suggested change before proceeding with that.

## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->
* n/a
