### PR TITLE
fix: fund with multiple funding sources

### DIFF
--- a/lib/fund.js
+++ b/lib/fund.js
@@ -42,26 +42,33 @@ function printHuman (fundingInfo, { color, unicode }) {
 
   const result = depth({
     tree: fundingInfo,
+
+    // composes human readable package name
+    // and creates a new archy item for readable output
     visit: ({ name, version, funding }) => {
-      // composes human readable package name
-      // and creates a new archy item for readable output
-      const { url } = funding || {}
+      const [fundingSource] = []
+        .concat(normalizeFunding(funding))
+        .filter(isValidFunding)
+      const { url } = fundingSource || {}
       const pkgRef = getPrintableName({ name, version })
-      const label = url ? tree({
-        label: color ? chalk.bgBlack.white(url) : url,
-        nodes: [pkgRef]
-      }).trim() : pkgRef
       let item = {
-        label
+        label: pkgRef
       }
 
-      // stacks all packages together under the same item
-      if (seenUrls.has(url)) {
-        item = seenUrls.get(url)
-        item.label += `, ${pkgRef}`
-        return null
-      } else {
-        seenUrls.set(url, item)
+      if (url) {
+        item.label = tree({
+          label: color ? chalk.bgBlack.white(url) : url,
+          nodes: [pkgRef]
+        }).trim()
+
+        // stacks all packages together under the same item
+        if (seenUrls.has(url)) {
+          item = seenUrls.get(url)
+          item.label += `, ${pkgRef}`
+          return null
+        } else {
+          seenUrls.set(url, item)
+        }
       }
 
       return item

--- a/tap-snapshots/test-lib-fund.js-TAP.test.js
+++ b/tap-snapshots/test-lib-fund.js-TAP.test.js
@@ -82,3 +82,13 @@ no-funding-package@0.0.0
 
 
 `
+
+exports[`test/lib/fund.js TAP sub dep with fund info and a parent with no funding info > should nest sub dep as child of root 1`] = `
+test-multiple-funding-sources@1.0.0
++-- http://example.com/b
+|   \`-- b@1.0.0
+\`-- http://example.com/c
+    \`-- c@1.0.0
+
+
+`


### PR DESCRIPTION
`npm fund` human output was appending any items that had multiple
funding sources to the current package title as comma-separated names.

This commit fixes the problem by properly selecting the first item of a
each funding element and only using that as its index for printing the
human output tree representation.