### PR TITLE
Add s390x, ppc64 and ppc64el in supported cpu list (fixes: #1455)

### DIFF
--- a/test/tap/legacy-platform-all.js
+++ b/test/tap/legacy-platform-all.js
@@ -36,6 +36,9 @@ var fixture = new Tacks(
         'arm64',
         'mips',
         'ia32',
+        'ppc64',
+        'ppc64el',
+        's390x',
         'x64',
         'sparc'
       ]


### PR DESCRIPTION
After tests with [Debian platforms](https://db.debian.org/machines.cgi), `s390x`, `ppc64` and `ppc64el` cpus seem well supported by npm.

## References

Fixes #1455