### PR TITLE
Isaacs/eresolve explanation

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -144,6 +144,10 @@ async function outdated_ (tree, deps, opts) {
     try {
       const packument = await getPackument(spec)
       const expected = edge.spec
+      // if it's not a range, version, or tag, skip it
+      if (!npa(`${edge.name}@${edge.spec}`).registry) {
+        return null
+      }
       const wanted = pickManifest(packument, expected, npm.flatOptions)
       const latest = pickManifest(packument, '*', npm.flatOptions)
 

--- a/lib/utils/error-message.js
+++ b/lib/utils/error-message.js
@@ -4,11 +4,18 @@ const { format } = require('util')
 const { resolve } = require('path')
 const nameValidator = require('validate-npm-package-name')
 const npmlog = require('npmlog')
+const { report: explainEresolve } = require('./explain-eresolve.js')
 
 module.exports = (er) => {
   const short = []
   const detail = []
   switch (er.code) {
+    case 'ERESOLVE':
+      short.push(['ERESOLVE', er.message])
+      detail.push(['', ''])
+      detail.push(['', explainEresolve(er)])
+      break
+
     case 'ENOLOCK': {
       const cmd = npm.command || ''
       short.push([cmd, 'This command requires an existing lockfile.'])

--- a/lib/utils/explain-eresolve.js
+++ b/lib/utils/explain-eresolve.js
@@ -1,0 +1,148 @@
+// this is called when an ERESOLVE error is caught in the error-handler,
+// or when there's a log.warn('eresolve', msg, explanation), to turn it
+// into a human-intelligible explanation of what's wrong and how to fix.
+//
+// TODO: abstract out the explainNode methods into a separate util for
+// use by a future `npm explain <path || spec>` command.
+
+const npm = require('../npm.js')
+const { writeFileSync } = require('fs')
+const { resolve } = require('path')
+
+const chalk = require('chalk')
+const nocolor = {
+  bold: s => s,
+  dim: s => s
+}
+
+// expl is an explanation object that comes from Arborist.  It looks like:
+// {
+//   dep: {
+//     whileInstalling: {
+//       explanation of the thing being installed when we hit the conflict
+//     },
+//     name,
+//     version,
+//     dependents: [
+//       things depending on this node (ie, reason for inclusion)
+//       { name, version, dependents }, ...
+//     ]
+//   }
+//   current: {
+//     explanation of the current node that already was in the tree conflicting
+//   }
+//   peerConflict: {
+//     explanation of the peer dependency that couldn't be added, or null
+//   }
+//   fixWithForce: Boolean - can we use --force to push through this?
+//   type: type of the edge that couldn't be met
+//   isPeer: true if the edge that couldn't be met is a peer dependency
+// }
+// Depth is how far we want to want to descend into the object making a report.
+// The full report (ie, depth=Infinity) is always written to the cache folder
+// at ${cache}/eresolve-report.txt along with full json.
+const explainEresolve = (expl, color, depth) => {
+  const { dep, current, peerConflict } = expl
+
+  const out = []
+  /* istanbul ignore else - should always have this for ERESOLVEs */
+  if (dep.whileInstalling) {
+    out.push('While resolving: ' + printNode(dep.whileInstalling, color))
+  }
+
+  out.push(explainNode('Found:', current, depth, color))
+
+  out.push(explainNode('\nCould not add conflicting dependency:', dep, depth, color))
+
+  if (peerConflict) {
+    const heading = '\nConflicting peer dependency:'
+    const pc = explainNode(heading, peerConflict, depth, color)
+    out.push(pc)
+  }
+
+  return out.join('\n')
+}
+
+const explainNode = (heading, node, depth, color) =>
+  `${heading} ${printNode(node, color)}` +
+  explainDependents(node, depth, color)
+
+const printNode = ({ name, version, location }, color) => {
+  const { bold, dim } = color ? chalk : nocolor
+  return `${bold(name)}@${bold(version)}` +
+    (location ? dim(` at ${location}`) : '')
+}
+
+const explainDependents = ({ name, dependents }, depth, color) => {
+  if (!dependents || !dependents.length || depth <= 0) {
+    return ''
+  }
+
+  const max = Math.ceil(depth / 2)
+  const messages = dependents.slice(0, max)
+    .map(dep => explainDependency(name, dep, depth, color))
+
+  // show just the names of the first 5 deps that overflowed the list
+  if (dependents.length > max) {
+    const names = dependents.slice(max).map(d => d.from.name)
+    const showNames = names.slice(0, 5)
+    if (showNames.length < names.length) {
+      showNames.push('...')
+    }
+    const show = `(${showNames.join(', ')})`
+    messages.push(`${names.length} more ${show}`)
+  }
+
+  const str = '\nfor: ' + messages.join('\nand: ')
+  return str.split('\n').join('\n  ')
+}
+
+const explainDependency = (name, { type, from, spec }, depth, color) => {
+  const { bold } = color ? chalk : nocolor
+  return `${type} dependency ` +
+    `${bold(name)}@"${bold(spec)}"\nfrom: ` +
+    explainFrom(from, depth, color)
+}
+
+const explainFrom = (from, depth, color) => {
+  if (!from.name && !from.version) {
+    return 'the root project'
+  }
+
+  return printNode(from, color) +
+    explainDependents(from, depth - 1, color)
+}
+
+// generate a full verbose report and tell the user how to fix it
+const report = (expl, depth = 4) => {
+  const fullReport = resolve(npm.cache, 'eresolve-report.txt')
+
+  const orForce = expl.fixWithForce ? ' or --force' : ''
+  const fix = `Fix the upstream dependency conflict, or retry
+this command with --legacy-peer-deps${orForce}
+to accept an incorrect (and potentially broken) dependency resolution.`
+
+  writeFileSync(fullReport, `# npm resolution error report
+
+${new Date().toISOString()}
+
+${explainEresolve(expl, false, Infinity)}
+
+${fix}
+
+Raw JSON explanation object:
+
+${JSON.stringify(expl, null, 2)}
+`, 'utf8')
+
+  return explainEresolve(expl, npm.color, depth) +
+    `\n\n${fix}\n\nSee ${fullReport} for a full report.`
+}
+
+// the terser explain method for the warning when using --force
+const explain = (expl, depth = 2) => explainEresolve(expl, npm.color, depth)
+
+module.exports = {
+  explain,
+  report
+}

--- a/lib/utils/setup-log.js
+++ b/lib/utils/setup-log.js
@@ -1,9 +1,26 @@
 // module to set the appropriate log settings based on configs
 // returns a boolean to say whether we should enable color on
 // stdout or not.
+//
+// Also (and this is a really inexcusable kludge), we patch the
+// log.warn() method so that when we see a peerDep override
+// explanation from Arborist, we can replace the object with a
+// highly abbreviated explanation of what's being overridden.
 const log = require('npmlog')
+const { explain } = require('./explain-eresolve.js')
+
 module.exports = (config) => {
   const color = config.get('color')
+
+  const { warn } = log
+
+  log.warn = (heading, ...args) => {
+    if (heading === 'ERESOLVE' && args[1] && typeof args[1] === 'object') {
+      warn(heading, args[0])
+      return warn('', explain(args[1]))
+    }
+    return warn(heading, ...args)
+  }
 
   if (config.get('timing') && config.get('loglevel') === 'notice') {
     log.level = 'timing'

--- a/node_modules/@npmcli/arborist/README.md
+++ b/node_modules/@npmcli/arborist/README.md
@@ -46,8 +46,6 @@ const arb = new Arborist({
   // rather unusual pattern:
   '//registry.foo.com:token': 'blahblahblah',
   '//basic.auth.only.foo.com:_auth': 'aXNhYWNzOm5vdCBteSByZWFsIHBhc3N3b3Jk',
-
-  // in fact, ANY config can be scoped to a registry...
   '//registry.foo.com:always-auth': true,
 })
 

--- a/node_modules/@npmcli/arborist/lib/arborist/build-ideal-tree.js
+++ b/node_modules/@npmcli/arborist/lib/arborist/build-ideal-tree.js
@@ -6,6 +6,7 @@ const cacache = require('cacache')
 const semver = require('semver')
 const pickManifest = require('npm-pick-manifest')
 const promiseCallLimit = require('promise-call-limit')
+const getPeerSet = require('../peer-set.js')
 
 const fromPath = require('../from-path.js')
 const calcDepFlags = require('../calc-dep-flags.js')
@@ -36,6 +37,7 @@ const _depsQueue = Symbol('depsQueue')
 const _currentDep = Symbol('currentDep')
 const _updateAll = Symbol('updateAll')
 const _mutateTree = Symbol('mutateTree')
+const _flagsSuspect = Symbol.for('flagsSuspect')
 const _prune = Symbol('prune')
 const _preferDedupe = Symbol('preferDedupe')
 const _legacyBundling = Symbol('legacyBundling')
@@ -75,6 +77,9 @@ const _globalStyle = Symbol('globalStyle')
 const _globalRootNode = Symbol('globalRootNode')
 const _isVulnerable = Symbol.for('isVulnerable')
 const _usePackageLock = Symbol.for('usePackageLock')
+
+// used for the ERESOLVE error to show the last peer conflict encountered
+const _peerConflict = Symbol('peerConflict')
 
 // used by Reify mixin
 const _force = Symbol.for('force')
@@ -122,6 +127,7 @@ module.exports = cls => class IdealTreeBuilder extends cls {
     this[_loadFailures] = new Set()
     this[_linkNodes] = new Set()
     this[_manifests] = new Map()
+    this[_peerConflict] = null
   }
 
   get explicitRequests () {
@@ -661,7 +667,7 @@ This is a one-time fix-up, please be patient...
     const { legacyPeerDeps } = this
     parent = parent || new Node({
       path: '/virtual-root',
-      pkg: edge.from.package,
+      sourceReference: edge.from,
       legacyPeerDeps,
     })
 
@@ -700,18 +706,24 @@ This is a one-time fix-up, please be patient...
           node.isRoot && this[_explicitRequests].has(edge.name)))
   }
 
-  [_fetchManifest] (spec) {
+  async [_fetchManifest] (spec) {
+    const options = {
+      ...this.options,
+      avoid: this[_avoidRange](spec.name),
+    }
+    // get the intended spec and stored metadata from yarn.lock file,
+    // if available and valid.
+    spec = this.idealTree.meta.checkYarnLock(spec, options)
+
     if (this[_manifests].has(spec.raw))
       return this[_manifests].get(spec.raw)
     else {
-      const options = {
-        ...this.options,
-        avoid: this[_avoidRange](spec.name),
-      }
-      // get the intended spec and stored metadata from yarn.lock file,
-      // if available and valid.
-      spec = this.idealTree.meta.checkYarnLock(spec, options)
+      this.log.silly('fetch manifest', spec.raw)
       const p = pacote.manifest(spec, options)
+        .then(mani => {
+          this[_manifests].set(spec.raw, mani)
+          return mani
+        })
       this[_manifests].set(spec.raw, p)
       return p
     }
@@ -728,6 +740,7 @@ This is a one-time fix-up, please be patient...
       : this[_fetchManifest](spec)
         .then(pkg => new Node({ name, pkg, parent, legacyPeerDeps }), error => {
           error.requiredBy = edge.from.location || '.'
+
           // failed to load the spec, either because of enotarget or
           // fetch failure of some other sort.  save it so we can verify
           // later that it's optional, otherwise the error is fatal.
@@ -787,16 +800,25 @@ This is a one-time fix-up, please be patient...
 
     let target
     let canPlace = null
+    let warnPeer = false
     for (let check = start; check; check = check.resolveParent) {
       const cp = this[_canPlaceDep](dep, check, edge, peerEntryEdge)
-      this.log.silly('placeDep', check.location, `${edge.name}@${edge.spec}`, cp, `for: ${node.package._id}`)
 
       // anything other than a conflict is fine to proceed with
       if (cp !== CONFLICT) {
         canPlace = cp
         target = check
-      } else
+      } else {
+        if (check === start) {
+          // if it's a peer dep, and the first place we're putting it conflicts
+          // because the node has a direct dependency on the pkg in question,
+          // then we treat that as an override when --force is applied, and
+          // just warn about it.
+          const checkEdge = check.edgesOut.get(edge.name)
+          warnPeer = check === start && edge.peer && checkEdge
+        }
         break
+      }
 
       // nest packages like npm v1 and v2
       // very disk-inefficient
@@ -810,22 +832,40 @@ This is a one-time fix-up, please be patient...
     }
 
     if (!target) {
-      const current = node.resolve(edge.name)
-      throw Object.assign(new Error('unable to resolve dependency tree'), {
+      const curNode = node.resolve(edge.name)
+      const pc = this[_peerConflict] || { peer: null, current: null }
+      // we'll only get one of these
+      const current = curNode ? curNode.explain() : pc.current
+      const peerConflict = pc.peer
+      const expl = {
         code: 'ERESOLVE',
-        package: edge.name,
-        spec: edge.spec,
+        dep: dep.explain(edge),
+        current,
+        peerConflict,
+        fixWithForce: edge.peer && !!warnPeer,
         type: edge.type,
-        requiredBy: node.package._id,
-        location: node.path,
-        ...(!current ? {} : {
-          current: {
-            pkgid: current.package._id,
-            location: current.location,
-          },
-        })
-      })
+        isPeer: edge.peer,
+      }
+
+      if (this[_force] && expl.fixWithForce) {
+        this.log.warn('ERESOLVE', 'overriding peer dependency', expl)
+        return []
+      } else {
+        const er = new Error('unable to resolve dependency tree')
+        throw Object.assign(er, expl)
+      }
     }
+
+    this.log.silly(
+      'placeDep',
+      target.location || 'ROOT',
+      `${edge.name}@${edge.spec}`,
+      canPlace,
+      `for: ${node.package._id || node.location}`
+    )
+
+    // it worked, so we clearly have no peer conflicts at this point.
+    this[_peerConflict] = null
 
     // Can only get KEEP here if the original edge was valid,
     // and we're checking for an update but it's already up to date.
@@ -854,6 +894,15 @@ This is a one-time fix-up, please be patient...
       }
       dep.replace(oldChild)
       this[_pruneForReplacement](dep, oldDeps)
+      // this may also create some invalid edges, for example if we're
+      // intentionally causing something to get nested which was previously
+      // placed in this location.
+      for (const edge of dep.edgesIn) {
+        if (edge.invalid) {
+          this[_depsQueue].push(edge.from)
+          this[_depsSeen].delete(edge.from)
+        }
+      }
     } else
       dep.parent = target
 
@@ -876,7 +925,6 @@ This is a one-time fix-up, please be patient...
     // in case we just made some duplicates that can be removed,
     // prune anything deeper in the tree that can be replaced by this
     if (this.idealTree) {
-
       for (const node of this.idealTree.inventory.query('name', dep.name)) {
         if (node !== dep &&
             node.isDescendantOf(target) &&
@@ -908,13 +956,24 @@ This is a one-time fix-up, please be patient...
     // note that dep has now been removed from the virtualRoot set
     // by virtue of being placed in the target's node_modules.
     if (virtualRoot) {
+      const peers = []
+      // double loop so that we don't yank things out and then fail to find
+      // them in the virtualRoot's children.
       for (const peerEdge of dep.edgesOut.values()) {
+        // XXX needs some rework
         if (peerEdge.peer && !peerEdge.valid) {
           const peer = virtualRoot.children.get(peerEdge.name)
-          const peerPlaced = this[_placeDep](
-            peer, dep, peerEdge, peerEntryEdge || edge)
-          placed.push(...peerPlaced)
+            || /* istanbul ignore next - should be impossible */ peerEdge.to
+          /* istanbul ignore else - should be impossible */
+          if (peer)
+            peers.push([peer, peerEdge])
         }
+      }
+
+      for (const [peer, peerEdge] of peers) {
+        const peerPlaced = this[_placeDep](
+          peer, dep, peerEdge, peerEntryEdge || edge)
+        placed.push(...peerPlaced)
       }
     }
 
@@ -1004,7 +1063,46 @@ This is a one-time fix-up, please be patient...
       // last try, if we prefer deduplication over novelty, check to see if
       // this (older) dep can satisfy the needs of the less nested instance
       if (this[_preferDedupe] && current.canReplaceWith(dep)) {
-        return this[_canPlacePeers](dep, target, edge, REPLACE, peerEntryEdge)
+        const res = this[_canPlacePeers](dep, target, edge, REPLACE, peerEntryEdge)
+        /* istanbul ignore else - It's extremely rare that a replaceable
+         * node would be a conflict, if the current one wasn't a conflict,
+         * but it is theoretically possible if peer deps are pinned.  In
+         * that case we treat it like any other conflict, and keep trying */
+        if (res !== CONFLICT)
+          return res
+      }
+
+      // if this is a peer dep, AND target is the resolveParent of the edge,
+      // then this is the only place it can go.  If the current node is not
+      // a non-peer dependency of this specific target, then it can replace
+      // and dupe it deeper in the tree.  If the current node is a peer dep
+      // in a set that is a non-peer dep of a deeper target, then replace
+      // the whole peer set and the module bringing it in, and add the
+      // dependent to the queue for re-evaluation.
+      if (edge.peer && target === edge.from.resolveParent && !peerEntryEdge) {
+        const peerSet = getPeerSet(current)
+        for (const p of peerSet) {
+          // if any have a non-peer dep from the target, or a peer dep if
+          // the target is root, then we can't safely replace.
+          for (const edge of p.edgesIn) {
+            if (edge.peer) {
+              // root deps take precedence always.
+              // other peer deps on this node are irrelevant though.
+              if (edge.from.isRoot) {
+                return CONFLICT
+              }
+              continue
+            }
+            // note that we MAY resolve this conflict by using the target's
+            // conflicting dep on the peer, if --force is set.
+            if (edge.from === target) {
+              return CONFLICT
+            }
+          }
+        }
+        // all peers could be nested deeper in the tree, so replace
+        // adding to the queue will happen later when we scan dep's edgesIn
+        return REPLACE
       }
 
       // no agreement could be reached :(
@@ -1068,8 +1166,14 @@ This is a one-time fix-up, please be patient...
            being cautious */
         if (peerEdge) {
           const canPlacePeer = this[_canPlaceDep](peer, target, peerEdge, edge)
-          if (canPlacePeer === CONFLICT)
+          if (canPlacePeer === CONFLICT) {
+            const current = target.resolve(peer.name)
+            this[_peerConflict] = {
+              peer: peer.explain(peerEdge),
+              current: current && current.explain(),
+            }
             return CONFLICT
+          }
         }
       }
     }
@@ -1137,6 +1241,8 @@ This is a one-time fix-up, please be patient...
   [_fixDepFlags] () {
     process.emit('time', 'idealTree:fixDepFlags')
     const metaFromDisk = this.idealTree.meta.loadedFromDisk
+    const flagsSuspect = this[_flagsSuspect]
+    const mutateTree = this[_mutateTree]
     // if the options set prune:false, then we don't prune, but we still
     // mark the extraneous items in the tree if we modified it at all.
     // If we did no modifications, we just iterate over the extraneous nodes.
@@ -1144,7 +1250,7 @@ This is a one-time fix-up, please be patient...
     // all set to true, and there can be nothing extraneous, so there's
     // nothing to prune, because we built it from scratch.  if we didn't
     // add or remove anything, then also nothing to do.
-    if (metaFromDisk && this[_mutateTree])
+    if (metaFromDisk && mutateTree)
       this[_resetDepFlags]()
 
     // update all the dev/optional/etc flags in the tree
@@ -1153,7 +1259,7 @@ This is a one-time fix-up, please be patient...
     //
     // if we started from a blank slate, or changed something, then
     // the dep flags will be all set to true.
-    if (!metaFromDisk || this[_mutateTree])
+    if (!metaFromDisk || mutateTree)
       calcDepFlags(this.idealTree)
     else {
       // otherwise just unset all the flags on the root node
@@ -1169,9 +1275,9 @@ This is a one-time fix-up, please be patient...
     // if we started from a shrinkwrap, and then added/removed something,
     // then the tree is suspect.  Prune what is marked as extraneous.
     // otherwise, don't bother.
-    if (this[_prune] && metaFromDisk && this[_mutateTree]) {
+    const needPrune = metaFromDisk && (mutateTree || flagsSuspect)
+    if (this[_prune] && needPrune)
       this[_idealTreePrune]()
-    }
     process.emit('timeEnd', 'idealTree:fixDepFlags')
   }
 

--- a/node_modules/@npmcli/arborist/lib/arborist/load-virtual.js
+++ b/node_modules/@npmcli/arborist/lib/arborist/load-virtual.js
@@ -10,6 +10,7 @@ const Shrinkwrap = require('../shrinkwrap.js')
 const Node = require('../node.js')
 const Link = require('../link.js')
 const relpath = require('../relpath.js')
+const calcDepFlags = require('../calc-dep-flags.js')
 const rpj = require('read-package-json-fast')
 
 const loadFromShrinkwrap = Symbol('loadFromShrinkwrap')
@@ -20,6 +21,12 @@ const loadRoot = Symbol('loadRoot')
 const loadNode = Symbol('loadVirtualNode')
 const loadLink = Symbol('loadVirtualLink')
 const loadWorkspaces = Symbol('loadWorkspaces')
+const flagsSuspect = Symbol.for('flagsSuspect')
+const reCalcDepFlags = Symbol('reCalcDepFlags')
+const checkRootEdges = Symbol('checkRootEdges')
+
+const depsToEdges = (type, deps) =>
+  Object.entries(deps).map(d => [type, ...d])
 
 module.exports = cls => class VirtualLoader extends cls {
   constructor (options) {
@@ -27,6 +34,7 @@ module.exports = cls => class VirtualLoader extends cls {
 
     // the virtual tree we load from a shrinkwrap
     this.virtualTree = options.virtualTree
+    this[flagsSuspect] = false
   }
 
   // public method
@@ -71,12 +79,84 @@ module.exports = cls => class VirtualLoader extends cls {
     root.optional = false
     root.devOptional = false
     root.peer = false
+    this[checkRootEdges](s, root)
     s.add(root)
     this.virtualTree = root
     const {links, nodes} = this[resolveNodes](s, root)
     await this[resolveLinks](links, nodes)
     this[assignParentage](nodes)
+    if (this[flagsSuspect])
+      this[reCalcDepFlags]()
     return root
+  }
+
+  [reCalcDepFlags] () {
+    // reset all dep flags
+    for (const node of this.virtualTree.inventory.values()) {
+      node.extraneous = true
+      node.dev = true
+      node.optional = true
+      node.devOptional = true
+      node.peer = true
+    }
+    calcDepFlags(this.virtualTree, true)
+  }
+
+  // check the lockfile deps, and see if they match.  if they do not
+  // then we have to reset dep flags at the end.  for example, if the
+  // user manually edits their package.json file, then we need to know
+  // that the idealTree is no longer entirely trustworthy.
+  [checkRootEdges] (s, root) {
+    // loaded virtually from tree, no chance of being out of sync
+    // ancient lockfiles are critically damaged by this process,
+    // so we need to just hope for the best in those cases.
+    if (!s.loadedFromDisk || s.ancientLockfile)
+      return
+
+    const lock = s.get('')
+    const prod = lock.dependencies || {}
+    const dev = lock.devDependencies || {}
+    const optional = lock.optionalDependencies || {}
+    const peer = lock.peerDependencies || {}
+    const peerOptional = {}
+    if (lock.peerDependenciesMeta) {
+      for (const [name, meta] of Object.entries(lock.peerDependenciesMeta)) {
+        if (meta.optional && peer[name] !== undefined) {
+          peerOptional[name] = peer[name]
+          delete peer[name]
+        }
+      }
+    }
+    for (const name of Object.keys(optional)) {
+      delete prod[name]
+    }
+
+    const lockEdges = [
+      ...depsToEdges('prod', prod),
+      ...depsToEdges('dev', dev),
+      ...depsToEdges('optional', optional),
+      ...depsToEdges('peer', peer),
+      ...depsToEdges('peerOptional', peerOptional),
+    ].sort(([atype, aname], [btype, bname]) =>
+      atype.localeCompare(btype) || aname.localeCompare(bname))
+
+    const rootEdges = [...root.edgesOut.values()]
+      .map(e => [e.type, e.name, e.spec])
+      .sort(([atype, aname], [btype, bname]) =>
+        atype.localeCompare(btype) || aname.localeCompare(bname))
+
+    if (rootEdges.length !== lockEdges.length) {
+      // something added or removed
+      return this[flagsSuspect] = true
+    }
+
+    for (let i = 0; i < lockEdges.length; i++) {
+      if (rootEdges[i][0] !== lockEdges[i][0] ||
+          rootEdges[i][1] !== lockEdges[i][1] ||
+          rootEdges[i][2] !== lockEdges[i][2]) {
+        return this[flagsSuspect] = true
+      }
+    }
   }
 
   // separate out link metadatas, and create Node objects for nodes
@@ -186,7 +266,7 @@ module.exports = cls => class VirtualLoader extends cls {
   [loadWorkspaces] (node, s) {
     const workspaces = mapWorkspaces.virtual({
       cwd: node.path,
-      lockfile: s.data
+      lockfile: s.data,
     })
     if (workspaces.size)
       node.workspaces = workspaces

--- a/node_modules/@npmcli/arborist/lib/node.js
+++ b/node_modules/@npmcli/arborist/lib/node.js
@@ -58,6 +58,9 @@ const _refreshPath = Symbol('_refreshPath')
 const _delistFromMeta = Symbol('_delistFromMeta')
 const _global = Symbol.for('global')
 const _workspaces = Symbol('_workspaces')
+const _explain = Symbol('_explain')
+const _explainEdge = Symbol('_explainEdge')
+const _explanation = Symbol('_explanation')
 
 const relpath = require('./relpath.js')
 const consistentResolve = require('./consistent-resolve.js')
@@ -89,6 +92,7 @@ class Node {
       peer = true,
       global = false,
       dummy = false,
+      sourceReference = null,
     } = options
 
     // true if part of a global install
@@ -97,7 +101,13 @@ class Node {
     this[_workspaces] = null
 
     this.errors = error ? [error] : []
-    const pkg = normalize(options.pkg || {})
+
+    // this will usually be null, except when modeling a
+    // package's dependencies in a virtual root.
+    this.sourceReference = sourceReference
+
+    const pkg = sourceReference ? sourceReference.package
+      : normalize(options.pkg || {})
 
     this.name = name ||
       nameFromFolder(path || pkg.name || realpath) ||
@@ -230,11 +240,11 @@ class Node {
     return this.global && this.parent.isRoot
   }
 
-  get workspaces() {
+  get workspaces () {
     return this[_workspaces]
   }
 
-  set workspaces(workspaces) {
+  set workspaces (workspaces) {
     // deletes edges if they already exists
     if (this[_workspaces])
       for (const [name, path] of this[_workspaces].entries()) {
@@ -291,12 +301,97 @@ class Node {
       edge.detach()
     }
 
+    this[_explanation] = null
     this[_package] = pkg
     this[_loadWorkspaces]()
     this[_loadDeps]()
     // do a hard reload, since the dependents may now be valid or invalid
     // as a result of the package change.
     this.edgesIn.forEach(edge => edge.reload(true))
+  }
+
+  // node.explain(nodes seen already, edge we're trying to satisfy
+  // if edge is not specified, it lists every edge into the node.
+  explain (edge = null, seen = []) {
+    if (this[_explanation])
+      return this[_explanation]
+
+    return this[_explanation] = this[_explain](edge, seen)
+  }
+
+  [_explain] (edge, seen) {
+    if (this.isRoot && !this.sourceReference) {
+      return {
+        location: this.path
+      }
+    }
+
+    const why = {
+      name: this.isRoot ? this.package.name : this.name,
+      version: this.package.version,
+    }
+    if (this.errors.length || !this.package.name || !this.package.version) {
+      why.errors = this.errors.length ? this.errors : [
+        new Error('invalid package: lacks name and/or version')
+      ]
+      why.package = this.package
+    }
+
+    if (this.root.sourceReference) {
+      const {name, version} = this.root.package
+      why.whileInstalling = {
+        name,
+        version,
+      }
+      if (edge)
+        this[_explainEdge](edge, seen)
+    }
+
+    if (this.sourceReference)
+      return this.sourceReference.explain(edge, seen)
+
+    if (seen.includes(this))
+      return why
+
+    why.location = this.location
+
+    // make a new list each time.  we can revisit, but not loop.
+    seen = seen.concat(this)
+
+    why.dependents = []
+    if (edge) {
+      why.dependents.push(this[_explainEdge](edge, seen))
+    } else {
+      // if we have an edge from the root, just show that, and stop there
+      // no need to go deeper, because it doesn't provide much more value.
+      const edges = []
+      for (const edge of this.edgesIn) {
+        if (!edge.valid && !edge.from.isRoot)
+          continue
+
+        if (edge.from.isRoot) {
+          edges.length = 0
+          edges.push(edge)
+          break
+        }
+
+        edges.push(edge)
+      }
+      for (const edge of edges) {
+        why.dependents.push(this[_explainEdge](edge, seen))
+      }
+    }
+    return why
+  }
+
+  // return the edge data, and an explanation of how that edge came to be here
+  [_explainEdge] (edge, seen) {
+    return {
+      type: edge.type,
+      spec: edge.spec,
+      ...(edge.error ? { error: edge.error } : {}),
+      from: edge.from.explain(null, seen),
+    }
   }
 
   isDescendantOf (node) {
@@ -495,6 +590,7 @@ class Node {
   // called when we find that we have an fsParent which could account
   // for some missing edges which are actually fine and not missing at all.
   [_reloadEdges] (filter) {
+    this[_explanation] = null
     this.edgesOut.forEach(edge => filter(edge) && edge.reload())
     this.fsChildren.forEach(c => c[_reloadEdges](filter))
     this.children.forEach(c => c[_reloadEdges](filter))

--- a/node_modules/@npmcli/arborist/lib/peer-set.js
+++ b/node_modules/@npmcli/arborist/lib/peer-set.js
@@ -1,0 +1,25 @@
+// when we have to dupe a set of peer dependencies deeper into the tree in
+// order to make room for a dep that would otherwise conflict, we use
+// this to get the set of all deps that have to be checked to ensure
+// nothing is locking them into the current location.
+//
+// this is different in its semantics from an "optional set" (ie, the nodes
+// that should be removed if an optional dep fails), because in this case,
+// we specifically intend to include deps in the peer set that have
+// dependants outside the set.
+const peerSet = node => {
+  const set = new Set([node])
+  for (const node of set) {
+    for (const edge of node.edgesOut.values()) {
+      if (edge.valid && edge.peer && edge.to)
+        set.add(edge.to)
+    }
+    for (const edge of node.edgesIn) {
+      if (edge.valid && edge.peer)
+        set.add(edge.from)
+    }
+  }
+  return set
+}
+
+module.exports = peerSet

--- a/node_modules/@npmcli/arborist/package.json
+++ b/node_modules/@npmcli/arborist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@npmcli/arborist",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Manage node_modules trees",
   "dependencies": {
     "@npmcli/installed-package-contents": "^1.0.5",
@@ -22,8 +22,9 @@
     "read-package-json-fast": "^1.2.1",
     "readdir-scoped-modules": "^1.1.0",
     "semver": "^7.1.2",
-    "treeverse": "^1.0.1",
-    "walk-up-path": "^1.0.0"
+    "treeverse": "^1.0.4",
+    "walk-up-path": "^1.0.0",
+    "json-parse-even-better-errors": "^2.3.1"
   },
   "devDependencies": {
     "minify-registry-metadata": "^2.1.0",
@@ -57,6 +58,6 @@
     ],
     "coverage-map": "map.js",
     "esm": false,
-    "timeout": "60"
+    "timeout": "120"
   }
 }

--- a/node_modules/json-parse-even-better-errors/LICENSE.md
+++ b/node_modules/json-parse-even-better-errors/LICENSE.md
@@ -1,5 +1,5 @@
 Copyright 2017 Kat Marchán
-Copyright npm, Inc. and Contributors
+Copyright npm, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/node_modules/json-parse-even-better-errors/package.json
+++ b/node_modules/json-parse-even-better-errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-parse-even-better-errors",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "JSON.parse with context information on error",
   "main": "index.js",
   "files": [

--- a/node_modules/treeverse/README.md
+++ b/node_modules/treeverse/README.md
@@ -110,3 +110,20 @@ to the result of visiting (and leaving) the top node in the tree.
 * `filter` - Filter out child nodes from the traversal.  Note that this
   filters the entire branch of the tree, not just that one node.  That is,
   children of filtered nodes are not traversed either.
+
+## STACK DEPTH WARNING
+
+When a `leave` method is specified, then recursion is used, because
+maintaining state otherwise is challenging.  This means that using `leave`
+with a synchronous depth first traversal of very deeply nested trees will
+result in stack overflow errors.
+
+To avoid this, either make one or more of the functions async, or do all of
+the work in the `visit` method.
+
+Breadth-first traversal always uses a loop, and is stack-safe.
+
+It is _possible_ to implement depth first traversal with a leave method
+using a loop rather than recursion, but maintaining the `leave(node,
+[children])` API surface would be challenging, and is not implemented at
+this time.

--- a/node_modules/treeverse/lib/depth-descent.js
+++ b/node_modules/treeverse/lib/depth-descent.js
@@ -1,25 +1,46 @@
-// Perform a breadth-first walk of a tree, either logical or physical
-// This one only visits, it doesn't leave.  That's because
-// in a breadth-first traversal, children may be visited long
-// after their parent, so the "exit" pass ends up being just
-// another breadth-first walk.
+// Perform a depth-first walk of a tree, ONLY doing the descent (visit)
 //
-// Breadth-first traversals are good for either creating a tree (ie,
-// reifying a dep graph based on a package.json without a node_modules
-// or package-lock), or mutating it in-place.  For a map-reduce type of
-// walk, it doesn't make a lot of sense, and is very expensive.
-const breadth = ({
+// This uses a stack rather than recursion, so that it can handle deeply
+// nested trees without call stack overflows.  (My kingdom for proper TCO!)
+//
+// This is only used for cases where leave() is not specified.
+//
+// a
+// +-- b
+// |   +-- 1
+// |   +-- 2
+// +-- c
+//     +-- 3
+//     +-- 4
+//
+// Expect:
+// visit a
+// visit b
+// visit 1
+// visit 2
+// visit c
+// visit 3
+// visit 4
+//
+// stack.push(tree)
+// while stack not empty
+//   pop T from stack
+//   VISIT(T)
+//   get children C of T
+//   push each C onto stack
+
+const depth = ({
   visit,
-  filter = () => true,
+  filter,
   getChildren,
   tree,
 }) => {
-  const queue = []
+  const stack = []
   const seen = new Map()
 
   const next = () => {
-    while (queue.length) {
-      const node = queue.shift()
+    while (stack.length) {
+      const node = stack.pop()
       const res = visitNode(node)
       if (isPromise(res)) {
         return res.then(() => next())
@@ -54,13 +75,13 @@ const breadth = ({
 
   const processKids = (kids) => {
     kids = (kids || []).filter(filter)
-    queue.push(...kids)
+    stack.push(...kids)
   }
 
-  queue.push(tree)
+  stack.push(tree)
   return next()
 }
 
 const isPromise = p => p && typeof p.then === 'function'
 
-module.exports = breadth
+module.exports = depth

--- a/node_modules/treeverse/lib/depth.js
+++ b/node_modules/treeverse/lib/depth.js
@@ -14,6 +14,7 @@
 // If either visit or leave return a Promise for any node, then the
 // walk returns a Promise.
 
+const depthDescent = require('./depth-descent.js')
 const depth = ({
   visit,
   leave,
@@ -22,6 +23,9 @@ const depth = ({
   getChildren,
   tree,
 }) => {
+  if (!leave)
+    return depthDescent({ visit, filter, getChildren, tree })
+
   if (seen.has(tree))
     return seen.get(tree)
 
@@ -56,8 +60,6 @@ const depth = ({
   }
 
   const leaveNode = kids => {
-    if (!leave)
-      return seen.get(tree)
     const res = leave(seen.get(tree), kids)
     seen.set(tree, res)
     // if it's a promise at this point, the caller deals with it

--- a/node_modules/treeverse/package.json
+++ b/node_modules/treeverse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treeverse",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Walk any kind of tree structure depth- or breadth-first. Supports promises and advanced map-reduce operations with a very small API.",
   "author": "Isaac Z. Schlueter <i@izs.me> (https://izs.me)",
   "license": "ISC",

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
       ],
       "license": "Artistic-2.0",
       "dependencies": {
-        "@npmcli/arborist": "^0.0.19",
+        "@npmcli/arborist": "^0.0.20",
         "@npmcli/ci-detect": "^1.2.0",
         "@npmcli/config": "^1.1.7",
         "@npmcli/run-script": "^1.5.0",
@@ -397,9 +397,9 @@
       "dev": true
     },
     "node_modules/@npmcli/arborist": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-0.0.19.tgz",
-      "integrity": "sha512-Y8JY1FnE3HoCZDBTXN1TIqMoGnywV9l0L21cBZQPx+MEAJoF87gfhg56RAwEICUD8wca6X1v4/A2fqPPMGzscw==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-0.0.20.tgz",
+      "integrity": "sha512-MklbWx9KFkMgi6gdzyzNMyWOX+f+OEwebyRkOSxTyYFfgLtqU+SlmrlhQ0mgF4jODZ70YkR5lfAvF0T5V57XVw==",
       "inBundle": true,
       "dependencies": {
         "@npmcli/installed-package-contents": "^1.0.5",
@@ -409,6 +409,7 @@
         "bin-links": "^2.1.2",
         "cacache": "^15.0.3",
         "common-ancestor-path": "^1.0.1",
+        "json-parse-even-better-errors": "^2.3.1",
         "json-stringify-nice": "^1.1.1",
         "mkdirp-infer-owner": "^2.0.0",
         "npm-install-checks": "^4.0.0",
@@ -421,7 +422,7 @@
         "read-package-json-fast": "^1.2.1",
         "readdir-scoped-modules": "^1.1.0",
         "semver": "^7.1.2",
-        "treeverse": "^1.0.1",
+        "treeverse": "^1.0.4",
         "walk-up-path": "^1.0.0"
       }
     },
@@ -8618,9 +8619,9 @@
       }
     },
     "node_modules/treeverse": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/treeverse/-/treeverse-1.0.3.tgz",
-      "integrity": "sha512-vE1An8RHapGybKZq+iD3tLvtZy3qboEWDh9wFTjVS5B+BUEJrK1rHjJBVokmv8uLSD6/dhvSDSDX6oY4XVnVvg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/treeverse/-/treeverse-1.0.4.tgz",
+      "integrity": "sha512-whw60l7r+8ZU8Tu/Uc2yxtc4ZTZbR/PF3u1IPNKGQ6p8EICLb3Z2lAgoqw9bqYd8IkgnsaOcLzYHFckjqNsf0g==",
       "inBundle": true
     },
     "node_modules/trivial-deferred": {
@@ -9459,9 +9460,9 @@
       "dev": true
     },
     "@npmcli/arborist": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-0.0.19.tgz",
-      "integrity": "sha512-Y8JY1FnE3HoCZDBTXN1TIqMoGnywV9l0L21cBZQPx+MEAJoF87gfhg56RAwEICUD8wca6X1v4/A2fqPPMGzscw==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-0.0.20.tgz",
+      "integrity": "sha512-MklbWx9KFkMgi6gdzyzNMyWOX+f+OEwebyRkOSxTyYFfgLtqU+SlmrlhQ0mgF4jODZ70YkR5lfAvF0T5V57XVw==",
       "requires": {
         "@npmcli/installed-package-contents": "^1.0.5",
         "@npmcli/map-workspaces": "0.0.0-pre.1",
@@ -9470,6 +9471,7 @@
         "bin-links": "^2.1.2",
         "cacache": "^15.0.3",
         "common-ancestor-path": "^1.0.1",
+        "json-parse-even-better-errors": "^2.3.1",
         "json-stringify-nice": "^1.1.1",
         "mkdirp-infer-owner": "^2.0.0",
         "npm-install-checks": "^4.0.0",
@@ -9482,7 +9484,7 @@
         "read-package-json-fast": "^1.2.1",
         "readdir-scoped-modules": "^1.1.0",
         "semver": "^7.1.2",
-        "treeverse": "^1.0.1",
+        "treeverse": "^1.0.4",
         "walk-up-path": "^1.0.0"
       }
     },
@@ -15743,9 +15745,9 @@
       }
     },
     "treeverse": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/treeverse/-/treeverse-1.0.3.tgz",
-      "integrity": "sha512-vE1An8RHapGybKZq+iD3tLvtZy3qboEWDh9wFTjVS5B+BUEJrK1rHjJBVokmv8uLSD6/dhvSDSDX6oY4XVnVvg=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/treeverse/-/treeverse-1.0.4.tgz",
+      "integrity": "sha512-whw60l7r+8ZU8Tu/Uc2yxtc4ZTZbR/PF3u1IPNKGQ6p8EICLb3Z2lAgoqw9bqYd8IkgnsaOcLzYHFckjqNsf0g=="
     },
     "trivial-deferred": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3602,9 +3602,9 @@
       "dev": true
     },
     "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.0.tgz",
-      "integrity": "sha512-o3aP+RsWDJZayj1SbHNQAI8x0v3T3SKiGoZlNYfbUP1S3omJQ6i9CnqADqkSPaOAxwua4/1YWx5CM7oiChJt2Q==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "inBundle": true
     },
     "node_modules/json-schema": {
@@ -11931,9 +11931,9 @@
       "dev": true
     },
     "json-parse-even-better-errors": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.0.tgz",
-      "integrity": "sha512-o3aP+RsWDJZayj1SbHNQAI8x0v3T3SKiGoZlNYfbUP1S3omJQ6i9CnqADqkSPaOAxwua4/1YWx5CM7oiChJt2Q=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "json-schema": {
       "version": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@npmcli/arborist": "^0.0.19",
+    "@npmcli/arborist": "^0.0.20",
     "@npmcli/ci-detect": "^1.2.0",
     "@npmcli/run-script": "^1.5.0",
     "abbrev": "~1.1.1",

--- a/tap-snapshots/test-lib-utils-error-message.js-TAP.test.js
+++ b/tap-snapshots/test-lib-utils-error-message.js-TAP.test.js
@@ -782,6 +782,27 @@ Object {
 }
 `
 
+exports[`test/lib/utils/error-message.js TAP explain ERESOLVE errors > must match snapshot 1`] = `
+Object {
+  "detail": Array [
+    Array [
+      "",
+      "",
+    ],
+    Array [
+      "",
+      "explanation",
+    ],
+  ],
+  "summary": Array [
+    Array [
+      "ERESOLVE",
+      "could not resolve",
+    ],
+  ],
+}
+`
+
 exports[`test/lib/utils/error-message.js TAP just simple messages > must match snapshot 1`] = `
 Object {
   "detail": Array [],

--- a/tap-snapshots/test-lib-utils-explain-eresolve.js-TAP.test.js
+++ b/tap-snapshots/test-lib-utils-explain-eresolve.js-TAP.test.js
@@ -1,0 +1,999 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/lib/utils/explain-eresolve.js TAP cycleNested > explain with color 1`] = `
+While resolving: [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m
+Found: [1m@isaacs/peer-dep-cycle-c[22m@[1m2.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-c[22m
+  for: prod dependency [1m@isaacs/peer-dep-cycle-c[22m@"[1m2.x[22m"
+  from: the root project
+
+Could not add conflicting dependency: [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-b[22m
+  for: peer dependency [1m@isaacs/peer-dep-cycle-b[22m@"[1m1[22m"
+  from: [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-a[22m
+    for: prod dependency [1m@isaacs/peer-dep-cycle-a[22m@"[1m1.x[22m"
+    from: the root project
+
+Conflicting peer dependency: [1m@isaacs/peer-dep-cycle-c[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-c[22m
+  for: peer dependency [1m@isaacs/peer-dep-cycle-c[22m@"[1m1[22m"
+  from: [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-b[22m
+    for: peer dependency [1m@isaacs/peer-dep-cycle-b[22m@"[1m1[22m"
+    from: [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-a[22m
+`
+
+exports[`test/lib/utils/explain-eresolve.js TAP cycleNested > explain with no color, depth of 6 1`] = `
+While resolving: @isaacs/peer-dep-cycle-a@1.0.0
+Found: @isaacs/peer-dep-cycle-c@2.0.0 at node_modules/@isaacs/peer-dep-cycle-c
+  for: prod dependency @isaacs/peer-dep-cycle-c@"2.x"
+  from: the root project
+
+Could not add conflicting dependency: @isaacs/peer-dep-cycle-b@1.0.0 at node_modules/@isaacs/peer-dep-cycle-b
+  for: peer dependency @isaacs/peer-dep-cycle-b@"1"
+  from: @isaacs/peer-dep-cycle-a@1.0.0 at node_modules/@isaacs/peer-dep-cycle-a
+    for: prod dependency @isaacs/peer-dep-cycle-a@"1.x"
+    from: the root project
+
+Conflicting peer dependency: @isaacs/peer-dep-cycle-c@1.0.0 at node_modules/@isaacs/peer-dep-cycle-c
+  for: peer dependency @isaacs/peer-dep-cycle-c@"1"
+  from: @isaacs/peer-dep-cycle-b@1.0.0 at node_modules/@isaacs/peer-dep-cycle-b
+    for: peer dependency @isaacs/peer-dep-cycle-b@"1"
+    from: @isaacs/peer-dep-cycle-a@1.0.0 at node_modules/@isaacs/peer-dep-cycle-a
+      for: prod dependency @isaacs/peer-dep-cycle-a@"1.x"
+      from: the root project
+`
+
+exports[`test/lib/utils/explain-eresolve.js TAP cycleNested > report 1`] = `
+# npm resolution error report
+
+\${TIME}
+
+While resolving: @isaacs/peer-dep-cycle-a@1.0.0
+Found: @isaacs/peer-dep-cycle-c@2.0.0 at node_modules/@isaacs/peer-dep-cycle-c
+  for: prod dependency @isaacs/peer-dep-cycle-c@"2.x"
+  from: the root project
+
+Could not add conflicting dependency: @isaacs/peer-dep-cycle-b@1.0.0 at node_modules/@isaacs/peer-dep-cycle-b
+  for: peer dependency @isaacs/peer-dep-cycle-b@"1"
+  from: @isaacs/peer-dep-cycle-a@1.0.0 at node_modules/@isaacs/peer-dep-cycle-a
+    for: prod dependency @isaacs/peer-dep-cycle-a@"1.x"
+    from: the root project
+
+Conflicting peer dependency: @isaacs/peer-dep-cycle-c@1.0.0 at node_modules/@isaacs/peer-dep-cycle-c
+  for: peer dependency @isaacs/peer-dep-cycle-c@"1"
+  from: @isaacs/peer-dep-cycle-b@1.0.0 at node_modules/@isaacs/peer-dep-cycle-b
+    for: peer dependency @isaacs/peer-dep-cycle-b@"1"
+    from: @isaacs/peer-dep-cycle-a@1.0.0 at node_modules/@isaacs/peer-dep-cycle-a
+      for: prod dependency @isaacs/peer-dep-cycle-a@"1.x"
+      from: the root project
+
+Fix the upstream dependency conflict, or retry
+this command with --legacy-peer-deps
+to accept an incorrect (and potentially broken) dependency resolution.
+
+Raw JSON explanation object:
+
+{
+  "name": "cycleNested",
+  "json": true
+}
+
+`
+
+exports[`test/lib/utils/explain-eresolve.js TAP cycleNested > report with color 1`] = `
+While resolving: [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m
+Found: [1m@isaacs/peer-dep-cycle-c[22m@[1m2.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-c[22m
+  for: prod dependency [1m@isaacs/peer-dep-cycle-c[22m@"[1m2.x[22m"
+  from: the root project
+
+Could not add conflicting dependency: [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-b[22m
+  for: peer dependency [1m@isaacs/peer-dep-cycle-b[22m@"[1m1[22m"
+  from: [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-a[22m
+    for: prod dependency [1m@isaacs/peer-dep-cycle-a[22m@"[1m1.x[22m"
+    from: the root project
+
+Conflicting peer dependency: [1m@isaacs/peer-dep-cycle-c[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-c[22m
+  for: peer dependency [1m@isaacs/peer-dep-cycle-c[22m@"[1m1[22m"
+  from: [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-b[22m
+    for: peer dependency [1m@isaacs/peer-dep-cycle-b[22m@"[1m1[22m"
+    from: [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-a[22m
+      for: prod dependency [1m@isaacs/peer-dep-cycle-a[22m@"[1m1.x[22m"
+      from: the root project
+
+Fix the upstream dependency conflict, or retry
+this command with --legacy-peer-deps
+to accept an incorrect (and potentially broken) dependency resolution.
+
+See \${REPORT} for a full report.
+`
+
+exports[`test/lib/utils/explain-eresolve.js TAP cycleNested > report with color, depth only 2 1`] = `
+While resolving: [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m
+Found: [1m@isaacs/peer-dep-cycle-c[22m@[1m2.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-c[22m
+  for: prod dependency [1m@isaacs/peer-dep-cycle-c[22m@"[1m2.x[22m"
+  from: the root project
+
+Could not add conflicting dependency: [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-b[22m
+  for: peer dependency [1m@isaacs/peer-dep-cycle-b[22m@"[1m1[22m"
+  from: [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-a[22m
+    for: prod dependency [1m@isaacs/peer-dep-cycle-a[22m@"[1m1.x[22m"
+    from: the root project
+
+Conflicting peer dependency: [1m@isaacs/peer-dep-cycle-c[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-c[22m
+  for: peer dependency [1m@isaacs/peer-dep-cycle-c[22m@"[1m1[22m"
+  from: [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-b[22m
+    for: peer dependency [1m@isaacs/peer-dep-cycle-b[22m@"[1m1[22m"
+    from: [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-a[22m
+
+Fix the upstream dependency conflict, or retry
+this command with --legacy-peer-deps
+to accept an incorrect (and potentially broken) dependency resolution.
+
+See \${REPORT} for a full report.
+`
+
+exports[`test/lib/utils/explain-eresolve.js TAP cycleNested > report with no color, depth of 6 1`] = `
+While resolving: @isaacs/peer-dep-cycle-a@1.0.0
+Found: @isaacs/peer-dep-cycle-c@2.0.0 at node_modules/@isaacs/peer-dep-cycle-c
+  for: prod dependency @isaacs/peer-dep-cycle-c@"2.x"
+  from: the root project
+
+Could not add conflicting dependency: @isaacs/peer-dep-cycle-b@1.0.0 at node_modules/@isaacs/peer-dep-cycle-b
+  for: peer dependency @isaacs/peer-dep-cycle-b@"1"
+  from: @isaacs/peer-dep-cycle-a@1.0.0 at node_modules/@isaacs/peer-dep-cycle-a
+    for: prod dependency @isaacs/peer-dep-cycle-a@"1.x"
+    from: the root project
+
+Conflicting peer dependency: @isaacs/peer-dep-cycle-c@1.0.0 at node_modules/@isaacs/peer-dep-cycle-c
+  for: peer dependency @isaacs/peer-dep-cycle-c@"1"
+  from: @isaacs/peer-dep-cycle-b@1.0.0 at node_modules/@isaacs/peer-dep-cycle-b
+    for: peer dependency @isaacs/peer-dep-cycle-b@"1"
+    from: @isaacs/peer-dep-cycle-a@1.0.0 at node_modules/@isaacs/peer-dep-cycle-a
+      for: prod dependency @isaacs/peer-dep-cycle-a@"1.x"
+      from: the root project
+
+Fix the upstream dependency conflict, or retry
+this command with --legacy-peer-deps
+to accept an incorrect (and potentially broken) dependency resolution.
+
+See \${REPORT} for a full report.
+`
+
+exports[`test/lib/utils/explain-eresolve.js TAP gatsby > explain with color 1`] = `
+While resolving: [1mgatsby-interface[22m@[1m0.0.166[22m
+Found: [1mreact[22m@[1m16.13.1[22m[2m at node_modules/react[22m
+  for: peer dependency [1mreact[22m@"[1m^16.4.2[22m"
+  from: [1mgatsby[22m@[1m2.24.53[22m[2m at node_modules/gatsby[22m
+    for: prod dependency [1mgatsby[22m@""
+    from: the root project
+  and: 26 more (react-dom, @reach/router, gatsby-cli, gatsby-link, gatsby-react-router-scroll, ...)
+
+Could not add conflicting dependency: [1mreact[22m@[1m16.8.1[22m[2m at node_modules/react[22m
+  for: peer dependency [1mreact[22m@"[1m16.8.1[22m"
+  from: [1mgatsby-interface[22m@[1m0.0.166[22m[2m at node_modules/gatsby-recipes/node_modules/gatsby-interface[22m
+    for: prod dependency [1mgatsby-interface[22m@"[1m^0.0.166[22m"
+    from: [1mgatsby-recipes[22m@[1m0.2.20[22m[2m at node_modules/gatsby-recipes[22m
+`
+
+exports[`test/lib/utils/explain-eresolve.js TAP gatsby > explain with no color, depth of 6 1`] = `
+While resolving: gatsby-interface@0.0.166
+Found: react@16.13.1 at node_modules/react
+  for: peer dependency react@"^16.4.2"
+  from: gatsby@2.24.53 at node_modules/gatsby
+    for: prod dependency gatsby@""
+    from: the root project
+  and: peer dependency react@"^16.13.1"
+  from: react-dom@16.13.1 at node_modules/react-dom
+    for: peer dependency react-dom@"^16.4.2"
+    from: gatsby@2.24.53 at node_modules/gatsby
+      for: prod dependency gatsby@""
+      from: the root project
+    and: peer dependency react-dom@"15.x || 16.x || 16.4.0-alpha.0911da3"
+    from: @reach/router@1.3.4 at node_modules/@reach/router
+      for: prod dependency @reach/router@"^1.3.4"
+      from: gatsby@2.24.53 at node_modules/gatsby
+        for: prod dependency gatsby@""
+        from: the root project
+      and: peer dependency @reach/router@"^1.3.3"
+      from: gatsby-link@2.4.13 at node_modules/gatsby-link
+        for: prod dependency gatsby-link@"^2.4.13"
+        from: gatsby@2.24.53 at node_modules/gatsby
+          for: prod dependency gatsby@""
+          from: the root project
+      and: 1 more (gatsby-react-router-scroll)
+    and: peer dependency react-dom@"^16.4.2"
+    from: gatsby-link@2.4.13 at node_modules/gatsby-link
+      for: prod dependency gatsby-link@"^2.4.13"
+      from: gatsby@2.24.53 at node_modules/gatsby
+        for: prod dependency gatsby@""
+        from: the root project
+    and: 2 more (gatsby-react-router-scroll, react-hot-loader)
+  and: peer dependency react@"15.x || 16.x || 16.4.0-alpha.0911da3"
+  from: @reach/router@1.3.4 at node_modules/@reach/router
+    for: prod dependency @reach/router@"^1.3.4"
+    from: gatsby@2.24.53 at node_modules/gatsby
+      for: prod dependency gatsby@""
+      from: the root project
+    and: peer dependency @reach/router@"^1.3.3"
+    from: gatsby-link@2.4.13 at node_modules/gatsby-link
+      for: prod dependency gatsby-link@"^2.4.13"
+      from: gatsby@2.24.53 at node_modules/gatsby
+        for: prod dependency gatsby@""
+        from: the root project
+    and: peer dependency @reach/router@"^1.0.0"
+    from: gatsby-react-router-scroll@3.0.12 at node_modules/gatsby-react-router-scroll
+      for: prod dependency gatsby-react-router-scroll@"^3.0.12"
+      from: gatsby@2.24.53 at node_modules/gatsby
+        for: prod dependency gatsby@""
+        from: the root project
+  and: 24 more (gatsby-cli, gatsby-link, gatsby-react-router-scroll, react-hot-loader, create-react-context, ...)
+
+Could not add conflicting dependency: react@16.8.1 at node_modules/react
+  for: peer dependency react@"16.8.1"
+  from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
+    for: prod dependency gatsby-interface@"^0.0.166"
+    from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+      for: prod dependency gatsby-recipes@"^0.2.20"
+      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+        for: prod dependency gatsby-cli@"^2.12.91"
+        from: gatsby@2.24.53 at node_modules/gatsby
+          for: prod dependency gatsby@""
+          from: the root project
+`
+
+exports[`test/lib/utils/explain-eresolve.js TAP gatsby > report 1`] = `
+# npm resolution error report
+
+\${TIME}
+
+While resolving: gatsby-interface@0.0.166
+Found: react@16.13.1 at node_modules/react
+  for: peer dependency react@"^16.4.2"
+  from: gatsby@2.24.53 at node_modules/gatsby
+    for: prod dependency gatsby@""
+    from: the root project
+  and: peer dependency react@"^16.13.1"
+  from: react-dom@16.13.1 at node_modules/react-dom
+    for: peer dependency react-dom@"^16.4.2"
+    from: gatsby@2.24.53 at node_modules/gatsby
+      for: prod dependency gatsby@""
+      from: the root project
+    and: peer dependency react-dom@"15.x || 16.x || 16.4.0-alpha.0911da3"
+    from: @reach/router@1.3.4 at node_modules/@reach/router
+      for: prod dependency @reach/router@"^1.3.4"
+      from: gatsby@2.24.53 at node_modules/gatsby
+        for: prod dependency gatsby@""
+        from: the root project
+      and: peer dependency @reach/router@"^1.3.3"
+      from: gatsby-link@2.4.13 at node_modules/gatsby-link
+        for: prod dependency gatsby-link@"^2.4.13"
+        from: gatsby@2.24.53 at node_modules/gatsby
+          for: prod dependency gatsby@""
+          from: the root project
+      and: peer dependency @reach/router@"^1.0.0"
+      from: gatsby-react-router-scroll@3.0.12 at node_modules/gatsby-react-router-scroll
+        for: prod dependency gatsby-react-router-scroll@"^3.0.12"
+        from: gatsby@2.24.53 at node_modules/gatsby
+          for: prod dependency gatsby@""
+          from: the root project
+    and: peer dependency react-dom@"^16.4.2"
+    from: gatsby-link@2.4.13 at node_modules/gatsby-link
+      for: prod dependency gatsby-link@"^2.4.13"
+      from: gatsby@2.24.53 at node_modules/gatsby
+        for: prod dependency gatsby@""
+        from: the root project
+    and: peer dependency react-dom@"^16.4.2"
+    from: gatsby-react-router-scroll@3.0.12 at node_modules/gatsby-react-router-scroll
+      for: prod dependency gatsby-react-router-scroll@"^3.0.12"
+      from: gatsby@2.24.53 at node_modules/gatsby
+        for: prod dependency gatsby@""
+        from: the root project
+    and: peer dependency react-dom@"^15.0.0 || ^16.0.0"
+    from: react-hot-loader@4.12.21 at node_modules/react-hot-loader
+      for: prod dependency react-hot-loader@"^4.12.21"
+      from: gatsby@2.24.53 at node_modules/gatsby
+        for: prod dependency gatsby@""
+        from: the root project
+  and: peer dependency react@"15.x || 16.x || 16.4.0-alpha.0911da3"
+  from: @reach/router@1.3.4 at node_modules/@reach/router
+    for: prod dependency @reach/router@"^1.3.4"
+    from: gatsby@2.24.53 at node_modules/gatsby
+      for: prod dependency gatsby@""
+      from: the root project
+    and: peer dependency @reach/router@"^1.3.3"
+    from: gatsby-link@2.4.13 at node_modules/gatsby-link
+      for: prod dependency gatsby-link@"^2.4.13"
+      from: gatsby@2.24.53 at node_modules/gatsby
+        for: prod dependency gatsby@""
+        from: the root project
+    and: peer dependency @reach/router@"^1.0.0"
+    from: gatsby-react-router-scroll@3.0.12 at node_modules/gatsby-react-router-scroll
+      for: prod dependency gatsby-react-router-scroll@"^3.0.12"
+      from: gatsby@2.24.53 at node_modules/gatsby
+        for: prod dependency gatsby@""
+        from: the root project
+  and: prod dependency react@"^16.8.0"
+  from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+    for: prod dependency gatsby-cli@"^2.12.91"
+    from: gatsby@2.24.53 at node_modules/gatsby
+      for: prod dependency gatsby@""
+      from: the root project
+  and: peer dependency react@"^16.4.2"
+  from: gatsby-link@2.4.13 at node_modules/gatsby-link
+    for: prod dependency gatsby-link@"^2.4.13"
+    from: gatsby@2.24.53 at node_modules/gatsby
+      for: prod dependency gatsby@""
+      from: the root project
+  and: peer dependency react@"^16.4.2"
+  from: gatsby-react-router-scroll@3.0.12 at node_modules/gatsby-react-router-scroll
+    for: prod dependency gatsby-react-router-scroll@"^3.0.12"
+    from: gatsby@2.24.53 at node_modules/gatsby
+      for: prod dependency gatsby@""
+      from: the root project
+  and: peer dependency react@"^15.0.0 || ^16.0.0"
+  from: react-hot-loader@4.12.21 at node_modules/react-hot-loader
+    for: prod dependency react-hot-loader@"^4.12.21"
+    from: gatsby@2.24.53 at node_modules/gatsby
+      for: prod dependency gatsby@""
+      from: the root project
+  and: peer dependency react@"^0.14.0 || ^15.0.0 || ^16.0.0"
+  from: create-react-context@0.3.0 at node_modules/create-react-context
+    for: prod dependency create-react-context@"0.3.0"
+    from: @reach/router@1.3.4 at node_modules/@reach/router
+      for: prod dependency @reach/router@"^1.3.4"
+      from: gatsby@2.24.53 at node_modules/gatsby
+        for: prod dependency gatsby@""
+        from: the root project
+      and: peer dependency @reach/router@"^1.3.3"
+      from: gatsby-link@2.4.13 at node_modules/gatsby-link
+        for: prod dependency gatsby-link@"^2.4.13"
+        from: gatsby@2.24.53 at node_modules/gatsby
+          for: prod dependency gatsby@""
+          from: the root project
+      and: peer dependency @reach/router@"^1.0.0"
+      from: gatsby-react-router-scroll@3.0.12 at node_modules/gatsby-react-router-scroll
+        for: prod dependency gatsby-react-router-scroll@"^3.0.12"
+        from: gatsby@2.24.53 at node_modules/gatsby
+          for: prod dependency gatsby@""
+          from: the root project
+  and: peer dependency react@"^16.12.0"
+  from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+    for: prod dependency gatsby-recipes@"^0.2.20"
+    from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+      for: prod dependency gatsby-cli@"^2.12.91"
+      from: gatsby@2.24.53 at node_modules/gatsby
+        for: prod dependency gatsby@""
+        from: the root project
+  and: peer dependency react@">=16.8.0"
+  from: ink@2.7.1 at node_modules/ink
+    for: prod dependency ink@"^2.7.1"
+    from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+      for: prod dependency gatsby-cli@"^2.12.91"
+      from: gatsby@2.24.53 at node_modules/gatsby
+        for: prod dependency gatsby@""
+        from: the root project
+    and: peer dependency ink@"^2.0.0"
+    from: ink-spinner@3.1.0 at node_modules/ink-spinner
+      for: prod dependency ink-spinner@"^3.1.0"
+      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+        for: prod dependency gatsby-cli@"^2.12.91"
+        from: gatsby@2.24.53 at node_modules/gatsby
+          for: prod dependency gatsby@""
+          from: the root project
+    and: peer dependency ink@">=2.0.0"
+    from: ink-box@1.0.0 at node_modules/ink-box
+      for: prod dependency ink-box@"^1.0.0"
+      from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+        for: prod dependency gatsby-recipes@"^0.2.20"
+        from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+          for: prod dependency gatsby-cli@"^2.12.91"
+          from: gatsby@2.24.53 at node_modules/gatsby
+            for: prod dependency gatsby@""
+            from: the root project
+  and: peer dependency react@"^16.8.2"
+  from: ink-spinner@3.1.0 at node_modules/ink-spinner
+    for: prod dependency ink-spinner@"^3.1.0"
+    from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+      for: prod dependency gatsby-cli@"^2.12.91"
+      from: gatsby@2.24.53 at node_modules/gatsby
+        for: prod dependency gatsby@""
+        from: the root project
+  and: peer dependency react@">=16.3.0"
+  from: @emotion/core@10.0.35 at node_modules/@emotion/core
+    for: prod dependency @emotion/core@"^10.0.14"
+    from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+      for: prod dependency gatsby-recipes@"^0.2.20"
+      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+        for: prod dependency gatsby-cli@"^2.12.91"
+        from: gatsby@2.24.53 at node_modules/gatsby
+          for: prod dependency gatsby@""
+          from: the root project
+    and: peer dependency @emotion/core@"^10.0.27"
+    from: @emotion/styled@10.0.27 at node_modules/@emotion/styled
+      for: prod dependency @emotion/styled@"^10.0.14"
+      from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+        for: prod dependency gatsby-recipes@"^0.2.20"
+        from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+          for: prod dependency gatsby-cli@"^2.12.91"
+          from: gatsby@2.24.53 at node_modules/gatsby
+            for: prod dependency gatsby@""
+            from: the root project
+      and: peer dependency @emotion/styled@"^10.0.14"
+      from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
+        for: prod dependency gatsby-interface@"^0.0.166"
+        from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+          for: prod dependency gatsby-recipes@"^0.2.20"
+          from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+            for: prod dependency gatsby-cli@"^2.12.91"
+            from: gatsby@2.24.53 at node_modules/gatsby
+              for: prod dependency gatsby@""
+              from: the root project
+    and: peer dependency @emotion/core@"^10.0.14"
+    from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
+      for: prod dependency gatsby-interface@"^0.0.166"
+      from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+        for: prod dependency gatsby-recipes@"^0.2.20"
+        from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+          for: prod dependency gatsby-cli@"^2.12.91"
+          from: gatsby@2.24.53 at node_modules/gatsby
+            for: prod dependency gatsby@""
+            from: the root project
+    and: peer dependency @emotion/core@"^10.0.28"
+    from: @emotion/styled-base@10.0.31 at node_modules/@emotion/styled-base
+      for: prod dependency @emotion/styled-base@"^10.0.27"
+      from: @emotion/styled@10.0.27 at node_modules/@emotion/styled
+        for: prod dependency @emotion/styled@"^10.0.14"
+        from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+          for: prod dependency gatsby-recipes@"^0.2.20"
+          from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+            for: prod dependency gatsby-cli@"^2.12.91"
+            from: gatsby@2.24.53 at node_modules/gatsby
+              for: prod dependency gatsby@""
+              from: the root project
+        and: peer dependency @emotion/styled@"^10.0.14"
+        from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
+          for: prod dependency gatsby-interface@"^0.0.166"
+          from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+            for: prod dependency gatsby-recipes@"^0.2.20"
+            from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+              for: prod dependency gatsby-cli@"^2.12.91"
+              from: gatsby@2.24.53 at node_modules/gatsby
+                for: prod dependency gatsby@""
+                from: the root project
+  and: peer dependency react@">=16.3.0"
+  from: @emotion/styled@10.0.27 at node_modules/@emotion/styled
+    for: prod dependency @emotion/styled@"^10.0.14"
+    from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+      for: prod dependency gatsby-recipes@"^0.2.20"
+      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+        for: prod dependency gatsby-cli@"^2.12.91"
+        from: gatsby@2.24.53 at node_modules/gatsby
+          for: prod dependency gatsby@""
+          from: the root project
+    and: peer dependency @emotion/styled@"^10.0.14"
+    from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
+      for: prod dependency gatsby-interface@"^0.0.166"
+      from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+        for: prod dependency gatsby-recipes@"^0.2.20"
+        from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+          for: prod dependency gatsby-cli@"^2.12.91"
+          from: gatsby@2.24.53 at node_modules/gatsby
+            for: prod dependency gatsby@""
+            from: the root project
+  and: peer dependency react@"^16.13.1"
+  from: @mdx-js/react@2.0.0-next.7 at node_modules/@mdx-js/react
+    for: prod dependency @mdx-js/react@"^2.0.0-next.4"
+    from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+      for: prod dependency gatsby-recipes@"^0.2.20"
+      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+        for: prod dependency gatsby-cli@"^2.12.91"
+        from: gatsby@2.24.53 at node_modules/gatsby
+          for: prod dependency gatsby@""
+          from: the root project
+    and: prod dependency @mdx-js/react@"^2.0.0-next.7"
+    from: @mdx-js/runtime@2.0.0-next.7 at node_modules/@mdx-js/runtime
+      for: prod dependency @mdx-js/runtime@"^2.0.0-next.4"
+      from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+        for: prod dependency gatsby-recipes@"^0.2.20"
+        from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+          for: prod dependency gatsby-cli@"^2.12.91"
+          from: gatsby@2.24.53 at node_modules/gatsby
+            for: prod dependency gatsby@""
+            from: the root project
+  and: peer dependency react@"^16.13.1"
+  from: @mdx-js/runtime@2.0.0-next.7 at node_modules/@mdx-js/runtime
+    for: prod dependency @mdx-js/runtime@"^2.0.0-next.4"
+    from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+      for: prod dependency gatsby-recipes@"^0.2.20"
+      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+        for: prod dependency gatsby-cli@"^2.12.91"
+        from: gatsby@2.24.53 at node_modules/gatsby
+          for: prod dependency gatsby@""
+          from: the root project
+  and: peer dependency react@">=16.8.0"
+  from: formik@2.1.5 at node_modules/formik
+    for: prod dependency formik@"^2.0.8"
+    from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+      for: prod dependency gatsby-recipes@"^0.2.20"
+      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+        for: prod dependency gatsby-cli@"^2.12.91"
+        from: gatsby@2.24.53 at node_modules/gatsby
+          for: prod dependency gatsby@""
+          from: the root project
+    and: peer dependency formik@"^2.0.8"
+    from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
+      for: prod dependency gatsby-interface@"^0.0.166"
+      from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+        for: prod dependency gatsby-recipes@"^0.2.20"
+        from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+          for: prod dependency gatsby-cli@"^2.12.91"
+          from: gatsby@2.24.53 at node_modules/gatsby
+            for: prod dependency gatsby@""
+            from: the root project
+  and: peer dependency react@"^16.4.2"
+  from: gatsby@2.6.0 at node_modules/gatsby-recipes/node_modules/gatsby
+    for: peer dependency gatsby@"2.6.0"
+    from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
+      for: prod dependency gatsby-interface@"^0.0.166"
+      from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+        for: prod dependency gatsby-recipes@"^0.2.20"
+        from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+          for: prod dependency gatsby-cli@"^2.12.91"
+          from: gatsby@2.24.53 at node_modules/gatsby
+            for: prod dependency gatsby@""
+            from: the root project
+  and: peer dependency react@"^16.0.0"
+  from: react-dom@16.8.1 at node_modules/gatsby-recipes/node_modules/react-dom
+    for: peer dependency react-dom@"16.8.1"
+    from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
+      for: prod dependency gatsby-interface@"^0.0.166"
+      from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+        for: prod dependency gatsby-recipes@"^0.2.20"
+        from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+          for: prod dependency gatsby-cli@"^2.12.91"
+          from: gatsby@2.24.53 at node_modules/gatsby
+            for: prod dependency gatsby@""
+            from: the root project
+    and: peer dependency react-dom@"^16.4.2"
+    from: gatsby@2.6.0 at node_modules/gatsby-recipes/node_modules/gatsby
+      for: peer dependency gatsby@"2.6.0"
+      from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
+        for: prod dependency gatsby-interface@"^0.0.166"
+        from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+          for: prod dependency gatsby-recipes@"^0.2.20"
+          from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+            for: prod dependency gatsby-cli@"^2.12.91"
+            from: gatsby@2.24.53 at node_modules/gatsby
+              for: prod dependency gatsby@""
+              from: the root project
+    and: peer dependency react-dom@"^0.14.0 || ^15.0.0 || ^16.0.0"
+    from: gatsby-react-router-scroll@2.3.1 at node_modules/gatsby-recipes/node_modules/gatsby-react-router-scroll
+      for: prod dependency gatsby-react-router-scroll@"^2.0.7"
+      from: gatsby@2.6.0 at node_modules/gatsby-recipes/node_modules/gatsby
+        for: peer dependency gatsby@"2.6.0"
+        from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
+          for: prod dependency gatsby-interface@"^0.0.166"
+          from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+            for: prod dependency gatsby-recipes@"^0.2.20"
+            from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+              for: prod dependency gatsby-cli@"^2.12.91"
+              from: gatsby@2.24.53 at node_modules/gatsby
+                for: prod dependency gatsby@""
+                from: the root project
+  and: peer dependency react@"*"
+  from: react-icons@3.11.0 at node_modules/react-icons
+    for: prod dependency react-icons@"^3.0.1"
+    from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+      for: prod dependency gatsby-recipes@"^0.2.20"
+      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+        for: prod dependency gatsby-cli@"^2.12.91"
+        from: gatsby@2.24.53 at node_modules/gatsby
+          for: prod dependency gatsby@""
+          from: the root project
+    and: peer dependency react-icons@"^3.2.1"
+    from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
+      for: prod dependency gatsby-interface@"^0.0.166"
+      from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+        for: prod dependency gatsby-recipes@"^0.2.20"
+        from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+          for: prod dependency gatsby-cli@"^2.12.91"
+          from: gatsby@2.24.53 at node_modules/gatsby
+            for: prod dependency gatsby@""
+            from: the root project
+  and: peer dependency react@">=16.8.0"
+  from: ink-box@1.0.0 at node_modules/ink-box
+    for: prod dependency ink-box@"^1.0.0"
+    from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+      for: prod dependency gatsby-recipes@"^0.2.20"
+      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+        for: prod dependency gatsby-cli@"^2.12.91"
+        from: gatsby@2.24.53 at node_modules/gatsby
+          for: prod dependency gatsby@""
+          from: the root project
+  and: peer dependency react@"^0.14.0 || ^15.0.0 || ^16.0.0"
+  from: react-circular-progressbar@2.0.3 at node_modules/react-circular-progressbar
+    for: prod dependency react-circular-progressbar@"^2.0.0"
+    from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+      for: prod dependency gatsby-recipes@"^0.2.20"
+      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+        for: prod dependency gatsby-cli@"^2.12.91"
+        from: gatsby@2.24.53 at node_modules/gatsby
+          for: prod dependency gatsby@""
+          from: the root project
+  and: peer dependency react@"^16.13.1"
+  from: react-reconciler@0.25.1 at node_modules/react-reconciler
+    for: prod dependency react-reconciler@"^0.25.1"
+    from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+      for: prod dependency gatsby-recipes@"^0.2.20"
+      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+        for: prod dependency gatsby-cli@"^2.12.91"
+        from: gatsby@2.24.53 at node_modules/gatsby
+          for: prod dependency gatsby@""
+          from: the root project
+  and: peer dependency react@">= 16.8.0"
+  from: urql@1.10.0 at node_modules/urql
+    for: prod dependency urql@"^1.9.7"
+    from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+      for: prod dependency gatsby-recipes@"^0.2.20"
+      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+        for: prod dependency gatsby-cli@"^2.12.91"
+        from: gatsby@2.24.53 at node_modules/gatsby
+          for: prod dependency gatsby@""
+          from: the root project
+  and: peer dependency react@">=16.3.0"
+  from: @emotion/styled-base@10.0.31 at node_modules/@emotion/styled-base
+    for: prod dependency @emotion/styled-base@"^10.0.27"
+    from: @emotion/styled@10.0.27 at node_modules/@emotion/styled
+      for: prod dependency @emotion/styled@"^10.0.14"
+      from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+        for: prod dependency gatsby-recipes@"^0.2.20"
+        from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+          for: prod dependency gatsby-cli@"^2.12.91"
+          from: gatsby@2.24.53 at node_modules/gatsby
+            for: prod dependency gatsby@""
+            from: the root project
+      and: peer dependency @emotion/styled@"^10.0.14"
+      from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
+        for: prod dependency gatsby-interface@"^0.0.166"
+        from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+          for: prod dependency gatsby-recipes@"^0.2.20"
+          from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+            for: prod dependency gatsby-cli@"^2.12.91"
+            from: gatsby@2.24.53 at node_modules/gatsby
+              for: prod dependency gatsby@""
+              from: the root project
+  and: peer dependency react@"^16.0.0"
+  from: react-reconciler@0.24.0 at node_modules/ink/node_modules/react-reconciler
+    for: prod dependency react-reconciler@"^0.24.0"
+    from: ink@2.7.1 at node_modules/ink
+      for: prod dependency ink@"^2.7.1"
+      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+        for: prod dependency gatsby-cli@"^2.12.91"
+        from: gatsby@2.24.53 at node_modules/gatsby
+          for: prod dependency gatsby@""
+          from: the root project
+      and: peer dependency ink@"^2.0.0"
+      from: ink-spinner@3.1.0 at node_modules/ink-spinner
+        for: prod dependency ink-spinner@"^3.1.0"
+        from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+          for: prod dependency gatsby-cli@"^2.12.91"
+          from: gatsby@2.24.53 at node_modules/gatsby
+            for: prod dependency gatsby@""
+            from: the root project
+      and: peer dependency ink@">=2.0.0"
+      from: ink-box@1.0.0 at node_modules/ink-box
+        for: prod dependency ink-box@"^1.0.0"
+        from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+          for: prod dependency gatsby-recipes@"^0.2.20"
+          from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+            for: prod dependency gatsby-cli@"^2.12.91"
+            from: gatsby@2.24.53 at node_modules/gatsby
+              for: prod dependency gatsby@""
+              from: the root project
+  and: peer dependency react@"^0.14.0 || ^15.0.0 || ^16.0.0"
+  from: gatsby-react-router-scroll@2.3.1 at node_modules/gatsby-recipes/node_modules/gatsby-react-router-scroll
+    for: prod dependency gatsby-react-router-scroll@"^2.0.7"
+    from: gatsby@2.6.0 at node_modules/gatsby-recipes/node_modules/gatsby
+      for: peer dependency gatsby@"2.6.0"
+      from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
+        for: prod dependency gatsby-interface@"^0.0.166"
+        from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+          for: prod dependency gatsby-recipes@"^0.2.20"
+          from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+            for: prod dependency gatsby-cli@"^2.12.91"
+            from: gatsby@2.24.53 at node_modules/gatsby
+              for: prod dependency gatsby@""
+              from: the root project
+  and: peer dependency react@"^16.13.1"
+  from: @mdx-js/react@1.6.16 at node_modules/gatsby-recipes/node_modules/gatsby-interface/node_modules/@mdx-js/react
+    for: prod dependency @mdx-js/react@"^1.5.2"
+    from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
+      for: prod dependency gatsby-interface@"^0.0.166"
+      from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+        for: prod dependency gatsby-recipes@"^0.2.20"
+        from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+          for: prod dependency gatsby-cli@"^2.12.91"
+          from: gatsby@2.24.53 at node_modules/gatsby
+            for: prod dependency gatsby@""
+            from: the root project
+
+Could not add conflicting dependency: react@16.8.1 at node_modules/react
+  for: peer dependency react@"16.8.1"
+  from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
+    for: prod dependency gatsby-interface@"^0.0.166"
+    from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+      for: prod dependency gatsby-recipes@"^0.2.20"
+      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+        for: prod dependency gatsby-cli@"^2.12.91"
+        from: gatsby@2.24.53 at node_modules/gatsby
+          for: prod dependency gatsby@""
+          from: the root project
+
+Fix the upstream dependency conflict, or retry
+this command with --legacy-peer-deps or --force
+to accept an incorrect (and potentially broken) dependency resolution.
+
+Raw JSON explanation object:
+
+{
+  "name": "gatsby",
+  "json": true
+}
+
+`
+
+exports[`test/lib/utils/explain-eresolve.js TAP gatsby > report with color 1`] = `
+While resolving: [1mgatsby-interface[22m@[1m0.0.166[22m
+Found: [1mreact[22m@[1m16.13.1[22m[2m at node_modules/react[22m
+  for: peer dependency [1mreact[22m@"[1m^16.4.2[22m"
+  from: [1mgatsby[22m@[1m2.24.53[22m[2m at node_modules/gatsby[22m
+    for: prod dependency [1mgatsby[22m@""
+    from: the root project
+  and: peer dependency [1mreact[22m@"[1m^16.13.1[22m"
+  from: [1mreact-dom[22m@[1m16.13.1[22m[2m at node_modules/react-dom[22m
+    for: peer dependency [1mreact-dom[22m@"[1m^16.4.2[22m"
+    from: [1mgatsby[22m@[1m2.24.53[22m[2m at node_modules/gatsby[22m
+      for: prod dependency [1mgatsby[22m@""
+      from: the root project
+    and: peer dependency [1mreact-dom[22m@"[1m15.x || 16.x || 16.4.0-alpha.0911da3[22m"
+    from: [1m@reach/router[22m@[1m1.3.4[22m[2m at node_modules/@reach/router[22m
+      for: prod dependency [1m@reach/router[22m@"[1m^1.3.4[22m"
+      from: [1mgatsby[22m@[1m2.24.53[22m[2m at node_modules/gatsby[22m
+        for: prod dependency [1mgatsby[22m@""
+        from: the root project
+      and: 2 more (gatsby-link, gatsby-react-router-scroll)
+    and: 3 more (gatsby-link, gatsby-react-router-scroll, react-hot-loader)
+  and: 25 more (@reach/router, gatsby-cli, gatsby-link, gatsby-react-router-scroll, react-hot-loader, ...)
+
+Could not add conflicting dependency: [1mreact[22m@[1m16.8.1[22m[2m at node_modules/react[22m
+  for: peer dependency [1mreact[22m@"[1m16.8.1[22m"
+  from: [1mgatsby-interface[22m@[1m0.0.166[22m[2m at node_modules/gatsby-recipes/node_modules/gatsby-interface[22m
+    for: prod dependency [1mgatsby-interface[22m@"[1m^0.0.166[22m"
+    from: [1mgatsby-recipes[22m@[1m0.2.20[22m[2m at node_modules/gatsby-recipes[22m
+      for: prod dependency [1mgatsby-recipes[22m@"[1m^0.2.20[22m"
+      from: [1mgatsby-cli[22m@[1m2.12.91[22m[2m at node_modules/gatsby-cli[22m
+        for: prod dependency [1mgatsby-cli[22m@"[1m^2.12.91[22m"
+        from: [1mgatsby[22m@[1m2.24.53[22m[2m at node_modules/gatsby[22m
+
+Fix the upstream dependency conflict, or retry
+this command with --legacy-peer-deps or --force
+to accept an incorrect (and potentially broken) dependency resolution.
+
+See \${REPORT} for a full report.
+`
+
+exports[`test/lib/utils/explain-eresolve.js TAP gatsby > report with color, depth only 2 1`] = `
+While resolving: [1mgatsby-interface[22m@[1m0.0.166[22m
+Found: [1mreact[22m@[1m16.13.1[22m[2m at node_modules/react[22m
+  for: peer dependency [1mreact[22m@"[1m^16.4.2[22m"
+  from: [1mgatsby[22m@[1m2.24.53[22m[2m at node_modules/gatsby[22m
+    for: prod dependency [1mgatsby[22m@""
+    from: the root project
+  and: 26 more (react-dom, @reach/router, gatsby-cli, gatsby-link, gatsby-react-router-scroll, ...)
+
+Could not add conflicting dependency: [1mreact[22m@[1m16.8.1[22m[2m at node_modules/react[22m
+  for: peer dependency [1mreact[22m@"[1m16.8.1[22m"
+  from: [1mgatsby-interface[22m@[1m0.0.166[22m[2m at node_modules/gatsby-recipes/node_modules/gatsby-interface[22m
+    for: prod dependency [1mgatsby-interface[22m@"[1m^0.0.166[22m"
+    from: [1mgatsby-recipes[22m@[1m0.2.20[22m[2m at node_modules/gatsby-recipes[22m
+
+Fix the upstream dependency conflict, or retry
+this command with --legacy-peer-deps or --force
+to accept an incorrect (and potentially broken) dependency resolution.
+
+See \${REPORT} for a full report.
+`
+
+exports[`test/lib/utils/explain-eresolve.js TAP gatsby > report with no color, depth of 6 1`] = `
+While resolving: gatsby-interface@0.0.166
+Found: react@16.13.1 at node_modules/react
+  for: peer dependency react@"^16.4.2"
+  from: gatsby@2.24.53 at node_modules/gatsby
+    for: prod dependency gatsby@""
+    from: the root project
+  and: peer dependency react@"^16.13.1"
+  from: react-dom@16.13.1 at node_modules/react-dom
+    for: peer dependency react-dom@"^16.4.2"
+    from: gatsby@2.24.53 at node_modules/gatsby
+      for: prod dependency gatsby@""
+      from: the root project
+    and: peer dependency react-dom@"15.x || 16.x || 16.4.0-alpha.0911da3"
+    from: @reach/router@1.3.4 at node_modules/@reach/router
+      for: prod dependency @reach/router@"^1.3.4"
+      from: gatsby@2.24.53 at node_modules/gatsby
+        for: prod dependency gatsby@""
+        from: the root project
+      and: peer dependency @reach/router@"^1.3.3"
+      from: gatsby-link@2.4.13 at node_modules/gatsby-link
+        for: prod dependency gatsby-link@"^2.4.13"
+        from: gatsby@2.24.53 at node_modules/gatsby
+          for: prod dependency gatsby@""
+          from: the root project
+      and: 1 more (gatsby-react-router-scroll)
+    and: peer dependency react-dom@"^16.4.2"
+    from: gatsby-link@2.4.13 at node_modules/gatsby-link
+      for: prod dependency gatsby-link@"^2.4.13"
+      from: gatsby@2.24.53 at node_modules/gatsby
+        for: prod dependency gatsby@""
+        from: the root project
+    and: 2 more (gatsby-react-router-scroll, react-hot-loader)
+  and: peer dependency react@"15.x || 16.x || 16.4.0-alpha.0911da3"
+  from: @reach/router@1.3.4 at node_modules/@reach/router
+    for: prod dependency @reach/router@"^1.3.4"
+    from: gatsby@2.24.53 at node_modules/gatsby
+      for: prod dependency gatsby@""
+      from: the root project
+    and: peer dependency @reach/router@"^1.3.3"
+    from: gatsby-link@2.4.13 at node_modules/gatsby-link
+      for: prod dependency gatsby-link@"^2.4.13"
+      from: gatsby@2.24.53 at node_modules/gatsby
+        for: prod dependency gatsby@""
+        from: the root project
+    and: peer dependency @reach/router@"^1.0.0"
+    from: gatsby-react-router-scroll@3.0.12 at node_modules/gatsby-react-router-scroll
+      for: prod dependency gatsby-react-router-scroll@"^3.0.12"
+      from: gatsby@2.24.53 at node_modules/gatsby
+        for: prod dependency gatsby@""
+        from: the root project
+  and: 24 more (gatsby-cli, gatsby-link, gatsby-react-router-scroll, react-hot-loader, create-react-context, ...)
+
+Could not add conflicting dependency: react@16.8.1 at node_modules/react
+  for: peer dependency react@"16.8.1"
+  from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
+    for: prod dependency gatsby-interface@"^0.0.166"
+    from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
+      for: prod dependency gatsby-recipes@"^0.2.20"
+      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
+        for: prod dependency gatsby-cli@"^2.12.91"
+        from: gatsby@2.24.53 at node_modules/gatsby
+          for: prod dependency gatsby@""
+          from: the root project
+
+Fix the upstream dependency conflict, or retry
+this command with --legacy-peer-deps or --force
+to accept an incorrect (and potentially broken) dependency resolution.
+
+See \${REPORT} for a full report.
+`
+
+exports[`test/lib/utils/explain-eresolve.js TAP withShrinkwrap > explain with color 1`] = `
+While resolving: [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m
+Found: [1m@isaacs/peer-dep-cycle-c[22m@[1m2.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-c[22m
+  for: prod dependency [1m@isaacs/peer-dep-cycle-c[22m@"[1m2.x[22m"
+  from: the root project
+
+Could not add conflicting dependency: [1m@isaacs/peer-dep-cycle-c[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-c[22m
+  for: peer dependency [1m@isaacs/peer-dep-cycle-c[22m@"[1m1[22m"
+  from: [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-b[22m
+    for: peer dependency [1m@isaacs/peer-dep-cycle-b[22m@"[1m1[22m"
+    from: [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-a[22m
+`
+
+exports[`test/lib/utils/explain-eresolve.js TAP withShrinkwrap > explain with no color, depth of 6 1`] = `
+While resolving: @isaacs/peer-dep-cycle-b@1.0.0
+Found: @isaacs/peer-dep-cycle-c@2.0.0 at node_modules/@isaacs/peer-dep-cycle-c
+  for: prod dependency @isaacs/peer-dep-cycle-c@"2.x"
+  from: the root project
+
+Could not add conflicting dependency: @isaacs/peer-dep-cycle-c@1.0.0 at node_modules/@isaacs/peer-dep-cycle-c
+  for: peer dependency @isaacs/peer-dep-cycle-c@"1"
+  from: @isaacs/peer-dep-cycle-b@1.0.0 at node_modules/@isaacs/peer-dep-cycle-b
+    for: peer dependency @isaacs/peer-dep-cycle-b@"1"
+    from: @isaacs/peer-dep-cycle-a@1.0.0 at node_modules/@isaacs/peer-dep-cycle-a
+      for: prod dependency @isaacs/peer-dep-cycle-a@"1.x"
+      from: the root project
+`
+
+exports[`test/lib/utils/explain-eresolve.js TAP withShrinkwrap > report 1`] = `
+# npm resolution error report
+
+\${TIME}
+
+While resolving: @isaacs/peer-dep-cycle-b@1.0.0
+Found: @isaacs/peer-dep-cycle-c@2.0.0 at node_modules/@isaacs/peer-dep-cycle-c
+  for: prod dependency @isaacs/peer-dep-cycle-c@"2.x"
+  from: the root project
+
+Could not add conflicting dependency: @isaacs/peer-dep-cycle-c@1.0.0 at node_modules/@isaacs/peer-dep-cycle-c
+  for: peer dependency @isaacs/peer-dep-cycle-c@"1"
+  from: @isaacs/peer-dep-cycle-b@1.0.0 at node_modules/@isaacs/peer-dep-cycle-b
+    for: peer dependency @isaacs/peer-dep-cycle-b@"1"
+    from: @isaacs/peer-dep-cycle-a@1.0.0 at node_modules/@isaacs/peer-dep-cycle-a
+      for: prod dependency @isaacs/peer-dep-cycle-a@"1.x"
+      from: the root project
+
+Fix the upstream dependency conflict, or retry
+this command with --legacy-peer-deps or --force
+to accept an incorrect (and potentially broken) dependency resolution.
+
+Raw JSON explanation object:
+
+{
+  "name": "withShrinkwrap",
+  "json": true
+}
+
+`
+
+exports[`test/lib/utils/explain-eresolve.js TAP withShrinkwrap > report with color 1`] = `
+While resolving: [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m
+Found: [1m@isaacs/peer-dep-cycle-c[22m@[1m2.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-c[22m
+  for: prod dependency [1m@isaacs/peer-dep-cycle-c[22m@"[1m2.x[22m"
+  from: the root project
+
+Could not add conflicting dependency: [1m@isaacs/peer-dep-cycle-c[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-c[22m
+  for: peer dependency [1m@isaacs/peer-dep-cycle-c[22m@"[1m1[22m"
+  from: [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-b[22m
+    for: peer dependency [1m@isaacs/peer-dep-cycle-b[22m@"[1m1[22m"
+    from: [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-a[22m
+      for: prod dependency [1m@isaacs/peer-dep-cycle-a[22m@"[1m1.x[22m"
+      from: the root project
+
+Fix the upstream dependency conflict, or retry
+this command with --legacy-peer-deps or --force
+to accept an incorrect (and potentially broken) dependency resolution.
+
+See \${REPORT} for a full report.
+`
+
+exports[`test/lib/utils/explain-eresolve.js TAP withShrinkwrap > report with color, depth only 2 1`] = `
+While resolving: [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m
+Found: [1m@isaacs/peer-dep-cycle-c[22m@[1m2.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-c[22m
+  for: prod dependency [1m@isaacs/peer-dep-cycle-c[22m@"[1m2.x[22m"
+  from: the root project
+
+Could not add conflicting dependency: [1m@isaacs/peer-dep-cycle-c[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-c[22m
+  for: peer dependency [1m@isaacs/peer-dep-cycle-c[22m@"[1m1[22m"
+  from: [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-b[22m
+    for: peer dependency [1m@isaacs/peer-dep-cycle-b[22m@"[1m1[22m"
+    from: [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-a[22m
+
+Fix the upstream dependency conflict, or retry
+this command with --legacy-peer-deps or --force
+to accept an incorrect (and potentially broken) dependency resolution.
+
+See \${REPORT} for a full report.
+`
+
+exports[`test/lib/utils/explain-eresolve.js TAP withShrinkwrap > report with no color, depth of 6 1`] = `
+While resolving: @isaacs/peer-dep-cycle-b@1.0.0
+Found: @isaacs/peer-dep-cycle-c@2.0.0 at node_modules/@isaacs/peer-dep-cycle-c
+  for: prod dependency @isaacs/peer-dep-cycle-c@"2.x"
+  from: the root project
+
+Could not add conflicting dependency: @isaacs/peer-dep-cycle-c@1.0.0 at node_modules/@isaacs/peer-dep-cycle-c
+  for: peer dependency @isaacs/peer-dep-cycle-c@"1"
+  from: @isaacs/peer-dep-cycle-b@1.0.0 at node_modules/@isaacs/peer-dep-cycle-b
+    for: peer dependency @isaacs/peer-dep-cycle-b@"1"
+    from: @isaacs/peer-dep-cycle-a@1.0.0 at node_modules/@isaacs/peer-dep-cycle-a
+      for: prod dependency @isaacs/peer-dep-cycle-a@"1.x"
+      from: the root project
+
+Fix the upstream dependency conflict, or retry
+this command with --legacy-peer-deps or --force
+to accept an incorrect (and potentially broken) dependency resolution.
+
+See \${REPORT} for a full report.
+`

--- a/test/fixtures/eresolve-explanations.js
+++ b/test/fixtures/eresolve-explanations.js
@@ -1,0 +1,2576 @@
+// some real-world examples of ERESOLVE error explaination objects,
+// copied from arborist or generated there.
+module.exports = {
+  cycleNested: {
+    code: 'ERESOLVE',
+    dep: {
+      name: '@isaacs/peer-dep-cycle-b',
+      version: '1.0.0',
+      whileInstalling: { name: '@isaacs/peer-dep-cycle-a', version: '1.0.0' },
+      location: 'node_modules/@isaacs/peer-dep-cycle-b',
+      dependents: [
+        {
+          type: 'peer',
+          spec: '1',
+          from: {
+            name: '@isaacs/peer-dep-cycle-a',
+            version: '1.0.0',
+            location: 'node_modules/@isaacs/peer-dep-cycle-a',
+            dependents: [
+              {
+                type: 'prod',
+                spec: '1.x',
+                from: { location: '/some/project' }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    current: {
+      name: '@isaacs/peer-dep-cycle-c',
+      version: '2.0.0',
+      location: 'node_modules/@isaacs/peer-dep-cycle-c',
+      dependents: [
+        {
+          type: 'prod',
+          spec: '2.x',
+          from: { location: '/some/project' }
+        }
+      ]
+    },
+    peerConflict: {
+      name: '@isaacs/peer-dep-cycle-c',
+      version: '1.0.0',
+      whileInstalling: { name: '@isaacs/peer-dep-cycle-a', version: '1.0.0' },
+      location: 'node_modules/@isaacs/peer-dep-cycle-c',
+      dependents: [
+        {
+          type: 'peer',
+          spec: '1',
+          from: {
+            name: '@isaacs/peer-dep-cycle-b',
+            version: '1.0.0',
+            whileInstalling: { name: '@isaacs/peer-dep-cycle-a', version: '1.0.0' },
+            location: 'node_modules/@isaacs/peer-dep-cycle-b',
+            dependents: [
+              {
+                type: 'peer',
+                spec: '1',
+                from: {
+                  name: '@isaacs/peer-dep-cycle-a',
+                  version: '1.0.0',
+                  location: 'node_modules/@isaacs/peer-dep-cycle-a',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '1.x',
+                      from: { location: '/some/project' }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    fixWithForce: false,
+    type: 'peer',
+    isPeer: true
+  },
+
+  withShrinkwrap: {
+    code: 'ERESOLVE',
+    dep: {
+      name: '@isaacs/peer-dep-cycle-c',
+      version: '1.0.0',
+      whileInstalling: { name: '@isaacs/peer-dep-cycle-b', version: '1.0.0' },
+      location: 'node_modules/@isaacs/peer-dep-cycle-c',
+      dependents: [
+        {
+          type: 'peer',
+          spec: '1',
+          error: 'INVALID',
+          from: {
+            name: '@isaacs/peer-dep-cycle-b',
+            version: '1.0.0',
+            location: 'node_modules/@isaacs/peer-dep-cycle-b',
+            dependents: [
+              {
+                type: 'peer',
+                spec: '1',
+                from: {
+                  name: '@isaacs/peer-dep-cycle-a',
+                  version: '1.0.0',
+                  location: 'node_modules/@isaacs/peer-dep-cycle-a',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '1.x',
+                      from: { location: '/some/project' }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    current: {
+      name: '@isaacs/peer-dep-cycle-c',
+      version: '2.0.0',
+      location: 'node_modules/@isaacs/peer-dep-cycle-c',
+      dependents: [
+        {
+          type: 'prod',
+          spec: '2.x',
+          from: { location: '/some/project' }
+        }
+      ]
+    },
+    fixWithForce: true,
+    type: 'peer'
+  },
+
+  gatsby: {
+    code: 'ERESOLVE',
+    dep: {
+      name: 'react',
+      version: '16.8.1',
+      whileInstalling: {
+        name: 'gatsby-interface',
+        version: '0.0.166'
+      },
+      location: 'node_modules/react',
+      dependents: [
+        {
+          type: 'peer',
+          spec: '16.8.1',
+          error: 'INVALID',
+          from: {
+            name: 'gatsby-interface',
+            version: '0.0.166',
+            location: 'node_modules/gatsby-recipes/node_modules/gatsby-interface',
+            dependents: [
+              {
+                type: 'prod',
+                spec: '^0.0.166',
+                from: {
+                  name: 'gatsby-recipes',
+                  version: '0.2.20',
+                  location: 'node_modules/gatsby-recipes',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^0.2.20',
+                      from: {
+                        name: 'gatsby-cli',
+                        version: '2.12.91',
+                        location: 'node_modules/gatsby-cli',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^2.12.91',
+                            from: {
+                              name: 'gatsby',
+                              version: '2.24.53',
+                              location: 'node_modules/gatsby',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '',
+                                  from: {
+                                    location: '/path/to/gatsby-user'
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    current: {
+      name: 'react',
+      version: '16.13.1',
+      location: 'node_modules/react',
+      dependents: [
+        {
+          type: 'peer',
+          spec: '^16.4.2',
+          from: {
+            name: 'gatsby',
+            version: '2.24.53',
+            location: 'node_modules/gatsby',
+            dependents: [
+              {
+                type: 'prod',
+                spec: '',
+                from: {
+                  location: '/path/to/gatsby-user'
+                }
+              }
+            ]
+          }
+        },
+        {
+          type: 'peer',
+          spec: '^16.13.1',
+          from: {
+            name: 'react-dom',
+            version: '16.13.1',
+            location: 'node_modules/react-dom',
+            dependents: [
+              {
+                type: 'peer',
+                spec: '^16.4.2',
+                from: {
+                  name: 'gatsby',
+                  version: '2.24.53',
+                  location: 'node_modules/gatsby',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '',
+                      from: {
+                        location: '/path/to/gatsby-user'
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                type: 'peer',
+                spec: '15.x || 16.x || 16.4.0-alpha.0911da3',
+                from: {
+                  name: '@reach/router',
+                  version: '1.3.4',
+                  location: 'node_modules/@reach/router',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^1.3.4',
+                      from: {
+                        name: 'gatsby',
+                        version: '2.24.53',
+                        location: 'node_modules/gatsby',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '',
+                            from: {
+                              location: '/path/to/gatsby-user'
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      type: 'peer',
+                      spec: '^1.3.3',
+                      from: {
+                        name: 'gatsby-link',
+                        version: '2.4.13',
+                        location: 'node_modules/gatsby-link',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^2.4.13',
+                            from: {
+                              name: 'gatsby',
+                              version: '2.24.53',
+                              location: 'node_modules/gatsby',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '',
+                                  from: {
+                                    location: '/path/to/gatsby-user'
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      type: 'peer',
+                      spec: '^1.0.0',
+                      from: {
+                        name: 'gatsby-react-router-scroll',
+                        version: '3.0.12',
+                        location: 'node_modules/gatsby-react-router-scroll',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^3.0.12',
+                            from: {
+                              name: 'gatsby',
+                              version: '2.24.53',
+                              location: 'node_modules/gatsby',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '',
+                                  from: {
+                                    location: '/path/to/gatsby-user'
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                type: 'peer',
+                spec: '^16.4.2',
+                from: {
+                  name: 'gatsby-link',
+                  version: '2.4.13',
+                  location: 'node_modules/gatsby-link',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^2.4.13',
+                      from: {
+                        name: 'gatsby',
+                        version: '2.24.53',
+                        location: 'node_modules/gatsby',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '',
+                            from: {
+                              location: '/path/to/gatsby-user'
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                type: 'peer',
+                spec: '^16.4.2',
+                from: {
+                  name: 'gatsby-react-router-scroll',
+                  version: '3.0.12',
+                  location: 'node_modules/gatsby-react-router-scroll',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^3.0.12',
+                      from: {
+                        name: 'gatsby',
+                        version: '2.24.53',
+                        location: 'node_modules/gatsby',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '',
+                            from: {
+                              location: '/path/to/gatsby-user'
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                type: 'peer',
+                spec: '^15.0.0 || ^16.0.0',
+                from: {
+                  name: 'react-hot-loader',
+                  version: '4.12.21',
+                  location: 'node_modules/react-hot-loader',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^4.12.21',
+                      from: {
+                        name: 'gatsby',
+                        version: '2.24.53',
+                        location: 'node_modules/gatsby',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '',
+                            from: {
+                              location: '/path/to/gatsby-user'
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          type: 'peer',
+          spec: '15.x || 16.x || 16.4.0-alpha.0911da3',
+          from: {
+            name: '@reach/router',
+            version: '1.3.4',
+            location: 'node_modules/@reach/router',
+            dependents: [
+              {
+                type: 'prod',
+                spec: '^1.3.4',
+                from: {
+                  name: 'gatsby',
+                  version: '2.24.53',
+                  location: 'node_modules/gatsby',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '',
+                      from: {
+                        location: '/path/to/gatsby-user'
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                type: 'peer',
+                spec: '^1.3.3',
+                from: {
+                  name: 'gatsby-link',
+                  version: '2.4.13',
+                  location: 'node_modules/gatsby-link',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^2.4.13',
+                      from: {
+                        name: 'gatsby',
+                        version: '2.24.53',
+                        location: 'node_modules/gatsby',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '',
+                            from: {
+                              location: '/path/to/gatsby-user'
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                type: 'peer',
+                spec: '^1.0.0',
+                from: {
+                  name: 'gatsby-react-router-scroll',
+                  version: '3.0.12',
+                  location: 'node_modules/gatsby-react-router-scroll',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^3.0.12',
+                      from: {
+                        name: 'gatsby',
+                        version: '2.24.53',
+                        location: 'node_modules/gatsby',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '',
+                            from: {
+                              location: '/path/to/gatsby-user'
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          type: 'prod',
+          spec: '^16.8.0',
+          from: {
+            name: 'gatsby-cli',
+            version: '2.12.91',
+            location: 'node_modules/gatsby-cli',
+            dependents: [
+              {
+                type: 'prod',
+                spec: '^2.12.91',
+                from: {
+                  name: 'gatsby',
+                  version: '2.24.53',
+                  location: 'node_modules/gatsby',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '',
+                      from: {
+                        location: '/path/to/gatsby-user'
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          type: 'peer',
+          spec: '^16.4.2',
+          from: {
+            name: 'gatsby-link',
+            version: '2.4.13',
+            location: 'node_modules/gatsby-link',
+            dependents: [
+              {
+                type: 'prod',
+                spec: '^2.4.13',
+                from: {
+                  name: 'gatsby',
+                  version: '2.24.53',
+                  location: 'node_modules/gatsby',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '',
+                      from: {
+                        location: '/path/to/gatsby-user'
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          type: 'peer',
+          spec: '^16.4.2',
+          from: {
+            name: 'gatsby-react-router-scroll',
+            version: '3.0.12',
+            location: 'node_modules/gatsby-react-router-scroll',
+            dependents: [
+              {
+                type: 'prod',
+                spec: '^3.0.12',
+                from: {
+                  name: 'gatsby',
+                  version: '2.24.53',
+                  location: 'node_modules/gatsby',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '',
+                      from: {
+                        location: '/path/to/gatsby-user'
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          type: 'peer',
+          spec: '^15.0.0 || ^16.0.0',
+          from: {
+            name: 'react-hot-loader',
+            version: '4.12.21',
+            location: 'node_modules/react-hot-loader',
+            dependents: [
+              {
+                type: 'prod',
+                spec: '^4.12.21',
+                from: {
+                  name: 'gatsby',
+                  version: '2.24.53',
+                  location: 'node_modules/gatsby',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '',
+                      from: {
+                        location: '/path/to/gatsby-user'
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          type: 'peer',
+          spec: '^0.14.0 || ^15.0.0 || ^16.0.0',
+          from: {
+            name: 'create-react-context',
+            version: '0.3.0',
+            location: 'node_modules/create-react-context',
+            dependents: [
+              {
+                type: 'prod',
+                spec: '0.3.0',
+                from: {
+                  name: '@reach/router',
+                  version: '1.3.4',
+                  location: 'node_modules/@reach/router',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^1.3.4',
+                      from: {
+                        name: 'gatsby',
+                        version: '2.24.53',
+                        location: 'node_modules/gatsby',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '',
+                            from: {
+                              location: '/path/to/gatsby-user'
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      type: 'peer',
+                      spec: '^1.3.3',
+                      from: {
+                        name: 'gatsby-link',
+                        version: '2.4.13',
+                        location: 'node_modules/gatsby-link',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^2.4.13',
+                            from: {
+                              name: 'gatsby',
+                              version: '2.24.53',
+                              location: 'node_modules/gatsby',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '',
+                                  from: {
+                                    location: '/path/to/gatsby-user'
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      type: 'peer',
+                      spec: '^1.0.0',
+                      from: {
+                        name: 'gatsby-react-router-scroll',
+                        version: '3.0.12',
+                        location: 'node_modules/gatsby-react-router-scroll',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^3.0.12',
+                            from: {
+                              name: 'gatsby',
+                              version: '2.24.53',
+                              location: 'node_modules/gatsby',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '',
+                                  from: {
+                                    location: '/path/to/gatsby-user'
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          type: 'peer',
+          spec: '^16.12.0',
+          from: {
+            name: 'gatsby-recipes',
+            version: '0.2.20',
+            location: 'node_modules/gatsby-recipes',
+            dependents: [
+              {
+                type: 'prod',
+                spec: '^0.2.20',
+                from: {
+                  name: 'gatsby-cli',
+                  version: '2.12.91',
+                  location: 'node_modules/gatsby-cli',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^2.12.91',
+                      from: {
+                        name: 'gatsby',
+                        version: '2.24.53',
+                        location: 'node_modules/gatsby',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '',
+                            from: {
+                              location: '/path/to/gatsby-user'
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          type: 'peer',
+          spec: '>=16.8.0',
+          from: {
+            name: 'ink',
+            version: '2.7.1',
+            location: 'node_modules/ink',
+            dependents: [
+              {
+                type: 'prod',
+                spec: '^2.7.1',
+                from: {
+                  name: 'gatsby-cli',
+                  version: '2.12.91',
+                  location: 'node_modules/gatsby-cli',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^2.12.91',
+                      from: {
+                        name: 'gatsby',
+                        version: '2.24.53',
+                        location: 'node_modules/gatsby',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '',
+                            from: {
+                              location: '/path/to/gatsby-user'
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                type: 'peer',
+                spec: '^2.0.0',
+                from: {
+                  name: 'ink-spinner',
+                  version: '3.1.0',
+                  location: 'node_modules/ink-spinner',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^3.1.0',
+                      from: {
+                        name: 'gatsby-cli',
+                        version: '2.12.91',
+                        location: 'node_modules/gatsby-cli',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^2.12.91',
+                            from: {
+                              name: 'gatsby',
+                              version: '2.24.53',
+                              location: 'node_modules/gatsby',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '',
+                                  from: {
+                                    location: '/path/to/gatsby-user'
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                type: 'peer',
+                spec: '>=2.0.0',
+                from: {
+                  name: 'ink-box',
+                  version: '1.0.0',
+                  location: 'node_modules/ink-box',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^1.0.0',
+                      from: {
+                        name: 'gatsby-recipes',
+                        version: '0.2.20',
+                        location: 'node_modules/gatsby-recipes',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^0.2.20',
+                            from: {
+                              name: 'gatsby-cli',
+                              version: '2.12.91',
+                              location: 'node_modules/gatsby-cli',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '^2.12.91',
+                                  from: {
+                                    name: 'gatsby',
+                                    version: '2.24.53',
+                                    location: 'node_modules/gatsby',
+                                    dependents: [
+                                      {
+                                        type: 'prod',
+                                        spec: '',
+                                        from: {
+                                          location: '/path/to/gatsby-user'
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          type: 'peer',
+          spec: '^16.8.2',
+          from: {
+            name: 'ink-spinner',
+            version: '3.1.0',
+            location: 'node_modules/ink-spinner',
+            dependents: [
+              {
+                type: 'prod',
+                spec: '^3.1.0',
+                from: {
+                  name: 'gatsby-cli',
+                  version: '2.12.91',
+                  location: 'node_modules/gatsby-cli',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^2.12.91',
+                      from: {
+                        name: 'gatsby',
+                        version: '2.24.53',
+                        location: 'node_modules/gatsby',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '',
+                            from: {
+                              location: '/path/to/gatsby-user'
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          type: 'peer',
+          spec: '>=16.3.0',
+          from: {
+            name: '@emotion/core',
+            version: '10.0.35',
+            location: 'node_modules/@emotion/core',
+            dependents: [
+              {
+                type: 'prod',
+                spec: '^10.0.14',
+                from: {
+                  name: 'gatsby-recipes',
+                  version: '0.2.20',
+                  location: 'node_modules/gatsby-recipes',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^0.2.20',
+                      from: {
+                        name: 'gatsby-cli',
+                        version: '2.12.91',
+                        location: 'node_modules/gatsby-cli',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^2.12.91',
+                            from: {
+                              name: 'gatsby',
+                              version: '2.24.53',
+                              location: 'node_modules/gatsby',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '',
+                                  from: {
+                                    location: '/path/to/gatsby-user'
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                type: 'peer',
+                spec: '^10.0.27',
+                from: {
+                  name: '@emotion/styled',
+                  version: '10.0.27',
+                  location: 'node_modules/@emotion/styled',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^10.0.14',
+                      from: {
+                        name: 'gatsby-recipes',
+                        version: '0.2.20',
+                        location: 'node_modules/gatsby-recipes',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^0.2.20',
+                            from: {
+                              name: 'gatsby-cli',
+                              version: '2.12.91',
+                              location: 'node_modules/gatsby-cli',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '^2.12.91',
+                                  from: {
+                                    name: 'gatsby',
+                                    version: '2.24.53',
+                                    location: 'node_modules/gatsby',
+                                    dependents: [
+                                      {
+                                        type: 'prod',
+                                        spec: '',
+                                        from: {
+                                          location: '/path/to/gatsby-user'
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      type: 'peer',
+                      spec: '^10.0.14',
+                      from: {
+                        name: 'gatsby-interface',
+                        version: '0.0.166',
+                        location: 'node_modules/gatsby-recipes/node_modules/gatsby-interface',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^0.0.166',
+                            from: {
+                              name: 'gatsby-recipes',
+                              version: '0.2.20',
+                              location: 'node_modules/gatsby-recipes',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '^0.2.20',
+                                  from: {
+                                    name: 'gatsby-cli',
+                                    version: '2.12.91',
+                                    location: 'node_modules/gatsby-cli',
+                                    dependents: [
+                                      {
+                                        type: 'prod',
+                                        spec: '^2.12.91',
+                                        from: {
+                                          name: 'gatsby',
+                                          version: '2.24.53',
+                                          location: 'node_modules/gatsby',
+                                          dependents: [
+                                            {
+                                              type: 'prod',
+                                              spec: '',
+                                              from: {
+                                                location: '/path/to/gatsby-user'
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                type: 'peer',
+                spec: '^10.0.14',
+                from: {
+                  name: 'gatsby-interface',
+                  version: '0.0.166',
+                  location: 'node_modules/gatsby-recipes/node_modules/gatsby-interface',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^0.0.166',
+                      from: {
+                        name: 'gatsby-recipes',
+                        version: '0.2.20',
+                        location: 'node_modules/gatsby-recipes',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^0.2.20',
+                            from: {
+                              name: 'gatsby-cli',
+                              version: '2.12.91',
+                              location: 'node_modules/gatsby-cli',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '^2.12.91',
+                                  from: {
+                                    name: 'gatsby',
+                                    version: '2.24.53',
+                                    location: 'node_modules/gatsby',
+                                    dependents: [
+                                      {
+                                        type: 'prod',
+                                        spec: '',
+                                        from: {
+                                          location: '/path/to/gatsby-user'
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                type: 'peer',
+                spec: '^10.0.28',
+                from: {
+                  name: '@emotion/styled-base',
+                  version: '10.0.31',
+                  location: 'node_modules/@emotion/styled-base',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^10.0.27',
+                      from: {
+                        name: '@emotion/styled',
+                        version: '10.0.27',
+                        location: 'node_modules/@emotion/styled',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^10.0.14',
+                            from: {
+                              name: 'gatsby-recipes',
+                              version: '0.2.20',
+                              location: 'node_modules/gatsby-recipes',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '^0.2.20',
+                                  from: {
+                                    name: 'gatsby-cli',
+                                    version: '2.12.91',
+                                    location: 'node_modules/gatsby-cli',
+                                    dependents: [
+                                      {
+                                        type: 'prod',
+                                        spec: '^2.12.91',
+                                        from: {
+                                          name: 'gatsby',
+                                          version: '2.24.53',
+                                          location: 'node_modules/gatsby',
+                                          dependents: [
+                                            {
+                                              type: 'prod',
+                                              spec: '',
+                                              from: {
+                                                location: '/path/to/gatsby-user'
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            type: 'peer',
+                            spec: '^10.0.14',
+                            from: {
+                              name: 'gatsby-interface',
+                              version: '0.0.166',
+                              location: 'node_modules/gatsby-recipes/node_modules/gatsby-interface',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '^0.0.166',
+                                  from: {
+                                    name: 'gatsby-recipes',
+                                    version: '0.2.20',
+                                    location: 'node_modules/gatsby-recipes',
+                                    dependents: [
+                                      {
+                                        type: 'prod',
+                                        spec: '^0.2.20',
+                                        from: {
+                                          name: 'gatsby-cli',
+                                          version: '2.12.91',
+                                          location: 'node_modules/gatsby-cli',
+                                          dependents: [
+                                            {
+                                              type: 'prod',
+                                              spec: '^2.12.91',
+                                              from: {
+                                                name: 'gatsby',
+                                                version: '2.24.53',
+                                                location: 'node_modules/gatsby',
+                                                dependents: [
+                                                  {
+                                                    type: 'prod',
+                                                    spec: '',
+                                                    from: {
+                                                      location: '/path/to/gatsby-user'
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          type: 'peer',
+          spec: '>=16.3.0',
+          from: {
+            name: '@emotion/styled',
+            version: '10.0.27',
+            location: 'node_modules/@emotion/styled',
+            dependents: [
+              {
+                type: 'prod',
+                spec: '^10.0.14',
+                from: {
+                  name: 'gatsby-recipes',
+                  version: '0.2.20',
+                  location: 'node_modules/gatsby-recipes',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^0.2.20',
+                      from: {
+                        name: 'gatsby-cli',
+                        version: '2.12.91',
+                        location: 'node_modules/gatsby-cli',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^2.12.91',
+                            from: {
+                              name: 'gatsby',
+                              version: '2.24.53',
+                              location: 'node_modules/gatsby',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '',
+                                  from: {
+                                    location: '/path/to/gatsby-user'
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                type: 'peer',
+                spec: '^10.0.14',
+                from: {
+                  name: 'gatsby-interface',
+                  version: '0.0.166',
+                  location: 'node_modules/gatsby-recipes/node_modules/gatsby-interface',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^0.0.166',
+                      from: {
+                        name: 'gatsby-recipes',
+                        version: '0.2.20',
+                        location: 'node_modules/gatsby-recipes',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^0.2.20',
+                            from: {
+                              name: 'gatsby-cli',
+                              version: '2.12.91',
+                              location: 'node_modules/gatsby-cli',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '^2.12.91',
+                                  from: {
+                                    name: 'gatsby',
+                                    version: '2.24.53',
+                                    location: 'node_modules/gatsby',
+                                    dependents: [
+                                      {
+                                        type: 'prod',
+                                        spec: '',
+                                        from: {
+                                          location: '/path/to/gatsby-user'
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          type: 'peer',
+          spec: '^16.13.1',
+          from: {
+            name: '@mdx-js/react',
+            version: '2.0.0-next.7',
+            location: 'node_modules/@mdx-js/react',
+            dependents: [
+              {
+                type: 'prod',
+                spec: '^2.0.0-next.4',
+                from: {
+                  name: 'gatsby-recipes',
+                  version: '0.2.20',
+                  location: 'node_modules/gatsby-recipes',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^0.2.20',
+                      from: {
+                        name: 'gatsby-cli',
+                        version: '2.12.91',
+                        location: 'node_modules/gatsby-cli',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^2.12.91',
+                            from: {
+                              name: 'gatsby',
+                              version: '2.24.53',
+                              location: 'node_modules/gatsby',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '',
+                                  from: {
+                                    location: '/path/to/gatsby-user'
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                type: 'prod',
+                spec: '^2.0.0-next.7',
+                from: {
+                  name: '@mdx-js/runtime',
+                  version: '2.0.0-next.7',
+                  location: 'node_modules/@mdx-js/runtime',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^2.0.0-next.4',
+                      from: {
+                        name: 'gatsby-recipes',
+                        version: '0.2.20',
+                        location: 'node_modules/gatsby-recipes',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^0.2.20',
+                            from: {
+                              name: 'gatsby-cli',
+                              version: '2.12.91',
+                              location: 'node_modules/gatsby-cli',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '^2.12.91',
+                                  from: {
+                                    name: 'gatsby',
+                                    version: '2.24.53',
+                                    location: 'node_modules/gatsby',
+                                    dependents: [
+                                      {
+                                        type: 'prod',
+                                        spec: '',
+                                        from: {
+                                          location: '/path/to/gatsby-user'
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          type: 'peer',
+          spec: '^16.13.1',
+          from: {
+            name: '@mdx-js/runtime',
+            version: '2.0.0-next.7',
+            location: 'node_modules/@mdx-js/runtime',
+            dependents: [
+              {
+                type: 'prod',
+                spec: '^2.0.0-next.4',
+                from: {
+                  name: 'gatsby-recipes',
+                  version: '0.2.20',
+                  location: 'node_modules/gatsby-recipes',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^0.2.20',
+                      from: {
+                        name: 'gatsby-cli',
+                        version: '2.12.91',
+                        location: 'node_modules/gatsby-cli',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^2.12.91',
+                            from: {
+                              name: 'gatsby',
+                              version: '2.24.53',
+                              location: 'node_modules/gatsby',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '',
+                                  from: {
+                                    location: '/path/to/gatsby-user'
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          type: 'peer',
+          spec: '>=16.8.0',
+          from: {
+            name: 'formik',
+            version: '2.1.5',
+            location: 'node_modules/formik',
+            dependents: [
+              {
+                type: 'prod',
+                spec: '^2.0.8',
+                from: {
+                  name: 'gatsby-recipes',
+                  version: '0.2.20',
+                  location: 'node_modules/gatsby-recipes',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^0.2.20',
+                      from: {
+                        name: 'gatsby-cli',
+                        version: '2.12.91',
+                        location: 'node_modules/gatsby-cli',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^2.12.91',
+                            from: {
+                              name: 'gatsby',
+                              version: '2.24.53',
+                              location: 'node_modules/gatsby',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '',
+                                  from: {
+                                    location: '/path/to/gatsby-user'
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                type: 'peer',
+                spec: '^2.0.8',
+                from: {
+                  name: 'gatsby-interface',
+                  version: '0.0.166',
+                  location: 'node_modules/gatsby-recipes/node_modules/gatsby-interface',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^0.0.166',
+                      from: {
+                        name: 'gatsby-recipes',
+                        version: '0.2.20',
+                        location: 'node_modules/gatsby-recipes',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^0.2.20',
+                            from: {
+                              name: 'gatsby-cli',
+                              version: '2.12.91',
+                              location: 'node_modules/gatsby-cli',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '^2.12.91',
+                                  from: {
+                                    name: 'gatsby',
+                                    version: '2.24.53',
+                                    location: 'node_modules/gatsby',
+                                    dependents: [
+                                      {
+                                        type: 'prod',
+                                        spec: '',
+                                        from: {
+                                          location: '/path/to/gatsby-user'
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          type: 'peer',
+          spec: '^16.4.2',
+          from: {
+            name: 'gatsby',
+            version: '2.6.0',
+            location: 'node_modules/gatsby-recipes/node_modules/gatsby',
+            dependents: [
+              {
+                type: 'peer',
+                spec: '2.6.0',
+                from: {
+                  name: 'gatsby-interface',
+                  version: '0.0.166',
+                  location: 'node_modules/gatsby-recipes/node_modules/gatsby-interface',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^0.0.166',
+                      from: {
+                        name: 'gatsby-recipes',
+                        version: '0.2.20',
+                        location: 'node_modules/gatsby-recipes',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^0.2.20',
+                            from: {
+                              name: 'gatsby-cli',
+                              version: '2.12.91',
+                              location: 'node_modules/gatsby-cli',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '^2.12.91',
+                                  from: {
+                                    name: 'gatsby',
+                                    version: '2.24.53',
+                                    location: 'node_modules/gatsby',
+                                    dependents: [
+                                      {
+                                        type: 'prod',
+                                        spec: '',
+                                        from: {
+                                          location: '/path/to/gatsby-user'
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          type: 'peer',
+          spec: '^16.0.0',
+          from: {
+            name: 'react-dom',
+            version: '16.8.1',
+            location: 'node_modules/gatsby-recipes/node_modules/react-dom',
+            dependents: [
+              {
+                type: 'peer',
+                spec: '16.8.1',
+                from: {
+                  name: 'gatsby-interface',
+                  version: '0.0.166',
+                  location: 'node_modules/gatsby-recipes/node_modules/gatsby-interface',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^0.0.166',
+                      from: {
+                        name: 'gatsby-recipes',
+                        version: '0.2.20',
+                        location: 'node_modules/gatsby-recipes',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^0.2.20',
+                            from: {
+                              name: 'gatsby-cli',
+                              version: '2.12.91',
+                              location: 'node_modules/gatsby-cli',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '^2.12.91',
+                                  from: {
+                                    name: 'gatsby',
+                                    version: '2.24.53',
+                                    location: 'node_modules/gatsby',
+                                    dependents: [
+                                      {
+                                        type: 'prod',
+                                        spec: '',
+                                        from: {
+                                          location: '/path/to/gatsby-user'
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                type: 'peer',
+                spec: '^16.4.2',
+                from: {
+                  name: 'gatsby',
+                  version: '2.6.0',
+                  location: 'node_modules/gatsby-recipes/node_modules/gatsby',
+                  dependents: [
+                    {
+                      type: 'peer',
+                      spec: '2.6.0',
+                      from: {
+                        name: 'gatsby-interface',
+                        version: '0.0.166',
+                        location: 'node_modules/gatsby-recipes/node_modules/gatsby-interface',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^0.0.166',
+                            from: {
+                              name: 'gatsby-recipes',
+                              version: '0.2.20',
+                              location: 'node_modules/gatsby-recipes',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '^0.2.20',
+                                  from: {
+                                    name: 'gatsby-cli',
+                                    version: '2.12.91',
+                                    location: 'node_modules/gatsby-cli',
+                                    dependents: [
+                                      {
+                                        type: 'prod',
+                                        spec: '^2.12.91',
+                                        from: {
+                                          name: 'gatsby',
+                                          version: '2.24.53',
+                                          location: 'node_modules/gatsby',
+                                          dependents: [
+                                            {
+                                              type: 'prod',
+                                              spec: '',
+                                              from: {
+                                                location: '/path/to/gatsby-user'
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                type: 'peer',
+                spec: '^0.14.0 || ^15.0.0 || ^16.0.0',
+                from: {
+                  name: 'gatsby-react-router-scroll',
+                  version: '2.3.1',
+                  location: 'node_modules/gatsby-recipes/node_modules/gatsby-react-router-scroll',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^2.0.7',
+                      from: {
+                        name: 'gatsby',
+                        version: '2.6.0',
+                        location: 'node_modules/gatsby-recipes/node_modules/gatsby',
+                        dependents: [
+                          {
+                            type: 'peer',
+                            spec: '2.6.0',
+                            from: {
+                              name: 'gatsby-interface',
+                              version: '0.0.166',
+                              location: 'node_modules/gatsby-recipes/node_modules/gatsby-interface',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '^0.0.166',
+                                  from: {
+                                    name: 'gatsby-recipes',
+                                    version: '0.2.20',
+                                    location: 'node_modules/gatsby-recipes',
+                                    dependents: [
+                                      {
+                                        type: 'prod',
+                                        spec: '^0.2.20',
+                                        from: {
+                                          name: 'gatsby-cli',
+                                          version: '2.12.91',
+                                          location: 'node_modules/gatsby-cli',
+                                          dependents: [
+                                            {
+                                              type: 'prod',
+                                              spec: '^2.12.91',
+                                              from: {
+                                                name: 'gatsby',
+                                                version: '2.24.53',
+                                                location: 'node_modules/gatsby',
+                                                dependents: [
+                                                  {
+                                                    type: 'prod',
+                                                    spec: '',
+                                                    from: {
+                                                      location: '/path/to/gatsby-user'
+                                                    }
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          type: 'peer',
+          spec: '*',
+          from: {
+            name: 'react-icons',
+            version: '3.11.0',
+            location: 'node_modules/react-icons',
+            dependents: [
+              {
+                type: 'prod',
+                spec: '^3.0.1',
+                from: {
+                  name: 'gatsby-recipes',
+                  version: '0.2.20',
+                  location: 'node_modules/gatsby-recipes',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^0.2.20',
+                      from: {
+                        name: 'gatsby-cli',
+                        version: '2.12.91',
+                        location: 'node_modules/gatsby-cli',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^2.12.91',
+                            from: {
+                              name: 'gatsby',
+                              version: '2.24.53',
+                              location: 'node_modules/gatsby',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '',
+                                  from: {
+                                    location: '/path/to/gatsby-user'
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                type: 'peer',
+                spec: '^3.2.1',
+                from: {
+                  name: 'gatsby-interface',
+                  version: '0.0.166',
+                  location: 'node_modules/gatsby-recipes/node_modules/gatsby-interface',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^0.0.166',
+                      from: {
+                        name: 'gatsby-recipes',
+                        version: '0.2.20',
+                        location: 'node_modules/gatsby-recipes',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^0.2.20',
+                            from: {
+                              name: 'gatsby-cli',
+                              version: '2.12.91',
+                              location: 'node_modules/gatsby-cli',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '^2.12.91',
+                                  from: {
+                                    name: 'gatsby',
+                                    version: '2.24.53',
+                                    location: 'node_modules/gatsby',
+                                    dependents: [
+                                      {
+                                        type: 'prod',
+                                        spec: '',
+                                        from: {
+                                          location: '/path/to/gatsby-user'
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          type: 'peer',
+          spec: '>=16.8.0',
+          from: {
+            name: 'ink-box',
+            version: '1.0.0',
+            location: 'node_modules/ink-box',
+            dependents: [
+              {
+                type: 'prod',
+                spec: '^1.0.0',
+                from: {
+                  name: 'gatsby-recipes',
+                  version: '0.2.20',
+                  location: 'node_modules/gatsby-recipes',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^0.2.20',
+                      from: {
+                        name: 'gatsby-cli',
+                        version: '2.12.91',
+                        location: 'node_modules/gatsby-cli',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^2.12.91',
+                            from: {
+                              name: 'gatsby',
+                              version: '2.24.53',
+                              location: 'node_modules/gatsby',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '',
+                                  from: {
+                                    location: '/path/to/gatsby-user'
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          type: 'peer',
+          spec: '^0.14.0 || ^15.0.0 || ^16.0.0',
+          from: {
+            name: 'react-circular-progressbar',
+            version: '2.0.3',
+            location: 'node_modules/react-circular-progressbar',
+            dependents: [
+              {
+                type: 'prod',
+                spec: '^2.0.0',
+                from: {
+                  name: 'gatsby-recipes',
+                  version: '0.2.20',
+                  location: 'node_modules/gatsby-recipes',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^0.2.20',
+                      from: {
+                        name: 'gatsby-cli',
+                        version: '2.12.91',
+                        location: 'node_modules/gatsby-cli',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^2.12.91',
+                            from: {
+                              name: 'gatsby',
+                              version: '2.24.53',
+                              location: 'node_modules/gatsby',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '',
+                                  from: {
+                                    location: '/path/to/gatsby-user'
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          type: 'peer',
+          spec: '^16.13.1',
+          from: {
+            name: 'react-reconciler',
+            version: '0.25.1',
+            location: 'node_modules/react-reconciler',
+            dependents: [
+              {
+                type: 'prod',
+                spec: '^0.25.1',
+                from: {
+                  name: 'gatsby-recipes',
+                  version: '0.2.20',
+                  location: 'node_modules/gatsby-recipes',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^0.2.20',
+                      from: {
+                        name: 'gatsby-cli',
+                        version: '2.12.91',
+                        location: 'node_modules/gatsby-cli',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^2.12.91',
+                            from: {
+                              name: 'gatsby',
+                              version: '2.24.53',
+                              location: 'node_modules/gatsby',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '',
+                                  from: {
+                                    location: '/path/to/gatsby-user'
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          type: 'peer',
+          spec: '>= 16.8.0',
+          from: {
+            name: 'urql',
+            version: '1.10.0',
+            location: 'node_modules/urql',
+            dependents: [
+              {
+                type: 'prod',
+                spec: '^1.9.7',
+                from: {
+                  name: 'gatsby-recipes',
+                  version: '0.2.20',
+                  location: 'node_modules/gatsby-recipes',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^0.2.20',
+                      from: {
+                        name: 'gatsby-cli',
+                        version: '2.12.91',
+                        location: 'node_modules/gatsby-cli',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^2.12.91',
+                            from: {
+                              name: 'gatsby',
+                              version: '2.24.53',
+                              location: 'node_modules/gatsby',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '',
+                                  from: {
+                                    location: '/path/to/gatsby-user'
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          type: 'peer',
+          spec: '>=16.3.0',
+          from: {
+            name: '@emotion/styled-base',
+            version: '10.0.31',
+            location: 'node_modules/@emotion/styled-base',
+            dependents: [
+              {
+                type: 'prod',
+                spec: '^10.0.27',
+                from: {
+                  name: '@emotion/styled',
+                  version: '10.0.27',
+                  location: 'node_modules/@emotion/styled',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^10.0.14',
+                      from: {
+                        name: 'gatsby-recipes',
+                        version: '0.2.20',
+                        location: 'node_modules/gatsby-recipes',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^0.2.20',
+                            from: {
+                              name: 'gatsby-cli',
+                              version: '2.12.91',
+                              location: 'node_modules/gatsby-cli',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '^2.12.91',
+                                  from: {
+                                    name: 'gatsby',
+                                    version: '2.24.53',
+                                    location: 'node_modules/gatsby',
+                                    dependents: [
+                                      {
+                                        type: 'prod',
+                                        spec: '',
+                                        from: {
+                                          location: '/path/to/gatsby-user'
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      type: 'peer',
+                      spec: '^10.0.14',
+                      from: {
+                        name: 'gatsby-interface',
+                        version: '0.0.166',
+                        location: 'node_modules/gatsby-recipes/node_modules/gatsby-interface',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^0.0.166',
+                            from: {
+                              name: 'gatsby-recipes',
+                              version: '0.2.20',
+                              location: 'node_modules/gatsby-recipes',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '^0.2.20',
+                                  from: {
+                                    name: 'gatsby-cli',
+                                    version: '2.12.91',
+                                    location: 'node_modules/gatsby-cli',
+                                    dependents: [
+                                      {
+                                        type: 'prod',
+                                        spec: '^2.12.91',
+                                        from: {
+                                          name: 'gatsby',
+                                          version: '2.24.53',
+                                          location: 'node_modules/gatsby',
+                                          dependents: [
+                                            {
+                                              type: 'prod',
+                                              spec: '',
+                                              from: {
+                                                location: '/path/to/gatsby-user'
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          type: 'peer',
+          spec: '^16.0.0',
+          from: {
+            name: 'react-reconciler',
+            version: '0.24.0',
+            location: 'node_modules/ink/node_modules/react-reconciler',
+            dependents: [
+              {
+                type: 'prod',
+                spec: '^0.24.0',
+                from: {
+                  name: 'ink',
+                  version: '2.7.1',
+                  location: 'node_modules/ink',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^2.7.1',
+                      from: {
+                        name: 'gatsby-cli',
+                        version: '2.12.91',
+                        location: 'node_modules/gatsby-cli',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^2.12.91',
+                            from: {
+                              name: 'gatsby',
+                              version: '2.24.53',
+                              location: 'node_modules/gatsby',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '',
+                                  from: {
+                                    location: '/path/to/gatsby-user'
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      type: 'peer',
+                      spec: '^2.0.0',
+                      from: {
+                        name: 'ink-spinner',
+                        version: '3.1.0',
+                        location: 'node_modules/ink-spinner',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^3.1.0',
+                            from: {
+                              name: 'gatsby-cli',
+                              version: '2.12.91',
+                              location: 'node_modules/gatsby-cli',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '^2.12.91',
+                                  from: {
+                                    name: 'gatsby',
+                                    version: '2.24.53',
+                                    location: 'node_modules/gatsby',
+                                    dependents: [
+                                      {
+                                        type: 'prod',
+                                        spec: '',
+                                        from: {
+                                          location: '/path/to/gatsby-user'
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      type: 'peer',
+                      spec: '>=2.0.0',
+                      from: {
+                        name: 'ink-box',
+                        version: '1.0.0',
+                        location: 'node_modules/ink-box',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^1.0.0',
+                            from: {
+                              name: 'gatsby-recipes',
+                              version: '0.2.20',
+                              location: 'node_modules/gatsby-recipes',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '^0.2.20',
+                                  from: {
+                                    name: 'gatsby-cli',
+                                    version: '2.12.91',
+                                    location: 'node_modules/gatsby-cli',
+                                    dependents: [
+                                      {
+                                        type: 'prod',
+                                        spec: '^2.12.91',
+                                        from: {
+                                          name: 'gatsby',
+                                          version: '2.24.53',
+                                          location: 'node_modules/gatsby',
+                                          dependents: [
+                                            {
+                                              type: 'prod',
+                                              spec: '',
+                                              from: {
+                                                location: '/path/to/gatsby-user'
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          type: 'peer',
+          spec: '^0.14.0 || ^15.0.0 || ^16.0.0',
+          from: {
+            name: 'gatsby-react-router-scroll',
+            version: '2.3.1',
+            location: 'node_modules/gatsby-recipes/node_modules/gatsby-react-router-scroll',
+            dependents: [
+              {
+                type: 'prod',
+                spec: '^2.0.7',
+                from: {
+                  name: 'gatsby',
+                  version: '2.6.0',
+                  location: 'node_modules/gatsby-recipes/node_modules/gatsby',
+                  dependents: [
+                    {
+                      type: 'peer',
+                      spec: '2.6.0',
+                      from: {
+                        name: 'gatsby-interface',
+                        version: '0.0.166',
+                        location: 'node_modules/gatsby-recipes/node_modules/gatsby-interface',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^0.0.166',
+                            from: {
+                              name: 'gatsby-recipes',
+                              version: '0.2.20',
+                              location: 'node_modules/gatsby-recipes',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '^0.2.20',
+                                  from: {
+                                    name: 'gatsby-cli',
+                                    version: '2.12.91',
+                                    location: 'node_modules/gatsby-cli',
+                                    dependents: [
+                                      {
+                                        type: 'prod',
+                                        spec: '^2.12.91',
+                                        from: {
+                                          name: 'gatsby',
+                                          version: '2.24.53',
+                                          location: 'node_modules/gatsby',
+                                          dependents: [
+                                            {
+                                              type: 'prod',
+                                              spec: '',
+                                              from: {
+                                                location: '/path/to/gatsby-user'
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        {
+          type: 'peer',
+          spec: '^16.13.1',
+          from: {
+            name: '@mdx-js/react',
+            version: '1.6.16',
+            location: 'node_modules/gatsby-recipes/node_modules/gatsby-interface/node_modules/@mdx-js/react',
+            dependents: [
+              {
+                type: 'prod',
+                spec: '^1.5.2',
+                from: {
+                  name: 'gatsby-interface',
+                  version: '0.0.166',
+                  location: 'node_modules/gatsby-recipes/node_modules/gatsby-interface',
+                  dependents: [
+                    {
+                      type: 'prod',
+                      spec: '^0.0.166',
+                      from: {
+                        name: 'gatsby-recipes',
+                        version: '0.2.20',
+                        location: 'node_modules/gatsby-recipes',
+                        dependents: [
+                          {
+                            type: 'prod',
+                            spec: '^0.2.20',
+                            from: {
+                              name: 'gatsby-cli',
+                              version: '2.12.91',
+                              location: 'node_modules/gatsby-cli',
+                              dependents: [
+                                {
+                                  type: 'prod',
+                                  spec: '^2.12.91',
+                                  from: {
+                                    name: 'gatsby',
+                                    version: '2.24.53',
+                                    location: 'node_modules/gatsby',
+                                    dependents: [
+                                      {
+                                        type: 'prod',
+                                        spec: '',
+                                        from: {
+                                          location: '/path/to/gatsby-user'
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    peerConflict: null,
+    fixWithForce: true,
+    type: 'peer',
+    isPeer: true
+  }
+}

--- a/test/lib/utils/explain-eresolve.js
+++ b/test/lib/utils/explain-eresolve.js
@@ -1,0 +1,50 @@
+const t = require('tap')
+const requireInject = require('require-inject')
+const npm = {}
+const { explain, report } = requireInject('../../../lib/utils/explain-eresolve.js', {
+  '../../../lib/npm.js': npm
+})
+const { statSync, readFileSync, unlinkSync } = require('fs')
+// strip out timestamps from reports
+const read = f => readFileSync(f, 'utf8')
+  .replace(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/g, '${TIME}')
+
+const { resolve } = require('path')
+
+const cases = require('../../fixtures/eresolve-explanations.js')
+
+for (const [name, expl] of Object.entries(cases)) {
+  // no sense storing the whole contents of each object in the snapshot
+  // we can trust that JSON.stringify still works just fine.
+  expl.toJSON = () => {
+    return { name, json: true }
+  }
+
+  t.test(name, t => {
+    npm.cache = t.testdir()
+    const reportFile = resolve(npm.cache, 'eresolve-report.txt')
+    t.cleanSnapshot = str => str.split(reportFile).join('${REPORT}')
+
+    npm.color = true
+    t.matchSnapshot(report(expl), 'report with color')
+    const reportData = read(reportFile)
+    t.matchSnapshot(reportData, 'report')
+    unlinkSync(reportFile)
+    t.matchSnapshot(report(expl, 2), 'report with color, depth only 2')
+    t.equal(read(reportFile), reportData, 'same report written for object')
+    unlinkSync(reportFile)
+    npm.color = false
+    t.matchSnapshot(report(expl, 6), 'report with no color, depth of 6')
+    t.equal(read(reportFile), reportData, 'same report written for object')
+
+    unlinkSync(reportFile)
+    npm.color = true
+    t.matchSnapshot(explain(expl), 'explain with color')
+    t.throws(() => statSync(reportFile), { code: 'ENOENT' }, 'no report')
+    npm.color = false
+    t.matchSnapshot(explain(expl, 6), 'explain with no color, depth of 6')
+    t.throws(() => statSync(reportFile), { code: 'ENOENT' }, 'no report')
+
+    t.end()
+  })
+}

--- a/test/lib/utils/setup-log.js
+++ b/test/lib/utils/setup-log.js
@@ -7,30 +7,43 @@ t.afterEach(cb => {
   cb()
 })
 
+const WARN_CALLED = []
+const npmlog = {
+  level: 'warn',
+  warn: (...args) => {
+    WARN_CALLED.push(args)
+  },
+  levels: {
+    silly: -Infinity,
+    verbose: 1000,
+    info: 2000,
+    timing: 2500,
+    http: 3000,
+    notice: 3500,
+    warn: 4000,
+    error: 5000,
+    silent: Infinity
+  },
+  settings,
+  enableColor: () => { settings.color = true },
+  disableColor: () => { settings.color = false },
+  enableUnicode: () => { settings.unicode = true },
+  disableUnicode: () => { settings.unicode = false },
+  enableProgress: () => { settings.progress = true },
+  disableProgress: () => { settings.progress = false },
+  set heading (h) { settings.heading = h },
+  set level (l) { settings.level = l }
+}
+
+const EXPLAIN_CALLED = []
 const setupLog = requireInject('../../../lib/utils/setup-log.js', {
-  npmlog: {
-    level: 'warn',
-    levels: {
-      silly: -Infinity,
-      verbose: 1000,
-      info: 2000,
-      timing: 2500,
-      http: 3000,
-      notice: 3500,
-      warn: 4000,
-      error: 5000,
-      silent: Infinity
-    },
-    settings,
-    enableColor: () => { settings.color = true },
-    disableColor: () => { settings.color = false },
-    enableUnicode: () => { settings.unicode = true },
-    disableUnicode: () => { settings.unicode = false },
-    enableProgress: () => { settings.progress = true },
-    disableProgress: () => { settings.progress = false },
-    set heading (h) { settings.heading = h },
-    set level (l) { settings.level = l }
-  }
+  '../../../lib/utils/explain-eresolve.js': {
+    explain: (...args) => {
+      EXPLAIN_CALLED.push(args)
+      return 'explanation'
+    }
+  },
+  npmlog
 })
 
 const config = obj => ({
@@ -43,12 +56,30 @@ const config = obj => ({
 })
 
 t.test('setup with color=always and unicode', t => {
+  npmlog.warn('ERESOLVE', 'hello', { some: 'object' })
+  t.strictSame(EXPLAIN_CALLED, [], 'log.warn() not patched yet')
+  t.strictSame(WARN_CALLED, [['ERESOLVE', 'hello', { some: 'object' }]])
+  WARN_CALLED.length = 0
+
   t.equal(setupLog(config({
     loglevel: 'warn',
     color: 'always',
     unicode: true,
     progress: false
   })), true)
+
+  npmlog.warn('ERESOLVE', 'hello', { some: { other: 'object' } })
+  t.strictSame(EXPLAIN_CALLED, [[{ some: { other: 'object' } }]],
+    'log.warn(ERESOLVE) patched to call explainEresolve()')
+  t.strictSame(WARN_CALLED, [
+    ['ERESOLVE', 'hello'],
+    ['', 'explanation']
+  ], 'warn the explanation')
+  EXPLAIN_CALLED.length = 0
+  WARN_CALLED.length = 0
+  npmlog.warn('some', 'other', 'thing')
+  t.strictSame(EXPLAIN_CALLED, [], 'do not try to explain other things')
+  t.strictSame(WARN_CALLED, [['some', 'other', 'thing']], 'warnings passed through')
 
   t.strictSame(settings, {
     level: 'warn',


### PR DESCRIPTION
When peerDependencies conflict, Arborist is now providing details of the
nodes and their reasons for inclusion on the Error object, including
whether or not this resolution error could be overridden using the
--force flag.

Print this data out in a minimal way as a warning if we override an
ERESOLVE forcefully.  When the ERESOLVE causes the install to fail,
print a somewhat longer message, and save a MUCH longer full report to
the cache folder.
