### PR TITLE
feat(version): add support for monorepos

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -210,7 +210,11 @@ function dump (data, cb) {
 }
 
 function statGitFolder (cb) {
-  fs.stat(path.join(npm.localPrefix, '.git'), cb)
+  git.whichAndExec(
+    [ 'rev-parse', '--git-dir' ],
+    { env: process.env },
+    cb
+  )
 }
 
 function callGitStatus (cb) {

--- a/lib/version.js
+++ b/lib/version.js
@@ -212,7 +212,7 @@ function dump (data, cb) {
 function statGitFolder (cb) {
   git.whichAndExec(
     [ 'rev-parse', '--git-dir' ],
-    { env: process.env },
+    { env: process.env, cwd: npm.localPrefix },
     cb
   )
 }


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
The `.git` folder lookup in `version` command is based on localPrefix which is not the right location always for monorepos where `.git` folder is at a different location and not there `npm version` command is executed.

Fixes by doing the right lookup that will support `.git` in monorepos.

## References
Fixes #1082, [#9111](https://github.com/npm/npm/issues/9111)
