### PR TITLE
fix: update "see also" links in npm-update

### DIFF
--- a/docs/content/cli-commands/npm-link.md
+++ b/docs/content/cli-commands/npm-link.md
@@ -33,7 +33,7 @@ of the current folder.
 Note that `package-name` is taken from `package.json`,
 not from directory name.
 
-The package name can be optionally prefixed with a scope. See [`scope`](/using-npm/npm-scope).
+The package name can be optionally prefixed with a scope. See [`scope`](/using-npm/scope).
 The scope must be preceded by an @-symbol and followed by a slash.
 
 When creating tarballs for `npm publish`, the linked packages are
@@ -76,7 +76,7 @@ installation target into your project's `node_modules` folder.
 Note that in this case, you are referring to the directory name, `node-redis`,
 rather than the package name `redis`.
 
-If your linked package is scoped (see [`scope`](/using-npm/npm-scope)) your link command must include that scope, e.g.
+If your linked package is scoped (see [`scope`](/using-npm/scope)) your link command must include that scope, e.g.
 
 ```bash
 npm link @myorg/privatepackage

--- a/docs/content/cli-commands/npm-logout.md
+++ b/docs/content/cli-commands/npm-logout.md
@@ -40,7 +40,7 @@ it takes precedence.
 
 Default: The scope of your current project, if any, otherwise none.
 
-If specified, you will be logged out of the specified scope. See [`scope`](/using-npm/npm-scope).
+If specified, you will be logged out of the specified scope. See [`scope`](/using-npm/scope).
 
 ```bash
 npm logout --scope=@myco

--- a/docs/content/cli-commands/npm-publish.md
+++ b/docs/content/cli-commands/npm-publish.md
@@ -25,7 +25,7 @@ files in the package directory are included if no local `.gitignore` or
 [`developers`](/using-npm/developers) for full details on what's included in the published package, as well as details on how the package is built.
 
 By default npm will publish to the public registry. This can be overridden by
-specifying a different default registry or using a [`scope`](/using-npm/npm-scope) in the name (see [`package.json`](/configuring-npm/package-json)).
+specifying a different default registry or using a [`scope`](/using-npm/scope) in the name (see [`package.json`](/configuring-npm/package-json)).
 
 * `<folder>`:
   A folder containing a package.json file

--- a/docs/content/cli-commands/npm-update.md
+++ b/docs/content/cli-commands/npm-update.md
@@ -132,9 +132,9 @@ be _downgraded_.
 
 ### See Also
 
-* [npm install](/cli-commands/install.html)
-* [npm outdated](/cli-commands/outdated.html)
-* [npm shrinkwrap](/cli-commands/shrinkwrap.html)
-* [npm registry](/using-npm/registry.html)
-* [npm folders](/configuring-npm/folders.html)
-* [npm ls](/cli-commands/ls.html)
+* [npm install](/cli-commands/install)
+* [npm outdated](/cli-commands/outdated)
+* [npm shrinkwrap](/cli-commands/shrinkwrap)
+* [npm registry](/using-npm/registry)
+* [npm folders](/configuring-npm/folders)
+* [npm ls](/cli-commands/ls)

--- a/docs/content/cli-commands/npm-update.md
+++ b/docs/content/cli-commands/npm-update.md
@@ -132,9 +132,9 @@ be _downgraded_.
 
 ### See Also
 
-* [npm install](/cli-commands/install)
-* [npm outdated](/cli-commands/outdated)
-* [npm shrinkwrap](/cli-commands/shrinkwrap)
-* [npm registry](/using-npm/registry)
-* [npm folders](/configuring-npm/folders)
-* [npm ls](/cli-commands/ls)
+* [npm install](/cli-commands/install.html)
+* [npm outdated](/cli-commands/outdated.html)
+* [npm shrinkwrap](/cli-commands/shrinkwrap.html)
+* [npm registry](/using-npm/registry.html)
+* [npm folders](/configuring-npm/folders.html)
+* [npm ls](/cli-commands/ls.html)

--- a/docs/content/cli-commands/npm.md
+++ b/docs/content/cli-commands/npm.md
@@ -45,7 +45,7 @@ terms of use.
 You probably got npm because you want to install stuff.
 
 Use `npm install blerg` to install the latest version of "blerg".  Check out
-[`npm install`](/cli-commands/npm-install) for more info.  It can do a lot of stuff.
+[`npm install`](/cli-commands/install) for more info.  It can do a lot of stuff.
 
 Use the `npm search` command to show everything that's available.
 Use `npm ls` to show everything you've installed.
@@ -162,8 +162,8 @@ reproduction to report.
 <i@izs.me>
 
 ### See Also
-* [npm help](/cli-commands/npm-help)
+* [npm help](/cli-commands/help)
 * [package.json](/configuring-npm/package-json)
-* [npm install](/cli-commands/npm-install)
-* [npm config](/cli-commands/npm-config)
+* [npm install](/cli-commands/install)
+* [npm config](/cli-commands/config)
 * [npmrc](/configuring-npm/npmrc)

--- a/docs/content/using-npm/developers.md
+++ b/docs/content/using-npm/developers.md
@@ -100,7 +100,7 @@ least, you need:
   they'll get installed just like these ones.
 
 You can use `npm init` in the root of your package in order to get you
-started with a pretty basic package.json file.  See [`npm init`](/cli-commands/npm-init) for
+started with a pretty basic package.json file.  See [`npm init`](/cli-commands/init) for
 more info.
 
 ### Keeping files *out* of your package
@@ -169,7 +169,7 @@ changes in real time without having to keep re-installing it.  (You do
 need to either re-link or `npm rebuild -g` to update compiled packages,
 of course.)
 
-More info at [`npm link`](/cli-commands/npm-link).
+More info at [`npm link`](/cli-commands/link).
 
 ### Before Publishing: Make Sure Your Package Installs and Works
 
@@ -217,7 +217,7 @@ npm adduser
 
 and then follow the prompts.
 
-This is documented better in [npm adduser](/cli-commands/npm-adduser).
+This is documented better in [npm adduser](/cli-commands/adduser).
 
 ### Publish your package
 
@@ -244,9 +244,9 @@ Tell the world how easy it is to install your program!
 ### See also
 
 * [npm](/cli-commands/npm)
-* [npm init](/cli-commands/npm-init)
+* [npm init](/cli-commands/init)
 * [package.json](/configuring-npm/package-json)
 * [npm scripts](/using-npm/scripts)
-* [npm publish](/cli-commands/npm-publish)
-* [npm adduser](/cli-commands/npm-adduser)
+* [npm publish](/cli-commands/publish)
+* [npm adduser](/cli-commands/adduser)
 * [npm registry](/using-npm/registry)


### PR DESCRIPTION
# What / Why
The "See also" links of `npm-update` are outdated and lead to a 404 / default page. I will check for other occurrences as well to have it working everywhere.
