### PR TITLE
fix: scope config

### DIFF
--- a/lib/utils/flat-options.js
+++ b/lib/utils/flat-options.js
@@ -68,9 +68,7 @@ const flatOptions = npm => npm.flatOptions || Object.freeze({
     npm.config.get('registry'),
   sendMetrics: npm.config.get('send-metrics'),
   registry: npm.config.get('registry'),
-  get scope () {
-    return npm.projectScope
-  },
+  scope: npm.config.get('scope'),
   access: npm.config.get('access'),
   alwaysAuth: npm.config.get('always-auth'),
   audit: npm.config.get('audit'),

--- a/tap-snapshots/test-lib-utils-flat-options.js-TAP.test.js
+++ b/tap-snapshots/test-lib-utils-flat-options.js-TAP.test.js
@@ -96,7 +96,7 @@ Object {
   "saveBundle": false,
   "savePrefix": "",
   "saveType": "peerOptional",
-  "scope": "@npmcli",
+  "scope": "",
   "scriptShell": "script-shell",
   "search": Object {
     "description": "description",

--- a/test/lib/utils/flat-options.js
+++ b/test/lib/utils/flat-options.js
@@ -104,6 +104,7 @@ class MockConfig {
       'cache-max': 'cache-max',
       'cache-min': 'cache-min',
       'strict-ssl': 'strict-ssl',
+      scope: '',
       tag: 'tag',
       'user-agent': 'user-agent',
       '@scope:registry': '@scope:registry',
@@ -182,15 +183,6 @@ t.test('get preferOnline from cache-max', t => {
 t.test('tag emits warning', t => {
   const npm = new Mocknpm({ tag: 'foobar' })
   t.equal(flatOptions(npm).tag, 'foobar', 'tag is foobar')
-  t.match(logs, [])
-  logs.length = 0
-  t.end()
-})
-
-t.test('scope emits warning', t => {
-  const npm = new Mocknpm()
-  logs.length = 0
-  t.equal(flatOptions(npm).scope, '@npmcli')
   t.match(logs, [])
   logs.length = 0
   t.end()
@@ -291,6 +283,7 @@ t.test('various default values and falsey fallbacks', t => {
     'metricsRegistry defaults to registry')
   t.equal(opts.search.limit, 20, 'searchLimit defaults to 20')
   t.equal(opts.savePrefix, '>=', 'save-prefix respected if no save-exact')
+  t.equal(opts.scope, '', 'scope defaults to empty string')
   logs.length = 0
   t.end()
 })


### PR DESCRIPTION
The `flatOptions.scope` option should not default to `projectScope` since that's causing projects that have a defined `projectScope` corresponding to a configured scoped registry to try and download ALL packages (including the ones that should be downloaded from the public registry) to be fetch from that scoped registry url (as if `npm install --scope="@myscope"`).

This PR fixes it by reinstating a regular `flatOptions.scope` config.

fix #1654
