### PR TITLE
docs: Fix typo

### DIFF
--- a/docs/content/using-npm/config.md
+++ b/docs/content/using-npm/config.md
@@ -455,7 +455,7 @@ packages.
 * Type: Boolean
 
 When "true" displays the message at the end of each `npm install`
-aknowledging the number of dependencies looking for funding.
+acknowledging the number of dependencies looking for funding.
 See [`npm fund`](/cli-commands/fund) for details.
 
 #### git


### PR DESCRIPTION
# What / Why

I've added a `c` to fix a typo.

Thanks folks. 👏 