### PR TITLE
Rfc 0027 npm audit app id

### DIFF
--- a/lib/audit.js
+++ b/lib/audit.js
@@ -185,6 +185,13 @@ function auditCmd (args, cb) {
         result.errors.join('\n    '))
       err.code = 'ELOCKVERIFY'
       throw err
+    }).then((result) => {
+      const wrappedAudit = {}
+      wrappedAudit.data = result
+      if (pkgJson.metadata !== undefined) {
+        wrappedAudit.metadata = pkgJson.metadata
+      }
+      return wrappedAudit
     })
   }).then((auditReport) => {
     return audit.submitForFullReport(auditReport)

--- a/lib/install.js
+++ b/lib/install.js
@@ -641,6 +641,13 @@ Installer.prototype.startAudit = function (cb) {
   this.auditSubmission = Bluebird.try(() => {
     return audit.generateFromInstall(this.idealTree, this.differences, this.args, this.remove)
   }).then((auditData) => {
+    const wrappedAudit = {}
+    if (this.idealTree.package.metadata !== undefined) {
+      wrappedAudit.metadata = this.idealTree.package.metadata
+    }
+    wrappedAudit.data = auditData
+    return wrappedAudit
+  }).then((auditData) => {
     return audit.submitForInstallReport(auditData)
   }).catch(_ => {})
   cb()

--- a/lib/install/audit.js
+++ b/lib/install/audit.js
@@ -277,5 +277,5 @@ function generateFromInstall (tree, diffs, install, remove) {
     }
   })
 
-  return generate(treeToShrinkwrap(tree), requires, undefined, auditDiffs, auditInstall, auditRemove)
+  return generate(treeToShrinkwrap(tree), requires, auditDiffs, auditInstall, auditRemove)
 }

