### PR TITLE
test: refactor install tests

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -1,7 +1,9 @@
 'use strict'
 /* eslint-disable camelcase */
 /* eslint-disable standard/no-callback-literal */
-
+const fs = require('fs')
+const util = require('util')
+const readdir = util.promisify(fs.readdir)
 const npm = require('./npm.js')
 const usageUtil = require('./utils/usage.js')
 const reifyOutput = require('./utils/reify-output.js')
@@ -9,16 +11,11 @@ const log = require('npmlog')
 const { resolve, join } = require('path')
 const Arborist = require('@npmcli/arborist')
 
-// XXX remove anything relying on this "where" argument, then remove it
-const install = async (where, args, cb) => {
+const install = async (args, cb) => {
   // the /path/to/node_modules/..
   const globalTop = resolve(npm.globalDir, '..')
-  const { dryRun, global: isGlobalInstall } = npm.flatOptions
-  if (typeof args === 'function') {
-    cb = args
-    args = where
-    where = isGlobalInstall ? globalTop : npm.prefix
-  }
+  const { global: isGlobalInstall } = npm.flatOptions
+  const where = isGlobalInstall ? globalTop : npm.prefix
 
   // don't try to install the prefix into itself
   args = args.filter(a => resolve(a) !== npm.prefix)
@@ -39,7 +36,7 @@ const install = async (where, args, cb) => {
   })
 
   try {
-    const tree = await arb.reify({
+    await arb.reify({
       ...npm.flatOptions,
       add: args,
     })
@@ -66,60 +63,65 @@ const usage = usageUtil(
   '[--save-prod|--save-dev|--save-optional] [--save-exact] [--no-save]'
 )
 
-const completion = (opts, cb) => {
+const completion = async (opts, cb) => {
+  const { partialWord } = opts
   // install can complete to a folder with a package.json, or any package.
   // if it has a slash, then it's gotta be a folder
   // if it starts with https?://, then just give up, because it's a url
-  if (/^https?:\/\//.test(opts.partialWord)) {
+  if (/^https?:\/\//.test(partialWord)) {
     // do not complete to URLs
     return cb(null, [])
   }
 
-  if (/\//.test(opts.partialWord)) {
+  if (/\//.test(partialWord)) {
     // Complete fully to folder if there is exactly one match and it
     // is a folder containing a package.json file.  If that is not the
     // case we return 0 matches, which will trigger the default bash
     // complete.
-    const lastSlashIdx = opts.partialWord.lastIndexOf('/')
-    const partialName = opts.partialWord.slice(lastSlashIdx + 1)
-    const partialPath = opts.partialWord.slice(0, lastSlashIdx) || '/'
+    const lastSlashIdx = partialWord.lastIndexOf('/')
+    const partialName = partialWord.slice(lastSlashIdx + 1)
+    const partialPath = partialWord.slice(0, lastSlashIdx) || '/'
 
-    const annotatePackageDirMatch = (sibling, cb) => {
+    const annotatePackageDirMatch = async (sibling) => {
       const fullPath = join(partialPath, sibling)
       if (sibling.slice(0, partialName.length) !== partialName) {
-        return cb(null, null) // not name match
+        return null // not name match
       }
-      fs.readdir(fullPath, function (err, contents) {
-        if (err) return cb(null, { isPackage: false })
 
-        cb(
-          null,
-          {
-            fullPath,
-            isPackage: contents.indexOf('package.json') !== -1
-          }
-        )
-      })
+      try {
+        const contents = await readdir(fullPath)
+        return {
+          fullPath,
+          isPackage: contents.indexOf('package.json') !== -1
+        }
+      } catch {
+        return { isPackage: false }
+      }
     }
 
-    return fs.readdir(partialPath, (err, siblings) => {
-      if (err) return cb(null, []) // invalid dir: no matching
-
-      asyncMap(siblings, annotatePackageDirMatch, (err, matches) => {
-        if (err) return cb(err)
-
-        const cleaned = matches.filter(x => x !== null)
-        if (cleaned.length !== 1) return cb(null, [])
-        if (!cleaned[0].isPackage) return cb(null, [])
-
+    try {
+      const siblings = await readdir(partialPath)
+      const matches = await Promise.all(
+        siblings.map(async sibling => {
+          return await annotatePackageDirMatch(sibling)
+        })
+      )
+      const match = matches.filter(el => !el || el.isPackage).pop()
+      if (match) {
         // Success - only one match and it is a package dir
-        return cb(null, [cleaned[0].fullPath])
-      })
-    })
-  }
+        return cb(null, [match.fullPath])
+      } else {
+        // no matches
+        return cb(null, [])
+      }
 
-  // Note: there used to be registry completion here, but it stopped making
-  // sense somewhere around 50,000 packages on the registry
+    } catch {
+      return cb(null, []) // invalid dir: no matching
+    }
+  }
+  // Note: there used to be registry completion here,
+  // but it stopped making sense somewhere around
+  // 50,000 packages on the registry
   cb()
 }
 

--- a/test/lib/dedupe.js
+++ b/test/lib/dedupe.js
@@ -47,9 +47,3 @@ test('should remove dupes using Arborist - no arguments', (t) => {
   })
 })
 
-test('calls completion', (t) => {
-  dedupe.completion({}, () => {
-    t.ok(true, 'callback is called')
-    t.end()
-  })
-})

--- a/test/lib/find-dupes.js
+++ b/test/lib/find-dupes.js
@@ -15,9 +15,3 @@ test('should run dedupe in dryRun mode', (t) => {
   })
 })
 
-test('calls completion', (t) => {
-  findDupes.completion({}, () => {
-    t.ok(true, 'callback is called')
-    t.end()
-  })
-})

--- a/test/lib/install.js
+++ b/test/lib/install.js
@@ -1,0 +1,161 @@
+const { test } = require('tap')
+
+const install = require('../../lib/install.js')
+const requireInject = require('require-inject')
+
+test('should install using Arborist', (t) => {
+  const install = requireInject('../../lib/install.js', {
+    '../../lib/npm.js': {
+      globalDir: 'path/to/node_modules/',
+      prefix: 'foo',
+      flatOptions: {},
+      config: {
+        get: () => true
+      }
+    },
+    'npmlog': {
+      warn: () => {}
+    },
+    '@npmcli/arborist': function (args) {
+      t.ok(args, 'gets options object')
+      this.reify = () => {
+        t.ok(true, 'reify is called')
+      }
+    },
+    '../../lib/utils/reify-output.js': function (arb) {
+      t.ok(arb, 'gets arborist tree')
+    }
+  })
+  install(['fizzbuzz'], () => {
+    t.end()
+  })
+})
+
+test('should install globally using Arborist', (t) => {
+  const install = requireInject('../../lib/install.js', {
+    '../../lib/npm.js': {
+      globalDir: 'path/to/node_modules/',
+      prefix: 'foo',
+      flatOptions: {
+        'global': 'true',
+      },
+      config: {
+        get: () => false
+      }
+    },
+    '@npmcli/arborist': function () {
+      this.reify = () => {}
+    },
+  })
+  install([], () => {
+    t.end()
+  })
+})
+
+test('completion to folder', (t) => {
+  const install = requireInject('../../lib/install.js', {
+    'util': {
+      'promisify': (fn) => fn
+    },
+    'fs': {
+      'readdir': (path) => {
+        if (path === '/') {
+          return ['arborist']
+        } else {
+          return ['package.json']
+        }
+      }
+    }
+  })
+  install.completion({
+    partialWord: '/ar'
+  }, (er, res) => {
+    t.equal(er, null)
+    t.strictSame(res, ['/arborist'], 'package dir match')
+    t.end()
+  })
+})
+
+test('completion to folder - invalid dir', (t) => {
+  const install = requireInject('../../lib/install.js', {
+    'util': {
+      'promisify': (fn) => fn
+    },
+    'fs': {
+      'readdir': () => {
+        throw new Error('EONT')
+      }
+    }
+  })
+  install.completion({
+    partialWord: 'path/to/folder'
+  }, (er, res) => {
+    t.equal(er, null)
+    t.strictSame(res, [], 'invalid dir: no matching')
+    t.end()
+  })
+})
+
+test('completion to folder - no matches', (t) => {
+  const install = requireInject('../../lib/install.js', {
+    'util': {
+      'promisify': (fn) => fn
+    },
+    'fs': {
+      'readdir': (path) => {
+        return ['foobar']
+      }
+    }
+  })
+  install.completion({
+    partialWord: '/pa'
+  }, (er, res) => {
+    t.equal(er, null)
+    t.strictSame(res, [], 'no name match')
+    t.end()
+  })
+})
+
+test('completion to folder - match is not a package', (t) => {
+  const install = requireInject('../../lib/install.js', {
+    'util': {
+      'promisify': (fn) => fn
+    },
+    'fs': {
+      'readdir': (path) => {
+        if (path === '/') {
+          return ['arborist']
+        } else {
+          throw new Error('EONT')
+        }
+      }
+    }
+  })
+  install.completion({
+    partialWord: '/ar'
+  }, (er, res) => {
+    t.equal(er, null)
+    t.strictSame(res, [], 'no name match')
+    t.end()
+  })
+})
+
+test('completion to url', (t) => {
+  install.completion({
+    partialWord: 'http://path/to/url'
+  }, (er, res) => {
+    t.equal(er, null)
+    t.strictSame(res, [])
+    t.end()
+  })
+})
+
+test('completion', (t) => {
+  install.completion({
+    partialWord: 'toto'
+  }, (er, res) => {
+    t.notOk(er)
+    t.notOk(res)
+    t.end()
+  })
+})

--- a/test/lib/prune.js
+++ b/test/lib/prune.js
@@ -27,9 +27,3 @@ test('should prune using Arborist', (t) => {
   })
 })
 
-test('calls completion', (t) => {
-  prune.completion({}, () => {
-    t.ok(true, 'callback is called')
-    t.end()
-  })
-})


### PR DESCRIPTION
Added unit tests for install. I'll delete the integration tests once I make sure all the cases have been covered in Arborist. Made a minor `async/await` refactor on the completion function to avoid using unneeded external libraries.
