### PR TITLE
chore(docs): fixed links to cli commands

### DIFF
--- a/docs/content/cli-commands/npm-access.md
+++ b/docs/content/cli-commands/npm-access.md
@@ -87,7 +87,7 @@ Management of teams and team memberships is done with the `npm team` command.
 ### See Also
 
 * [`libnpmaccess`](https://npm.im/libnpmaccess)
-* [npm team](/cli-commands/team)
-* [npm publish](/cli-commands/publish)
-* [npm config](/cli-commands/config)
+* [npm team](/cli-commands/npm-team)
+* [npm publish](/cli-commands/npm-publish)
+* [npm config](/cli-commands/npm-config)
 * [npm registry](/using-npm/registry)

--- a/docs/content/cli-commands/npm-adduser.md
+++ b/docs/content/cli-commands/npm-adduser.md
@@ -89,7 +89,7 @@ username/password entry in legacy npm.
 ### See Also
 
 * [npm registry](/using-npm/registry)
-* [npm config](/cli-commands/config)
+* [npm config](/cli-commands/npm-config)
 * [npmrc](/configuring-npm/npmrc)
-* [npm owner](/cli-commands/owner)
-* [npm whoami](/cli-commands/whoami)
+* [npm owner](/cli-commands/npm-owner)
+* [npm whoami](/cli-commands/npm-whoami)

--- a/docs/content/cli-commands/npm-audit.md
+++ b/docs/content/cli-commands/npm-audit.md
@@ -131,6 +131,6 @@ configuration setting.
 
 ### See Also
 
-* [npm install](/cli-commands/install)
+* [npm install](/cli-commands/npm-install)
 * [package-locks](/configuring-npm/package-locks)
 * [config](/using-npm/config)

--- a/docs/content/cli-commands/npm-bin.md
+++ b/docs/content/cli-commands/npm-bin.md
@@ -19,8 +19,8 @@ Print the folder where npm will install executables.
 
 ### See Also
 
-* [npm prefix](/cli-commands/prefix)
-* [npm root](/cli-commands/root)
+* [npm prefix](/cli-commands/npm-prefix)
+* [npm root](/cli-commands/npm-root)
 * [npm folders](/configuring-npm/folders)
-* [npm config](/cli-commands/config)
+* [npm config](/cli-commands/npm-config)
 * [npmrc](/configuring-npm/npmrc)

--- a/docs/content/cli-commands/npm-bugs.md
+++ b/docs/content/cli-commands/npm-bugs.md
@@ -41,10 +41,10 @@ The base URL of the npm package registry.
 
 ### See Also
 
-* [npm docs](/cli-commands/docs)
-* [npm view](/cli-commands/view)
-* [npm publish](/cli-commands/publish)
+* [npm docs](/cli-commands/npm-docs)
+* [npm view](/cli-commands/npm-view)
+* [npm publish](/cli-commands/npm-publish)
 * [npm registry](/using-npm/registry)
-* [npm config](/cli-commands/config)
+* [npm config](/cli-commands/npm-config)
 * [npmrc](/configuring-npm/npmrc)
 * [package.json](/configuring-npm/package-json)

--- a/docs/content/cli-commands/npm-build.md
+++ b/docs/content/cli-commands/npm-build.md
@@ -28,7 +28,7 @@ directly, run:
 
 ### See Also
 
-* [npm install](/cli-commands/install)
-* [npm link](/cli-commands/link)
+* [npm install](/cli-commands/npm-install)
+* [npm link](/cli-commands/npm-link)
 * [npm scripts](/using-npm/scripts)
 * [package.json](/configuring-npm/package-json)

--- a/docs/content/cli-commands/npm-bundle.md
+++ b/docs/content/cli-commands/npm-bundle.md
@@ -18,4 +18,4 @@ Just use `npm install` now to do what `npm bundle` used to do.
 
 ### See Also
 
-* [npm install](/cli-commands/install)
+* [npm install](/cli-commands/npm-install)

--- a/docs/content/cli-commands/npm-cache.md
+++ b/docs/content/cli-commands/npm-cache.md
@@ -82,10 +82,10 @@ The root cache folder.
 ### See Also
 
 * [npm folders](/configuring-npm/folders)
-* [npm config](/cli-commands/config)
+* [npm config](/cli-commands/npm-config)
 * [npmrc](/configuring-npm/npmrc)
-* [npm install](/cli-commands/install)
-* [npm publish](/cli-commands/publish)
-* [npm pack](/cli-commands/pack)
+* [npm install](/cli-commands/npm-install)
+* [npm publish](/cli-commands/npm-publish)
+* [npm pack](/cli-commands/npm-pack)
 * https://npm.im/cacache
 * https://npm.im/pacote

--- a/docs/content/cli-commands/npm-ci.md
+++ b/docs/content/cli-commands/npm-ci.md
@@ -45,7 +45,7 @@ cache:
 
 ### Description
 
-This command is similar to [`npm install`](/cli-commands/install), except it's meant to be used in
+This command is similar to [`npm install`](/cli-commands/npm-install), except it's meant to be used in
 automated environments such as test platforms, continuous integration, and
 deployment -- or any situation where you want to make sure you're doing a clean
 install of your dependencies. It can be significantly faster than a regular npm
@@ -63,5 +63,5 @@ In short, the main differences between using `npm install` and `npm ci` are:
 
 ### See Also
 
-* [npm install](/cli-commands/install)
+* [npm install](/cli-commands/npm-install)
 * [package-locks](/configuring-npm/package-locks)

--- a/docs/content/cli-commands/npm-config.md
+++ b/docs/content/cli-commands/npm-config.md
@@ -79,7 +79,7 @@ global config.
 ### See Also
 
 * [npm folders](/configuring-npm/folders)
-* [npm config](/cli-commands/config)
+* [npm config](/cli-commands/npm-config)
 * [package.json](/configuring-npm/package-json)
 * [npmrc](/configuring-npm/npmrc)
 * [npm](/cli-commands/npm)

--- a/docs/content/cli-commands/npm-dedupe.md
+++ b/docs/content/cli-commands/npm-dedupe.md
@@ -62,6 +62,6 @@ result in new modules being installed.
 
 ### See Also
 
-* [npm ls](/cli-commands/ls)
-* [npm update](/cli-commands/update)
-* [npm install](/cli-commands/install)
+* [npm ls](/cli-commands/npm-ls)
+* [npm update](/cli-commands/npm-update)
+* [npm install](/cli-commands/npm-install)

--- a/docs/content/cli-commands/npm-deprecate.md
+++ b/docs/content/cli-commands/npm-deprecate.md
@@ -32,5 +32,5 @@ format an empty string.
 
 ### See Also
 
-* [npm publish](/cli-commands/publish)
+* [npm publish](/cli-commands/npm-publish)
 * [npm registry](/using-npm/registry)

--- a/docs/content/cli-commands/npm-dist-tag.md
+++ b/docs/content/cli-commands/npm-dist-tag.md
@@ -92,9 +92,9 @@ begin with a number or the letter `v`.
 
 ### See Also
 
-* [npm publish](/cli-commands/publish)
-* [npm install](/cli-commands/install)
-* [npm dedupe](/cli-commands/dedupe)
+* [npm publish](/cli-commands/npm-publish)
+* [npm install](/cli-commands/npm-install)
+* [npm dedupe](/cli-commands/npm-dedupe)
 * [npm registry](/using-npm/registry)
-* [npm config](/cli-commands/config)
+* [npm config](/cli-commands/npm-config)
 * [npmrc](/configuring-npm/npmrc)

--- a/docs/content/cli-commands/npm-docs.md
+++ b/docs/content/cli-commands/npm-docs.md
@@ -44,9 +44,9 @@ The base URL of the npm package registry.
 
 ### See Also
 
-* [npm view](/cli-commands/view)
-* [npm publish](/cli-commands/publish)
+* [npm view](/cli-commands/npm-view)
+* [npm publish](/cli-commands/npm-publish)
 * [npm registry](/using-npm/registry)
-* [npm config](/cli-commands/config)
+* [npm config](/cli-commands/npm-config)
 * [npmrc](/configuring-npm/npmrc)
 * [package.json](/configuring-npm/package-json)

--- a/docs/content/cli-commands/npm-doctor.md
+++ b/docs/content/cli-commands/npm-doctor.md
@@ -106,6 +106,6 @@ cache, you should probably run `npm cache clean` and reset the cache.
 
 ### See Also
 
-* [npm bugs](/cli-commands/bugs)
-* [npm help](/cli-commands/help)
-* [npm ping](/cli-commands/ping)
+* [npm bugs](/cli-commands/npm-bugs)
+* [npm help](/cli-commands/npm-help)
+* [npm ping](/cli-commands/npm-ping)

--- a/docs/content/cli-commands/npm-edit.md
+++ b/docs/content/cli-commands/npm-edit.md
@@ -41,7 +41,7 @@ The command to run for `npm edit` or `npm config edit`.
 ### See Also
 
 * [npm folders](/configuring-npm/folders)
-* [npm explore](/cli-commands/explore)
-* [npm install](/cli-commands/install)
-* [npm config](/cli-commands/config)
+* [npm explore](/cli-commands/npm-explore)
+* [npm install](/cli-commands/npm-install)
+* [npm config](/cli-commands/npm-config)
 * [npmrc](/configuring-npm/npmrc)

--- a/docs/content/cli-commands/npm-explore.md
+++ b/docs/content/cli-commands/npm-explore.md
@@ -44,7 +44,7 @@ The shell to run for the `npm explore` command.
 ### See Also
 
 * [npm folders](/configuring-npm/folders)
-* [npm edit](/cli-commands/edit)
-* [npm rebuild](/cli-commands/rebuild)
-* [npm build](/cli-commands/build)
-* [npm install](/cli-commands/install)
+* [npm edit](/cli-commands/npm-edit)
+* [npm rebuild](/cli-commands/npm-rebuild)
+* [npm build](/cli-commands/npm-build)
+* [npm install](/cli-commands/npm-install)

--- a/docs/content/cli-commands/npm-fund.md
+++ b/docs/content/cli-commands/npm-fund.md
@@ -61,8 +61,8 @@ If there are multiple funding sources, which 1-indexed source URL to open.
 
 ## See Also
 
-* [npm docs](/cli-commands/docs)
-* [npm config](/cli-commands/config)
-* [npm install](/cli-commands/install)
-* [npm ls](/cli-commands/ls)
+* [npm docs](/cli-commands/npm-docs)
+* [npm config](/cli-commands/npm-config)
+* [npm install](/cli-commands/npm-install)
+* [npm ls](/cli-commands/npm-ls)
 

--- a/docs/content/cli-commands/npm-help-search.md
+++ b/docs/content/cli-commands/npm-help-search.md
@@ -40,4 +40,4 @@ If false, then help-search will just list out the help topics found.
 ### See Also
 
 * [npm](/cli-commands/npm)
-* [npm help](/cli-commands/help)
+* [npm help](/cli-commands/npm-help)

--- a/docs/content/cli-commands/npm-help.md
+++ b/docs/content/cli-commands/npm-help.md
@@ -38,7 +38,7 @@ Set to `"browser"` to view html help content in the default web browser.
 
 * [npm](/cli-commands/npm)
 * [npm folders](/configuring-npm/folders)
-* [npm config](/cli-commands/config)
+* [npm config](/cli-commands/npm-config)
 * [npmrc](/configuring-npm/npmrc)
 * [package.json](/configuring-npm/package-json)
-* [npm help-search](/cli-commands/help-search)
+* [npm help-search](/cli-commands/npm-help-search)

--- a/docs/content/cli-commands/npm-init.md
+++ b/docs/content/cli-commands/npm-init.md
@@ -70,5 +70,5 @@ will create a scoped package.
 
 * <https://github.com/isaacs/init-package-json>
 * [package.json](/configuring-npm/package-json)
-* [npm version](/cli-commands/version)
+* [npm version](/cli-commands/npm-version)
 * [npm scope](/using-npm/scope)

--- a/docs/content/cli-commands/npm-install-ci-test.md
+++ b/docs/content/cli-commands/npm-install-ci-test.md
@@ -22,5 +22,5 @@ This command runs an `npm ci` followed immediately by an `npm test`.
 
 ### See Also
 
-* [npm ci](/cli-commands/ci)
-* [npm test](/cli-commands/test)
+* [npm ci](/cli-commands/npm-ci)
+* [npm test](/cli-commands/npm-test)

--- a/docs/content/cli-commands/npm-install-test.md
+++ b/docs/content/cli-commands/npm-install-test.md
@@ -31,5 +31,5 @@ takes exactly the same arguments as `npm install`.
 
 ### See Also
 
-* [npm install](/cli-commands/install)
-* [npm test](/cli-commands/test)
+* [npm install](/cli-commands/npm-install)
+* [npm test](/cli-commands/npm-test)

--- a/docs/content/cli-commands/npm-install.md
+++ b/docs/content/cli-commands/npm-install.md
@@ -32,7 +32,7 @@ common options: [-P|--save-prod|-D|--save-dev|-O|--save-optional] [-E|--save-exa
 This command installs a package, and any packages that it depends on. If the
 package has a package-lock or shrinkwrap file, the installation of dependencies
 will be driven by that, with an `npm-shrinkwrap.json` taking precedence if both
-files exist. See [package-lock.json](/configuring-npm/package-lock-json) and [`npm shrinkwrap`](/cli-commands/shrinkwrap).
+files exist. See [package-lock.json](/configuring-npm/package-lock-json) and [`npm shrinkwrap`](/cli-commands/npm-shrinkwrap).
 
 A `package` is:
 
@@ -40,7 +40,7 @@ A `package` is:
 * b) a gzipped tarball containing (a)
 * c) a url that resolves to (b)
 * d) a `<name>@<version>` that is published on the registry (see [`registry`](/using-npm/registry)) with (c)
