### PR TITLE
Isaacs/set envs fix

### DIFF
--- a/lib/config/set-envs.js
+++ b/lib/config/set-envs.js
@@ -8,11 +8,14 @@
 // and the value is a string or array.  Otherwise return false.
 const envKey = (key, val) => {
   return !/^[/@_]/.test(key) &&
-    (typeof val === 'string' || Array.isArray(val)) &&
-    `npm_config_${key.replace(/-/g, '_').toLowerCase()}`
+    (typeof envVal(val) === 'string') &&
+      `npm_config_${key.replace(/-/g, '_').toLowerCase()}`
 }
 
-const envVal = val => Array.isArray(val) ? val.join('\n\n') : val
+const envVal = val => Array.isArray(val) ? val.map(v => envVal(v)).join('\n\n')
+  : val === null || val === undefined || val === false ? ''
+  : typeof val === 'object' ? null
+  : String(val)
 
 const sameConfigValue = (def, val) =>
   !Array.isArray(val) || !Array.isArray(def) ? def === val
@@ -30,20 +33,48 @@ const sameArrayValue = (def, val) => {
   return true
 }
 
+const setEnv = (rawKey, rawVal) => {
+  const val = envVal(rawVal)
+  const key = envKey(rawKey, val)
+  if (key)
+    process.env[key] = val
+}
+
 const setEnvs = npm => {
-  // The objects in the config.list array are arranged in
-  // a prototype chain, so we can just for/in over the top
-  // of the stack and grab any that don't match the default
-  const { config: { list: [configs] } } = npm
+  // This ensures that all npm config values that are not the defaults are
+  // shared appropriately with child processes, without false positives.
+  //
+  // if the key is the default value,
+  //   if the environ is NOT the default value,
+  //     set the environ
+  //   else skip it, it's fine
+  // if the key is NOT the default value,
+  //   if the env is setting it, then leave it (already set)
+  //   otherwise, set the env
+  console.error(npm.config.list)
+  const { config: { list: [cli, env] } } = npm
+  const cliSet = new Set(Object.keys(cli))
+  const envSet = new Set(Object.keys(env))
   const { defaults } = require('./defaults.js')
-  for (const key in configs) {
-    const val = configs[key]
-    const environ = envKey(key, val)
-    if (!sameConfigValue(defaults[key], val) && environ) {
-      process.env[environ] = envVal(val)
+  // the configs form a prototype chain, so we can for/in over cli to
+  // see all the current values, and hasOwnProperty to see if it's
+  // set therre.
+  for (const key in cli) {
+    if (sameConfigValue(defaults[key], cli[key])) {
+      if (!sameConfigValue(defaults[key], env[key])) {
+        // getting set back to the default in the cli config
+        setEnv(key, cli[key])
+      }
+    } else {
+      // config is not the default
+      if (!(envSet.has(key) && !cliSet.has(key))) {
+        // was not set in the env, so we have to put it there
+        setEnv(key, cli[key])
+      }
     }
   }
 
+  // also set some other common ones.
   process.env.npm_execpath = require.main.filename
   process.env.npm_node_execpath = process.execPath
   process.env.npm_command = npm.command

--- a/lib/config/set-envs.js
+++ b/lib/config/set-envs.js
@@ -26,6 +26,9 @@ const sameArrayValue = (def, val) => {
     return false
   }
   for (let i = 0; i < def.length; i++) {
+    /* istanbul ignore next - there are no array configs where the default
+     * is not an empty array, so this loop is a no-op, but it's the correct
+     * thing to do if we ever DO add a config like that. */
     if (def[i] !== val[i]) {
       return false
     }
@@ -33,14 +36,15 @@ const sameArrayValue = (def, val) => {
   return true
 }
 
-const setEnv = (rawKey, rawVal) => {
+const setEnv = (env, rawKey, rawVal) => {
   const val = envVal(rawVal)
   const key = envKey(rawKey, val)
-  if (key)
-    process.env[key] = val
+  if (key && val !== null) {
+    env[key] = val
+  }
 }
 
-const setEnvs = npm => {
+const setEnvs = (npm, env = process.env) => {
   // This ensures that all npm config values that are not the defaults are
   // shared appropriately with child processes, without false positives.
   //
@@ -51,38 +55,37 @@ const setEnvs = npm => {
   // if the key is NOT the default value,
   //   if the env is setting it, then leave it (already set)
   //   otherwise, set the env
-  console.error(npm.config.list)
-  const { config: { list: [cli, env] } } = npm
-  const cliSet = new Set(Object.keys(cli))
-  const envSet = new Set(Object.keys(env))
+  const { config: { list: [cliConf, envConf] } } = npm
+  const cliSet = new Set(Object.keys(cliConf))
+  const envSet = new Set(Object.keys(envConf))
   const { defaults } = require('./defaults.js')
   // the configs form a prototype chain, so we can for/in over cli to
   // see all the current values, and hasOwnProperty to see if it's
   // set therre.
-  for (const key in cli) {
-    if (sameConfigValue(defaults[key], cli[key])) {
-      if (!sameConfigValue(defaults[key], env[key])) {
+  for (const key in cliConf) {
+    if (sameConfigValue(defaults[key], cliConf[key])) {
+      if (!sameConfigValue(defaults[key], envConf[key])) {
         // getting set back to the default in the cli config
-        setEnv(key, cli[key])
+        setEnv(env, key, cliConf[key])
       }
     } else {
       // config is not the default
       if (!(envSet.has(key) && !cliSet.has(key))) {
         // was not set in the env, so we have to put it there
-        setEnv(key, cli[key])
+        setEnv(env, key, cliConf[key])
       }
     }
   }
 
   // also set some other common ones.
-  process.env.npm_execpath = require.main.filename
-  process.env.npm_node_execpath = process.execPath
-  process.env.npm_command = npm.command
+  env.npm_execpath = require.main.filename
+  env.npm_node_execpath = process.execPath
+  env.npm_command = npm.command
 
   // note: this doesn't afect the *current* node process, of course, since
   // it's already started, but it does affect the options passed to scripts.
-  if (configs['node-options']) {
-    process.env.NODE_OPTIONS = configs['node-options']
+  if (cliConf['node-options']) {
+    env.NODE_OPTIONS = cliConf['node-options']
   }
 }
 

--- a/node_modules/@npmcli/run-script/README.md
+++ b/node_modules/@npmcli/run-script/README.md
@@ -30,6 +30,7 @@ runScript({
   // - npm_package_json The package.json file in the folder
   // - npm_lifecycle_event The event that this is being run for
   // - npm_lifecycle_script The script being run
+  // The fields described in https://github.com/npm/rfcs/pull/183
   env: {
     npm_package_from: 'foo@bar',
     npm_package_resolved: 'https://registry.npmjs.org/foo/-/foo-1.2.3.tgz',
@@ -99,6 +100,8 @@ terminal, then it is up to the user to end it, of course.
   - `npm_package_json` The package.json file in the folder
   - `npm_lifecycle_event` The event that this is being run for
   - `npm_lifecycle_script` The script being run
+  - The `package.json` fields described in
+    [RFC183](https://github.com/npm/rfcs/pull/183/files).
 - `scriptShell` Optional, defaults to `/bin/sh` on Unix, defaults to
   `env.comspec` or `cmd` on Windows.  Custom script to use to execute the
   command.

--- a/node_modules/@npmcli/run-script/lib/package-envs.js
+++ b/node_modules/@npmcli/run-script/lib/package-envs.js
@@ -1,0 +1,25 @@
+// https://github.com/npm/rfcs/pull/183
+
+const envVal = val => Array.isArray(val) ? val.map(v => envVal(v)).join('\n\n')
+  : val === null || val === false ? ''
+  : String(val)
+
+const packageEnvs = (env, vals, prefix) => {
+  for (const [key, val] of Object.entries(vals)) {
+    if (val === undefined)
+      continue
+    else if (val && !Array.isArray(val) && typeof val === 'object')
+      packageEnvs(env, val, `${prefix}${key}_`)
+    else
+      env[`${prefix}${key}`] = envVal(val)
+  }
+  return env
+}
+
+module.exports = (env, pkg) => packageEnvs({ ...env }, {
+  name: pkg.name,
+  version: pkg.version,
+  config: pkg.config,
+  engines: pkg.engines,
+  bin: pkg.bin,
+}, 'npm_package_')

--- a/node_modules/@npmcli/run-script/lib/run-script-pkg.js
+++ b/node_modules/@npmcli/run-script/lib/run-script-pkg.js
@@ -1,5 +1,6 @@
 const makeSpawnArgs = require('./make-spawn-args.js')
 const promiseSpawn = require('@npmcli/promise-spawn')
+const packageEnvs = require('./package-envs.js')
 
 // you wouldn't like me when I'm angry...
 const bruce = (id, event, cmd) =>`\n> ${id ? id + ' ' : ''}${event}\n> ${cmd}\n`
@@ -36,7 +37,7 @@ const runScriptPkg = options => {
     event,
     path,
     scriptShell,
-    env,
+    env: packageEnvs(env, pkg),
     stdio,
     cmd,
     stdioString,

--- a/node_modules/@npmcli/run-script/package.json
+++ b/node_modules/@npmcli/run-script/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@npmcli/run-script",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Run a lifecycle script for a package (descendant of npm-lifecycle)",
   "author": "Isaac Z. Schlueter <i@izs.me> (https://izs.me)",
   "license": "ISC",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "npm",
-      "version": "7.0.0-beta.2",
+      "version": "7.0.0-beta.3",
       "bundleDependencies": [
         "@npmcli/arborist",
         "@npmcli/ci-detect",
@@ -89,7 +89,7 @@
       "dependencies": {
         "@npmcli/arborist": "^0.0.16",
         "@npmcli/ci-detect": "^1.2.0",
-        "@npmcli/run-script": "^1.4.0",
+        "@npmcli/run-script": "^1.5.0",
         "abbrev": "~1.1.1",
         "ansicolors": "~0.3.2",
         "ansistyles": "~0.1.3",
@@ -504,9 +504,9 @@
       }
     },
     "node_modules/@npmcli/run-script": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.4.0.tgz",
-      "integrity": "sha512-evlD0Ur2ILGyTP7FfMYi90x80bto9+nEbGjoWzdF+gmIX3HuA1nW0Ghj91JFaTJAHiXnDEEduZS24oAve/aeOA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.5.0.tgz",
+      "integrity": "sha512-z7AzLmsMtVntMRJt35M5VAjb/jH6yH37Q8Ku011JVR7rEoy+p2a6/NkwqChCRZORlJaS9rwjXmZKM6UmwXLkqA==",
       "inBundle": true,
       "dependencies": {
         "@npmcli/promise-spawn": "^1.2.0",
@@ -9521,9 +9521,9 @@
       }
     },
     "@npmcli/run-script": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.4.0.tgz",
-      "integrity": "sha512-evlD0Ur2ILGyTP7FfMYi90x80bto9+nEbGjoWzdF+gmIX3HuA1nW0Ghj91JFaTJAHiXnDEEduZS24oAve/aeOA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.5.0.tgz",
+      "integrity": "sha512-z7AzLmsMtVntMRJt35M5VAjb/jH6yH37Q8Ku011JVR7rEoy+p2a6/NkwqChCRZORlJaS9rwjXmZKM6UmwXLkqA==",
       "requires": {
         "@npmcli/promise-spawn": "^1.2.0",
         "infer-owner": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@npmcli/arborist": "^0.0.16",
     "@npmcli/ci-detect": "^1.2.0",
-    "@npmcli/run-script": "^1.4.0",
+    "@npmcli/run-script": "^1.5.0",
     "abbrev": "~1.1.1",
     "ansicolors": "~0.3.2",
     "ansistyles": "~0.1.3",

--- a/test/lib/config/set-envs.js
+++ b/test/lib/config/set-envs.js
@@ -1,0 +1,165 @@
+const t = require('tap')
+const setEnvs = require('../../../lib/config/set-envs.js')
+const { defaults } = require('../../../lib/config/defaults.js')
+
+t.test('set envs that are not defaults and not already in env', t => {
+  const envConf = Object.create(defaults)
+  const cliConf = Object.create(envConf)
+  const npm = {
+    config: {
+      list: [cliConf, envConf]
+    }
+  }
+  const extras = {
+    npm_execpath: require.main.filename,
+    npm_node_execpath: process.execPath,
+    npm_command: undefined
+  }
+  const env = {}
+  setEnvs(npm, env)
+  t.strictSame(env, { ...extras }, 'no new environment vars to create')
+  envConf.call = 'me, maybe'
+  setEnvs(npm, env)
+  t.strictSame(env, { ...extras }, 'no new environment vars to create, already in env')
+  delete envConf.call
+  cliConf.call = 'me, maybe'
+  setEnvs(npm, env)
+  t.strictSame(env, {
+    ...extras,
+    npm_config_call: 'me, maybe'
+  }, 'set in env, because changed from default in cli')
+  envConf.call = 'me, maybe'
+  cliConf.call = ''
+  cliConf['node-options'] = 'some options for node'
+  setEnvs(npm, env)
+  t.strictSame(env, {
+    ...extras,
+    npm_config_call: '',
+    npm_config_node_options: 'some options for node',
+    NODE_OPTIONS: 'some options for node'
+  }, 'set in env, because changed from default in env, back to default in cli')
+  t.end()
+})
+
+t.test('set envs that are not defaults and not already in env, array style', t => {
+  const envConf = Object.create(defaults)
+  const cliConf = Object.create(envConf)
+  const npm = {
+    config: {
+      list: [cliConf, envConf]
+    }
+  }
+  const extras = {
+    npm_execpath: require.main.filename,
+    npm_node_execpath: process.execPath,
+    npm_command: undefined
+  }
+  const env = {}
+  setEnvs(npm, env)
+  t.strictSame(env, { ...extras }, 'no new environment vars to create')
+  envConf.omit = ['dev']
+  setEnvs(npm, env)
+  t.strictSame(env, { ...extras }, 'no new environment vars to create, already in env')
+  delete envConf.omit
+  cliConf.omit = ['dev', 'optional']
+  setEnvs(npm, env)
+  t.strictSame(env, {
+    ...extras,
+    npm_config_omit: 'dev\n\noptional'
+  }, 'set in env, because changed from default in cli')
+  envConf.omit = ['optional', 'peer']
+  cliConf.omit = []
+  setEnvs(npm, env)
+  t.strictSame(env, {
+    ...extras,
+    npm_config_omit: ''
+  }, 'set in env, because changed from default in env, back to default in cli')
+  t.end()
+})
+
+t.test('set envs that are not defaults and not already in env, boolean edition', t => {
+  const envConf = Object.create(defaults)
+  const cliConf = Object.create(envConf)
+  const npm = {
+    config: {
+      list: [cliConf, envConf]
+    }
+  }
+  const extras = {
+    npm_execpath: require.main.filename,
+    npm_node_execpath: process.execPath,
+    npm_command: undefined
+  }
+  const env = {}
+  setEnvs(npm, env)
+  t.strictSame(env, { ...extras }, 'no new environment vars to create')
+  envConf.audit = false
+  setEnvs(npm, env)
+  t.strictSame(env, { ...extras }, 'no new environment vars to create, already in env')
+  delete envConf.audit
+  cliConf.audit = false
+  cliConf.ignoreObjects = {
+    some: { object: 12345 }
+  }
+  setEnvs(npm, env)
+  t.strictSame(env, {
+    ...extras,
+    npm_config_audit: ''
+  }, 'set in env, because changed from default in cli')
+  envConf.audit = false
+  cliConf.audit = true
+  setEnvs(npm, env)
+  t.strictSame(env, {
+    ...extras,
+    npm_config_audit: 'true'
+  }, 'set in env, because changed from default in env, back to default in cli')
+  t.end()
+})
+
+t.test('default to process.env', t => {
+  const envConf = Object.create(defaults)
+  const cliConf = Object.create(envConf)
+  const npm = {
+    config: {
+      list: [cliConf, envConf]
+    }
+  }
+  const extras = {
+    npm_execpath: require.main.filename,
+    npm_node_execpath: process.execPath,
+    npm_command: undefined
+  }
+  const env = {}
+  const envDescriptor = Object.getOwnPropertyDescriptor(process, 'env')
+  Object.defineProperty(process, 'env', {
+    value: env,
+    configurable: true,
+    enumerable: true,
+    writable: true
+  })
+  t.teardown(() => Object.defineProperty(process, env, envDescriptor))
+
+  setEnvs(npm)
+  t.strictSame(env, { ...extras }, 'no new environment vars to create')
+  envConf.audit = false
+  setEnvs(npm)
+  t.strictSame(env, { ...extras }, 'no new environment vars to create, already in env')
+  delete envConf.audit
+  cliConf.audit = false
+  cliConf.ignoreObjects = {
+    some: { object: 12345 }
+  }
+  setEnvs(npm)
+  t.strictSame(env, {
+    ...extras,
+    npm_config_audit: ''
+  }, 'set in env, because changed from default in cli')
+  envConf.audit = false
+  cliConf.audit = true
+  setEnvs(npm)
+  t.strictSame(env, {
+    ...extras,
+    npm_config_audit: 'true'
+  }, 'set in env, because changed from default in env, back to default in cli')
+  t.end()
+})


### PR DESCRIPTION
Implement the changes in https://github.com/npm/rfcs/pull/183, and set environment variables properly when they are not strings.

Also adds tests for the set-envs util.