### PR TITLE
Node-gyp supports both Python and legacy Python

### DIFF
--- a/docs/content/cli-commands/npm.md
+++ b/docs/content/cli-commands/npm.md
@@ -60,8 +60,7 @@ requires compiling of C++ Code, npm will use
 [node-gyp](https://github.com/nodejs/node-gyp) for that task.
 For a Unix system, [node-gyp](https://github.com/nodejs/node-gyp)
 needs Python, make and a buildchain like GCC. On Windows,
-Python and Microsoft Visual Studio C++ are needed. Python 3 is
-not supported by [node-gyp](https://github.com/nodejs/node-gyp).
+Python and Microsoft Visual Studio C++ are needed.
 For more information visit
 [the node-gyp repository](https://github.com/nodejs/node-gyp) and
 the [node-gyp Wiki](https://github.com/nodejs/node-gyp/wiki).


### PR DESCRIPTION
<!-- What / Why -->
Node-gyp has supported Python 3 for 6+ months and Python 2 has been end of life since 1/1/2020 so this PR recommends removing out-of-date information.
<!-- Describe the request in detail. What it does and why it's being changed. -->
To align with https://github.com/nodejs/node-gyp#installation

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
