### PR TITLE
Avoid blowing stack when checking if a failed dependency is required or optional

### DIFF
--- a/lib/install/deps.js
+++ b/lib/install/deps.js
@@ -436,7 +436,11 @@ function isDepOptional (tree, name, pkg) {
 }
 
 exports.failedDependency = failedDependency
-function failedDependency (tree, name, pkg) {
+function failedDependency (tree, name, pkg, visited = new Set()) {
+  // cycle detection
+  if (visited.has(tree)) return false
+  visited.add(tree)
+
   if (name) {
     if (isDepOptional(tree, name, pkg || {})) {
       return false
@@ -454,7 +458,7 @@ function failedDependency (tree, name, pkg) {
   let anyFailed = false
   for (var ii = 0; ii < tree.requiredBy.length; ++ii) {
     var requireParent = tree.requiredBy[ii]
-    if (failedDependency(requireParent, moduleName(tree), tree)) {
+    if (failedDependency(requireParent, moduleName(tree), tree, visited)) {
       anyFailed = true
     }
   }


### PR DESCRIPTION
# Avoid blowing stack when checking if a failed dependency is required or optional

I see this issue in our private repository, I can't provide a public reproduction.
If I install a package with a cycle in it's dependencies and one of the packages in the cycle fails npm will error with `Maximum call stack size exceeded` and a track trace pointing to `failedDependency`.
