### PR TITLE
bug: fix otp function for publishing

### DIFF
--- a/lib/utils/read-user-info.js
+++ b/lib/utils/read-user-info.js
@@ -10,13 +10,8 @@ exports.username = readUsername
 exports.email = readEmail
 
 function read (opts) {
-  return Promise.resolve().then(() => {
-    log.clearProgress()
-    return readAsync(opts)
-  }).then(() => log.showProgress(), er => {
-    log.showProgress()
-    throw er
-  })
+  log.clearProgress()
+  return readAsync(opts).finally(() => log.showProgress())
 }
 
 function readOTP (msg, otp, isRetry) {


### PR DESCRIPTION
A recent refactor while removing `bluebird` forgot to continue passing the user input (`readAsync`) to the promise chain creating a bug on the otp fn. This piece of logic has been refactored again using async/await instead of promises. 

Tested the solution and managed to successfully publish a package with `v7`.