-* e) a `<name>@<tag>` (see [`npm dist-tag`](/cli-commands/dist-tag)) that points to (d)
+* e) a `<name>@<tag>` (see [`npm dist-tag`](/cli-commands/npm-dist-tag)) that points to (d)
 * f) a `<name>` that has a "latest" tag satisfying (e)
 * g) a `<git remote url>` that resolves to (a)
 
@@ -503,17 +503,17 @@ affects a real use-case, it will be investigated.
 ### See Also
 
 * [npm folders](/configuring-npm/folders)
-* [npm update](/cli-commands/update)
-* [npm audit](/cli-commands/audit)
-* [npm fund](/cli-commands/fund)
-* [npm link](/cli-commands/link)
-* [npm rebuild](/cli-commands/rebuild)
+* [npm update](/cli-commands/npm-update)
+* [npm audit](/cli-commands/npm-audit)
+* [npm fund](/cli-commands/npm-fund)
+* [npm link](/cli-commands/npm-link)
+* [npm rebuild](/cli-commands/npm-rebuild)
 * [npm scripts](/using-npm/scripts)
-* [npm build](/cli-commands/build)
-* [npm config](/cli-commands/config)
+* [npm build](/cli-commands/npm-build)
+* [npm config](/cli-commands/npm-config)
 * [npmrc](/configuring-npm/npmrc)
 * [npm registry](/using-npm/registry)
