### PR TITLE
test: add coverage map

### DIFF
--- a/lib/get.js
+++ b/lib/get.js
@@ -1,12 +1,14 @@
+const npm = require('./npm.js')
+const usageUtil = require('./utils/usage.js')
 
-module.exports = get
+const usage = usageUtil(
+  'get',
+  'npm get <key> <value> (See `npm config`)'
+)
 
-get.usage = 'npm get <key> <value> (See `npm config`)'
+const completion = npm.commands.config.completion
 
-var npm = require('./npm.js')
-
-get.completion = npm.commands.config.completion
-
-function get (args, cb) {
+const cmd = (args, cb) =>
   npm.commands.config(['get'].concat(args), cb)
-}
+
+module.exports = Object.assign(cmd, { usage, completion })

--- a/package.json
+++ b/package.json
@@ -307,6 +307,7 @@
     "test-node": "tap --timeout 240 \"test/tap/*.js\" \"test/network/*.js\""
   },
   "tap": {
+    "coverage-map": "test/coverage-map.js",
     "esm": false,
     "timeout": 600
   },

--- a/test/coverage-map.js
+++ b/test/coverage-map.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const coverageMap = (filename) => {
+  if (/^test\/lib\//.test(filename)) {
+    return filename.replace(/^test\//, '')
+  }
+  return []
+}
+
+module.exports = coverageMap

--- a/test/lib/get.js
+++ b/test/lib/get.js
@@ -1,0 +1,18 @@
+const { test } = require('tap')
+const requireInject = require('require-inject')
+
+test('should retrieve values from npm.commands.config', (t) => {
+  const get = requireInject('../../lib/get.js', {
+    '../../lib/npm.js': {
+      commands: {
+        config: ([action, arg]) => {
+          t.equal(action, 'get', 'should use config get action')
+          t.equal(arg, 'foo', 'should use expected key')
+          t.end()
+        }
+      }
+    }
+  })
+
+  get(['foo'])
+})


### PR DESCRIPTION
- Setup tap coverage map, ref: https://node-tap.org/docs/coverage/coverage-map/
- Refactor `lib/get.js` to follow standard cmd pattern
- Added unit tests for `lib/get.js`