### PR TITLE
test: increase whoami with bearer auth timeout

### DIFF
--- a/test/tap/whoami.js
+++ b/test/tap/whoami.js
@@ -36,7 +36,7 @@ test('npm whoami with basic auth', function (t) {
   )
 })
 
-test('npm whoami with bearer auth', { timeout: 6000 }, function (t) {
+test('npm whoami with bearer auth', { timeout: 8000 }, function (t) {
   var s = '//localhost:' + common.port +
           '/:_authToken = wombat-developers-union\n'
   fs.writeFileSync(FIXTURE_PATH, s, 'ascii')


### PR DESCRIPTION
This makes the test pass on slow architectures (such as armhf) on emulated environments (such as qemu)

See e.g.:
https://objectstorage.prodstack4-5.canonical.com/v1/AUTH_77e2ada1e7a84929a74ba3b87153c0ac/autopkgtest-groovy/groovy/armhf/n/npm/20200506_003912_868e4@/log.gz

```
not ok 186 - test/tap/whoami.js # time=19002.663ms
  ---
  timeout: 300000
  file: test/tap/whoami.js
  command: /usr/bin/node
  args:
    - test/tap/whoami.js
  stdio:
    - 0
    - pipe
    - 2
  cwd: /tmp/autopkgtest.w8Bn2l/autopkgtest_tmp/smokeH32cpa
  exitCode: 1
  ...
{
    # Subtest: npm whoami with basic auth
        ok 1 - should not error
        ok 2 - got nothing on stderr
        ok 3 - exit ok
        ok 4 - got username
        1..4
    ok 1 - npm whoami with basic auth # time=6547.914ms
    
    # Subtest: npm whoami with bearer auth
        not ok 1 - timeout!
          ---
          expired: npm whoami with bearer auth
          timeout: 6000
          test: npm whoami with bearer auth
          ...
        
        1..1
        # failed 1 test
    not ok 2 - npm whoami with bearer auth # time=6231.806ms
      ---
      timeout: 6000
      ...
    
    1..2
    # failed 1 of 2 tests
    # time=12951.956ms
}
```