--- a/lib/install/audit.js
+++ b/lib/install/audit.js
@@ -47,7 +47,7 @@ function submitForInstallReport (auditData) {
       method: 'POST',
       registry,
       gzip: true,
-      body: auditData
+      body: auditData.data
     })).then(_ => {
       _.body.on('error', () => {})
       if (_.body.destroy) {
@@ -61,7 +61,8 @@ function submitForInstallReport (auditData) {
   return regFetch('/-/npm/v1/security/audits/quick', opts.concat({
     method: 'POST',
     gzip: true,
-    body: auditData
+    headers: { 'metadata': JSON.stringify(auditData.metadata) },
+    body: auditData.data
   })).then(response => {
     perf.emit('timeEnd', 'audit submit')
     perf.emit('time', 'audit body')
@@ -78,7 +79,8 @@ function submitForFullReport (auditData) {
   return regFetch('/-/npm/v1/security/audits', opts.concat({
     method: 'POST',
     gzip: true,
-    body: auditData
+    headers: { 'metadata': JSON.stringify(auditData.metadata) },
+    body: auditData.data
   })).then(response => {
     perf.emit('timeEnd', 'audit submit')
     perf.emit('time', 'audit body')
@@ -275,5 +277,5 @@ function generateFromInstall (tree, diffs, install, remove) {
     }
   })
 
-  return generate(treeToShrinkwrap(tree), requires, auditDiffs, auditInstall, auditRemove)
+  return generate(treeToShrinkwrap(tree), requires, undefined, auditDiffs, auditInstall, auditRemove)
 }

--- a/test/tap/audit.js
+++ b/test/tap/audit.js
@@ -573,7 +573,7 @@ test('exits with non-zero exit code for vulnerabilities in dependencies when run
   })
 })
 
-test('exits with zero exit code for vulnerabilities below the `audit-level` flag', t => {
+test('exits with zero exit code using metadata in package.json', t => {
   const fixture = new Tacks(new Dir({
     'package.json': new File({
       name: 'foo',

--- a/test/tap/audit.js
+++ b/test/tap/audit.js
@@ -164,415 +164,495 @@ test('exits with zero exit code for vulnerabilities below the `audit-level` flag
   })
 })
 
-// test('shows quick audit results summary for human', t => {
-//   const fixture = new Tacks(new Dir({
-//     'package.json': new File({
-//       name: 'foo',
-//       version: '1.0.0',
-//       dependencies: {
-//         baddep: '1.0.0'
-//       }
-//     })
-//   }))
-//   fixture.create(testDir)
-//   return tmock(t).then(srv => {
-//     srv.filteringRequestBody(req => 'ok')
-//     srv.post('/-/npm/v1/security/audits/quick', 'ok').reply(200, quickAuditResult)
-//     srv.get('/baddep').twice().reply(200, {
-//       name: 'baddep',
-//       'dist-tags': {
-//         'latest': '1.2.3'
-//       },
-//       versions: {
-//         '1.0.0': {
-//           name: 'baddep',
-//           version: '1.0.0',
-//           _hasShrinkwrap: false,
-//           dist: {
-//             shasum: 'deadbeef',
-//             tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
-//           }
-//         },
-//         '1.2.3': {
-//           name: 'baddep',
-//           version: '1.2.3',
-//           _hasShrinkwrap: false,
-//           dist: {
-//             shasum: 'deadbeef',
-//             tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
-//           }
-//         }
-//       }
-//     })
-//     return common.npm([
-//       'install',
-//       '--audit',
-//       '--no-json',
-//       '--package-lock-only',
-//       '--registry', common.registry,
-//       '--cache', path.join(testDir, 'npm-cache')
-//     ], EXEC_OPTS).then(([code, stdout, stderr]) => {
-//       t.match(stdout, new RegExp('added 1 package and audited 1 package in .*\\n' +
-//         'found 1 high severity vulnerability\\n' +
-//         '  run `npm audit fix` to fix them, or `npm audit` for details\\n'),
-//       'shows quick audit result')
-//     })
-//   })
-// })
-//
-// test('exits with non-zero exit code for vulnerabilities at the `audit-level` flag', t => {
-//   const fixture = new Tacks(new Dir({
-//     'package.json': new File({
-//       name: 'foo',
-//       version: '1.0.0',
-//       dependencies: {
-//         baddep: '1.0.0'
-//       }
-//     })
-//   }))
-//   fixture.create(testDir)
-//   return tmock(t).then(srv => {
-//     srv.filteringRequestBody(req => 'ok')
-//     srv.post('/-/npm/v1/security/audits/quick', 'ok').reply(200, 'yeah')
-//     srv.get('/baddep').twice().reply(200, {
-//       name: 'baddep',
-//       'dist-tags': {
-//         'latest': '1.2.3'
-//       },
-//       versions: {
-//         '1.0.0': {
-//           name: 'baddep',
-//           version: '1.0.0',
-//           _hasShrinkwrap: false,
-//           dist: {
-//             shasum: 'deadbeef',
-//             tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
-//           }
-//         },
-//         '1.2.3': {
-//           name: 'baddep',
-//           version: '1.2.3',
-//           _hasShrinkwrap: false,
-//           dist: {
-//             shasum: 'deadbeef',
-//             tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
-//           }
-//         }
-//       }
-//     })
-//     return common.npm([
-//       'install',
-//       '--audit',
-//       '--json',
-//       '--package-lock-only',
-//       '--registry', common.registry,
-//       '--cache', path.join(testDir, 'npm-cache')
-//     ], EXEC_OPTS).then(([code, stdout, stderr]) => {
-//       srv.filteringRequestBody(req => 'ok')
-//       srv.post('/-/npm/v1/security/audits', 'ok').reply(200, {
-//         actions: [{
-//           action: 'update',
-//           module: 'baddep',
-//           target: '1.2.3',
-//           resolves: [{path: 'baddep'}]
-//         }],
-//         metadata: {
-//           vulnerabilities: {
-//             high: 1
-//           }
-//         }
-//       })
-//       return common.npm([
-//         'audit',
-//         '--audit-level', 'high',
-//         '--json',
-//         '--registry', common.registry,
-//         '--cache', path.join(testDir, 'npm-cache')
-//       ], EXEC_OPTS).then(([code, stdout, stderr]) => {
-//         t.equal(code, 1, 'exited OK')
-//       })
-//     })
-//   })
-// })
-//
-// test('exits with non-zero exit code for vulnerabilities at the `audit-level` flag', t => {
-//   const fixture = new Tacks(new Dir({
-//     'package.json': new File({
-//       name: 'foo',
-//       version: '1.0.0',
-//       dependencies: {
-//         baddep: '1.0.0'
-//       }
-//     })
-//   }))
-//   fixture.create(testDir)
-//   return tmock(t).then(srv => {
-//     srv.filteringRequestBody(req => 'ok')
-//     srv.post('/-/npm/v1/security/audits/quick', 'ok').reply(200, 'yeah')
-//     srv.get('/baddep').twice().reply(200, {
-//       name: 'baddep',
-//       'dist-tags': {
-//         'latest': '1.2.3'
-//       },
-//       versions: {
-//         '1.0.0': {
-//           name: 'baddep',
-//           version: '1.0.0',
-//           _hasShrinkwrap: false,
-//           dist: {
-//             shasum: 'deadbeef',
-//             tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
-//           }
-//         },
-//         '1.2.3': {
-//           name: 'baddep',
-//           version: '1.2.3',
-//           _hasShrinkwrap: false,
-//           dist: {
-//             shasum: 'deadbeef',
-//             tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
-//           }
-//         }
-//       }
-//     })
-//     return common.npm([
-//       'install',
-//       '--audit',
-//       '--json',
-//       '--package-lock-only',
-//       '--registry', common.registry,
-//       '--cache', path.join(testDir, 'npm-cache')
-//     ], EXEC_OPTS).then(([code, stdout, stderr]) => {
-//       srv.filteringRequestBody(req => 'ok')
-//       srv.post('/-/npm/v1/security/audits', 'ok').reply(200, {
-//         actions: [{
-//           action: 'update',
-//           module: 'baddep',
-//           target: '1.2.3',
-//           resolves: [{path: 'baddep'}]
-//         }],
-//         metadata: {
-//           vulnerabilities: {
-//             high: 1
-//           }
-//         }
-//       })
-//       return common.npm([
-//         'audit',
-//         '--audit-level', 'moderate',
-//         '--json',
-//         '--registry', common.registry,
-//         '--cache', path.join(testDir, 'npm-cache')
-//       ], EXEC_OPTS).then(([code, stdout, stderr]) => {
-//         t.equal(code, 1, 'exited OK')
-//       })
-//     })
-//   })
-// })
-//
-// test('exits with zero exit code for vulnerabilities in devDependencies when running with production flag', t => {
-//   const fixture = new Tacks(new Dir({
-//     'package.json': new File({
-//       name: 'foo',
-//       version: '1.0.0',
-//       dependencies: {
-//         gooddep: '1.0.0'
-//       },
-//       devDependencies: {
-//         baddep: '1.0.0'
-//       }
-//     })
-//   }))
-//   fixture.create(testDir)
-//   return tmock(t).then(srv => {
-//     srv.filteringRequestBody(req => 'ok')
-//     srv.post('/-/npm/v1/security/audits/quick', 'ok').reply(200, 'yeah')
-//     srv.get('/gooddep').twice().reply(200, {
-//       name: 'gooddep',
-//       'dist-tags': {
-//         'latest': '1.2.3'
-//       },
-//       versions: {
-//         '1.0.0': {
-//           name: 'gooddep',
-//           version: '1.0.0',
-//           _hasShrinkwrap: false,
-//           dist: {
-//             shasum: 'deadbeef',
-//             tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
-//           }
-//         },
-//         '1.2.3': {
-//           name: 'gooddep',
-//           version: '1.2.3',
-//           _hasShrinkwrap: false,
-//           dist: {
-//             shasum: 'deadbeef',
-//             tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
-//           }
-//         }
-//       }
-//     })
-//     srv.get('/baddep').twice().reply(200, {
-//       name: 'baddep',
-//       'dist-tags': {
-//         'latest': '1.2.3'
-//       },
-//       versions: {
-//         '1.0.0': {
-//           name: 'baddep',
-//           version: '1.0.0',
-//           _hasShrinkwrap: false,
-//           dist: {
-//             shasum: 'deadbeef',
-//             tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
-//           }
-//         },
-//         '1.2.3': {
-//           name: 'baddep',
-//           version: '1.2.3',
-//           _hasShrinkwrap: false,
-//           dist: {
-//             shasum: 'deadbeef',
-//             tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
-//           }
-//         }
-//       }
-//     })
-//     return common.npm([
-//       'install',
-//       '--audit',
-//       '--json',
-//       '--production',
-//       '--package-lock-only',
-//       '--registry', common.registry,
-//       '--cache', path.join(testDir, 'npm-cache')
-//     ], EXEC_OPTS).then(([code, stdout, stderr]) => {
-//       srv.filteringRequestBody(req => 'ok')
-//       srv.post('/-/npm/v1/security/audits', 'ok').reply(200, {
-//         actions: [],
-//         metadata: {
-//           vulnerabilities: {}
-//         }
-//       })
-//       return common.npm([
-//         'audit',
-//         '--json',
-//         '--production',
-//         '--registry', common.registry,
-//         '--cache', path.join(testDir, 'npm-cache')
-//       ], EXEC_OPTS).then(([code, stdout, stderr]) => {
-//         t.equal(code, 0, 'exited OK')
-//       })
-//     })
-//   })
-// })
-//
-// test('exits with non-zero exit code for vulnerabilities in dependencies when running with production flag', t => {
-//   const fixture = new Tacks(new Dir({
-//     'package.json': new File({
-//       name: 'foo',
-//       version: '1.0.0',
-//       dependencies: {
-//         baddep: '1.0.0'
-//       },
-//       devDependencies: {
-//         gooddep: '1.0.0'
-//       }
-//     })
-//   }))
-//   fixture.create(testDir)
-//   return tmock(t).then(srv => {
-//     srv.filteringRequestBody(req => 'ok')
-//     srv.post('/-/npm/v1/security/audits/quick', 'ok').reply(200, 'yeah')
-//     srv.get('/baddep').twice().reply(200, {
-//       name: 'baddep',
-//       'dist-tags': {
-//         'latest': '1.2.3'
-//       },
-//       versions: {
-//         '1.0.0': {
-//           name: 'baddep',
-//           version: '1.0.0',
-//           _hasShrinkwrap: false,
-//           dist: {
-//             shasum: 'deadbeef',
-//             tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
-//           }
-//         },
-//         '1.2.3': {
-//           name: 'baddep',
-//           version: '1.2.3',
-//           _hasShrinkwrap: false,
-//           dist: {
-//             shasum: 'deadbeef',
-//             tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
-//           }
-//         }
-//       }
-//     })
-//     srv.get('/gooddep').twice().reply(200, {
-//       name: 'gooddep',
-//       'dist-tags': {
-//         'latest': '1.2.3'
-//       },
-//       versions: {
-//         '1.0.0': {
-//           name: 'gooddep',
-//           version: '1.0.0',
-//           _hasShrinkwrap: false,
-//           dist: {
-//             shasum: 'deadbeef',
-//             tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
-//           }
-//         },
-//         '1.2.3': {
-//           name: 'gooddep',
-//           version: '1.2.3',
-//           _hasShrinkwrap: false,
-//           dist: {
-//             shasum: 'deadbeef',
-//             tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
-//           }
-//         }
-//       }
-//     })
-//     return common.npm([
-//       'install',
-//       '--audit',
-//       '--json',
-//       '--production',
-//       '--package-lock-only',
-//       '--registry', common.registry,
-//       '--cache', path.join(testDir, 'npm-cache')
-//     ], EXEC_OPTS).then(([code, stdout, stderr]) => {
-//       srv.filteringRequestBody(req => 'ok')
-//       srv.post('/-/npm/v1/security/audits', 'ok').reply(200, {
-//         actions: [{
-//           action: 'update',
-//           module: 'baddep',
-//           target: '1.2.3',
-//           resolves: [{path: 'baddep'}]
-//         }],
-//         metadata: {
-//           vulnerabilities: {
-//             low: 1
-//           }
-//         }
-//       })
-//       return common.npm([
-//         'audit',
-//         '--json',
-//         '--production',
-//         '--registry', common.registry,
-//         '--cache', path.join(testDir, 'npm-cache')
-//       ], EXEC_OPTS).then(([code, stdout, stderr]) => {
-//         t.equal(code, 1, 'exited OK')
-//       })
-//     })
-//   })
-// })
-//
-// test('cleanup', t => {
-//   return rimraf(testDir)
-// })
+test('shows quick audit results summary for human', t => {
+  const fixture = new Tacks(new Dir({
+    'package.json': new File({
+      name: 'foo',
+      version: '1.0.0',
+      dependencies: {
+        baddep: '1.0.0'
+      }
+    })
+  }))
+  fixture.create(testDir)
+  return tmock(t).then(srv => {
+    srv.filteringRequestBody(req => 'ok')
+    srv.post('/-/npm/v1/security/audits/quick', 'ok').reply(200, quickAuditResult)
+    srv.get('/baddep').twice().reply(200, {
+      name: 'baddep',
+      'dist-tags': {
+        'latest': '1.2.3'
+      },
+      versions: {
+        '1.0.0': {
+          name: 'baddep',
+          version: '1.0.0',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
+          }
+        },
+        '1.2.3': {
+          name: 'baddep',
+          version: '1.2.3',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
+          }
+        }
+      }
+    })
+    return common.npm([
+      'install',
+      '--audit',
+      '--no-json',
+      '--package-lock-only',
+      '--registry', common.registry,
+      '--cache', path.join(testDir, 'npm-cache')
+    ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+      t.match(stdout, new RegExp('added 1 package and audited 1 package in .*\\n' +
+        'found 1 high severity vulnerability\\n' +
+        '  run `npm audit fix` to fix them, or `npm audit` for details\\n'),
+      'shows quick audit result')
+    })
+  })
+})
+
+test('exits with non-zero exit code for vulnerabilities at the `audit-level` flag', t => {
+  const fixture = new Tacks(new Dir({
+    'package.json': new File({
+      name: 'foo',
+      version: '1.0.0',
+      dependencies: {
+        baddep: '1.0.0'
+      }
+    })
+  }))
+  fixture.create(testDir)
+  return tmock(t).then(srv => {
+    srv.filteringRequestBody(req => 'ok')
+    srv.post('/-/npm/v1/security/audits/quick', 'ok').reply(200, 'yeah')
+    srv.get('/baddep').twice().reply(200, {
+      name: 'baddep',
+      'dist-tags': {
+        'latest': '1.2.3'
+      },
+      versions: {
+        '1.0.0': {
+          name: 'baddep',
+          version: '1.0.0',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
+          }
+        },
+        '1.2.3': {
+          name: 'baddep',
+          version: '1.2.3',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
+          }
+        }
+      }
+    })
+    return common.npm([
+      'install',
+      '--audit',
+      '--json',
+      '--package-lock-only',
+      '--registry', common.registry,
+      '--cache', path.join(testDir, 'npm-cache')
+    ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+      srv.filteringRequestBody(req => 'ok')
+      srv.post('/-/npm/v1/security/audits', 'ok').reply(200, {
+        actions: [{
+          action: 'update',
+          module: 'baddep',
+          target: '1.2.3',
+          resolves: [{path: 'baddep'}]
+        }],
+        metadata: {
+          vulnerabilities: {
+            high: 1
+          }
+        }
+      })
+      return common.npm([
+        'audit',
+        '--audit-level', 'high',
+        '--json',
+        '--registry', common.registry,
+        '--cache', path.join(testDir, 'npm-cache')
+      ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+        t.equal(code, 1, 'exited OK')
+      })
+    })
+  })
+})
+
+test('exits with non-zero exit code for vulnerabilities at the `audit-level` flag', t => {
+  const fixture = new Tacks(new Dir({
+    'package.json': new File({
+      name: 'foo',
+      version: '1.0.0',
+      dependencies: {
+        baddep: '1.0.0'
+      }
+    })
+  }))
+  fixture.create(testDir)
+  return tmock(t).then(srv => {
+    srv.filteringRequestBody(req => 'ok')
+    srv.post('/-/npm/v1/security/audits/quick', 'ok').reply(200, 'yeah')
+    srv.get('/baddep').twice().reply(200, {
+      name: 'baddep',
+      'dist-tags': {
+        'latest': '1.2.3'
+      },
+      versions: {
+        '1.0.0': {
+          name: 'baddep',
+          version: '1.0.0',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
+          }
+        },
+        '1.2.3': {
+          name: 'baddep',
+          version: '1.2.3',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
+          }
+        }
+      }
+    })
+    return common.npm([
+      'install',
+      '--audit',
+      '--json',
+      '--package-lock-only',
+      '--registry', common.registry,
+      '--cache', path.join(testDir, 'npm-cache')
+    ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+      srv.filteringRequestBody(req => 'ok')
+      srv.post('/-/npm/v1/security/audits', 'ok').reply(200, {
+        actions: [{
+          action: 'update',
+          module: 'baddep',
+          target: '1.2.3',
+          resolves: [{path: 'baddep'}]
+        }],
+        metadata: {
+          vulnerabilities: {
+            high: 1
+          }
+        }
+      })
+      return common.npm([
+        'audit',
+        '--audit-level', 'moderate',
+        '--json',
+        '--registry', common.registry,
+        '--cache', path.join(testDir, 'npm-cache')
+      ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+        t.equal(code, 1, 'exited OK')
+      })
+    })
+  })
+})
+
+test('exits with zero exit code for vulnerabilities in devDependencies when running with production flag', t => {
+  const fixture = new Tacks(new Dir({
+    'package.json': new File({
+      name: 'foo',
+      version: '1.0.0',
+      dependencies: {
+        gooddep: '1.0.0'
+      },
+      devDependencies: {
+        baddep: '1.0.0'
+      }
+    })
+  }))
+  fixture.create(testDir)
+  return tmock(t).then(srv => {
+    srv.filteringRequestBody(req => 'ok')
+    srv.post('/-/npm/v1/security/audits/quick', 'ok').reply(200, 'yeah')
+    srv.get('/gooddep').twice().reply(200, {
+      name: 'gooddep',
+      'dist-tags': {
+        'latest': '1.2.3'
+      },
+      versions: {
+        '1.0.0': {
+          name: 'gooddep',
+          version: '1.0.0',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
+          }
+        },
+        '1.2.3': {
+          name: 'gooddep',
+          version: '1.2.3',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
+          }
+        }
+      }
+    })
+    srv.get('/baddep').twice().reply(200, {
+      name: 'baddep',
+      'dist-tags': {
+        'latest': '1.2.3'
+      },
+      versions: {
+        '1.0.0': {
+          name: 'baddep',
+          version: '1.0.0',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
+          }
+        },
+        '1.2.3': {
+          name: 'baddep',
+          version: '1.2.3',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
+          }
+        }
+      }
+    })
+    return common.npm([
+      'install',
+      '--audit',
+      '--json',
+      '--production',
+      '--package-lock-only',
+      '--registry', common.registry,
+      '--cache', path.join(testDir, 'npm-cache')
+    ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+      srv.filteringRequestBody(req => 'ok')
+      srv.post('/-/npm/v1/security/audits', 'ok').reply(200, {
+        actions: [],
+        metadata: {
+          vulnerabilities: {}
+        }
+      })
+      return common.npm([
+        'audit',
+        '--json',
+        '--production',
+        '--registry', common.registry,
+        '--cache', path.join(testDir, 'npm-cache')
+      ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+        t.equal(code, 0, 'exited OK')
+      })
+    })
+  })
+})
+
+test('exits with non-zero exit code for vulnerabilities in dependencies when running with production flag', t => {
+  const fixture = new Tacks(new Dir({
+    'package.json': new File({
+      name: 'foo',
+      version: '1.0.0',
+      dependencies: {
+        baddep: '1.0.0'
+      },
+      devDependencies: {
+        gooddep: '1.0.0'
+      }
+    })
+  }))
+  fixture.create(testDir)
+  return tmock(t).then(srv => {
+    srv.filteringRequestBody(req => 'ok')
+    srv.post('/-/npm/v1/security/audits/quick', 'ok').reply(200, 'yeah')
+    srv.get('/baddep').twice().reply(200, {
+      name: 'baddep',
+      'dist-tags': {
+        'latest': '1.2.3'
+      },
+      versions: {
+        '1.0.0': {
+          name: 'baddep',
+          version: '1.0.0',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
+          }
+        },
+        '1.2.3': {
+          name: 'baddep',
+          version: '1.2.3',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
+          }
+        }
+      }
+    })
+    srv.get('/gooddep').twice().reply(200, {
+      name: 'gooddep',
+      'dist-tags': {
+        'latest': '1.2.3'
+      },
+      versions: {
+        '1.0.0': {
+          name: 'gooddep',
+          version: '1.0.0',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
+          }
+        },
+        '1.2.3': {
+          name: 'gooddep',
+          version: '1.2.3',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
+          }
+        }
+      }
+    })
+    return common.npm([
+      'install',
+      '--audit',
+      '--json',
+      '--production',
+      '--package-lock-only',
+      '--registry', common.registry,
+      '--cache', path.join(testDir, 'npm-cache')
+    ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+      srv.filteringRequestBody(req => 'ok')
+      srv.post('/-/npm/v1/security/audits', 'ok').reply(200, {
+        actions: [{
+          action: 'update',
+          module: 'baddep',
+          target: '1.2.3',
+          resolves: [{path: 'baddep'}]
+        }],
+        metadata: {
+          vulnerabilities: {
+            low: 1
+          }
+        }
+      })
+      return common.npm([
+        'audit',
+        '--json',
+        '--production',
+        '--registry', common.registry,
+        '--cache', path.join(testDir, 'npm-cache')
+      ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+        t.equal(code, 1, 'exited OK')
+      })
+    })
+  })
+})
+
+test('exits with zero exit code for vulnerabilities below the `audit-level` flag', t => {
+  const fixture = new Tacks(new Dir({
+    'package.json': new File({
+      name: 'foo',
+      version: '1.0.0',
+      dependencies: {
+        baddep: '1.0.0'
+      },
+      metadata: {
+        'npm-app-id': 'myapp'
+      }
+    })
+  }))
+  fixture.create(testDir)
+  return tmock(t).then(srv => {
+    srv.filteringRequestBody(req => 'ok')
+    srv.post('/-/npm/v1/security/audits/quick', 'ok').reply(200, quickAuditResult)
+    srv.get('/baddep').twice().reply(200, {
+      name: 'baddep',
+      'dist-tags': {
+        'latest': '1.2.3'
+      },
+      versions: {
+        '1.0.0': {
+          name: 'baddep',
+          version: '1.0.0',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
+          }
+        },
+        '1.2.3': {
+          name: 'baddep',
+          version: '1.2.3',
+          _hasShrinkwrap: false,
+          dist: {
+            shasum: 'deadbeef',
+            tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
+          }
+        }
+      }
+    })
+    return common.npm([
+      'install',
+      '--audit',
+      '--json',
+      '--package-lock-only',
+      '--registry', common.registry,
+      '--cache', path.join(testDir, 'npm-cache')
+    ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+      const result = JSON.parse(stdout)
+      t.same(result.audit, quickAuditResult, 'printed quick audit result')
+      srv.filteringRequestBody(req => 'ok')
+      srv.post('/-/npm/v1/security/audits', 'ok').reply(200, {
+        actions: [{
+          action: 'update',
+          module: 'baddep',
+          target: '1.2.3',
+          resolves: [{path: 'baddep'}]
+        }],
+        metadata: {
+          vulnerabilities: {
+            low: 1
+          }
+        }
+      })
+      return common.npm([
+        'audit',
+        '--audit-level', 'high',
+        '--json',
+        '--registry', common.registry,
+        '--cache', path.join(testDir, 'npm-cache')
+      ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+        t.equal(code, 0, 'exited OK')
+      })
+    })
+  })
+})
+
+test('cleanup', t => {
+  return rimraf(testDir)
+})

