### PR TITLE
fix: fix package spec parsing during cache add process

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -80,7 +80,7 @@ const add = async (args, where) => {
     '    npm cache add <folder>\n'
   log.silly('cache add', 'args', args)
   const spec = args[0] +
-    (args[1] === undefined || args[1] === null ? `@${args[1]}` : '')
+    (args[1] === undefined || args[1] === null ? '' : `@${args[1]}`)
 
   log.verbose('cache add', 'spec', spec)
   if (!spec) {

--- a/test/lib/cache.js
+++ b/test/lib/cache.js
@@ -1,0 +1,36 @@
+const { test } = require('tap')
+
+const requireInject = require('require-inject')
+
+test('should add package to cache', (t) => {
+  const tarballs = []
+  const cache = requireInject('../../lib/cache.js', {
+    '../../lib/npm.js': {
+      globalDir: 'path/to/node_modules/',
+      prefix: 'foo',
+      flatOptions: {
+        global: false
+      },
+      config: {
+        get: () => true
+      }
+    },
+    pacote: {
+      tarball: {
+        stream: (spec) => {
+          tarballs.push(spec)
+        }
+      }
+    }
+  })
+
+  t.test('using pacote', t => {
+    console.log('cache: ', cache)
+    cache(['add', 'fizzbuzz@1.0.0'], () => {
+      t.similar(tarballs, ['fizzbuzz@1.0.0'])
+      t.end()
+    })
+  })
+
+  t.end()
+})


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

This commit is a fix for #1734 
It fixes the spec "parsing" during the cache add command.


## References
Close #1734
