### PR TITLE
feat: add ability to skip pre/post hooks

### DIFF
--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -56,11 +56,13 @@ const runScript = async (args) => {
 
   // positional args only added to the main event, not pre/post
   const events = [[event, args]]
-  if (scripts[`pre${event}`]) {
-    events.unshift([`pre${event}`, []])
-  }
-  if (scripts[`post${event}`]) {
-    events.push([`post${event}`, []])
+  if (!npm.flatOptions.ignoreScripts) {
+    if (scripts[`pre${event}`]) {
+      events.unshift([`pre${event}`, []])
+    }
+    if (scripts[`post${event}`]) {
+      events.push([`post${event}`, []])
+    }
   }
 
   const opts = {

--- a/test/lib/run-script.js
+++ b/test/lib/run-script.js
@@ -223,6 +223,45 @@ t.test('run pre/post hooks', async t => {
   RUN_SCRIPTS.length = 0
 })
 
+t.test('skip pre/post hooks when using ignoreScripts', async t => {
+  npm.flatOptions.ignoreScripts = true
+
+  npm.localPrefix = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'x',
+      version: '1.2.3',
+      scripts: {
+        preenv: 'echo before the env',
+        postenv: 'echo after the env'
+      }
+    })
+  })
+
+  await runScript(['env'], er => {
+    if (er) {
+      throw er
+    }
+    t.deepEqual(RUN_SCRIPTS, [
+      {
+        path: npm.localPrefix,
+        args: [],
+        scriptShell: undefined,
+        stdio: 'inherit',
+        stdioString: true,
+        pkg: { name: 'x', version: '1.2.3', _id: 'x@1.2.3', scripts: {
+          preenv: 'echo before the env',
+          postenv: 'echo after the env',
+          env: 'env'
+        } },
+        event: 'env'
+      }
+    ])
+
+    delete npm.flatOptions.ignoreScripts
+  })
+  RUN_SCRIPTS.length = 0
+})
+
 t.test('run silent', async t => {
   npmlog.level = 'silent'
   t.teardown(() => { npmlog.level = 'warn' })


### PR DESCRIPTION
Implement support to `ignoreScripts` config option in `npm run-script`
allowing for skipping pre and post hooks when used as discussed in
RFC-0029.

ref: https://github.com/npm/rfcs/blob/ed67c2bc41873d8f1954f8ce4a8f00437f5f14eb/accepted/0029-add-ability-to-skip-hooks.md

/cc @lumaxis 