### PR TITLE
docs: Add note about dropped `*` filenames

### DIFF
--- a/docs/content/configuring-npm/package-json.md
+++ b/docs/content/configuring-npm/package-json.md
@@ -272,15 +272,13 @@ Conversely, some files are always ignored:
 * `.hg`
 * `.lock-wscript`
 * `.wafpickle-N`
-* `.*.swp`
 * `.DS_Store`
-* `._*`
 * `npm-debug.log`
 * `.npmrc`
 * `node_modules`
 * `config.gypi`
-* `*.orig`
 * `package-lock.json` (use shrinkwrap instead)
+* All files containing a `*` character (incompatible with Windows) 
 
 ### main
 


### PR DESCRIPTION
# What / Why
In https://github.com/npm/npm-packlist/pull/32, NPM started to drop filenames containing the `*` character.

## References
- https://github.com/npm/npm-packlist/pull/32
- https://github.com/npm/cli/issues/1096
- https://github.com/npm/cli/issues/1048
