### PR TITLE
Fix --dev deprecation message 

### DIFF
--- a/lib/ci.js
+++ b/lib/ci.js
@@ -32,6 +32,10 @@ function ci (args, cb) {
     dirPacker: pack.packGitDep
   }
 
+  if (npm.config.get('dev')) {
+    log.warn('ci', 'Usage of the `--dev` option is deprecated. Use `--also=dev` instead.')
+  }
+
   for (const key in npm.config.list[0]) {
     if (!['log', 'cache'].includes(key)) {
       opts[key] = npm.config.list[0][key]

--- a/lib/install.js
+++ b/lib/install.js
@@ -197,7 +197,7 @@ function install (where, args, cb) {
   var dryrun = !!npm.config.get('dry-run')
 
   if (npm.config.get('dev')) {
-    log.warn('install', 'Usage of the `--dev` option is deprecated. Use `--only=dev` instead.')
+    log.warn('install', 'Usage of the `--dev` option is deprecated. Use `--also=dev` instead.')
   }
 
   if (where === globalTop && !args.length) {


### PR DESCRIPTION
## Summary

When using `--dev` option with `npm install`, the command prints this deprecation message:

```
npm WARN install Usage of the `--dev` option is deprecated. Use `--only=dev` instead.
```

The `--only` option was added within https://github.com/npm/npm/pull/9024 and with `--only=dev`, only `devDependencies` are installed. This PR also introduced the `--also` option which can install both `dependencies` and `devDependencies`. I have checked that `npm install --dev` installs both `dependencies` and `devDependencies` (see https://github.com/npm/cli/blob/latest/lib/install.js#L233), so I think that the correct message should be:

```
npm WARN install Usage of the `--dev` option is deprecated. Use `--also=dev` instead.
```
I have added the deprecation message also to `npm ci --dev`. If this PR is approved I will add the `--also` option to [npm install documentation](https://github.com/npm/cli/blob/latest/docs/content/cli-commands/npm-install.md).

## References
- Related to #1539
- Related to https://github.com/npm/npm/pull/9024
