### PR TITLE
test: add outdated tests

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -22,7 +22,7 @@ const usage = usageUtil('outdated',
 const completion = require('./utils/completion/none.js')
 
 function cmd (args, cb) {
-  outdated(args, cb)
+  outdated(args)
     .then(() => cb())
     .catch(cb)
 }
@@ -78,14 +78,12 @@ async function outdated (args) {
     }
     output(table(outTable, tableOpts))
   }
-
-  process.exitCode = outdated.length ? 1 : 0
 }
 
 async function outdated_ (tree, deps, opts) {
   const list = []
-  const edges = new Set()
 
+  const edges = new Set()
   function getEdges (nodes, type) {
     const getEdgesIn = (node) => {
       for (const edge of node.edgesIn) {
@@ -94,8 +92,14 @@ async function outdated_ (tree, deps, opts) {
     }
 
     const getEdgesOut = (node) => {
-      for (const edge of node.edgesOut.values()) {
-        edges.add(edge)
+      if (opts.global) {
+        for (const child of node.children.values()) {
+          edges.add(child)
+        }
+      } else {
+        for (const edge of node.edgesOut.values()) {
+          edges.add(edge)
+        }
       }
     }
 
@@ -107,30 +111,19 @@ async function outdated_ (tree, deps, opts) {
     }
   }
 
-  // packument fetching memoizing
-  const packuments = new Map()
   async function getPackument (spec) {
-    if (packuments.has(spec)) {
-      return packuments.get(spec)
-    }
     const packument = await pacote.packument(spec, {
       fullMetadata: npm.flatOptions.long,
       preferOnline: true
     })
-    packuments.set(spec, packument)
     return packument
   }
 
   async function getOutdatedInfo (edge) {
     const spec = npa(edge.name)
-    const node = edge.to
-    const {
-      path,
-      location,
-      package: {
-        version: current
-      }
-    } = node || { package: {} }
+    const node = edge.to || edge
+    const { path, location } = node
+    const { version: current } = node.package || {}
 
     const type = edge.optional ? 'optionalDependencies'
       : edge.peer ? 'peerDependencies'
@@ -160,7 +153,7 @@ async function outdated_ (tree, deps, opts) {
           location,
           wanted: wanted.version,
           latest: latest.version,
-          dependent: edge.from.name,
+          dependent: edge.from ? edge.from.name : 'global',
           homepage: packument.homepage
         })
       }

--- a/tap-snapshots/test-lib-outdated.js-TAP.test.js
+++ b/tap-snapshots/test-lib-outdated.js-TAP.test.js
@@ -22,7 +22,7 @@ exports[`test/lib/outdated.js TAP should display outdated deps outdated --json -
     "wanted": "1.0.1",
     "latest": "1.0.1",
     "dependent": "outdated-should-display-outdated-deps",
-    "location": "/cli/test/lib/outdated-should-display-outdated-deps/node_modules/alpha",
+    "location": "{CWD}/test/lib/outdated-should-display-outdated-deps/node_modules/alpha",
     "type": "dependencies"
   },
   "beta": {
@@ -30,7 +30,7 @@ exports[`test/lib/outdated.js TAP should display outdated deps outdated --json -
     "wanted": "1.0.1",
     "latest": "1.0.1",
     "dependent": "outdated-should-display-outdated-deps",
-    "location": "/cli/test/lib/outdated-should-display-outdated-deps/node_modules/beta",
+    "location": "{CWD}/test/lib/outdated-should-display-outdated-deps/node_modules/beta",
     "type": "peerDependencies"
   },
   "gamma": {
@@ -38,7 +38,7 @@ exports[`test/lib/outdated.js TAP should display outdated deps outdated --json -
     "wanted": "1.0.1",
     "latest": "2.0.0",
     "dependent": "outdated-should-display-outdated-deps",
-    "location": "/cli/test/lib/outdated-should-display-outdated-deps/node_modules/gamma",
+    "location": "{CWD}/test/lib/outdated-should-display-outdated-deps/node_modules/gamma",
     "type": "dependencies"
   },
   "theta": {
@@ -58,21 +58,21 @@ exports[`test/lib/outdated.js TAP should display outdated deps outdated --json >
     "wanted": "1.0.1",
     "latest": "1.0.1",
     "dependent": "outdated-should-display-outdated-deps",
-    "location": "/cli/test/lib/outdated-should-display-outdated-deps/node_modules/alpha"
+    "location": "{CWD}/test/lib/outdated-should-display-outdated-deps/node_modules/alpha"
   },
   "beta": {
     "current": "1.0.0",
     "wanted": "1.0.1",
     "latest": "1.0.1",
     "dependent": "outdated-should-display-outdated-deps",
-    "location": "/cli/test/lib/outdated-should-display-outdated-deps/node_modules/beta"
+    "location": "{CWD}/test/lib/outdated-should-display-outdated-deps/node_modules/beta"
   },
   "gamma": {
     "current": "1.0.1",
     "wanted": "1.0.1",
     "latest": "2.0.0",
     "dependent": "outdated-should-display-outdated-deps",
-    "location": "/cli/test/lib/outdated-should-display-outdated-deps/node_modules/gamma"
+    "location": "{CWD}/test/lib/outdated-should-display-outdated-deps/node_modules/gamma"
   },
   "theta": {
     "wanted": "1.0.1",
@@ -93,17 +93,17 @@ theta    MISSING   1.0.1   1.0.1  -                   outdated-should-display-ou
 
 exports[`test/lib/outdated.js TAP should display outdated deps outdated --parseable --long > must match snapshot 1`] = `
 
-/cli/test/lib/outdated-should-display-outdated-deps/node_modules/alpha:alpha@1.0.1:alpha@1.0.0:alpha@1.0.1:outdated-should-display-outdated-deps:dependencies:
-/cli/test/lib/outdated-should-display-outdated-deps/node_modules/beta:beta@1.0.1:beta@1.0.0:beta@1.0.1:outdated-should-display-outdated-deps:peerDependencies:
-/cli/test/lib/outdated-should-display-outdated-deps/node_modules/gamma:gamma@1.0.1:gamma@1.0.1:gamma@2.0.0:outdated-should-display-outdated-deps:dependencies:
+{CWD}/test/lib/outdated-should-display-outdated-deps/node_modules/alpha:alpha@1.0.1:alpha@1.0.0:alpha@1.0.1:outdated-should-display-outdated-deps:dependencies:
+{CWD}/test/lib/outdated-should-display-outdated-deps/node_modules/beta:beta@1.0.1:beta@1.0.0:beta@1.0.1:outdated-should-display-outdated-deps:peerDependencies:
+{CWD}/test/lib/outdated-should-display-outdated-deps/node_modules/gamma:gamma@1.0.1:gamma@1.0.1:gamma@2.0.0:outdated-should-display-outdated-deps:dependencies:
 :theta@1.0.1:MISSING:theta@1.0.1:outdated-should-display-outdated-deps:dependencies:
 `
 
 exports[`test/lib/outdated.js TAP should display outdated deps outdated --parseable > must match snapshot 1`] = `
 
-/cli/test/lib/outdated-should-display-outdated-deps/node_modules/alpha:alpha@1.0.1:alpha@1.0.0:alpha@1.0.1:outdated-should-display-outdated-deps
-/cli/test/lib/outdated-should-display-outdated-deps/node_modules/beta:beta@1.0.1:beta@1.0.0:beta@1.0.1:outdated-should-display-outdated-deps
-/cli/test/lib/outdated-should-display-outdated-deps/node_modules/gamma:gamma@1.0.1:gamma@1.0.1:gamma@2.0.0:outdated-should-display-outdated-deps
+{CWD}/test/lib/outdated-should-display-outdated-deps/node_modules/alpha:alpha@1.0.1:alpha@1.0.0:alpha@1.0.1:outdated-should-display-outdated-deps
+{CWD}/test/lib/outdated-should-display-outdated-deps/node_modules/beta:beta@1.0.1:beta@1.0.0:beta@1.0.1:outdated-should-display-outdated-deps
+{CWD}/test/lib/outdated-should-display-outdated-deps/node_modules/gamma:gamma@1.0.1:gamma@1.0.1:gamma@2.0.0:outdated-should-display-outdated-deps
 :theta@1.0.1:MISSING:theta@1.0.1:outdated-should-display-outdated-deps
 `
 

--- a/tap-snapshots/test-lib-outdated.js-TAP.test.js
+++ b/tap-snapshots/test-lib-outdated.js-TAP.test.js
@@ -1,0 +1,129 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/lib/outdated.js TAP should display outdated deps outdated --all > must match snapshot 1`] = `
+
+Package  Current  Wanted  Latest  Location            Depended by
+alpha      1.0.0   1.0.1   1.0.1  node_modules/alpha  outdated-should-display-outdated-deps
+beta       1.0.0   1.0.1   1.0.1  node_modules/beta   outdated-should-display-outdated-deps
+gamma      1.0.1   1.0.1   2.0.0  node_modules/gamma  outdated-should-display-outdated-deps
+theta    MISSING   1.0.1   1.0.1  -                   outdated-should-display-outdated-deps
+`
+
+exports[`test/lib/outdated.js TAP should display outdated deps outdated --json --long > must match snapshot 1`] = `
+
+{
+  "alpha": {
+    "current": "1.0.0",
+    "wanted": "1.0.1",
+    "latest": "1.0.1",
+    "dependent": "outdated-should-display-outdated-deps",
+    "location": "/cli/test/lib/outdated-should-display-outdated-deps/node_modules/alpha",
+    "type": "dependencies"
+  },
+  "beta": {
+    "current": "1.0.0",
+    "wanted": "1.0.1",
+    "latest": "1.0.1",
+    "dependent": "outdated-should-display-outdated-deps",
+    "location": "/cli/test/lib/outdated-should-display-outdated-deps/node_modules/beta",
+    "type": "peerDependencies"
+  },
+  "gamma": {
+    "current": "1.0.1",
+    "wanted": "1.0.1",
+    "latest": "2.0.0",
+    "dependent": "outdated-should-display-outdated-deps",
+    "location": "/cli/test/lib/outdated-should-display-outdated-deps/node_modules/gamma",
+    "type": "dependencies"
+  },
+  "theta": {
+    "wanted": "1.0.1",
+    "latest": "1.0.1",
+    "dependent": "outdated-should-display-outdated-deps",
+    "type": "dependencies"
+  }
+}
+`
+
+exports[`test/lib/outdated.js TAP should display outdated deps outdated --json > must match snapshot 1`] = `
+
+{
+  "alpha": {
+    "current": "1.0.0",
+    "wanted": "1.0.1",
+    "latest": "1.0.1",
+    "dependent": "outdated-should-display-outdated-deps",
+    "location": "/cli/test/lib/outdated-should-display-outdated-deps/node_modules/alpha"
+  },
+  "beta": {
+    "current": "1.0.0",
+    "wanted": "1.0.1",
+    "latest": "1.0.1",
+    "dependent": "outdated-should-display-outdated-deps",
+    "location": "/cli/test/lib/outdated-should-display-outdated-deps/node_modules/beta"
+  },
+  "gamma": {
+    "current": "1.0.1",
+    "wanted": "1.0.1",
+    "latest": "2.0.0",
+    "dependent": "outdated-should-display-outdated-deps",
+    "location": "/cli/test/lib/outdated-should-display-outdated-deps/node_modules/gamma"
+  },
+  "theta": {
+    "wanted": "1.0.1",
+    "latest": "1.0.1",
+    "dependent": "outdated-should-display-outdated-deps"
+  }
+}
+`
+
+exports[`test/lib/outdated.js TAP should display outdated deps outdated --long > must match snapshot 1`] = `
+
+Package  Current  Wanted  Latest  Location            Depended by                            Package Type      Homepage
+alpha      1.0.0   1.0.1   1.0.1  node_modules/alpha  outdated-should-display-outdated-deps  dependencies
+beta       1.0.0   1.0.1   1.0.1  node_modules/beta   outdated-should-display-outdated-deps  peerDependencies
+gamma      1.0.1   1.0.1   2.0.0  node_modules/gamma  outdated-should-display-outdated-deps  dependencies
+theta    MISSING   1.0.1   1.0.1  -                   outdated-should-display-outdated-deps  dependencies
+`
+
+exports[`test/lib/outdated.js TAP should display outdated deps outdated --parseable --long > must match snapshot 1`] = `
+
+/cli/test/lib/outdated-should-display-outdated-deps/node_modules/alpha:alpha@1.0.1:alpha@1.0.0:alpha@1.0.1:outdated-should-display-outdated-deps:dependencies:
+/cli/test/lib/outdated-should-display-outdated-deps/node_modules/beta:beta@1.0.1:beta@1.0.0:beta@1.0.1:outdated-should-display-outdated-deps:peerDependencies:
+/cli/test/lib/outdated-should-display-outdated-deps/node_modules/gamma:gamma@1.0.1:gamma@1.0.1:gamma@2.0.0:outdated-should-display-outdated-deps:dependencies:
+:theta@1.0.1:MISSING:theta@1.0.1:outdated-should-display-outdated-deps:dependencies:
+`
+
+exports[`test/lib/outdated.js TAP should display outdated deps outdated --parseable > must match snapshot 1`] = `
+
+/cli/test/lib/outdated-should-display-outdated-deps/node_modules/alpha:alpha@1.0.1:alpha@1.0.0:alpha@1.0.1:outdated-should-display-outdated-deps
+/cli/test/lib/outdated-should-display-outdated-deps/node_modules/beta:beta@1.0.1:beta@1.0.0:beta@1.0.1:outdated-should-display-outdated-deps
+/cli/test/lib/outdated-should-display-outdated-deps/node_modules/gamma:gamma@1.0.1:gamma@1.0.1:gamma@2.0.0:outdated-should-display-outdated-deps
+:theta@1.0.1:MISSING:theta@1.0.1:outdated-should-display-outdated-deps
+`
+
+exports[`test/lib/outdated.js TAP should display outdated deps outdated > must match snapshot 1`] = `
+
+[4mPackage[24m  [4mCurrent[24m  [4mWanted[24m  [4mLatest[24m  [4mLocation[24m            [4mDepended by[24m
+[31malpha[39m      1.0.0   [32m1.0.1[39m   [35m1.0.1[39m  node_modules/alpha  outdated-should-display-outdated-deps
+[31mbeta[39m       1.0.0   [32m1.0.1[39m   [35m1.0.1[39m  node_modules/beta   outdated-should-display-outdated-deps
+[33mgamma[39m      1.0.1   [32m1.0.1[39m   [35m2.0.0[39m  node_modules/gamma  outdated-should-display-outdated-deps
+[31mtheta[39m    MISSING   [32m1.0.1[39m   [35m1.0.1[39m  -                   outdated-should-display-outdated-deps
+`
+
+exports[`test/lib/outdated.js TAP should display outdated deps outdated global > must match snapshot 1`] = `
+
+Package  Current  Wanted  Latest  Location            Depended by
+alpha      1.0.0   1.0.1   1.0.1  node_modules/alpha  global
+`
+
+exports[`test/lib/outdated.js TAP should display outdated deps outdated specific dep > must match snapshot 1`] = `
+
+Package  Current  Wanted  Latest  Location            Depended by
+alpha      1.0.0   1.0.1   1.0.1  node_modules/alpha  outdated-should-display-outdated-deps
+`

--- a/test/lib/outdated.js
+++ b/test/lib/outdated.js
@@ -1,0 +1,336 @@
+const t = require('tap')
+const requireInject = require('require-inject')
+
+const packument = spec => {
+  const mocks = {
+    'alpha': {
+      'name': 'alpha',
+      'dist-tags': {
+        'latest': '1.0.1'
+      },
+      'versions': {
+        '1.0.1': {
+          'version': '1.0.1',
+          'dependencies': {
+            'gamma': '2.0.0'
+          }
+        }
+      }
+    },
+    'beta': {
+      'name': 'beta',
+      'dist-tags': {
+        'latest': '1.0.1'
+      },
+      'versions': {
+        '1.0.1': {
+          'version': '1.0.1'
+        }
+      }
+    },
+    'gamma': {
+      'name': 'gamma',
+      'dist-tags': {
+        'latest': '2.0.0'
+      },
+      'versions': {
+        '1.0.1': {
+          'version': '1.0.1',
+        }, 
+        '2.0.0': {
+          'version': '2.0.0'
+        }
+      }
+    },
+    'theta': {
+      'name': 'theta',
+      'dist-tags': {
+        'latest': '1.0.1'
+      },
+      'versions': {
+        '1.0.1': {
+          'version': '1.0.1'
+        }
+      }
+    }
+  }
+
+  if (spec.name === 'eta') {
+    throw new Error('There is an error with this package.')
+  }
+
+  if (!mocks[spec.name]) {
+    const err = new Error()
+    err.code = 'E404'
+    throw err
+  }
+
+  return mocks[spec.name]
+}
+
+let logs
+const cleanLogs = (done) => {
+  logs = ''
+  const fn = (...args) => {
+    logs += '\n'
+    args.map(el => logs += el)
+  }
+  console.log = fn
+  done()
+}
+
+const globalDir = t.testdir({
+  'node_modules': {
+    'alpha': {
+      'package.json': JSON.stringify({
+        name: 'alpha',
+        version: '1.0.0'
+      }, null, 2)
+    }
+  }
+})
+
+const outdated = (dir, opts) => requireInject(
+  '../../lib/outdated.js', 
+  {
+    '../../lib/npm.js': {
+      prefix: dir,
+      globalDir: `${globalDir}/node_modules`,
+      flatOptions: opts
+    },
+    'pacote': {
+      packument
+    }
+  }
+)
+
+t.beforeEach(cleanLogs)
+t.cleanSnapshot = s => {
+  return s.replace(
+    /(\/.*)(cli\/test\/lib\/)|(D:\\.*)(cli(\\\\|\\)test(\\\\|\\)lib(\\\\|\\))/g,
+    '/cli/test/lib/'
+  ).replace(/(\\\\|\\)/g, '/')
+}
+
+t.test('should display outdated deps', t => {
+  const testDir = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'delta',
+      version: '1.0.0',
+      dependencies: {
+        alpha: '^1.0.0',
+        gamma: '^1.0.0',
+        theta: '^1.0.0'
+      },
+      devDependencies: {
+        zeta: '^1.0.0'
+      },
+      peerDependencies: {
+        beta: '^1.0.0'
+      }
+    }, null, 2),
+    'node_modules': {
+      'alpha': {
+        'package.json': JSON.stringify({
+          name: 'alpha',
+          version: '1.0.0',
+          dependencies: {
+            gamma: '2.0.0'
+          }
+        }, null, 2),
+        'node_modules': {
+          'gamma': {
+            'package.json': JSON.stringify({
+              name: 'gamma',
+              version: '2.0.0'
+            }, null, 2)
+          }
+        }
+      },
+      'beta': {
+        'package.json': JSON.stringify({
+          name: 'beta',
+          version: '1.0.0'
+        }, null, 2)
+      }, 
+      'gamma': {
+        'package.json': JSON.stringify({
+          name: 'gamma',
+          version: '1.0.1'
+        }, null, 2)
+      },
+      'zeta': {
+        'package.json': JSON.stringify({
+          name: 'zeta',
+          version: '1.0.0'
+        }, null, 2)
+      }
+    }
+  })
+
+  t.test('outdated global', t => {
+    outdated(null, {
+     global: true,
+    })([], () => {
+      t.matchSnapshot(logs)
+      t.end()
+    })
+  })
+
+  t.test('outdated', t => {
+    outdated(testDir, {
+     global: false,
+     color: true
+    })([], () => {
+      t.matchSnapshot(logs)
+      t.end()
+    })
+  })
+
+  t.test('outdated --long', t => {
+    outdated(testDir, {
+     global: false,
+     long: true,
+    })([], () => {
+      t.matchSnapshot(logs)
+      t.end()
+    })
+  })
+
+  t.test('outdated --json', t => {
+    outdated(testDir, {
+     global: false,
+     json: true,
+    })([], () => {
+      t.matchSnapshot(logs)
+      t.end()
+    })
+  })
+
+  t.test('outdated --json --long', t => {
+    outdated(testDir, {
+     global: false,
+     json: true,
+     long: true
+    })([], () => {
+      t.matchSnapshot(logs)
+      t.end()
+    })
+  })
+
+  t.test('outdated --parseable', t => {
+    outdated(testDir, {
+     global: false,
+     parseable: true,
+    })([], () => {
+      t.matchSnapshot(logs)
+      t.end()
+    })
+  })
+
+  t.test('outdated --parseable --long', t => {
+    outdated(testDir, {
+     global: false,
+     parseable: true,
+     long: true
+    })([], () => {
+      t.matchSnapshot(logs)
+      t.end()
+    })
+  })
+
+  t.test('outdated --all', t => {
+    outdated(testDir, {
+     all: true,
+    })([], () => {
+      t.matchSnapshot(logs)
+      t.end()
+    })
+  })
+
+  t.test('outdated specific dep', t => {
+    outdated(testDir, {
+     global: false,
+    })(['alpha'], () => {
+      t.matchSnapshot(logs)
+      t.end()
+    })
+  })
+
+  t.end()
+
+})
+
+t.test('should return if no outdated deps', t => {
+  const testDir = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'delta',
+      version: '1.0.0',
+      dependencies: {
+        alpha: '^1.0.0'
+      }
+    }, null, 2),
+    'node_modules': {
+      'alpha': {
+        'package.json': JSON.stringify({
+          name: 'alpha',
+          version: '1.0.1'
+        }, null, 2)
+      }
+    }
+  })
+
+  outdated(testDir, {
+    global: false,
+   })([], () => {
+    t.equals(logs.length, 0, 'no logs')
+    t.end()
+   })
+})
+
+t.test('throws if error with a dep', t => {
+  const testDir = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'delta',
+      version: '1.0.0',
+      dependencies: {
+        eta: '^1.0.0'
+      }
+    }, null, 2),
+    'node_modules': {
+      'eta': {
+        'package.json': JSON.stringify({
+          name: 'eta',
+          version: '1.0.1'
+        }, null, 2)
+      }
+    }
+  })
+
+  outdated(testDir, {
+    global: false,
+   })([], (err) => {
+    t.equals(err.message, 'There is an error with this package.')
+    t.end()
+   })
+})
+
+t.test('should skip missing non-prod deps', t => {
+  const testDir = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'delta',
+      version: '1.0.0',
+      devDependencies: {
+        beta: '^1.0.0'
+      }
+    }, null, 2),
+    'node_modules': {}
+  })
+
+  outdated(testDir, {
+    global: false,
+   })([], () => {
+    //t.equals(logs.length, 0, 'no logs')
+    t.end()
+   })
+})

--- a/test/lib/outdated.js
+++ b/test/lib/outdated.js
@@ -105,12 +105,16 @@ const outdated = (dir, opts) => requireInject(
 )
 
 t.beforeEach(cleanLogs)
-t.cleanSnapshot = s => {
-  return s.replace(
-    /(\/.*)(cli\/test\/lib\/)|(D:\\.*)(cli(\\\\|\\)test(\\\\|\\)lib(\\\\|\\))/g,
-    '/cli/test/lib/'
-  ).replace(/(\\\\|\\)/g, '/')
+
+const redactCwd = (path) => {
+  const normalizePath = p => p
+    .replace(/\\+/g, '/')
+    .replace(/\r\n/g, '\n')
+  return normalizePath(path)
+    .replace(new RegExp(normalizePath(process.cwd()), 'g'), '{CWD}')
 }
+
+t.cleanSnapshot = (str) => redactCwd(str)
 
 t.test('should display outdated deps', t => {
   const testDir = t.testdir({


### PR DESCRIPTION
This PR adds tests to npm outdated. While working on it I found some bugs:
1. `--global` wasn't working since the global directory doesn't behave like a normal package and there are no `edgesOut` coming out of it. Instead, I'm using the children property to iterate over the different globally installed packages.
2. We had a function for memoizing the packuments of the list of edges we had already taken from Arborist. However this list of edges is actually a `Set` and therefore no package in there gets ever duplicated. Memoizing doesn't make sense if we won't ever fetch the packument of a package twice. Concern: Are there cases when we need the duplication? `--all`?