### PR TITLE
[Breaking] add "exports" field

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,15 @@
     "npm": "./bin/npm-cli.js",
     "npx": "./bin/npx-cli.js"
   },
+  "exports": {
+    ".": [
+      {
+        "default": "./lib/npm.js"
+      },
+      "./lib/npm.js"
+    ],
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "JSONStream": "^1.3.5",
     "abbrev": "~1.1.1",


### PR DESCRIPTION
Since npm v7 is imminent, it's a great opportunity to add the "exports" field, which is otherwise very hard to make nonbreaking.

I used the verbose form for ".", because node v13.0 and v13.1 require the string fallback, and if you ever want to add an ESM wrapper, this will make it trivial to add the "import" key to the object form correctly. I used the "default" key because some node versions will produce an unfortunate experimental warning if you use the "node" or "require" keys.

I also included package.json since a ton of tools rely on this information being requireable.

If there are other entry points that you'd want npm 7 to expose, please let me know and I'm happy to add them :-)

# What / Why
<!-- Describe the request in detail -->
> n/a

## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->
* n/a
