### PR TITLE
feat: use Arborist for dedupe and prune

### DIFF
--- a/docs/content/cli-commands/npm-dedupe.md
+++ b/docs/content/cli-commands/npm-dedupe.md
@@ -60,6 +60,8 @@ Modules
 Note that this operation transforms the dependency tree, but will never
 result in new modules being installed.
 
+Using `npm find-dupes` will run the command in dryRun mode.
+
 ### See Also
 
 * [npm ls](/cli-commands/ls)

--- a/lib/config/cmd-list.js
+++ b/lib/config/cmd-list.js
@@ -33,7 +33,6 @@ var affordances = {
   'isntall-clean': 'ci',
   'dist-tags': 'dist-tag',
   'apihelp': 'help',
-  'find-dupes': 'dedupe',
   'upgrade': 'update',
   'udpate': 'update',
   'login': 'adduser',
@@ -70,6 +69,7 @@ var cmdList = [
   'outdated',
   'prune',
   'pack',
+  'find-dupes',
   'dedupe',
   'hook',
 

--- a/lib/dedupe.js
+++ b/lib/dedupe.js
@@ -10,7 +10,7 @@ const completion = (cb) => cb(null, [])
 const cmd = (args, cb) => dedupe().then(() => cb()).catch(cb)
 
 const dedupe = async () => {
-  const { dryRun } = npm.flatOptions
+  const dryRun = npm.command.match(/^find/) || npm.flatOptions.dryRun
   const where = npm.prefix
   const arb = new Arborist({
     ...npm.flatOptions,

--- a/lib/dedupe.js
+++ b/lib/dedupe.js
@@ -7,10 +7,10 @@ const reifyOutput = require('./utils/reify-output.js')
 const usage = usageUtil('dedupe', 'npm dedupe')
 const completion = (cb) => cb(null, [])
 
-const cmd = (args, cb) => dedupe().then(() => cb()).catch(cb)
+const cmd = (args, cb) => dedupe(args).then(() => cb()).catch(cb)
 
-const dedupe = async () => {
-  const dryRun = npm.command.match(/^find/) || npm.flatOptions.dryRun
+const dedupe = async (args) => {
+  const dryRun = args.dryRun || npm.flatOptions.dryRun
   const where = npm.prefix
   const arb = new Arborist({
     ...npm.flatOptions,

--- a/lib/dedupe.js
+++ b/lib/dedupe.js
@@ -1,19 +1,24 @@
 // dedupe duplicated packages, or find them in the tree
-const util = require('util')
+const npm = require('./npm.js')
 const Arborist = require('@npmcli/arborist')
-const rimraf = util.promisify(require('rimraf'))
-const reifyOutput = require('./utils/reify-output.js')
 const usageUtil = require('./utils/usage.js')
+const reifyOutput = require('./utils/reify-output.js')
 
 const usage = usageUtil('dedupe', 'npm dedupe')
-
 const completion = (cb) => cb(null, [])
 
-const cmd = (args, cb) => dedupe(args).then(() => cb()).catch(cb)
+const cmd = (args, cb) => dedupe().then(() => cb()).catch(cb)
 
-const dedupe = async args => {
-  require('npmlog').warn('coming soon!')
-  throw new Error('not yet implemented')
+const dedupe = async () => {
+  const { dryRun } = npm.flatOptions
+  const where = npm.prefix
+  const arb = new Arborist({
+    ...npm.flatOptions,
+    path: where,
+    dryRun
+  })
+  await arb.dedupe()
+  reifyOutput(arb)
 }
 
 module.exports = Object.assign(cmd, { usage, completion })

--- a/lib/find-dupes.js
+++ b/lib/find-dupes.js
@@ -1,0 +1,9 @@
+// dedupe duplicated packages, or find them in the tree
+const dedupe = require('./dedupe.js')
+const usageUtil = require('./utils/usage.js')
+
+const usage = usageUtil('find-dupes', 'npm find-dupes')
+const completion = (cb) => cb(null, [])
+const cmd = (args, cb) => dedupe({ dryRun: true } , cb)
+
+module.exports = Object.assign(cmd, { usage, completion })

--- a/lib/help.js
+++ b/lib/help.js
@@ -35,7 +35,10 @@ function help (args, cb) {
     return npm.commands['help-search'](args, argnum, cb)
   }
 
-  var section = npm.deref(args[0]) || args[0]
+  const affordances = {
+    'find-dupes': 'dedupe'
+  }
+  var section = affordances[args[0]] || npm.deref(args[0]) || args[0]
 
   // npm help <noargs>:  show basic usage
   if (!section) {

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -111,7 +111,7 @@
         npm.config.set('long', true)
       }
 
-      npm.command = actualCommand
+      npm.command = c
       npm.flatOptions = require('./config/flat-options.js')(npm)
       require('./config/set-envs.js')(npm)
 

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -111,7 +111,7 @@
         npm.config.set('long', true)
       }
 
-      npm.command = c
+      npm.command = actualCommand
       npm.flatOptions = require('./config/flat-options.js')(npm)
       require('./config/set-envs.js')(npm)
 

--- a/lib/prune.js
+++ b/lib/prune.js
@@ -1,20 +1,25 @@
-// prune extraneous packages.
-const util = require('util')
+// prune extraneous packages
+const npm = require('./npm.js')
 const Arborist = require('@npmcli/arborist')
-const rimraf = util.promisify(require('rimraf'))
-const reifyOutput = require('./utils/reify-output.js')
 const usageUtil = require('./utils/usage.js')
 
+const reifyOutput = require('./utils/reify-output.js')
+
 const usage = usageUtil('prune',
-  'npm prune [[<@scope>/]<pkg>...] [--production]')
+  'npm prune [[<@scope>/]<pkg>...] [--production]'
+)
+const completion = (cb) => cb(null, [])
 
-const completion = require('./utils/completion/installed-deep.js')
+const cmd = (args, cb) => prune().then(() => cb()).catch(cb)
 
-const cmd = (args, cb) => prune(args).then(() => cb()).catch(cb)
-
-const prune = async args => {
-  require('npmlog').warn('coming soon!')
-  throw new Error('not yet implemented')
+const prune = async () => {
+  const where = npm.prefix
+  const arb = new Arborist({
+    ...npm.flatOptions,
+    path: where
+  })
+  await arb.prune()
+  reifyOutput(arb)
 }
 
 module.exports = Object.assign(cmd, { usage, completion })


### PR DESCRIPTION
This PR uses Arborist for dedupe and prune. 

Dedupe docs have been updated to include the fact that `npm find-dupes` runs it in dryRun mode (which didn't seem to be documented anywhere).