-* [npm dist-tag](/cli-commands/dist-tag)
-* [npm uninstall](/cli-commands/uninstall)
-* [npm shrinkwrap](/cli-commands/shrinkwrap)
+* [npm dist-tag](/cli-commands/npm-dist-tag)
+* [npm uninstall](/cli-commands/npm-uninstall)
+* [npm shrinkwrap](/cli-commands/npm-shrinkwrap)
 * [package.json](/configuring-npm/package-json)

--- a/docs/content/cli-commands/npm-link.md
+++ b/docs/content/cli-commands/npm-link.md
@@ -86,7 +86,7 @@ npm link @myorg/privatepackage
 
 * [npm developers](/using-npm/developers)
 * [package.json](/configuring-npm/package-json)
-* [npm- nstall](/cli-commands/install)
+* [npm- nstall](/cli-commands/npm-install)
 * [npm folders](/configuring-npm/folders)
-* [npm config](/cli-commands/config)
+* [npm config](/cli-commands/npm-config)
 * [npmrc](/configuring-npm/npmrc)

--- a/docs/content/cli-commands/npm-logout.md
+++ b/docs/content/cli-commands/npm-logout.md
@@ -48,7 +48,7 @@ npm logout --scope=@myco
 
 ### See Also
 
-* [npm adduser](/cli-commands/adduser)
+* [npm adduser](/cli-commands/npm-adduser)
 * [npm registry](/using-npm/registry)
-* [npm config](/cli-commands/config)
-* [npm whoami](/cli-commands/whoami)
+* [npm config](/cli-commands/npm-config)
+* [npm whoami](/cli-commands/npm-whoami)

--- a/docs/content/cli-commands/npm-ls.md
+++ b/docs/content/cli-commands/npm-ls.md
@@ -119,11 +119,11 @@ Set it to false in order to use all-ansi output.
 
 ### See Also
 
-* [npm config](/cli-commands/config)
+* [npm config](/cli-commands/npm-config)
 * [npmrc](/configuring-npm/npmrc)
 * [npm folders](/configuring-npm/folders)
-* [npm install](/cli-commands/install)
-* [npm link](/cli-commands/link)
-* [npm prune](/cli-commands/prune)
-* [npm outdated](/cli-commands/outdated)
-* [npm update](/cli-commands/update)
+* [npm install](/cli-commands/npm-install)
+* [npm link](/cli-commands/npm-link)
+* [npm prune](/cli-commands/npm-prune)
+* [npm outdated](/cli-commands/npm-outdated)
+* [npm update](/cli-commands/npm-update)

--- a/docs/content/cli-commands/npm-outdated.md
+++ b/docs/content/cli-commands/npm-outdated.md
@@ -118,7 +118,7 @@ Max depth for checking dependency tree.
 
 ### See Also
 