--- a/test/tap/audit.js
+++ b/test/tap/audit.js
@@ -164,415 +164,415 @@ test('exits with zero exit code for vulnerabilities below the `audit-level` flag
   })
 })
 
-test('shows quick audit results summary for human', t => {
-  const fixture = new Tacks(new Dir({
-    'package.json': new File({
-      name: 'foo',
-      version: '1.0.0',
-      dependencies: {
-        baddep: '1.0.0'
-      }
-    })
-  }))
-  fixture.create(testDir)
-  return tmock(t).then(srv => {
-    srv.filteringRequestBody(req => 'ok')
-    srv.post('/-/npm/v1/security/audits/quick', 'ok').reply(200, quickAuditResult)
-    srv.get('/baddep').twice().reply(200, {
-      name: 'baddep',
-      'dist-tags': {
-        'latest': '1.2.3'
-      },
-      versions: {
-        '1.0.0': {
-          name: 'baddep',
-          version: '1.0.0',
-          _hasShrinkwrap: false,
-          dist: {
-            shasum: 'deadbeef',
-            tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
-          }
-        },
-        '1.2.3': {
-          name: 'baddep',
-          version: '1.2.3',
-          _hasShrinkwrap: false,
-          dist: {
-            shasum: 'deadbeef',
-            tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
-          }
-        }
-      }
-    })
-    return common.npm([
-      'install',
-      '--audit',
-      '--no-json',
-      '--package-lock-only',
-      '--registry', common.registry,
-      '--cache', path.join(testDir, 'npm-cache')
-    ], EXEC_OPTS).then(([code, stdout, stderr]) => {
-      t.match(stdout, new RegExp('added 1 package and audited 1 package in .*\\n' +
-        'found 1 high severity vulnerability\\n' +
-        '  run `npm audit fix` to fix them, or `npm audit` for details\\n'),
-      'shows quick audit result')
-    })
-  })
-})
-
-test('exits with non-zero exit code for vulnerabilities at the `audit-level` flag', t => {
-  const fixture = new Tacks(new Dir({
-    'package.json': new File({
-      name: 'foo',
-      version: '1.0.0',
-      dependencies: {
-        baddep: '1.0.0'
-      }
-    })
-  }))
-  fixture.create(testDir)
-  return tmock(t).then(srv => {
-    srv.filteringRequestBody(req => 'ok')
-    srv.post('/-/npm/v1/security/audits/quick', 'ok').reply(200, 'yeah')
-    srv.get('/baddep').twice().reply(200, {
-      name: 'baddep',
-      'dist-tags': {
-        'latest': '1.2.3'
-      },
-      versions: {
-        '1.0.0': {
-          name: 'baddep',
-          version: '1.0.0',
-          _hasShrinkwrap: false,
-          dist: {
-            shasum: 'deadbeef',
-            tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
-          }
-        },
-        '1.2.3': {
-          name: 'baddep',
-          version: '1.2.3',
-          _hasShrinkwrap: false,
-          dist: {
-            shasum: 'deadbeef',
-            tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
-          }
-        }
-      }
-    })
-    return common.npm([
-      'install',
-      '--audit',
-      '--json',
-      '--package-lock-only',
-      '--registry', common.registry,
-      '--cache', path.join(testDir, 'npm-cache')
-    ], EXEC_OPTS).then(([code, stdout, stderr]) => {
-      srv.filteringRequestBody(req => 'ok')
-      srv.post('/-/npm/v1/security/audits', 'ok').reply(200, {
-        actions: [{
-          action: 'update',
-          module: 'baddep',
-          target: '1.2.3',
-          resolves: [{path: 'baddep'}]
-        }],
-        metadata: {
-          vulnerabilities: {
-            high: 1
-          }
-        }
-      })
-      return common.npm([
-        'audit',
-        '--audit-level', 'high',
-        '--json',
-        '--registry', common.registry,
-        '--cache', path.join(testDir, 'npm-cache')
-      ], EXEC_OPTS).then(([code, stdout, stderr]) => {
-        t.equal(code, 1, 'exited OK')
-      })
-    })
-  })
-})
-
-test('exits with non-zero exit code for vulnerabilities at the `audit-level` flag', t => {
-  const fixture = new Tacks(new Dir({
-    'package.json': new File({
-      name: 'foo',
-      version: '1.0.0',
-      dependencies: {
-        baddep: '1.0.0'
-      }
-    })
-  }))
-  fixture.create(testDir)
-  return tmock(t).then(srv => {
-    srv.filteringRequestBody(req => 'ok')
-    srv.post('/-/npm/v1/security/audits/quick', 'ok').reply(200, 'yeah')
-    srv.get('/baddep').twice().reply(200, {
-      name: 'baddep',
-      'dist-tags': {
-        'latest': '1.2.3'
-      },
-      versions: {
-        '1.0.0': {
-          name: 'baddep',
-          version: '1.0.0',
-          _hasShrinkwrap: false,
-          dist: {
-            shasum: 'deadbeef',
-            tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
-          }
-        },
-        '1.2.3': {
-          name: 'baddep',
-          version: '1.2.3',
-          _hasShrinkwrap: false,
-          dist: {
-            shasum: 'deadbeef',
-            tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
-          }
-        }
-      }
-    })
-    return common.npm([
-      'install',
-      '--audit',
-      '--json',
-      '--package-lock-only',
-      '--registry', common.registry,
-      '--cache', path.join(testDir, 'npm-cache')
-    ], EXEC_OPTS).then(([code, stdout, stderr]) => {
-      srv.filteringRequestBody(req => 'ok')
-      srv.post('/-/npm/v1/security/audits', 'ok').reply(200, {
-        actions: [{
-          action: 'update',
-          module: 'baddep',
-          target: '1.2.3',
-          resolves: [{path: 'baddep'}]
-        }],
-        metadata: {
-          vulnerabilities: {
-            high: 1
-          }
-        }
-      })
-      return common.npm([
-        'audit',
-        '--audit-level', 'moderate',
-        '--json',
-        '--registry', common.registry,
-        '--cache', path.join(testDir, 'npm-cache')
-      ], EXEC_OPTS).then(([code, stdout, stderr]) => {
-        t.equal(code, 1, 'exited OK')
-      })
-    })
-  })
-})
-
-test('exits with zero exit code for vulnerabilities in devDependencies when running with production flag', t => {
-  const fixture = new Tacks(new Dir({
-    'package.json': new File({
-      name: 'foo',
-      version: '1.0.0',
-      dependencies: {
-        gooddep: '1.0.0'
-      },
-      devDependencies: {
-        baddep: '1.0.0'
-      }
-    })
-  }))
-  fixture.create(testDir)
-  return tmock(t).then(srv => {
-    srv.filteringRequestBody(req => 'ok')
-    srv.post('/-/npm/v1/security/audits/quick', 'ok').reply(200, 'yeah')
-    srv.get('/gooddep').twice().reply(200, {
-      name: 'gooddep',
-      'dist-tags': {
-        'latest': '1.2.3'
-      },
-      versions: {
-        '1.0.0': {
-          name: 'gooddep',
-          version: '1.0.0',
-          _hasShrinkwrap: false,
-          dist: {
-            shasum: 'deadbeef',
-            tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
-          }
-        },
-        '1.2.3': {
-          name: 'gooddep',
-          version: '1.2.3',
-          _hasShrinkwrap: false,
-          dist: {
-            shasum: 'deadbeef',
-            tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
-          }
-        }
-      }
-    })
-    srv.get('/baddep').twice().reply(200, {
-      name: 'baddep',
-      'dist-tags': {
-        'latest': '1.2.3'
-      },
-      versions: {
-        '1.0.0': {
-          name: 'baddep',
-          version: '1.0.0',
-          _hasShrinkwrap: false,
-          dist: {
-            shasum: 'deadbeef',
-            tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
-          }
-        },
-        '1.2.3': {
-          name: 'baddep',
-          version: '1.2.3',
-          _hasShrinkwrap: false,
-          dist: {
-            shasum: 'deadbeef',
-            tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
-          }
-        }
-      }
-    })
-    return common.npm([
-      'install',
-      '--audit',
-      '--json',
-      '--production',
-      '--package-lock-only',
-      '--registry', common.registry,
-      '--cache', path.join(testDir, 'npm-cache')
-    ], EXEC_OPTS).then(([code, stdout, stderr]) => {
-      srv.filteringRequestBody(req => 'ok')
-      srv.post('/-/npm/v1/security/audits', 'ok').reply(200, {
-        actions: [],
-        metadata: {
-          vulnerabilities: {}
-        }
-      })
-      return common.npm([
-        'audit',
-        '--json',
-        '--production',
-        '--registry', common.registry,
-        '--cache', path.join(testDir, 'npm-cache')
-      ], EXEC_OPTS).then(([code, stdout, stderr]) => {
-        t.equal(code, 0, 'exited OK')
-      })
-    })
-  })
-})
-
-test('exits with non-zero exit code for vulnerabilities in dependencies when running with production flag', t => {
-  const fixture = new Tacks(new Dir({
-    'package.json': new File({
-      name: 'foo',
-      version: '1.0.0',
-      dependencies: {
-        baddep: '1.0.0'
-      },
-      devDependencies: {
-        gooddep: '1.0.0'
-      }
-    })
-  }))
-  fixture.create(testDir)
-  return tmock(t).then(srv => {
-    srv.filteringRequestBody(req => 'ok')
-    srv.post('/-/npm/v1/security/audits/quick', 'ok').reply(200, 'yeah')
-    srv.get('/baddep').twice().reply(200, {
-      name: 'baddep',
-      'dist-tags': {
-        'latest': '1.2.3'
-      },
-      versions: {
-        '1.0.0': {
-          name: 'baddep',
-          version: '1.0.0',
-          _hasShrinkwrap: false,
-          dist: {
-            shasum: 'deadbeef',
-            tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
-          }
-        },
-        '1.2.3': {
-          name: 'baddep',
-          version: '1.2.3',
-          _hasShrinkwrap: false,
-          dist: {
-            shasum: 'deadbeef',
-            tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
-          }
-        }
-      }
-    })
-    srv.get('/gooddep').twice().reply(200, {
-      name: 'gooddep',
-      'dist-tags': {
-        'latest': '1.2.3'
-      },
-      versions: {
-        '1.0.0': {
-          name: 'gooddep',
-          version: '1.0.0',
-          _hasShrinkwrap: false,
-          dist: {
-            shasum: 'deadbeef',
-            tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
-          }
-        },
-        '1.2.3': {
-          name: 'gooddep',
-          version: '1.2.3',
-          _hasShrinkwrap: false,
-          dist: {
-            shasum: 'deadbeef',
-            tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
-          }
-        }
-      }
-    })
-    return common.npm([
-      'install',
-      '--audit',
-      '--json',
-      '--production',
-      '--package-lock-only',
-      '--registry', common.registry,
-      '--cache', path.join(testDir, 'npm-cache')
-    ], EXEC_OPTS).then(([code, stdout, stderr]) => {
-      srv.filteringRequestBody(req => 'ok')
-      srv.post('/-/npm/v1/security/audits', 'ok').reply(200, {
-        actions: [{
-          action: 'update',
-          module: 'baddep',
-          target: '1.2.3',
-          resolves: [{path: 'baddep'}]
-        }],
-        metadata: {
-          vulnerabilities: {
-            low: 1
-          }
-        }
-      })
-      return common.npm([
-        'audit',
-        '--json',
-        '--production',
-        '--registry', common.registry,
-        '--cache', path.join(testDir, 'npm-cache')
-      ], EXEC_OPTS).then(([code, stdout, stderr]) => {
-        t.equal(code, 1, 'exited OK')
-      })
-    })
-  })
-})
-
-test('cleanup', t => {
-  return rimraf(testDir)
-})
+// test('shows quick audit results summary for human', t => {
+//   const fixture = new Tacks(new Dir({
+//     'package.json': new File({
+//       name: 'foo',
+//       version: '1.0.0',
+//       dependencies: {
+//         baddep: '1.0.0'
+//       }
+//     })
+//   }))
+//   fixture.create(testDir)
+//   return tmock(t).then(srv => {
+//     srv.filteringRequestBody(req => 'ok')
+//     srv.post('/-/npm/v1/security/audits/quick', 'ok').reply(200, quickAuditResult)
+//     srv.get('/baddep').twice().reply(200, {
+//       name: 'baddep',
+//       'dist-tags': {
+//         'latest': '1.2.3'
+//       },
+//       versions: {
+//         '1.0.0': {
+//           name: 'baddep',
+//           version: '1.0.0',
+//           _hasShrinkwrap: false,
+//           dist: {
+//             shasum: 'deadbeef',
+//             tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
+//           }
+//         },
+//         '1.2.3': {
+//           name: 'baddep',
+//           version: '1.2.3',
+//           _hasShrinkwrap: false,
+//           dist: {
+//             shasum: 'deadbeef',
+//             tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
+//           }
+//         }
+//       }
+//     })
+//     return common.npm([
+//       'install',
+//       '--audit',
+//       '--no-json',
+//       '--package-lock-only',
+//       '--registry', common.registry,
+//       '--cache', path.join(testDir, 'npm-cache')
+//     ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+//       t.match(stdout, new RegExp('added 1 package and audited 1 package in .*\\n' +
+//         'found 1 high severity vulnerability\\n' +
+//         '  run `npm audit fix` to fix them, or `npm audit` for details\\n'),
+//       'shows quick audit result')
+//     })
+//   })
+// })
+//
+// test('exits with non-zero exit code for vulnerabilities at the `audit-level` flag', t => {
+//   const fixture = new Tacks(new Dir({
+//     'package.json': new File({
+//       name: 'foo',
+//       version: '1.0.0',
+//       dependencies: {
+//         baddep: '1.0.0'
+//       }
+//     })
+//   }))
+//   fixture.create(testDir)
+//   return tmock(t).then(srv => {
+//     srv.filteringRequestBody(req => 'ok')
+//     srv.post('/-/npm/v1/security/audits/quick', 'ok').reply(200, 'yeah')
+//     srv.get('/baddep').twice().reply(200, {
+//       name: 'baddep',
+//       'dist-tags': {
+//         'latest': '1.2.3'
+//       },
+//       versions: {
+//         '1.0.0': {
+//           name: 'baddep',
+//           version: '1.0.0',
+//           _hasShrinkwrap: false,
+//           dist: {
+//             shasum: 'deadbeef',
+//             tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
+//           }
+//         },
+//         '1.2.3': {
+//           name: 'baddep',
+//           version: '1.2.3',
+//           _hasShrinkwrap: false,
+//           dist: {
+//             shasum: 'deadbeef',
+//             tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
+//           }
+//         }
+//       }
+//     })
+//     return common.npm([
+//       'install',
+//       '--audit',
+//       '--json',
+//       '--package-lock-only',
+//       '--registry', common.registry,
+//       '--cache', path.join(testDir, 'npm-cache')
+//     ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+//       srv.filteringRequestBody(req => 'ok')
+//       srv.post('/-/npm/v1/security/audits', 'ok').reply(200, {
+//         actions: [{
+//           action: 'update',
+//           module: 'baddep',
+//           target: '1.2.3',
+//           resolves: [{path: 'baddep'}]
+//         }],
+//         metadata: {
+//           vulnerabilities: {
+//             high: 1
+//           }
+//         }
+//       })
+//       return common.npm([
+//         'audit',
+//         '--audit-level', 'high',
+//         '--json',
+//         '--registry', common.registry,
+//         '--cache', path.join(testDir, 'npm-cache')
+//       ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+//         t.equal(code, 1, 'exited OK')
+//       })
+//     })
+//   })
+// })
+//
+// test('exits with non-zero exit code for vulnerabilities at the `audit-level` flag', t => {
+//   const fixture = new Tacks(new Dir({
+//     'package.json': new File({
+//       name: 'foo',
+//       version: '1.0.0',
+//       dependencies: {
+//         baddep: '1.0.0'
+//       }
+//     })
+//   }))
+//   fixture.create(testDir)
+//   return tmock(t).then(srv => {
+//     srv.filteringRequestBody(req => 'ok')
+//     srv.post('/-/npm/v1/security/audits/quick', 'ok').reply(200, 'yeah')
+//     srv.get('/baddep').twice().reply(200, {
+//       name: 'baddep',
+//       'dist-tags': {
+//         'latest': '1.2.3'
+//       },
+//       versions: {
+//         '1.0.0': {
+//           name: 'baddep',
+//           version: '1.0.0',
+//           _hasShrinkwrap: false,
+//           dist: {
+//             shasum: 'deadbeef',
+//             tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
+//           }
+//         },
+//         '1.2.3': {
+//           name: 'baddep',
+//           version: '1.2.3',
+//           _hasShrinkwrap: false,
+//           dist: {
+//             shasum: 'deadbeef',
+//             tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
+//           }
+//         }
+//       }
+//     })
+//     return common.npm([
+//       'install',
+//       '--audit',
+//       '--json',
+//       '--package-lock-only',
+//       '--registry', common.registry,
+//       '--cache', path.join(testDir, 'npm-cache')
+//     ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+//       srv.filteringRequestBody(req => 'ok')
+//       srv.post('/-/npm/v1/security/audits', 'ok').reply(200, {
+//         actions: [{
+//           action: 'update',
+//           module: 'baddep',
+//           target: '1.2.3',
+//           resolves: [{path: 'baddep'}]
+//         }],
+//         metadata: {
+//           vulnerabilities: {
+//             high: 1
+//           }
+//         }
+//       })
+//       return common.npm([
+//         'audit',
+//         '--audit-level', 'moderate',
+//         '--json',
+//         '--registry', common.registry,
+//         '--cache', path.join(testDir, 'npm-cache')
+//       ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+//         t.equal(code, 1, 'exited OK')
+//       })
+//     })
+//   })
+// })
+//
+// test('exits with zero exit code for vulnerabilities in devDependencies when running with production flag', t => {
+//   const fixture = new Tacks(new Dir({
+//     'package.json': new File({
+//       name: 'foo',
+//       version: '1.0.0',
+//       dependencies: {
+//         gooddep: '1.0.0'
+//       },
+//       devDependencies: {
+//         baddep: '1.0.0'
+//       }
+//     })
+//   }))
+//   fixture.create(testDir)
+//   return tmock(t).then(srv => {
+//     srv.filteringRequestBody(req => 'ok')
+//     srv.post('/-/npm/v1/security/audits/quick', 'ok').reply(200, 'yeah')
+//     srv.get('/gooddep').twice().reply(200, {
+//       name: 'gooddep',
+//       'dist-tags': {
+//         'latest': '1.2.3'
+//       },
+//       versions: {
+//         '1.0.0': {
+//           name: 'gooddep',
+//           version: '1.0.0',
+//           _hasShrinkwrap: false,
+//           dist: {
+//             shasum: 'deadbeef',
+//             tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
+//           }
+//         },
+//         '1.2.3': {
+//           name: 'gooddep',
+//           version: '1.2.3',
+//           _hasShrinkwrap: false,
+//           dist: {
+//             shasum: 'deadbeef',
+//             tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
+//           }
+//         }
+//       }
+//     })
+//     srv.get('/baddep').twice().reply(200, {
+//       name: 'baddep',
+//       'dist-tags': {
+//         'latest': '1.2.3'
+//       },
+//       versions: {
+//         '1.0.0': {
+//           name: 'baddep',
+//           version: '1.0.0',
+//           _hasShrinkwrap: false,
+//           dist: {
+//             shasum: 'deadbeef',
+//             tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
+//           }
+//         },
+//         '1.2.3': {
+//           name: 'baddep',
+//           version: '1.2.3',
+//           _hasShrinkwrap: false,
+//           dist: {
+//             shasum: 'deadbeef',
+//             tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
+//           }
+//         }
+//       }
+//     })
+//     return common.npm([
+//       'install',
+//       '--audit',
+//       '--json',
+//       '--production',
+//       '--package-lock-only',
+//       '--registry', common.registry,
+//       '--cache', path.join(testDir, 'npm-cache')
+//     ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+//       srv.filteringRequestBody(req => 'ok')
+//       srv.post('/-/npm/v1/security/audits', 'ok').reply(200, {
+//         actions: [],
+//         metadata: {
+//           vulnerabilities: {}
+//         }
+//       })
+//       return common.npm([
+//         'audit',
+//         '--json',
+//         '--production',
+//         '--registry', common.registry,
+//         '--cache', path.join(testDir, 'npm-cache')
+//       ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+//         t.equal(code, 0, 'exited OK')
+//       })
+//     })
+//   })
+// })
+//
+// test('exits with non-zero exit code for vulnerabilities in dependencies when running with production flag', t => {
+//   const fixture = new Tacks(new Dir({
+//     'package.json': new File({
+//       name: 'foo',
+//       version: '1.0.0',
+//       dependencies: {
+//         baddep: '1.0.0'
+//       },
+//       devDependencies: {
+//         gooddep: '1.0.0'
+//       }
+//     })
+//   }))
+//   fixture.create(testDir)
+//   return tmock(t).then(srv => {
+//     srv.filteringRequestBody(req => 'ok')
+//     srv.post('/-/npm/v1/security/audits/quick', 'ok').reply(200, 'yeah')
+//     srv.get('/baddep').twice().reply(200, {
+//       name: 'baddep',
+//       'dist-tags': {
+//         'latest': '1.2.3'
+//       },
+//       versions: {
+//         '1.0.0': {
+//           name: 'baddep',
+//           version: '1.0.0',
+//           _hasShrinkwrap: false,
+//           dist: {
+//             shasum: 'deadbeef',
+//             tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
+//           }
+//         },
+//         '1.2.3': {
+//           name: 'baddep',
+//           version: '1.2.3',
+//           _hasShrinkwrap: false,
+//           dist: {
+//             shasum: 'deadbeef',
+//             tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
+//           }
+//         }
+//       }
+//     })
+//     srv.get('/gooddep').twice().reply(200, {
+//       name: 'gooddep',
+//       'dist-tags': {
+//         'latest': '1.2.3'
+//       },
+//       versions: {
+//         '1.0.0': {
+//           name: 'gooddep',
+//           version: '1.0.0',
+//           _hasShrinkwrap: false,
+//           dist: {
+//             shasum: 'deadbeef',
+//             tarball: common.registry + '/idk/-/idk-1.0.0.tgz'
+//           }
+//         },
+//         '1.2.3': {
+//           name: 'gooddep',
+//           version: '1.2.3',
+//           _hasShrinkwrap: false,
+//           dist: {
+//             shasum: 'deadbeef',
+//             tarball: common.registry + '/idk/-/idk-1.2.3.tgz'
+//           }
+//         }
+//       }
+//     })
+//     return common.npm([
+//       'install',
+//       '--audit',
+//       '--json',
+//       '--production',
+//       '--package-lock-only',
+//       '--registry', common.registry,
+//       '--cache', path.join(testDir, 'npm-cache')
+//     ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+//       srv.filteringRequestBody(req => 'ok')
+//       srv.post('/-/npm/v1/security/audits', 'ok').reply(200, {
+//         actions: [{
+//           action: 'update',
+//           module: 'baddep',
+//           target: '1.2.3',
+//           resolves: [{path: 'baddep'}]
+//         }],
+//         metadata: {
+//           vulnerabilities: {
+//             low: 1
+//           }
+//         }
+//       })
+//       return common.npm([
+//         'audit',
+//         '--json',
+//         '--production',
+//         '--registry', common.registry,
+//         '--cache', path.join(testDir, 'npm-cache')
+//       ], EXEC_OPTS).then(([code, stdout, stderr]) => {
+//         t.equal(code, 1, 'exited OK')
+//       })
+//     })
+//   })
+// })
+//
+// test('cleanup', t => {
+//   return rimraf(testDir)
+// })


### PR DESCRIPTION
<!-- What / Why -->
Following on from discussion against [rfc-0027](https://github.com/npm/rfcs/pull/138) this PR allows metadata from package.json to be appended to the header of the npm audit requests

<!-- Describe the request in detail. What it does and why it's being changed. -->
Some third party application require more details for auditing, such is Nexus Lifecycle. This application applies policy against an application, an application may have different policies.
This change allows a `metadata` object contained in the projects `package.json` file to be transmitted as a header definition.

Example
```
{
  "name": "npm_project",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "keywords": [],
  "author": "",
  "license": "ISC",
  "dependencies": {
    "qs": "^2.4.2"
  },
  "metadata": {
    "npm-app-id": "helloapp"
  }
}
```

This example will add a `metadata` key to the http request header with a `JSON.stringify` representation of the metadata object.