### PR TITLE
fix: npm ls --parseable --long output

### DIFF
--- a/lib/ls.js
+++ b/lib/ls.js
@@ -545,7 +545,7 @@ function makeParseable_ (data, long, dir, depth, parent, d) {
 
   return data.path +
          ':' + (data._id || '') +
-         ':' + (data.realPath !== data.path ? data.realPath : '') +
+         (data.link && data.link !== data.path ? ':' + data.link : '') +
          (data.extraneous ? ':EXTRANEOUS' : '') +
          (data.error && data.path !== path.resolve(npm.globalDir, '..') ? ':ERROR' : '') +
          (data.invalid ? ':INVALID' : '') +

--- a/test/tap/ls.js
+++ b/test/tap/ls.js
@@ -169,6 +169,40 @@ test('cleanup', function (t) {
   t.done()
 })
 
+test('ls parseable long', function (t) {
+  var fixture = new Tacks(
+    Dir({
+      'npm-test-ls': Dir({
+        'package.json': File({
+          name: 'npm-test-ls',
+          version: '1.0.0',
+          dependencies: {
+            'dep': 'file:../dep'
+          }
+        })
+      }),
+      'dep': Dir({
+        'package.json': File({
+          name: 'dep',
+          version: '1.0.0'
+        })
+      })
+    })
+  )
+  withFixture(t, fixture, function (done) {
+    common.npm([
+      'ls', '--parseable', '--long'
+    ], {
+      cwd: pkgpath
+    }, function (err, code, stdout, stderr) {
+      t.ifErr(err, 'ls succeeded')
+      t.equal(0, code, 'exit 0 on ls')
+      t.notMatch(stdout, /undefined/, 'must not output undefined for non-symlinked items')
+      done()
+    })
+  })
+})
+
 function withFixture (t, fixture, tester) {
   fixture.create(fixturepath)
   common.npm(['install'], {


### PR DESCRIPTION
Fixes `npm ls --parseable --long` printing `undefined` next to all items.

### Test

```sh
# Given a project structure:
ruyadorno@macbookpro ~/Documents/workspace/tmp \tree
.
├── c
│   └── package.json
├── node_modules
│   ├── a
│   │   └── package.json
│   ├── b
│   │   └── package.json
│   ├── c -> /Users/ruyadorno/Documents/workspace/tmp/c/
│   └── d
│       └── package.json
└── package.json

6 directories, 5 files

# BEFORE
ruyadorno@macbookpro ~/Documents/workspace/tmp npm6 ls --parseable --long
/Users/ruyadorno/Documents/workspace/tmp:tmp@1.0.0:undefined
/Users/ruyadorno/Documents/workspace/tmp/node_modules/a:a@1.0.0:undefined
/Users/ruyadorno/Documents/workspace/tmp/node_modules/b:b@1.0.0:undefined
/Users/ruyadorno/Documents/workspace/tmp/node_modules/c:c@1.0.0:undefined
/Users/ruyadorno/Documents/workspace/tmp/node_modules/d:e@1.0.0:undefined
/Users/ruyadorno/Documents/workspace/tmp/node_modules/f:f@"^2.0.0":INVALID:MISSING

# AFTER
ruyadorno@macbookpro ~/Documents/workspace/tmp node ~/Documents/workspace/cli/latest ls --parseable --long
/Users/ruyadorno/Documents/workspace/tmp:tmp@1.0.0
/Users/ruyadorno/Documents/workspace/tmp/node_modules/a:a@1.0.0
/Users/ruyadorno/Documents/workspace/tmp/node_modules/b:b@1.0.0
/Users/ruyadorno/Documents/workspace/tmp/node_modules/c:c@1.0.0:/Users/ruyadorno/Documents/workspace/tmp/c
/Users/ruyadorno/Documents/workspace/tmp/node_modules/d:e@1.0.0
/Users/ruyadorno/Documents/workspace/tmp/node_modules/f:f@"^2.0.0":INVALID:MISSING
```