-* [npm update](/cli-commands/update)
-* [npm dist-tag](/cli-commands/dist-tag)
+* [npm update](/cli-commands/npm-update)
+* [npm dist-tag](/cli-commands/npm-dist-tag)
 * [npm registry](/using-npm/registry)
 * [npm folders](/configuring-npm/folders)

--- a/docs/content/cli-commands/npm-owner.md
+++ b/docs/content/cli-commands/npm-owner.md
@@ -41,7 +41,7 @@ with `--otp`.
 
 ### See Also
 
-* [npm publish](/cli-commands/publish)
+* [npm publish](/cli-commands/npm-publish)
 * [npm registry](/using-npm/registry)
-* [npm adduser](/cli-commands/adduser)
+* [npm adduser](/cli-commands/npm-adduser)
 * [npm disputes](/using-npm/disputes)

--- a/docs/content/cli-commands/npm-pack.md
+++ b/docs/content/cli-commands/npm-pack.md
@@ -32,7 +32,7 @@ actually packing anything. Reports on what would have gone into the tarball.
 
 ### See Also
 
-* [npm cache](/cli-commands/cache)
-* [npm publish](/cli-commands/publish)
-* [npm config](/cli-commands/config)
+* [npm cache](/cli-commands/npm-cache)
+* [npm publish](/cli-commands/npm-publish)
+* [npm config](/cli-commands/npm-config)
 * [npmrc](/configuring-npm/npmrc)

--- a/docs/content/cli-commands/npm-ping.md
+++ b/docs/content/cli-commands/npm-ping.md
@@ -29,5 +29,5 @@ Ping error: {*Detail about error}
 
 ### See Also
 
-* [npm config](/cli-commands/config)
+* [npm config](/cli-commands/npm-config)
 * [npmrc](/configuring-npm/npmrc)

--- a/docs/content/cli-commands/npm-prefix.md
+++ b/docs/content/cli-commands/npm-prefix.md
@@ -21,12 +21,12 @@ to contain a `package.json` file or `node_modules` directory, unless `-g` is
 also specified.
 
 If `-g` is specified, this will be the value of the global prefix. See
-[`npm config`](/cli-commands/config) for more detail.
+[`npm config`](/cli-commands/npm-config) for more detail.
 
 ### See Also
 
-* [npm root](/cli-commands/root)
-* [npm bin](/cli-commands/bin)
+* [npm root](/cli-commands/npm-root)
+* [npm bin](/cli-commands/npm-bin)
 * [npm folders](/configuring-npm/folders)
-* [npm config](/cli-commands/config)
+* [npm config](/cli-commands/npm-config)
 * [npmrc](/configuring-npm/npmrc)

--- a/docs/content/cli-commands/npm-profile.md
+++ b/docs/content/cli-commands/npm-profile.md
@@ -79,4 +79,4 @@ available on non npmjs.com registries.
 
 ### See Also
 
-* [npm config](/cli-commands/config)
+* [npm config](/cli-commands/npm-config)

--- a/docs/content/cli-commands/npm-prune.md
+++ b/docs/content/cli-commands/npm-prune.md
@@ -41,6 +41,6 @@ and it's up to you to run `npm prune` from time-to-time to remove them.
 
 ### See Also
 
-* [npm uninstall](/cli-commands/uninstall)
+* [npm uninstall](/cli-commands/npm-uninstall)
 * [npm folders](/configuring-npm/folders)
-* [npm ls](/cli-commands/ls)
+* [npm ls](/cli-commands/npm-ls)

--- a/docs/content/cli-commands/npm-publish.md
+++ b/docs/content/cli-commands/npm-publish.md
@@ -60,13 +60,13 @@ the specified registry.
 
 Once a package is published with a given name and version, that
 specific name and version combination can never be used again, even if
-it is removed with [`npm unpublish`](/cli-commands/unpublish).
+it is removed with [`npm unpublish`](/cli-commands/npm-unpublish).
 
 As of `npm@5`, both a sha1sum and an integrity field with a sha512sum of the
 tarball will be submitted to the registry during publication. Subsequent
 installs will use the strongest supported algorithm to verify downloads.
 
-Similar to `--dry-run` see [`npm pack`](/cli-commands/pack), which figures out the files to be
+Similar to `--dry-run` see [`npm pack`](/cli-commands/npm-pack), which figures out the files to be
 included and packs them into a tarball to be uploaded to the registry.
 
 ### See Also

--- a/docs/content/cli-commands/npm-rebuild.md
+++ b/docs/content/cli-commands/npm-rebuild.md
@@ -22,5 +22,5 @@ This command runs the `npm build` command on the matched folders.  This is usefu
 
 ### See Also
 
-* [npm build](/cli-commands/build)
-* [npm install](/cli-commands/install)
+* [npm build](/cli-commands/npm-build)
+* [npm install](/cli-commands/npm-install)

--- a/docs/content/cli-commands/npm-repo.md
+++ b/docs/content/cli-commands/npm-repo.md
@@ -32,5 +32,5 @@ The browser that is called by the `npm repo` command to open websites.
 
 ### See Also
 
-* [npm docs](/cli-commands/docs)
-* [npm config](/cli-commands/config)
+* [npm docs](/cli-commands/npm-docs)
+* [npm config](/cli-commands/npm-config)

--- a/docs/content/cli-commands/npm-restart.md
+++ b/docs/content/cli-commands/npm-restart.md
@@ -41,9 +41,9 @@ behavior will be accompanied by an increase in major version number
 
 ### See Also
 
-* [npm run-script](/cli-commands/run-script)
+* [npm run-script](/cli-commands/npm-run-script)
 * [npm scripts](/using-npm/scripts)
-* [npm test](/cli-commands/test)
-* [npm start](/cli-commands/start)
-* [npm stop](/cli-commands/stop)
-* [npm restart](/cli-commands/restart)
+* [npm test](/cli-commands/npm-test)
+* [npm start](/cli-commands/npm-start)
+* [npm stop](/cli-commands/npm-stop)
+* [npm restart](/cli-commands/npm-restart)

