### PR TITLE
Add full integrity to pack's debug output

### DIFF
--- a/lib/pack.js
+++ b/lib/pack.js
@@ -207,6 +207,7 @@ function logContents (tarball) {
     include: ['name', 'value'],
     showHeaders: false
   }))
+  log.debug('tarball integrity: %s', tarball.integrity.toString())
   log.notice('', '')
 }
 


### PR DESCRIPTION
# What / Why
This will add the full integrity to the `debug` output.  The existing output only logs a partial version to `notice`:
https://github.com/npm/cli/blob/66092d5ce22b326c4d4aed1c5073ae7a6a4f4aa2/lib/pack.js#L201