### PR TITLE
fix: exec legacyPeerDeps

### DIFF
--- a/lib/exec.js
+++ b/lib/exec.js
@@ -141,7 +141,7 @@ const exec = async args => {
           throw 'canceled'
         }
       }
-      await arb.reify({ add })
+      await arb.reify({ ...npm.flatOptions, add })
     }
     pathArr.unshift(resolve(installDir, 'node_modules/.bin'))
   }


### PR DESCRIPTION
`npm exec` wasn't forwarding legacyPeerDeps to `arb.reify()`