--- a/docs/content/cli-commands/npm-root.md
+++ b/docs/content/cli-commands/npm-root.md
@@ -19,8 +19,8 @@ Print the effective `node_modules` folder to standard out.
 
 ### See Also
 
-* [npm prefix](/cli-commands/prefix)
-* [npm bin](/cli-commands/bin)
+* [npm prefix](/cli-commands/npm-prefix)
+* [npm bin](/cli-commands/npm-bin)
 * [npm folders](/configuring-npm/folders)
-* [npm config](/cli-commands/config)
+* [npm config](/cli-commands/npm-config)
 * [npmrc](/configuring-npm/npmrc)

--- a/docs/content/cli-commands/npm-run-script.md
+++ b/docs/content/cli-commands/npm-run-script.md
@@ -90,8 +90,8 @@ without breaking the execution chain.
 ### See Also
 
 * [npm scripts](/using-npm/scripts)
-* [npm test](/cli-commands/test)
-* [npm start](/cli-commands/start)
-* [npm restart](/cli-commands/restart)
-* [npm stop](/cli-commands/stop)
-* [npm config](/cli-commands/config)
+* [npm test](/cli-commands/npm-test)
+* [npm start](/cli-commands/npm-start)
+* [npm restart](/cli-commands/npm-restart)
+* [npm stop](/cli-commands/npm-stop)
+* [npm config](/cli-commands/npm-config)

--- a/docs/content/cli-commands/npm-search.md
+++ b/docs/content/cli-commands/npm-search.md
@@ -109,6 +109,6 @@ setting.
 ### See Also
 
 * [npm registry](/using-npm/registry)
-* [npm config](/cli-commands/config)
+* [npm config](/cli-commands/npm-config)
 * [npmrc](/configuring-npm/npmrc)
-* [npm view](/cli-commands/view)
+* [npm view](/cli-commands/npm-view)

--- a/docs/content/cli-commands/npm-shrinkwrap.md
+++ b/docs/content/cli-commands/npm-shrinkwrap.md
@@ -24,11 +24,11 @@ of package locks in npm, see [package-locks](/configuring-npm/package-locks).
 
 ### See Also
 
-* [npm install](/cli-commands/install)
-* [npm run-script](/cli-commands/run-script)
+* [npm install](/cli-commands/npm-install)
+* [npm run-script](/cli-commands/npm-run-script)
 * [npm scripts](/using-npm/scripts)
 * [package.js](/configuring-npm/package-json)
 * [package-locks](/configuring-npm/package-locks)
 * [package-lock.json](/configuring-npm/package-lock-json)
 * [shrinkwrap.json](/configuring-npm/shrinkwrap-json)
-* [npm ls](/cli-commands/ls)
+* [npm ls](/cli-commands/npm-ls)

--- a/docs/content/cli-commands/npm-star.md
+++ b/docs/content/cli-commands/npm-star.md
@@ -26,6 +26,6 @@ It's a boolean thing.  Starring repeatedly has no additional effect.
 
 ### See Also
 
-* [npm view](/cli-commands/view)
-* [npm whoami](/cli-commands/whoami)
-* [npm adduser](/cli-commands/adduser)
+* [npm view](/cli-commands/npm-view)
+* [npm whoami](/cli-commands/npm-whoami)
+* [npm adduser](/cli-commands/npm-adduser)

--- a/docs/content/cli-commands/npm-stars.md
+++ b/docs/content/cli-commands/npm-stars.md
@@ -23,7 +23,7 @@ you will most certainly enjoy this command.
 
 ### See Also
 
-* [npm star](/cli-commands/star)
-* [npm view](/cli-commands/view)
-* [npm whoami](/cli-commands/whoami)
-* [npm adduser](/cli-commands/adduser)
+* [npm star](/cli-commands/npm-star)
+* [npm view](/cli-commands/npm-view)
+* [npm whoami](/cli-commands/npm-whoami)
+* [npm adduser](/cli-commands/npm-adduser)

