### PR TITLE
fix: wrong `npm doctor` command result

### DIFF
--- a/lib/doctor/check-ping.js
+++ b/lib/doctor/check-ping.js
@@ -6,7 +6,7 @@ function checkPing (cb) {
   tracker.info('checkPing', 'Pinging registry')
   ping({}, true, (err, pong) => {
     if (err && err.code && err.code.match(/^E\d{3}$/)) {
-      return cb(null, [err.code.substr(1)])
+      return cb(null, [err.code.substr(1), 'failed'])
     } else {
       cb(null, [200, 'ok'])
     }

--- a/test/tap/doctor-ping-registry-404.js
+++ b/test/tap/doctor-ping-registry-404.js
@@ -54,18 +54,18 @@ t.test('setup', (t) => {
               _hasShrinkwrap: false,
               dist: {
                 shasum: 'deadbeef',
-                tarball: 'https://reg.eh/npm-0.0.0.tgz',
-              },
-            },
-          },
+                tarball: 'https://reg.eh/npm-0.0.0.tgz'
+              }
+            }
+          }
         })
       )
       const fixture = new Tacks(
         Dir({
           [path.basename(PKG)]: Dir({
-            'package.json': File({ name: 'npm', version: '0.0.0' }),
+            'package.json': File({ name: 'npm', version: '0.0.0' })
           }),
-          [path.basename(PREFIX)]: Dir({}),
+          [path.basename(PREFIX)]: Dir({})
         })
       )
       fixture.create(ROOT)
@@ -75,7 +75,7 @@ t.test('setup', (t) => {
           loglevel: 'silent',
           cache: CACHE,
           tmp: TMP,
-          prefix: PREFIX,
+          prefix: PREFIX
         },
         (err) => {
           t.ifError(err, 'npm loaded successfully')

--- a/test/tap/doctor-ping-registry-404.js
+++ b/test/tap/doctor-ping-registry-404.js
@@ -1,0 +1,108 @@
+'use strict'
+/* eslint-disable camelcase */
+const common = require('../common-tap.js')
+const http = require('http')
+const mr = require('npm-registry-mock')
+const npm = require('../../lib/npm.js')
+const path = require('path')
+const Tacks = require('tacks')
+const t = require('tap')
+const which = require('which')
+
+const Dir = Tacks.Dir
+const File = Tacks.File
+
+const ROOT = common.pkg
+const CACHE = common.cache
+const TMP = path.join(ROOT, 'tmp')
+const PREFIX = path.join(ROOT, 'global-prefix')
+const PKG = path.join(ROOT, 'pkg')
+
+let server, nodeServer
+let node_url
+
+t.teardown(() => {
+  if (server) {
+    server.close()
+  }
+  if (nodeServer) {
+    nodeServer.close()
+  }
+})
+
+t.test('setup', (t) => {
+  const port = common.port + 2
+  nodeServer = http.createServer(function (q, s) {
+    s.end(JSON.stringify([{ lts: true, version: '0.0.0' }]))
+  })
+  nodeServer.listen(port, () => {
+    node_url = 'http://localhost:' + port
+    mr({ port: common.port }, (err, s) => {
+      t.ifError(err, 'registry mocked successfully')
+      server = s
+      server.get('/-/ping?write=true').reply(404)
+      server.get('/npm').reply(
+        200,
+        JSON.stringify({
+          name: 'npm',
+          'dist-tags': { latest: '0.0.0' },
+          versions: {
+            '0.0.0': {
+              name: 'npm',
+              version: '0.0.0',
+              _shrinkwrap: null,
+              _hasShrinkwrap: false,
+              dist: {
+                shasum: 'deadbeef',
+                tarball: 'https://reg.eh/npm-0.0.0.tgz',
+              },
+            },
+          },
+        })
+      )
+      const fixture = new Tacks(
+        Dir({
+          [path.basename(PKG)]: Dir({
+            'package.json': File({ name: 'npm', version: '0.0.0' }),
+          }),
+          [path.basename(PREFIX)]: Dir({}),
+        })
+      )
+      fixture.create(ROOT)
+      npm.load(
+        {
+          registry: common.registry,
+          loglevel: 'silent',
+          cache: CACHE,
+          tmp: TMP,
+          prefix: PREFIX,
+        },
+        (err) => {
+          t.ifError(err, 'npm loaded successfully')
+          t.pass('all set up')
+          t.done()
+        }
+      )
+    })
+  })
+})
+
+t.test('npm doctor ping returns 404 (or any other error)', function (t) {
+  npm.commands.doctor({ 'node-url': node_url }, true, function (e, list) {
+    t.ifError(e, 'npm loaded successfully')
+    t.same(list.length, 9, 'list should have 9 prop')
+    t.same(list[0][1], 'failed', 'npm ping')
+    t.same(list[1][1], 'v' + npm.version, 'npm -v')
+    t.same(list[2][1], process.version, 'node -v')
+    t.same(list[3][1], common.registry + '/', 'npm config get registry')
+    t.same(list[5][1], 'ok', 'Perms check on cached files')
+    t.same(list[6][1], 'ok', 'Perms check on global node_modules')
+    t.same(list[7][1], 'ok', 'Perms check on local node_modules')
+    t.match(list[8][1], /^verified \d+ tarballs?$/, 'Cache verified')
+    which('git', function (e, resolvedPath) {
+      t.ifError(e, 'git command is installed')
+      t.same(list[4][1], resolvedPath, 'which git')
+      t.done()
+    })
+  })
+})


### PR DESCRIPTION
## Detail
<!-- Describe the request in detail -->
when I run `npm doctor`, I found that the some infomation in the result table were totaly wrong, look the screenshot:

![kvB9iFG6ApaOdtP](https://i.loli.net/2020/06/10/kvB9iFG6ApaOdtP.png)

**look at the `Recommendation` column**

the right result:

![YkHKdQ96gLieF1y](https://i.loli.net/2020/06/10/YkHKdQ96gLieF1y.png)

I found that if I changed the default registry to another url (such as https://registry.npm.taobao.org), and `ping` returns error, it would happend.

so i checked and modified the `check-ping.js`, when `ping` is failed, return `cb(null, [err.code.substr(1), 'failed'])` instead of `cb(null, [err.code.substr(1)])`

i don't know if it's a bug certainty, if it's realy not, i'll close this pr.

(forgive me that English is not my mother language······)

## Environment
macOS 10.15.5
node 10.18.0
npm 6.14.5 (from source code)
