### PR TITLE
lib: fix URL constructor

### DIFF
--- a/lib/utils/replace-info.js
+++ b/lib/utils/replace-info.js
@@ -1,4 +1,4 @@
-const URL = require('url')
+const URL = require('url').URL
 
 // replaces auth info in an array
 //  of arguments or in a strings


### PR DESCRIPTION
The return from `require('url')` is not the URL constructor, that is
exported as `url.URL`. The constructor is generally available as a
global, so this pattern isn't 100% necessary, but this is the best
way to do it based on existing patterns in npm

Refs: https://github.com/nodejs/node/issues/34738