--- a/docs/content/cli-commands/npm-start.md
+++ b/docs/content/cli-commands/npm-start.md
@@ -21,12 +21,12 @@ its `"scripts"` object. If no `"start"` property is specified on the
 `"scripts"` object, it will run `node server.js`.
 
 As of [`npm@2.0.0`](https://blog.npmjs.org/post/98131109725/npm-2-0-0), you can
-use custom arguments when executing scripts. Refer to [`npm run-script`](/cli-commands/run-script) for more details.
+use custom arguments when executing scripts. Refer to [`npm run-script`](/cli-commands/npm-run-script) for more details.
 
 ### See Also
 
-* [npm run-script](/cli-commands/run-script)
+* [npm run-script](/cli-commands/npm-run-script)
 * [npm scripts](/using-npm/scripts)
-* [npm test](/cli-commands/test)
-* [npm restart](/cli-commands/restart)
-* [npm stop](/cli-commands/stop)
+* [npm test](/cli-commands/npm-test)
+* [npm restart](/cli-commands/npm-restart)
+* [npm stop](/cli-commands/npm-stop)

--- a/docs/content/cli-commands/npm-stop.md
+++ b/docs/content/cli-commands/npm-stop.md
@@ -20,8 +20,8 @@ This runs a package's "stop" script, if one was provided.
 
 ### See Also
 
-* [npm run-script](/cli-commands/run-script)
+* [npm run-script](/cli-commands/npm-run-script)
 * [npm scripts](/using-npm/scripts)
-* [npm test](/cli-commands/test)
-* [npm start](/cli-commands/start)
-* [npm restart](/cli-commands/restart)
+* [npm test](/cli-commands/npm-test)
+* [npm start](/cli-commands/npm-start)
+* [npm restart](/cli-commands/npm-restart)

--- a/docs/content/cli-commands/npm-team.md
+++ b/docs/content/cli-commands/npm-team.md
@@ -62,5 +62,5 @@ use the `npm access` command to grant or revoke the appropriate permissions.
 
 ### See Also
 
-* [npm access](/cli-commands/access)
+* [npm access](/cli-commands/npm-access)
 * [npm registry](/using-npm/registry)

--- a/docs/content/cli-commands/npm-test.md
+++ b/docs/content/cli-commands/npm-test.md
@@ -22,8 +22,8 @@ This runs a package's "test" script, if one was provided.
 
 ### See Also
 
-* [npm run-script](/cli-commands/run-script)
+* [npm run-script](/cli-commands/npm-run-script)
 * [npm scripts](/using-npm/scripts)
-* [npm start](/cli-commands/start)
-* [npm restart](/cli-commands/restart)
-* [npm stop](/cli-commands/stop)
+* [npm start](/cli-commands/npm-start)
+* [npm restart](/cli-commands/npm-restart)
+* [npm stop](/cli-commands/npm-stop)

--- a/docs/content/cli-commands/npm-uninstall.md
+++ b/docs/content/cli-commands/npm-uninstall.md
@@ -57,8 +57,8 @@ npm uninstall lodash --no-save
 
 ### See Also
 
-* [npm prune](/cli-commands/prune)
-* [npm install](/cli-commands/install)
+* [npm prune](/cli-commands/npm-prune)
+* [npm install](/cli-commands/npm-install)
 * [npm folders](/configuring-npm/folders)
-* [npm config](/cli-commands/config)
+* [npm config](/cli-commands/npm-config)
 * [npmrc](/configuring-npm/npmrc)

--- a/docs/content/cli-commands/npm-unpublish.md
+++ b/docs/content/cli-commands/npm-unpublish.md
@@ -43,8 +43,8 @@ To learn more about how unpublish is treated on the npm registry, see our <a hre
 
 ### See Also
 
-* [npm deprecate](/cli-commands/deprecate)
-* [npm publish](/cli-commands/publish)
+* [npm deprecate](/cli-commands/npm-deprecate)
+* [npm publish](/cli-commands/npm-publish)
 * [npm registry](/using-npm/registry)
-* [npm adduser](/cli-commands/adduser)
-* [npm owner](/cli-commands/owner)
+* [npm adduser](/cli-commands/npm-adduser)
+* [npm owner](/cli-commands/npm-owner)

--- a/docs/content/cli-commands/npm-update.md
+++ b/docs/content/cli-commands/npm-update.md
@@ -132,9 +132,9 @@ be _downgraded_.
 
 ### See Also
 
-* [npm install](/cli-commands/install)
-* [npm outdated](/cli-commands/outdated)
-* [npm shrinkwrap](/cli-commands/shrinkwrap)
+* [npm install](/cli-commands/npm-install)
+* [npm outdated](/cli-commands/npm-outdated)
+* [npm shrinkwrap](/cli-commands/npm-shrinkwrap)
 * [npm registry](/using-npm/registry)
 * [npm folders](/configuring-npm/folders)
-* [npm ls](/cli-commands/ls)
+* [npm ls](/cli-commands/npm-ls)

--- a/docs/content/cli-commands/npm-version.md
+++ b/docs/content/cli-commands/npm-version.md
@@ -126,8 +126,8 @@ Note that you must have a default GPG key set up in your git config for this to 
 
 ### See Also
 
-* [npm init](/cli-commands/init)
-* [npm run-script](/cli-commands/run-script)
+* [npm init](/cli-commands/npm-init)
+* [npm run-script](/cli-commands/npm-run-script)
 * [npm scripts](/using-npm/scripts)
 * [package.json](/configuring-npm/package-json)
 * [semver](/using-npm/semver)

--- a/docs/content/cli-commands/npm-view.md
+++ b/docs/content/cli-commands/npm-view.md
@@ -117,8 +117,8 @@ the field name.
 
 ### See Also
 
-* [npm search](/cli-commands/search)
+* [npm search](/cli-commands/npm-search)
 * [npm registry](/using-npm/registry)
-* [npm config](/cli-commands/config)
+* [npm config](/cli-commands/npm-config)
 * [npmrc](/configuring-npm/npmrc)
-* [npm docs](/cli-commands/docs)
+* [npm docs](/cli-commands/npm-docs)

--- a/docs/content/cli-commands/npm-whoami.md
+++ b/docs/content/cli-commands/npm-whoami.md
@@ -19,6 +19,6 @@ Print the `username` config to standard output.
 
 ### See Also
 
-* [npm config](/cli-commands/config)
+* [npm config](/cli-commands/npm-config)
 * [npmrc](/configuring-npm/npmrc)
-* [npm adduser](/cli-commands/adduser)
+* [npm adduser](/cli-commands/npm-adduser)

--- a/docs/content/configuring-npm/folders.md
+++ b/docs/content/configuring-npm/folders.md
@@ -73,7 +73,7 @@ Man pages are not installed on Windows systems.
 
 #### Cache
 
-See [`npm cache`](/cli-commands/cache).  Cache files are stored in `~/.npm` on Posix, or
+See [`npm cache`](/cli-commands/npm-cache).  Cache files are stored in `~/.npm` on Posix, or
 `%AppData%/npm-cache` on Windows.
 
 This is controlled by the `cache` configuration param.
@@ -214,10 +214,10 @@ cannot be found elsewhere.  See [`package.json`](/configuring-npm/package.json) 
 ### See also
 
 * [package.json](/configuring-npm/package-json)
-* [npm install](/cli-commands/install)
-* [npm pack](/cli-commands/pack)
-* [npm cache](/cli-commands/cache)
-* [npm config](/cli-commands/config)
+* [npm install](/cli-commands/npm-install)
+* [npm pack](/cli-commands/npm-pack)
+* [npm cache](/cli-commands/npm-cache)
+* [npm config](/cli-commands/npm-config)
 * [npmrc](/configuring-npm/npmrc)
 * [config](/using-npm/config)
-* [npm publish](/cli-commands/publish)
+* [npm publish](/cli-commands/npm-publish)

--- a/docs/content/configuring-npm/npmrc.md
+++ b/docs/content/configuring-npm/npmrc.md
@@ -97,7 +97,7 @@ manner.
 ### See also
 
 * [npm folders](/configuring-npm/folders)
-* [npm config](/cli-commands/config)
+* [npm config](/cli-commands/npm-config)
 * [config](/using-npm/config)
 * [package.json](/configuring-npm/package-json)
 * [npm](/cli-commands/npm)

--- a/docs/content/configuring-npm/package-json.md
+++ b/docs/content/configuring-npm/package-json.md
@@ -533,7 +533,7 @@ See [semver](/using-npm/semver) for more details about specifying version ranges
 * `range1 || range2` Passes if either range1 or range2 are satisfied.
 * `git...` See 'Git URLs as Dependencies' below
 * `user/repo` See 'GitHub URLs' below
-* `tag` A specific version tagged and published as `tag`  See [`npm dist-tag`](/cli-commands/dist-tag)
+* `tag` A specific version tagged and published as `tag`  See [`npm dist-tag`](/cli-commands/npm-dist-tag)
 * `path/path/path` See [Local Paths](#local-paths) below
 
 For example, these are all valid:
@@ -910,10 +910,10 @@ npm will default some values based on package contents.
 ### SEE ALSO
 
 * [semver](/using-npm/semver)
-* [npm init](/cli-commands/init)
-* [npm version](/cli-commands/version)
-* [npm config](/cli-commands/config)
-* [npm help](/cli-commands/help)
-* [npm install](/cli-commands/install)
-* [npm publish](/cli-commands/publish)
-* [npm uninstall](/cli-commands/uninstall)
+* [npm init](/cli-commands/npm-init)
+* [npm version](/cli-commands/npm-version)
+* [npm config](/cli-commands/npm-config)
+* [npm help](/cli-commands/npm-help)
+* [npm install](/cli-commands/npm-install)
+* [npm publish](/cli-commands/npm-publish)
+* [npm uninstall](/cli-commands/npm-uninstall)

--- a/docs/content/configuring-npm/package-lock-json.md
+++ b/docs/content/configuring-npm/package-lock-json.md
@@ -142,8 +142,8 @@ The dependencies of this dependency, exactly as at the top level.
 
 ### See also
 
-* [npm shrinkwrap](/cli-commands/shrinkwrap)
+* [npm shrinkwrap](/cli-commands/npm-shrinkwrap)
 * [shrinkwrap.json](/configuring-npm/shrinkwrap-json)
 * [package-locks](/configuring-npm/package-locks)
 * [package.json](/configuring-npm/package-json)
-* [npm install](/cli-commands/install)
+* [npm install](/cli-commands/npm-install)

--- a/docs/content/configuring-npm/package-locks.md
+++ b/docs/content/configuring-npm/package-locks.md
@@ -10,7 +10,7 @@ description: An explanation of npm lockfiles
 
 ### Description
 
-Conceptually, the "input" to [`npm install`](/cli-commands/install) is a [package.json](/configuring-npm/package-json), while its
+Conceptually, the "input" to [`npm install`](/cli-commands/npm-install) is a [package.json](/configuring-npm/package-json), while its
 "output" is a fully-formed `node_modules` tree: a representation of the
 dependencies you declared. In an ideal world, npm would work like a pure
 function: the same `package.json` should produce the exact same `node_modules`
@@ -179,4 +179,4 @@ pre-`npm@5.7.0` versions of npm 5, albeit a bit more noisily. Note that if
 * [package.json](/configuring-npm/package-json)
 * [package-lock.json](/configuring-npm/package-lock-json)
 * [shrinkwrap.json](/configuring-npm/shrinkwrap-json)
-* [npm shrinkwrap](/cli-commands/shrinkwrap)
+* [npm shrinkwrap](/cli-commands/npm-shrinkwrap)

--- a/docs/content/configuring-npm/shrinkwrap-json.md
+++ b/docs/content/configuring-npm/shrinkwrap-json.md
@@ -10,7 +10,7 @@ description: A publishable lockfile
 
 ### Description
 
-`npm-shrinkwrap.json` is a file created by [`npm shrinkwrap`](/cli-commands/shrinkwrap). It is identical to
+`npm-shrinkwrap.json` is a file created by [`npm shrinkwrap`](/cli-commands/npm-shrinkwrap). It is identical to
 `package-lock.json`, with one major caveat: Unlike `package-lock.json`,
 `npm-shrinkwrap.json` may be included when publishing a package.
 
@@ -28,7 +28,7 @@ to the manual page for [package-lock.json](/configuring-npm/package-lock-json).
 
 ### See also
 
-* [npm shrinkwrap](/cli-commands/shrinkwrap)
+* [npm shrinkwrap](/cli-commands/npm-shrinkwrap)
 * [package-lock.json](/configuring-npm/package-lock-json)
 * [package.json](/configuring-npm/package-json)
-* [npm install](/cli-commands/install)
+* [npm install](/cli-commands/npm-install)

--- a/docs/content/using-npm/config.md
+++ b/docs/content/using-npm/config.md
@@ -179,7 +179,7 @@ When "dev" or "development" and running local `npm shrinkwrap`,
 
 When "true" submit audit reports alongside `npm install` runs to the default
 registry and all registries configured for scopes.  See the documentation
-for [`npm audit`](/cli-commands/audit) for details on what is submitted.
+for [`npm audit`](/cli-commands/npm-audit) for details on what is submitted.
 
 #### audit-level
 
@@ -270,7 +270,7 @@ well as for the CA information to be stored in a file on disk.
 * Default: Windows: `%AppData%\npm-cache`, Posix: `~/.npm`
 * Type: path
 
-The location of npm's cache directory.  See [`npm cache`](/cli-commands/cache)
+The location of npm's cache directory.  See [`npm cache`](/cli-commands/npm-cache)
 
 #### cache-lock-stale
 
@@ -456,7 +456,7 @@ packages.
 
 When "true" displays the message at the end of each `npm install`
 aknowledging the number of dependencies looking for funding.
-See [`npm fund`](/cli-commands/fund) for details.
+See [`npm fund`](/cli-commands/npm-fund) for details.
 
 #### git
 
@@ -571,7 +571,7 @@ If true, npm does not run scripts specified in package.json files.
 A module that will be loaded by the `npm init` command.  See the
 documentation for the
 [init-package-json](https://github.com/isaacs/init-package-json) module
-for more information, or [npm init](/cli-commands/init).
+for more information, or [npm init](/cli-commands/npm-init).
 
 #### init-author-name
 
@@ -1228,7 +1228,7 @@ version of npm than the latest.
 * Type: Boolean
 
 Set to show short usage output (like the -H output)
-instead of complete help when doing [`npm help`](/cli-commands/help).
+instead of complete help when doing [`npm help`](/cli-commands/npm-help).
 
 #### user
 
@@ -1293,7 +1293,7 @@ Set to `"browser"` to view html help content in the default web browser.
 
 ### See also
 
-* [npm config](/cli-commands/config)
+* [npm config](/cli-commands/npm-config)
 * [npmrc](/configuring-npm/npmrc)
 * [npm scripts](/using-npm/scripts)
 * [npm folders](/configuring-npm/folders)

--- a/docs/content/using-npm/disputes.md
+++ b/docs/content/using-npm/disputes.md
@@ -134,4 +134,4 @@ License.
 ### See also
 
 * [npm registry](/using-npm/registry)
-* [npm owner](/cli-commands/owner)
+* [npm owner](/cli-commands/npm-owner)

--- a/docs/content/using-npm/orgs.md
+++ b/docs/content/using-npm/orgs.md
@@ -24,8 +24,8 @@ The developer will be able to access packages based on the teams they are on. Ac
 
 There are two main commands:
 
-1. `npm team` see [npm team](/cli-commands/team) for more details
-2. `npm access` see [npm access](/cli-commands/access) for more details
+1. `npm team` see [npm team](/cli-commands/npm-team) for more details
+2. `npm access` see [npm access](/cli-commands/npm-access) for more details
 
 ### Team Admins create teams
 
@@ -92,6 +92,6 @@ npm access ls-collaborators <pkg>
 
 ### See also
 
-* [npm team](/cli-commands/team)
-* [npm access](/cli-commands/access)
+* [npm team](/cli-commands/npm-team)
+* [npm access](/cli-commands/npm-access)
 * [npm scope](/using-npm/scope)

--- a/docs/content/using-npm/registry.md
+++ b/docs/content/using-npm/registry.md
@@ -33,7 +33,7 @@ available at <https://github.com/npm/npm-registry-couchapp>.
 
 The registry URL used is determined by the scope of the package (see
 [`scope`](/using-npm/scope). If no scope is specified, the default registry is used, which is
-supplied by the `registry` config parameter.  See [`npm config`](/cli-commands/config),
+supplied by the `registry` config parameter.  See [`npm config`](/cli-commands/npm-config),
 [`npmrc`](/configuring-npm/npmrc), and [`config`](/using-npm/config) for more on managing npm's configuration.
 
 ### Does npm send any information about me back to the registry?
@@ -100,7 +100,7 @@ Yes, head over to <https://www.npmjs.com/>
 
 ### See also
 
-* [npm config](/cli-commands/config)
+* [npm config](/cli-commands/npm-config)
 * [config](/using-npm/config)
 * [npmrc](/configuring-npm/npmrc)
 * [npm developers](/using-npm/developers)

--- a/docs/content/using-npm/removal.md
+++ b/docs/content/using-npm/removal.md
@@ -66,5 +66,5 @@ find /usr/local/{lib/node,bin} -exec grep -l npm \{\} \; ;
 
 ### See also
 
-* [npm uninstall](/cli-commands/uninstall)
-* [npm prune](/cli-commands/prune)
+* [npm uninstall](/cli-commands/npm-uninstall)
+* [npm prune](/cli-commands/npm-prune)

--- a/docs/content/using-npm/scope.md
+++ b/docs/content/using-npm/scope.md
@@ -55,7 +55,7 @@ Or in `package.json`:
 ```
 
 Note that if the `@` symbol is omitted, in either case, npm will instead attempt to
-install from GitHub; see [`npm install`](/cli-commands/install).
+install from GitHub; see [`npm install`](/cli-commands/npm-install).
 
 ### Requiring scoped packages
 
@@ -125,7 +125,7 @@ that registry instead.
 
 ### See also
 
-* [npm install](/cli-commands/install)
-* [npm publish](/cli-commands/publish)
-* [npm access](/cli-commands/access)
+* [npm install](/cli-commands/npm-install)
+* [npm publish](/cli-commands/npm-publish)
+* [npm access](/cli-commands/npm-access)
 * [npm registry](/using-npm/registry)

--- a/docs/content/using-npm/scripts.md
+++ b/docs/content/using-npm/scripts.md
@@ -78,7 +78,7 @@ The advantage of doing these things at `prepublish` time is that they can be don
 
 ### Life Cycle Operation Order
 
-#### [`npm publish`](/cli-commands/publish)
+#### [`npm publish`](/cli-commands/npm-publish)
 
 * `prepublishOnly`
 * `prepare`
@@ -86,12 +86,12 @@ The advantage of doing these things at `prepublish` time is that they can be don
 * `publish`
 * `postpublish`
 
-#### [`npm pack`](/cli-commands/pack)
+#### [`npm pack`](/cli-commands/npm-pack)
 
 * `prepack`
 * `postpack`
 
-#### [`npm install`](/cli-commands/install)
+#### [`npm install`](/cli-commands/npm-install)
 
 * `preinstall`
 * `install`
@@ -102,7 +102,7 @@ Also triggers
 * `prepublish` (when on local)
 * `prepare` (when on local)
 
-#### [`npm start`](/cli-commands/start)
+#### [`npm start`](/cli-commands/npm-start)
 
 `npm run start` has an `npm start` shorthand.
 
@@ -304,7 +304,7 @@ above.
 
 ### See Also
 
-* [npm run-script](/cli-commands/run-script)
+* [npm run-script](/cli-commands/npm-run-script)
 * [package.json](/configuring-npm/package-json)
 * [npm developers](/using-npm/developers)
-* [npm install](/cli-commands/install)
+* [npm install](/cli-commands/npm-install)


### PR DESCRIPTION
This reverts commit https://github.com/npm/cli/commit/0eac801cdef344e9fbda6270145e062211255b0e.

These links shouldn't have been updated. Our app handles link creation and routing  internally.