### PR TITLE
Add 'npm explain' command

### DIFF
--- a/docs/content/cli-commands/npm-explain.md
+++ b/docs/content/cli-commands/npm-explain.md
@@ -1,0 +1,77 @@
+---
+section: cli-commands
+title: npm-explain
+description: Explain installed packages
+---
+
+# npm-explain(1)
+
+## Explain installed packages
+
+### Synopsis
+
+```bash
+npm explain <folder | specifier>
+```
+
+### Description
+
+This command will print the chain of dependencies causing a given package
+to be installed in the current project.
+
+Positional arguments can be either folders within `node_modules`, or
+`name@version-range` specifiers, which will select the dependency
+relationships to explain.
+
+For example, running `npm explain glob` within npm's source tree will show:
+
+```bash
+glob@7.1.6
+node_modules/glob
+  glob@"^7.1.4" from the root project
+
+glob@7.1.1 dev
+node_modules/tacks/node_modules/glob
+  glob@"^7.0.5" from rimraf@2.6.2
+  node_modules/tacks/node_modules/rimraf
+    rimraf@"^2.6.2" from tacks@1.3.0
+    node_modules/tacks
+      dev tacks@"^1.3.0" from the root project
+```
+
+To explain just the package residing at a specific folder, pass that as the
+argument to the command.  This can be useful when trying to figure out
+exactly why a given dependency is being duplicated to satisfy conflicting
+version requirements within the project.
+
+```bash
+$ npm explain node_modules/nyc/node_modules/find-up
+find-up@3.0.0 dev
+node_modules/nyc/node_modules/find-up
+  find-up@"^3.0.0" from nyc@14.1.1
+  node_modules/nyc
+    nyc@"^14.1.1" from tap@14.10.8
+    node_modules/tap
+      dev tap@"^14.10.8" from the root project
+```
+
+### Configuration
+
+#### json
+
+* Default: false
+* Type: Bolean
+
+Show information in JSON format.
+
+### See Also
+
+* [npm config](/cli-commands/config)
+* [npmrc](/configuring-npm/npmrc)
+* [npm folders](/configuring-npm/folders)
+* [npm ls](/cli-commands/ls)
+* [npm install](/cli-commands/install)
+* [npm link](/cli-commands/link)
+* [npm prune](/cli-commands/prune)
+* [npm outdated](/cli-commands/outdated)
+* [npm update](/cli-commands/update)

--- a/docs/content/cli-commands/npm-ls.md
+++ b/docs/content/cli-commands/npm-ls.md
@@ -1,5 +1,5 @@
 ---
-section: cli-commands 
+section: cli-commands
 title: npm-ls
 description: List installed packages
 ---
@@ -122,6 +122,7 @@ Set it to false in order to use all-ansi output.
 * [npm config](/cli-commands/config)
 * [npmrc](/configuring-npm/npmrc)
 * [npm folders](/configuring-npm/folders)
+* [npm explain](/cli-commands/explain)
 * [npm install](/cli-commands/install)
 * [npm link](/cli-commands/link)
 * [npm prune](/cli-commands/prune)

--- a/lib/explain.js
+++ b/lib/explain.js
@@ -1,0 +1,100 @@
+const usageUtil = require('./utils/usage.js')
+const npm = require('./npm.js')
+const { explainNode } = require('./utils/explain-dep.js')
+const completion = require('./utils/completion/installed-deep.js')
+const output = require('./utils/output.js')
+const Arborist = require('@npmcli/arborist')
+const npa = require('npm-package-arg')
+const semver = require('semver')
+const { relative, resolve } = require('path')
+const validName = require('validate-npm-package-name')
+
+const usage = usageUtil('explain', 'npm explain <folder | specifier>')
+
+const cmd = (args, cb) => explain(args).then(() => cb()).catch(cb)
+
+const explain = async (args) => {
+  if (!args.length) {
+    throw usage
+  }
+
+  const arb = new Arborist({ path: npm.prefix, ...npm.flatOptions })
+  const tree = await arb.loadActual()
+
+  const nodes = new Set()
+  for (const arg of args) {
+    for (const node of getNodes(tree, arg)) {
+      nodes.add(node)
+    }
+  }
+  if (nodes.size === 0) {
+    throw `No dependencies found matching ${args.join(', ')}`
+  }
+
+  const expls = []
+  for (const node of nodes) {
+    const { extraneous, dev, optional, devOptional, peer } = node
+    const expl = node.explain()
+    if (extraneous) {
+      expl.extraneous = true
+    } else {
+      expl.dev = dev
+      expl.optional = optional
+      expl.devOptional = devOptional
+      expl.peer = peer
+    }
+    expls.push(expl)
+  }
+
+  if (npm.flatOptions.json) {
+    output(JSON.stringify(expls, null, 2))
+  } else {
+    output(expls.map(expl => {
+      return explainNode(expl, Infinity, npm.color)
+    }).join('\n\n'))
+  }
+}
+
+const getNodes = (tree, arg) => {
+  // if it's just a name, return packages by that name
+  const { validForOldPackages: valid } = validName(arg)
+  if (valid) {
+    return tree.inventory.query('name', arg)
+  }
+
+  // if it's a location, get that node
+  const maybeLoc = arg.replace(/\\/g, '/').replace(/\/+$/, '')
+  const nodeByLoc = tree.inventory.get(maybeLoc)
+  if (nodeByLoc) {
+    return [nodeByLoc]
+  }
+
+  // maybe a path to a node_modules folder
+  const maybePath = relative(npm.prefix, resolve(maybeLoc))
+    .replace(/\\/g, '/').replace(/\/+$/, '')
+  const nodeByPath = tree.inventory.get(maybePath)
+  if (nodeByPath) {
+    return [nodeByPath]
+  }
+
+  // otherwise, try to select all matching nodes
+  try {
+    return getNodesByVersion(tree, arg)
+  } catch (er) {
+    return []
+  }
+}
+
+const getNodesByVersion = (tree, arg) => {
+  const spec = npa(arg, npm.prefix)
+  if (spec.type !== 'version' && spec.type !== 'range') {
+    return []
+  }
+
+  return tree.inventory.filter(node => {
+    return node.package.name === spec.name &&
+      semver.satisfies(node.package.version, spec.rawSpec)
+  })
+}
+
+module.exports = Object.assign(cmd, { usage, completion })

--- a/lib/utils/cmd-list.js
+++ b/lib/utils/cmd-list.js
@@ -20,7 +20,8 @@ const shorthands = {
   run: 'run-script',
   'clean-install': 'ci',
   'clean-install-test': 'cit',
-  x: 'exec'
+  x: 'exec',
+  why: 'explain'
 }
 
 const affordances = {
@@ -128,7 +129,8 @@ const cmdList = [
   'run-script',
   'completion',
   'doctor',
-  'exec'
+  'exec',
+  'explain'
 ]
 
 const plumbing = ['birthday', 'help-search']

--- a/lib/utils/explain-dep.js
+++ b/lib/utils/explain-dep.js
@@ -1,0 +1,101 @@
+const chalk = require('chalk')
+const nocolor = {
+  bold: s => s,
+  dim: s => s,
+  red: s => s,
+  yellow: s => s,
+  cyan: s => s,
+  magenta: s => s
+}
+
+const explainNode = (node, depth, color) =>
+  printNode(node, color) +
+  explainDependents(node, depth, color)
+
+const colorType = (type, color) => {
+  const { red, yellow, cyan, magenta } = color ? chalk : nocolor
+  const style = type === 'extraneous' ? red
+    : type === 'dev' ? yellow
+    : type === 'optional' ? cyan
+    : type === 'peer' ? magenta
+    : /* istanbul ignore next */ s => s
+  return style(type)
+}
+
+const printNode = (node, color) => {
+  const {
+    name,
+    version,
+    location,
+    extraneous,
+    dev,
+    optional,
+    peer
+  } = node
+  const { bold, dim } = color ? chalk : nocolor
+  const extra = []
+  if (extraneous) {
+    extra.push(' ' + bold(colorType('extraneous', color)))
+  }
+  if (dev) {
+    extra.push(' ' + bold(colorType('dev', color)))
+  }
+  if (optional) {
+    extra.push(' ' + bold(colorType('optional', color)))
+  }
+  if (peer) {
+    extra.push(' ' + bold(colorType('peer', color)))
+  }
+
+  return `${bold(name)}@${bold(version)}${extra.join('')}` +
+    (location ? dim(`\n${location}`) : '')
+}
+
+const explainDependents = ({ name, dependents }, depth, color) => {
+  if (!dependents || !dependents.length || depth <= 0) {
+    return ''
+  }
+
+  const max = Math.ceil(depth / 2)
+  const messages = dependents.slice(0, max)
+    .map(dep => explainDependency(name, dep, depth, color))
+
+  // show just the names of the first 5 deps that overflowed the list
+  if (dependents.length > max) {
+    let len = 0
+    const maxLen = 30
+    const showNames = []
+    for (let i = max; i < dependents.length; i++) {
+      const { from: { name } } = dependents[i]
+      len += name.length
+      if (len >= maxLen && i < dependents.length - 1) {
+        showNames.push('...')
+        break
+      }
+      showNames.push(name)
+    }
+    const show = `(${showNames.join(', ')})`
+    messages.push(`${dependents.length - max} more ${show}`)
+  }
+
+  const str = '\n' + messages.join('\n')
+  return str.split('\n').join('\n  ')
+}
+
+const explainDependency = (name, { type, from, spec }, depth, color) => {
+  const { bold } = color ? chalk : nocolor
+  return (type === 'prod' ? '' : `${colorType(type, color)} `) +
+    `${bold(name)}@"${bold(spec)}" from ` +
+    explainFrom(from, depth, color)
+}
+
+const explainFrom = (from, depth, color) => {
+  if (!from.name && !from.version) {
+    return 'the root project'
+  }
+
+  return printNode(from, color) +
+    explainDependents(from, depth - 1, color)
+}
+
+module.exports = { explainNode, printNode }

--- a/lib/utils/explain-dep.js
+++ b/lib/utils/explain-dep.js
@@ -63,7 +63,7 @@ const explainDependents = ({ name, dependents }, depth, color) => {
   // show just the names of the first 5 deps that overflowed the list
   if (dependents.length > max) {
     let len = 0
-    const maxLen = 30
+    const maxLen = 50
     const showNames = []
     for (let i = max; i < dependents.length; i++) {
       const { from: { name } } = dependents[i]

--- a/lib/utils/explain-eresolve.js
+++ b/lib/utils/explain-eresolve.js
@@ -8,12 +8,7 @@
 const npm = require('../npm.js')
 const { writeFileSync } = require('fs')
 const { resolve } = require('path')
-
-const chalk = require('chalk')
-const nocolor = {
-  bold: s => s,
-  dim: s => s
-}
+const { explainNode, printNode } = require('./explain-dep.js')
 
 // expl is an explanation object that comes from Arborist.  It looks like:
 // {
@@ -50,67 +45,18 @@ const explainEresolve = (expl, color, depth) => {
     out.push('While resolving: ' + printNode(dep.whileInstalling, color))
   }
 
-  out.push(explainNode('Found:', current, depth, color))
+  out.push('Found: ' + explainNode(current, depth, color))
 
-  out.push(explainNode('\nCould not add conflicting dependency:', dep, depth, color))
+  out.push('\nCould not add conflicting dependency: ' +
+    explainNode(dep, depth, color))
 
   if (peerConflict) {
     const heading = '\nConflicting peer dependency:'
-    const pc = explainNode(heading, peerConflict, depth, color)
-    out.push(pc)
+    const pc = explainNode(peerConflict, depth, color)
+    out.push(heading + ' ' + pc)
   }
 
   return out.join('\n')
-}
-
-const explainNode = (heading, node, depth, color) =>
-  `${heading} ${printNode(node, color)}` +
-  explainDependents(node, depth, color)
-
-const printNode = ({ name, version, location }, color) => {
-  const { bold, dim } = color ? chalk : nocolor
-  return `${bold(name)}@${bold(version)}` +
-    (location ? dim(` at ${location}`) : '')
-}
-
-const explainDependents = ({ name, dependents }, depth, color) => {
-  if (!dependents || !dependents.length || depth <= 0) {
-    return ''
-  }
-
-  const max = Math.ceil(depth / 2)
-  const messages = dependents.slice(0, max)
-    .map(dep => explainDependency(name, dep, depth, color))
-
-  // show just the names of the first 5 deps that overflowed the list
-  if (dependents.length > max) {
-    const names = dependents.slice(max).map(d => d.from.name)
-    const showNames = names.slice(0, 5)
-    if (showNames.length < names.length) {
-      showNames.push('...')
-    }
-    const show = `(${showNames.join(', ')})`
-    messages.push(`${names.length} more ${show}`)
-  }
-
-  const str = '\nfor: ' + messages.join('\nand: ')
-  return str.split('\n').join('\n  ')
-}
-
-const explainDependency = (name, { type, from, spec }, depth, color) => {
-  const { bold } = color ? chalk : nocolor
-  return `${type} dependency ` +
-    `${bold(name)}@"${bold(spec)}"\nfrom: ` +
-    explainFrom(from, depth, color)
-}
-
-const explainFrom = (from, depth, color) => {
-  if (!from.name && !from.version) {
-    return 'the root project'
-  }
-
-  return printNode(from, color) +
-    explainDependents(from, depth - 1, color)
 }
 
 // generate a full verbose report and tell the user how to fix it

--- a/tap-snapshots/test-lib-utils-cmd-list.js-TAP.test.js
+++ b/tap-snapshots/test-lib-utils-cmd-list.js-TAP.test.js
@@ -100,6 +100,7 @@ Object {
     "urn": "run-script",
     "v": "view",
     "verison": "version",
+    "why": "explain",
     "x": "exec",
   },
   "cmdList": Array [
@@ -164,6 +165,7 @@ Object {
     "completion",
     "doctor",
     "exec",
+    "explain",
   ],
   "plumbing": Array [
     "birthday",
@@ -190,6 +192,7 @@ Object {
     "unstar": "star",
     "up": "update",
     "v": "view",
+    "why": "explain",
     "x": "exec",
   },
 }

--- a/tap-snapshots/test-lib-utils-explain-dep.js-TAP.test.js
+++ b/tap-snapshots/test-lib-utils-explain-dep.js-TAP.test.js
@@ -1,0 +1,178 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/lib/utils/explain-dep.js TAP > ellipses test one 1`] = `
+manydep@1.0.0
+  manydep@"1.0.0" from prod-dep@1.2.3
+  node_modules/prod-dep
+    prod-dep@"1.x" from the root project
+  6 more (optdep, extra-neos, deep-dev, peer, ...)
+`
+
+exports[`test/lib/utils/explain-dep.js TAP > ellipses test two 1`] = `
+manydep@1.0.0
+  manydep@"1.0.0" from prod-dep@1.2.3
+  node_modules/prod-dep
+    prod-dep@"1.x" from the root project
+  5 more (optdep, extra-neos, deep-dev, peer, a package with a pretty long name)
+`
+
+exports[`test/lib/utils/explain-dep.js TAP deepDev > explain color deep 1`] = `
+[1mdeep-dev[22m@[1m2.3.4[22m [1m[33mdev[39m[22m[2m[22m
+[2mnode_modules/deep-dev[22m
+  [1mdeep-dev[22m@"[1m2.x[22m" from [1mmetadev[22m@[1m3.4.5[22m[2m[22m
+  [2mnode_modules/dev/node_modules/metadev[22m
+    [1mmetadev[22m@"[1m3.x[22m" from [1mtopdev[22m@[1m4.5.6[22m[2m[22m
+    [2mnode_modules/topdev[22m
+      [33mdev[39m [1mtopdev[22m@"[1m4.x[22m" from the root project
+`
+
+exports[`test/lib/utils/explain-dep.js TAP deepDev > explain nocolor shallow 1`] = `
+deep-dev@2.3.4 dev
+node_modules/deep-dev
+  deep-dev@"2.x" from metadev@3.4.5
+  node_modules/dev/node_modules/metadev
+    metadev@"3.x" from topdev@4.5.6
+    node_modules/topdev
+`
+
+exports[`test/lib/utils/explain-dep.js TAP deepDev > print color 1`] = `
+[1mdeep-dev[22m@[1m2.3.4[22m [1m[33mdev[39m[22m[2m[22m
+[2mnode_modules/deep-dev[22m
+`
+
+exports[`test/lib/utils/explain-dep.js TAP deepDev > print nocolor 1`] = `
+deep-dev@2.3.4 dev
+node_modules/deep-dev
+`
+
+exports[`test/lib/utils/explain-dep.js TAP extraneous > explain color deep 1`] = `
+[1mextra-neos[22m@[1m1337.420.69-lol[22m [1m[31mextraneous[39m[22m[2m[22m
+[2mnode_modules/extra-neos[22m
+`
+
+exports[`test/lib/utils/explain-dep.js TAP extraneous > explain nocolor shallow 1`] = `
+extra-neos@1337.420.69-lol extraneous
+node_modules/extra-neos
+`
+
+exports[`test/lib/utils/explain-dep.js TAP extraneous > print color 1`] = `
+[1mextra-neos[22m@[1m1337.420.69-lol[22m [1m[31mextraneous[39m[22m[2m[22m
+[2mnode_modules/extra-neos[22m
+`
+
+exports[`test/lib/utils/explain-dep.js TAP extraneous > print nocolor 1`] = `
+extra-neos@1337.420.69-lol extraneous
+node_modules/extra-neos
+`
+
+exports[`test/lib/utils/explain-dep.js TAP manyDeps > explain color deep 1`] = `
+[1mmanydep[22m@[1m1.0.0[22m
+  [1mmanydep[22m@"[1m1.0.0[22m" from [1mprod-dep[22m@[1m1.2.3[22m[2m[22m
+  [2mnode_modules/prod-dep[22m
+    [1mprod-dep[22m@"[1m1.x[22m" from the root project
+  [36moptional[39m [1mmanydep[22m@"[1m1.x[22m" from [1moptdep[22m@[1m1.0.0[22m [1m[36moptional[39m[22m[2m[22m
+  [2mnode_modules/optdep[22m
+    optdep [1moptdep[22m@"[1m1.0.0[22m" from the root project
+  [1mmanydep[22m@"[1m1.0.x[22m" from [1mextra-neos[22m@[1m1337.420.69-lol[22m [1m[31mextraneous[39m[22m[2m[22m
+  [2mnode_modules/extra-neos[22m
+  [33mdev[39m [1mmanydep[22m@"[1m*[22m" from [1mdeep-dev[22m@[1m2.3.4[22m [1m[33mdev[39m[22m[2m[22m
+  [2mnode_modules/deep-dev[22m
+    [1mdeep-dev[22m@"[1m2.x[22m" from [1mmetadev[22m@[1m3.4.5[22m[2m[22m
+    [2mnode_modules/dev/node_modules/metadev[22m
+      [1mmetadev[22m@"[1m3.x[22m" from [1mtopdev[22m@[1m4.5.6[22m[2m[22m
+      [2mnode_modules/topdev[22m
+        [33mdev[39m [1mtopdev[22m@"[1m4.x[22m" from the root project
+  [35mpeer[39m [1mmanydep[22m@"[1m>1.0.0-beta <1.0.1[22m" from [1mpeer[22m@[1m1.0.0[22m [1m[35mpeer[39m[22m[2m[22m
+  [2mnode_modules/peer[22m
+    [35mpeer[39m [1mpeer[22m@"[1m1.0.0[22m" from the root project
+  [1mmanydep[22m@"[1m1[22m" from [1ma package with a pretty long name[22m@[1m1.2.3[22m
+  [1mmanydep[22m@"[1m1[22m" from [1manother package with a pretty long name[22m@[1m1.2.3[22m
+  [1mmanydep[22m@"[1m1[22m" from [1myet another a package with a pretty long name[22m@[1m1.2.3[22m
+`
+
+exports[`test/lib/utils/explain-dep.js TAP manyDeps > explain nocolor shallow 1`] = `
+manydep@1.0.0
+  manydep@"1.0.0" from prod-dep@1.2.3
+  node_modules/prod-dep
+    prod-dep@"1.x" from the root project
+  7 more (optdep, extra-neos, deep-dev, peer, ...)
+`
+
+exports[`test/lib/utils/explain-dep.js TAP manyDeps > print color 1`] = `
+[1mmanydep[22m@[1m1.0.0[22m
+`
+
+exports[`test/lib/utils/explain-dep.js TAP manyDeps > print nocolor 1`] = `
+manydep@1.0.0
+`
+
+exports[`test/lib/utils/explain-dep.js TAP optional > explain color deep 1`] = `
+[1moptdep[22m@[1m1.0.0[22m [1m[36moptional[39m[22m[2m[22m
+[2mnode_modules/optdep[22m
+  optdep [1moptdep[22m@"[1m1.0.0[22m" from the root project
+`
+
+exports[`test/lib/utils/explain-dep.js TAP optional > explain nocolor shallow 1`] = `
+optdep@1.0.0 optional
+node_modules/optdep
+  optdep optdep@"1.0.0" from the root project
+`
+
+exports[`test/lib/utils/explain-dep.js TAP optional > print color 1`] = `
+[1moptdep[22m@[1m1.0.0[22m [1m[36moptional[39m[22m[2m[22m
+[2mnode_modules/optdep[22m
+`
+
+exports[`test/lib/utils/explain-dep.js TAP optional > print nocolor 1`] = `
+optdep@1.0.0 optional
+node_modules/optdep
+`
+
+exports[`test/lib/utils/explain-dep.js TAP peer > explain color deep 1`] = `
+[1mpeer[22m@[1m1.0.0[22m [1m[35mpeer[39m[22m[2m[22m
+[2mnode_modules/peer[22m
+  [35mpeer[39m [1mpeer[22m@"[1m1.0.0[22m" from the root project
+`
+
+exports[`test/lib/utils/explain-dep.js TAP peer > explain nocolor shallow 1`] = `
+peer@1.0.0 peer
+node_modules/peer
+  peer peer@"1.0.0" from the root project
+`
+
+exports[`test/lib/utils/explain-dep.js TAP peer > print color 1`] = `
+[1mpeer[22m@[1m1.0.0[22m [1m[35mpeer[39m[22m[2m[22m
+[2mnode_modules/peer[22m
+`
+
+exports[`test/lib/utils/explain-dep.js TAP peer > print nocolor 1`] = `
+peer@1.0.0 peer
+node_modules/peer
+`
+
+exports[`test/lib/utils/explain-dep.js TAP prodDep > explain color deep 1`] = `
+[1mprod-dep[22m@[1m1.2.3[22m[2m[22m
+[2mnode_modules/prod-dep[22m
+  [1mprod-dep[22m@"[1m1.x[22m" from the root project
+`
+
+exports[`test/lib/utils/explain-dep.js TAP prodDep > explain nocolor shallow 1`] = `
+prod-dep@1.2.3
+node_modules/prod-dep
+  prod-dep@"1.x" from the root project
+`
+
+exports[`test/lib/utils/explain-dep.js TAP prodDep > print color 1`] = `
+[1mprod-dep[22m@[1m1.2.3[22m[2m[22m
+[2mnode_modules/prod-dep[22m
+`
+
+exports[`test/lib/utils/explain-dep.js TAP prodDep > print nocolor 1`] = `
+prod-dep@1.2.3
+node_modules/prod-dep
+`

--- a/tap-snapshots/test-lib-utils-explain-eresolve.js-TAP.test.js
+++ b/tap-snapshots/test-lib-utils-explain-eresolve.js-TAP.test.js
@@ -170,7 +170,7 @@ Found: [1mreact[22m@[1m16.13.1[22m[2m[22m
   [35mpeer[39m [1mreact[22m@"[1m^16.4.2[22m" from [1mgatsby[22m@[1m2.24.53[22m[2m[22m
   [2mnode_modules/gatsby[22m
     [1mgatsby[22m@"" from the root project
-  26 more (react-dom, @reach/router, gatsby-cli, ...)
+  26 more (react-dom, @reach/router, gatsby-cli, gatsby-link, ...)
 
 Could not add conflicting dependency: [1mreact[22m@[1m16.8.1[22m[2m[22m
 [2mnode_modules/react[22m
@@ -734,7 +734,7 @@ Found: [1mreact[22m@[1m16.13.1[22m[2m[22m
   [35mpeer[39m [1mreact[22m@"[1m^16.4.2[22m" from [1mgatsby[22m@[1m2.24.53[22m[2m[22m
   [2mnode_modules/gatsby[22m
     [1mgatsby[22m@"" from the root project
-  26 more (react-dom, @reach/router, gatsby-cli, ...)
+  26 more (react-dom, @reach/router, gatsby-cli, gatsby-link, ...)
 
 Could not add conflicting dependency: [1mreact[22m@[1m16.8.1[22m[2m[22m
 [2mnode_modules/react[22m

--- a/tap-snapshots/test-lib-utils-explain-eresolve.js-TAP.test.js
+++ b/tap-snapshots/test-lib-utils-explain-eresolve.js-TAP.test.js
@@ -7,42 +7,43 @@
 'use strict'
 exports[`test/lib/utils/explain-eresolve.js TAP cycleNested > explain with color 1`] = `
 While resolving: [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m
-Found: [1m@isaacs/peer-dep-cycle-c[22m@[1m2.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-c[22m
-  for: prod dependency [1m@isaacs/peer-dep-cycle-c[22m@"[1m2.x[22m"
-  from: the root project
+Found: [1m@isaacs/peer-dep-cycle-c[22m@[1m2.0.0[22m[2m[22m
+[2mnode_modules/@isaacs/peer-dep-cycle-c[22m
+  [1m@isaacs/peer-dep-cycle-c[22m@"[1m2.x[22m" from the root project
 
-Could not add conflicting dependency: [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-b[22m
-  for: peer dependency [1m@isaacs/peer-dep-cycle-b[22m@"[1m1[22m"
-  from: [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-a[22m
-    for: prod dependency [1m@isaacs/peer-dep-cycle-a[22m@"[1m1.x[22m"
-    from: the root project
+Could not add conflicting dependency: [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m[2m[22m
+[2mnode_modules/@isaacs/peer-dep-cycle-b[22m
+  [35mpeer[39m [1m@isaacs/peer-dep-cycle-b[22m@"[1m1[22m" from [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m[2m[22m
+  [2mnode_modules/@isaacs/peer-dep-cycle-a[22m
+    [1m@isaacs/peer-dep-cycle-a[22m@"[1m1.x[22m" from the root project
 
-Conflicting peer dependency: [1m@isaacs/peer-dep-cycle-c[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-c[22m
-  for: peer dependency [1m@isaacs/peer-dep-cycle-c[22m@"[1m1[22m"
-  from: [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-b[22m
-    for: peer dependency [1m@isaacs/peer-dep-cycle-b[22m@"[1m1[22m"
-    from: [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-a[22m
+Conflicting peer dependency: [1m@isaacs/peer-dep-cycle-c[22m@[1m1.0.0[22m[2m[22m
+[2mnode_modules/@isaacs/peer-dep-cycle-c[22m
+  [35mpeer[39m [1m@isaacs/peer-dep-cycle-c[22m@"[1m1[22m" from [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m[2m[22m
+  [2mnode_modules/@isaacs/peer-dep-cycle-b[22m
+    [35mpeer[39m [1m@isaacs/peer-dep-cycle-b[22m@"[1m1[22m" from [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m[2m[22m
+    [2mnode_modules/@isaacs/peer-dep-cycle-a[22m
 `
 
 exports[`test/lib/utils/explain-eresolve.js TAP cycleNested > explain with no color, depth of 6 1`] = `
 While resolving: @isaacs/peer-dep-cycle-a@1.0.0
-Found: @isaacs/peer-dep-cycle-c@2.0.0 at node_modules/@isaacs/peer-dep-cycle-c
-  for: prod dependency @isaacs/peer-dep-cycle-c@"2.x"
-  from: the root project
+Found: @isaacs/peer-dep-cycle-c@2.0.0
+node_modules/@isaacs/peer-dep-cycle-c
+  @isaacs/peer-dep-cycle-c@"2.x" from the root project
 
-Could not add conflicting dependency: @isaacs/peer-dep-cycle-b@1.0.0 at node_modules/@isaacs/peer-dep-cycle-b
-  for: peer dependency @isaacs/peer-dep-cycle-b@"1"
-  from: @isaacs/peer-dep-cycle-a@1.0.0 at node_modules/@isaacs/peer-dep-cycle-a
-    for: prod dependency @isaacs/peer-dep-cycle-a@"1.x"
-    from: the root project
+Could not add conflicting dependency: @isaacs/peer-dep-cycle-b@1.0.0
+node_modules/@isaacs/peer-dep-cycle-b
+  peer @isaacs/peer-dep-cycle-b@"1" from @isaacs/peer-dep-cycle-a@1.0.0
+  node_modules/@isaacs/peer-dep-cycle-a
+    @isaacs/peer-dep-cycle-a@"1.x" from the root project
 
-Conflicting peer dependency: @isaacs/peer-dep-cycle-c@1.0.0 at node_modules/@isaacs/peer-dep-cycle-c
-  for: peer dependency @isaacs/peer-dep-cycle-c@"1"
-  from: @isaacs/peer-dep-cycle-b@1.0.0 at node_modules/@isaacs/peer-dep-cycle-b
-    for: peer dependency @isaacs/peer-dep-cycle-b@"1"
-    from: @isaacs/peer-dep-cycle-a@1.0.0 at node_modules/@isaacs/peer-dep-cycle-a
-      for: prod dependency @isaacs/peer-dep-cycle-a@"1.x"
-      from: the root project
+Conflicting peer dependency: @isaacs/peer-dep-cycle-c@1.0.0
+node_modules/@isaacs/peer-dep-cycle-c
+  peer @isaacs/peer-dep-cycle-c@"1" from @isaacs/peer-dep-cycle-b@1.0.0
+  node_modules/@isaacs/peer-dep-cycle-b
+    peer @isaacs/peer-dep-cycle-b@"1" from @isaacs/peer-dep-cycle-a@1.0.0
+    node_modules/@isaacs/peer-dep-cycle-a
+      @isaacs/peer-dep-cycle-a@"1.x" from the root project
 `
 
 exports[`test/lib/utils/explain-eresolve.js TAP cycleNested > report 1`] = `
@@ -51,23 +52,23 @@ exports[`test/lib/utils/explain-eresolve.js TAP cycleNested > report 1`] = `
 \${TIME}
 
 While resolving: @isaacs/peer-dep-cycle-a@1.0.0
-Found: @isaacs/peer-dep-cycle-c@2.0.0 at node_modules/@isaacs/peer-dep-cycle-c
-  for: prod dependency @isaacs/peer-dep-cycle-c@"2.x"
-  from: the root project
+Found: @isaacs/peer-dep-cycle-c@2.0.0
+node_modules/@isaacs/peer-dep-cycle-c
+  @isaacs/peer-dep-cycle-c@"2.x" from the root project
 
-Could not add conflicting dependency: @isaacs/peer-dep-cycle-b@1.0.0 at node_modules/@isaacs/peer-dep-cycle-b
-  for: peer dependency @isaacs/peer-dep-cycle-b@"1"
-  from: @isaacs/peer-dep-cycle-a@1.0.0 at node_modules/@isaacs/peer-dep-cycle-a
-    for: prod dependency @isaacs/peer-dep-cycle-a@"1.x"
-    from: the root project
+Could not add conflicting dependency: @isaacs/peer-dep-cycle-b@1.0.0
+node_modules/@isaacs/peer-dep-cycle-b
+  peer @isaacs/peer-dep-cycle-b@"1" from @isaacs/peer-dep-cycle-a@1.0.0
+  node_modules/@isaacs/peer-dep-cycle-a
+    @isaacs/peer-dep-cycle-a@"1.x" from the root project
 
-Conflicting peer dependency: @isaacs/peer-dep-cycle-c@1.0.0 at node_modules/@isaacs/peer-dep-cycle-c
-  for: peer dependency @isaacs/peer-dep-cycle-c@"1"
-  from: @isaacs/peer-dep-cycle-b@1.0.0 at node_modules/@isaacs/peer-dep-cycle-b
-    for: peer dependency @isaacs/peer-dep-cycle-b@"1"
-    from: @isaacs/peer-dep-cycle-a@1.0.0 at node_modules/@isaacs/peer-dep-cycle-a
-      for: prod dependency @isaacs/peer-dep-cycle-a@"1.x"
-      from: the root project
+Conflicting peer dependency: @isaacs/peer-dep-cycle-c@1.0.0
+node_modules/@isaacs/peer-dep-cycle-c
+  peer @isaacs/peer-dep-cycle-c@"1" from @isaacs/peer-dep-cycle-b@1.0.0
+  node_modules/@isaacs/peer-dep-cycle-b
+    peer @isaacs/peer-dep-cycle-b@"1" from @isaacs/peer-dep-cycle-a@1.0.0
+    node_modules/@isaacs/peer-dep-cycle-a
+      @isaacs/peer-dep-cycle-a@"1.x" from the root project
 
 Fix the upstream dependency conflict, or retry
 this command with --legacy-peer-deps
@@ -84,23 +85,23 @@ Raw JSON explanation object:
 
 exports[`test/lib/utils/explain-eresolve.js TAP cycleNested > report with color 1`] = `
 While resolving: [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m
-Found: [1m@isaacs/peer-dep-cycle-c[22m@[1m2.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-c[22m
-  for: prod dependency [1m@isaacs/peer-dep-cycle-c[22m@"[1m2.x[22m"
-  from: the root project
+Found: [1m@isaacs/peer-dep-cycle-c[22m@[1m2.0.0[22m[2m[22m
+[2mnode_modules/@isaacs/peer-dep-cycle-c[22m
+  [1m@isaacs/peer-dep-cycle-c[22m@"[1m2.x[22m" from the root project
 
-Could not add conflicting dependency: [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-b[22m
-  for: peer dependency [1m@isaacs/peer-dep-cycle-b[22m@"[1m1[22m"
-  from: [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-a[22m
-    for: prod dependency [1m@isaacs/peer-dep-cycle-a[22m@"[1m1.x[22m"
-    from: the root project
+Could not add conflicting dependency: [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m[2m[22m
+[2mnode_modules/@isaacs/peer-dep-cycle-b[22m
+  [35mpeer[39m [1m@isaacs/peer-dep-cycle-b[22m@"[1m1[22m" from [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m[2m[22m
+  [2mnode_modules/@isaacs/peer-dep-cycle-a[22m
+    [1m@isaacs/peer-dep-cycle-a[22m@"[1m1.x[22m" from the root project
 
-Conflicting peer dependency: [1m@isaacs/peer-dep-cycle-c[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-c[22m
-  for: peer dependency [1m@isaacs/peer-dep-cycle-c[22m@"[1m1[22m"
-  from: [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-b[22m
-    for: peer dependency [1m@isaacs/peer-dep-cycle-b[22m@"[1m1[22m"
-    from: [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-a[22m
-      for: prod dependency [1m@isaacs/peer-dep-cycle-a[22m@"[1m1.x[22m"
-      from: the root project
+Conflicting peer dependency: [1m@isaacs/peer-dep-cycle-c[22m@[1m1.0.0[22m[2m[22m
+[2mnode_modules/@isaacs/peer-dep-cycle-c[22m
+  [35mpeer[39m [1m@isaacs/peer-dep-cycle-c[22m@"[1m1[22m" from [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m[2m[22m
+  [2mnode_modules/@isaacs/peer-dep-cycle-b[22m
+    [35mpeer[39m [1m@isaacs/peer-dep-cycle-b[22m@"[1m1[22m" from [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m[2m[22m
+    [2mnode_modules/@isaacs/peer-dep-cycle-a[22m
+      [1m@isaacs/peer-dep-cycle-a[22m@"[1m1.x[22m" from the root project
 
 Fix the upstream dependency conflict, or retry
 this command with --legacy-peer-deps
@@ -111,21 +112,22 @@ See \${REPORT} for a full report.
 
 exports[`test/lib/utils/explain-eresolve.js TAP cycleNested > report with color, depth only 2 1`] = `
 While resolving: [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m
-Found: [1m@isaacs/peer-dep-cycle-c[22m@[1m2.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-c[22m
-  for: prod dependency [1m@isaacs/peer-dep-cycle-c[22m@"[1m2.x[22m"
-  from: the root project
+Found: [1m@isaacs/peer-dep-cycle-c[22m@[1m2.0.0[22m[2m[22m
+[2mnode_modules/@isaacs/peer-dep-cycle-c[22m
+  [1m@isaacs/peer-dep-cycle-c[22m@"[1m2.x[22m" from the root project
 
-Could not add conflicting dependency: [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-b[22m
-  for: peer dependency [1m@isaacs/peer-dep-cycle-b[22m@"[1m1[22m"
-  from: [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-a[22m
-    for: prod dependency [1m@isaacs/peer-dep-cycle-a[22m@"[1m1.x[22m"
-    from: the root project
+Could not add conflicting dependency: [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m[2m[22m
+[2mnode_modules/@isaacs/peer-dep-cycle-b[22m
+  [35mpeer[39m [1m@isaacs/peer-dep-cycle-b[22m@"[1m1[22m" from [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m[2m[22m
+  [2mnode_modules/@isaacs/peer-dep-cycle-a[22m
+    [1m@isaacs/peer-dep-cycle-a[22m@"[1m1.x[22m" from the root project
 
-Conflicting peer dependency: [1m@isaacs/peer-dep-cycle-c[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-c[22m
-  for: peer dependency [1m@isaacs/peer-dep-cycle-c[22m@"[1m1[22m"
-  from: [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-b[22m
-    for: peer dependency [1m@isaacs/peer-dep-cycle-b[22m@"[1m1[22m"
-    from: [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-a[22m
+Conflicting peer dependency: [1m@isaacs/peer-dep-cycle-c[22m@[1m1.0.0[22m[2m[22m
+[2mnode_modules/@isaacs/peer-dep-cycle-c[22m
+  [35mpeer[39m [1m@isaacs/peer-dep-cycle-c[22m@"[1m1[22m" from [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m[2m[22m
+  [2mnode_modules/@isaacs/peer-dep-cycle-b[22m
+    [35mpeer[39m [1m@isaacs/peer-dep-cycle-b[22m@"[1m1[22m" from [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m[2m[22m
+    [2mnode_modules/@isaacs/peer-dep-cycle-a[22m
 
 Fix the upstream dependency conflict, or retry
 this command with --legacy-peer-deps
@@ -136,23 +138,23 @@ See \${REPORT} for a full report.
 
 exports[`test/lib/utils/explain-eresolve.js TAP cycleNested > report with no color, depth of 6 1`] = `
 While resolving: @isaacs/peer-dep-cycle-a@1.0.0
-Found: @isaacs/peer-dep-cycle-c@2.0.0 at node_modules/@isaacs/peer-dep-cycle-c
-  for: prod dependency @isaacs/peer-dep-cycle-c@"2.x"
-  from: the root project
+Found: @isaacs/peer-dep-cycle-c@2.0.0
+node_modules/@isaacs/peer-dep-cycle-c
+  @isaacs/peer-dep-cycle-c@"2.x" from the root project
 
-Could not add conflicting dependency: @isaacs/peer-dep-cycle-b@1.0.0 at node_modules/@isaacs/peer-dep-cycle-b
-  for: peer dependency @isaacs/peer-dep-cycle-b@"1"
-  from: @isaacs/peer-dep-cycle-a@1.0.0 at node_modules/@isaacs/peer-dep-cycle-a
-    for: prod dependency @isaacs/peer-dep-cycle-a@"1.x"
-    from: the root project
+Could not add conflicting dependency: @isaacs/peer-dep-cycle-b@1.0.0
+node_modules/@isaacs/peer-dep-cycle-b
+  peer @isaacs/peer-dep-cycle-b@"1" from @isaacs/peer-dep-cycle-a@1.0.0
+  node_modules/@isaacs/peer-dep-cycle-a
+    @isaacs/peer-dep-cycle-a@"1.x" from the root project
 
-Conflicting peer dependency: @isaacs/peer-dep-cycle-c@1.0.0 at node_modules/@isaacs/peer-dep-cycle-c
-  for: peer dependency @isaacs/peer-dep-cycle-c@"1"
-  from: @isaacs/peer-dep-cycle-b@1.0.0 at node_modules/@isaacs/peer-dep-cycle-b
-    for: peer dependency @isaacs/peer-dep-cycle-b@"1"
-    from: @isaacs/peer-dep-cycle-a@1.0.0 at node_modules/@isaacs/peer-dep-cycle-a
-      for: prod dependency @isaacs/peer-dep-cycle-a@"1.x"
-      from: the root project
+Conflicting peer dependency: @isaacs/peer-dep-cycle-c@1.0.0
+node_modules/@isaacs/peer-dep-cycle-c
+  peer @isaacs/peer-dep-cycle-c@"1" from @isaacs/peer-dep-cycle-b@1.0.0
+  node_modules/@isaacs/peer-dep-cycle-b
+    peer @isaacs/peer-dep-cycle-b@"1" from @isaacs/peer-dep-cycle-a@1.0.0
+    node_modules/@isaacs/peer-dep-cycle-a
+      @isaacs/peer-dep-cycle-a@"1.x" from the root project
 
 Fix the upstream dependency conflict, or retry
 this command with --legacy-peer-deps
@@ -163,84 +165,78 @@ See \${REPORT} for a full report.
 
 exports[`test/lib/utils/explain-eresolve.js TAP gatsby > explain with color 1`] = `
 While resolving: [1mgatsby-interface[22m@[1m0.0.166[22m
-Found: [1mreact[22m@[1m16.13.1[22m[2m at node_modules/react[22m
-  for: peer dependency [1mreact[22m@"[1m^16.4.2[22m"
-  from: [1mgatsby[22m@[1m2.24.53[22m[2m at node_modules/gatsby[22m
-    for: prod dependency [1mgatsby[22m@""
-    from: the root project
-  and: 26 more (react-dom, @reach/router, gatsby-cli, gatsby-link, gatsby-react-router-scroll, ...)
+Found: [1mreact[22m@[1m16.13.1[22m[2m[22m
+[2mnode_modules/react[22m
+  [35mpeer[39m [1mreact[22m@"[1m^16.4.2[22m" from [1mgatsby[22m@[1m2.24.53[22m[2m[22m
+  [2mnode_modules/gatsby[22m
+    [1mgatsby[22m@"" from the root project
+  26 more (react-dom, @reach/router, gatsby-cli, ...)
 
-Could not add conflicting dependency: [1mreact[22m@[1m16.8.1[22m[2m at node_modules/react[22m
-  for: peer dependency [1mreact[22m@"[1m16.8.1[22m"
-  from: [1mgatsby-interface[22m@[1m0.0.166[22m[2m at node_modules/gatsby-recipes/node_modules/gatsby-interface[22m
-    for: prod dependency [1mgatsby-interface[22m@"[1m^0.0.166[22m"
-    from: [1mgatsby-recipes[22m@[1m0.2.20[22m[2m at node_modules/gatsby-recipes[22m
+Could not add conflicting dependency: [1mreact[22m@[1m16.8.1[22m[2m[22m
+[2mnode_modules/react[22m
+  [35mpeer[39m [1mreact[22m@"[1m16.8.1[22m" from [1mgatsby-interface[22m@[1m0.0.166[22m[2m[22m
+  [2mnode_modules/gatsby-recipes/node_modules/gatsby-interface[22m
+    [1mgatsby-interface[22m@"[1m^0.0.166[22m" from [1mgatsby-recipes[22m@[1m0.2.20[22m[2m[22m
+    [2mnode_modules/gatsby-recipes[22m
 `
 
 exports[`test/lib/utils/explain-eresolve.js TAP gatsby > explain with no color, depth of 6 1`] = `
 While resolving: gatsby-interface@0.0.166
-Found: react@16.13.1 at node_modules/react
-  for: peer dependency react@"^16.4.2"
-  from: gatsby@2.24.53 at node_modules/gatsby
-    for: prod dependency gatsby@""
-    from: the root project
-  and: peer dependency react@"^16.13.1"
-  from: react-dom@16.13.1 at node_modules/react-dom
-    for: peer dependency react-dom@"^16.4.2"
-    from: gatsby@2.24.53 at node_modules/gatsby
-      for: prod dependency gatsby@""
-      from: the root project
-    and: peer dependency react-dom@"15.x || 16.x || 16.4.0-alpha.0911da3"
-    from: @reach/router@1.3.4 at node_modules/@reach/router
-      for: prod dependency @reach/router@"^1.3.4"
-      from: gatsby@2.24.53 at node_modules/gatsby
-        for: prod dependency gatsby@""
-        from: the root project
-      and: peer dependency @reach/router@"^1.3.3"
-      from: gatsby-link@2.4.13 at node_modules/gatsby-link
-        for: prod dependency gatsby-link@"^2.4.13"
-        from: gatsby@2.24.53 at node_modules/gatsby
-          for: prod dependency gatsby@""
-          from: the root project
-      and: 1 more (gatsby-react-router-scroll)
-    and: peer dependency react-dom@"^16.4.2"
-    from: gatsby-link@2.4.13 at node_modules/gatsby-link
-      for: prod dependency gatsby-link@"^2.4.13"
-      from: gatsby@2.24.53 at node_modules/gatsby
-        for: prod dependency gatsby@""
-        from: the root project
-    and: 2 more (gatsby-react-router-scroll, react-hot-loader)
-  and: peer dependency react@"15.x || 16.x || 16.4.0-alpha.0911da3"
-  from: @reach/router@1.3.4 at node_modules/@reach/router
-    for: prod dependency @reach/router@"^1.3.4"
-    from: gatsby@2.24.53 at node_modules/gatsby
-      for: prod dependency gatsby@""
-      from: the root project
-    and: peer dependency @reach/router@"^1.3.3"
-    from: gatsby-link@2.4.13 at node_modules/gatsby-link
-      for: prod dependency gatsby-link@"^2.4.13"
-      from: gatsby@2.24.53 at node_modules/gatsby
-        for: prod dependency gatsby@""
-        from: the root project
-    and: peer dependency @reach/router@"^1.0.0"
-    from: gatsby-react-router-scroll@3.0.12 at node_modules/gatsby-react-router-scroll
-      for: prod dependency gatsby-react-router-scroll@"^3.0.12"
-      from: gatsby@2.24.53 at node_modules/gatsby
-        for: prod dependency gatsby@""
-        from: the root project
-  and: 24 more (gatsby-cli, gatsby-link, gatsby-react-router-scroll, react-hot-loader, create-react-context, ...)
+Found: react@16.13.1
+node_modules/react
+  peer react@"^16.4.2" from gatsby@2.24.53
+  node_modules/gatsby
+    gatsby@"" from the root project
+  peer react@"^16.13.1" from react-dom@16.13.1
+  node_modules/react-dom
+    peer react-dom@"^16.4.2" from gatsby@2.24.53
+    node_modules/gatsby
+      gatsby@"" from the root project
+    peer react-dom@"15.x || 16.x || 16.4.0-alpha.0911da3" from @reach/router@1.3.4
+    node_modules/@reach/router
+      @reach/router@"^1.3.4" from gatsby@2.24.53
+      node_modules/gatsby
+        gatsby@"" from the root project
+      peer @reach/router@"^1.3.3" from gatsby-link@2.4.13
+      node_modules/gatsby-link
+        gatsby-link@"^2.4.13" from gatsby@2.24.53
+        node_modules/gatsby
+          gatsby@"" from the root project
+      1 more (gatsby-react-router-scroll)
+    peer react-dom@"^16.4.2" from gatsby-link@2.4.13
+    node_modules/gatsby-link
+      gatsby-link@"^2.4.13" from gatsby@2.24.53
+      node_modules/gatsby
+        gatsby@"" from the root project
+    2 more (gatsby-react-router-scroll, react-hot-loader)
+  peer react@"15.x || 16.x || 16.4.0-alpha.0911da3" from @reach/router@1.3.4
+  node_modules/@reach/router
+    @reach/router@"^1.3.4" from gatsby@2.24.53
+    node_modules/gatsby
+      gatsby@"" from the root project
+    peer @reach/router@"^1.3.3" from gatsby-link@2.4.13
+    node_modules/gatsby-link
+      gatsby-link@"^2.4.13" from gatsby@2.24.53
+      node_modules/gatsby
+        gatsby@"" from the root project
+    peer @reach/router@"^1.0.0" from gatsby-react-router-scroll@3.0.12
+    node_modules/gatsby-react-router-scroll
+      gatsby-react-router-scroll@"^3.0.12" from gatsby@2.24.53
+      node_modules/gatsby
+        gatsby@"" from the root project
+  24 more (gatsby-cli, gatsby-link, gatsby-react-router-scroll, ...)
 
-Could not add conflicting dependency: react@16.8.1 at node_modules/react
-  for: peer dependency react@"16.8.1"
-  from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
-    for: prod dependency gatsby-interface@"^0.0.166"
-    from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-      for: prod dependency gatsby-recipes@"^0.2.20"
-      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-        for: prod dependency gatsby-cli@"^2.12.91"
-        from: gatsby@2.24.53 at node_modules/gatsby
-          for: prod dependency gatsby@""
-          from: the root project
+Could not add conflicting dependency: react@16.8.1
+node_modules/react
+  peer react@"16.8.1" from gatsby-interface@0.0.166
+  node_modules/gatsby-recipes/node_modules/gatsby-interface
+    gatsby-interface@"^0.0.166" from gatsby-recipes@0.2.20
+    node_modules/gatsby-recipes
+      gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+      node_modules/gatsby-cli
+        gatsby-cli@"^2.12.91" from gatsby@2.24.53
+        node_modules/gatsby
+          gatsby@"" from the root project
 `
 
 exports[`test/lib/utils/explain-eresolve.js TAP gatsby > report 1`] = `
@@ -249,487 +245,435 @@ exports[`test/lib/utils/explain-eresolve.js TAP gatsby > report 1`] = `
 \${TIME}
 
 While resolving: gatsby-interface@0.0.166
-Found: react@16.13.1 at node_modules/react
-  for: peer dependency react@"^16.4.2"
-  from: gatsby@2.24.53 at node_modules/gatsby
-    for: prod dependency gatsby@""
-    from: the root project
-  and: peer dependency react@"^16.13.1"
-  from: react-dom@16.13.1 at node_modules/react-dom
-    for: peer dependency react-dom@"^16.4.2"
-    from: gatsby@2.24.53 at node_modules/gatsby
-      for: prod dependency gatsby@""
-      from: the root project
-    and: peer dependency react-dom@"15.x || 16.x || 16.4.0-alpha.0911da3"
-    from: @reach/router@1.3.4 at node_modules/@reach/router
-      for: prod dependency @reach/router@"^1.3.4"
-      from: gatsby@2.24.53 at node_modules/gatsby
-        for: prod dependency gatsby@""
-        from: the root project
-      and: peer dependency @reach/router@"^1.3.3"
-      from: gatsby-link@2.4.13 at node_modules/gatsby-link
-        for: prod dependency gatsby-link@"^2.4.13"
-        from: gatsby@2.24.53 at node_modules/gatsby
-          for: prod dependency gatsby@""
-          from: the root project
-      and: peer dependency @reach/router@"^1.0.0"
-      from: gatsby-react-router-scroll@3.0.12 at node_modules/gatsby-react-router-scroll
-        for: prod dependency gatsby-react-router-scroll@"^3.0.12"
-        from: gatsby@2.24.53 at node_modules/gatsby
-          for: prod dependency gatsby@""
-          from: the root project
-    and: peer dependency react-dom@"^16.4.2"
-    from: gatsby-link@2.4.13 at node_modules/gatsby-link
-      for: prod dependency gatsby-link@"^2.4.13"
-      from: gatsby@2.24.53 at node_modules/gatsby
-        for: prod dependency gatsby@""
-        from: the root project
-    and: peer dependency react-dom@"^16.4.2"
-    from: gatsby-react-router-scroll@3.0.12 at node_modules/gatsby-react-router-scroll
-      for: prod dependency gatsby-react-router-scroll@"^3.0.12"
-      from: gatsby@2.24.53 at node_modules/gatsby
-        for: prod dependency gatsby@""
-        from: the root project
-    and: peer dependency react-dom@"^15.0.0 || ^16.0.0"
-    from: react-hot-loader@4.12.21 at node_modules/react-hot-loader
-      for: prod dependency react-hot-loader@"^4.12.21"
-      from: gatsby@2.24.53 at node_modules/gatsby
-        for: prod dependency gatsby@""
-        from: the root project
-  and: peer dependency react@"15.x || 16.x || 16.4.0-alpha.0911da3"
-  from: @reach/router@1.3.4 at node_modules/@reach/router
-    for: prod dependency @reach/router@"^1.3.4"
-    from: gatsby@2.24.53 at node_modules/gatsby
-      for: prod dependency gatsby@""
-      from: the root project
-    and: peer dependency @reach/router@"^1.3.3"
-    from: gatsby-link@2.4.13 at node_modules/gatsby-link
-      for: prod dependency gatsby-link@"^2.4.13"
-      from: gatsby@2.24.53 at node_modules/gatsby
-        for: prod dependency gatsby@""
-        from: the root project
-    and: peer dependency @reach/router@"^1.0.0"
-    from: gatsby-react-router-scroll@3.0.12 at node_modules/gatsby-react-router-scroll
-      for: prod dependency gatsby-react-router-scroll@"^3.0.12"
-      from: gatsby@2.24.53 at node_modules/gatsby
-        for: prod dependency gatsby@""
-        from: the root project
-  and: prod dependency react@"^16.8.0"
-  from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-    for: prod dependency gatsby-cli@"^2.12.91"
-    from: gatsby@2.24.53 at node_modules/gatsby
-      for: prod dependency gatsby@""
-      from: the root project
-  and: peer dependency react@"^16.4.2"
-  from: gatsby-link@2.4.13 at node_modules/gatsby-link
-    for: prod dependency gatsby-link@"^2.4.13"
-    from: gatsby@2.24.53 at node_modules/gatsby
-      for: prod dependency gatsby@""
-      from: the root project
-  and: peer dependency react@"^16.4.2"
-  from: gatsby-react-router-scroll@3.0.12 at node_modules/gatsby-react-router-scroll
-    for: prod dependency gatsby-react-router-scroll@"^3.0.12"
-    from: gatsby@2.24.53 at node_modules/gatsby
-      for: prod dependency gatsby@""
-      from: the root project
-  and: peer dependency react@"^15.0.0 || ^16.0.0"
-  from: react-hot-loader@4.12.21 at node_modules/react-hot-loader
-    for: prod dependency react-hot-loader@"^4.12.21"
-    from: gatsby@2.24.53 at node_modules/gatsby
-      for: prod dependency gatsby@""
-      from: the root project
-  and: peer dependency react@"^0.14.0 || ^15.0.0 || ^16.0.0"
-  from: create-react-context@0.3.0 at node_modules/create-react-context
-    for: prod dependency create-react-context@"0.3.0"
-    from: @reach/router@1.3.4 at node_modules/@reach/router
-      for: prod dependency @reach/router@"^1.3.4"
-      from: gatsby@2.24.53 at node_modules/gatsby
-        for: prod dependency gatsby@""
-        from: the root project
-      and: peer dependency @reach/router@"^1.3.3"
-      from: gatsby-link@2.4.13 at node_modules/gatsby-link
-        for: prod dependency gatsby-link@"^2.4.13"
-        from: gatsby@2.24.53 at node_modules/gatsby
-          for: prod dependency gatsby@""
-          from: the root project
-      and: peer dependency @reach/router@"^1.0.0"
-      from: gatsby-react-router-scroll@3.0.12 at node_modules/gatsby-react-router-scroll
-        for: prod dependency gatsby-react-router-scroll@"^3.0.12"
-        from: gatsby@2.24.53 at node_modules/gatsby
-          for: prod dependency gatsby@""
-          from: the root project
-  and: peer dependency react@"^16.12.0"
-  from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-    for: prod dependency gatsby-recipes@"^0.2.20"
-    from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-      for: prod dependency gatsby-cli@"^2.12.91"
-      from: gatsby@2.24.53 at node_modules/gatsby
-        for: prod dependency gatsby@""
-        from: the root project
-  and: peer dependency react@">=16.8.0"
-  from: ink@2.7.1 at node_modules/ink
-    for: prod dependency ink@"^2.7.1"
-    from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-      for: prod dependency gatsby-cli@"^2.12.91"
-      from: gatsby@2.24.53 at node_modules/gatsby
-        for: prod dependency gatsby@""
-        from: the root project
-    and: peer dependency ink@"^2.0.0"
-    from: ink-spinner@3.1.0 at node_modules/ink-spinner
-      for: prod dependency ink-spinner@"^3.1.0"
-      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-        for: prod dependency gatsby-cli@"^2.12.91"
-        from: gatsby@2.24.53 at node_modules/gatsby
-          for: prod dependency gatsby@""
-          from: the root project
-    and: peer dependency ink@">=2.0.0"
-    from: ink-box@1.0.0 at node_modules/ink-box
-      for: prod dependency ink-box@"^1.0.0"
-      from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-        for: prod dependency gatsby-recipes@"^0.2.20"
-        from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-          for: prod dependency gatsby-cli@"^2.12.91"
-          from: gatsby@2.24.53 at node_modules/gatsby
-            for: prod dependency gatsby@""
-            from: the root project
-  and: peer dependency react@"^16.8.2"
-  from: ink-spinner@3.1.0 at node_modules/ink-spinner
-    for: prod dependency ink-spinner@"^3.1.0"
-    from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-      for: prod dependency gatsby-cli@"^2.12.91"
-      from: gatsby@2.24.53 at node_modules/gatsby
-        for: prod dependency gatsby@""
-        from: the root project
-  and: peer dependency react@">=16.3.0"
-  from: @emotion/core@10.0.35 at node_modules/@emotion/core
-    for: prod dependency @emotion/core@"^10.0.14"
-    from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-      for: prod dependency gatsby-recipes@"^0.2.20"
-      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-        for: prod dependency gatsby-cli@"^2.12.91"
-        from: gatsby@2.24.53 at node_modules/gatsby
-          for: prod dependency gatsby@""
-          from: the root project
-    and: peer dependency @emotion/core@"^10.0.27"
-    from: @emotion/styled@10.0.27 at node_modules/@emotion/styled
-      for: prod dependency @emotion/styled@"^10.0.14"
-      from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-        for: prod dependency gatsby-recipes@"^0.2.20"
-        from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-          for: prod dependency gatsby-cli@"^2.12.91"
-          from: gatsby@2.24.53 at node_modules/gatsby
-            for: prod dependency gatsby@""
-            from: the root project
-      and: peer dependency @emotion/styled@"^10.0.14"
-      from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
-        for: prod dependency gatsby-interface@"^0.0.166"
-        from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-          for: prod dependency gatsby-recipes@"^0.2.20"
-          from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-            for: prod dependency gatsby-cli@"^2.12.91"
-            from: gatsby@2.24.53 at node_modules/gatsby
-              for: prod dependency gatsby@""
-              from: the root project
-    and: peer dependency @emotion/core@"^10.0.14"
-    from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
-      for: prod dependency gatsby-interface@"^0.0.166"
-      from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-        for: prod dependency gatsby-recipes@"^0.2.20"
-        from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-          for: prod dependency gatsby-cli@"^2.12.91"
-          from: gatsby@2.24.53 at node_modules/gatsby
-            for: prod dependency gatsby@""
-            from: the root project
-    and: peer dependency @emotion/core@"^10.0.28"
-    from: @emotion/styled-base@10.0.31 at node_modules/@emotion/styled-base
-      for: prod dependency @emotion/styled-base@"^10.0.27"
-      from: @emotion/styled@10.0.27 at node_modules/@emotion/styled
-        for: prod dependency @emotion/styled@"^10.0.14"
-        from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-          for: prod dependency gatsby-recipes@"^0.2.20"
-          from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-            for: prod dependency gatsby-cli@"^2.12.91"
-            from: gatsby@2.24.53 at node_modules/gatsby
-              for: prod dependency gatsby@""
-              from: the root project
-        and: peer dependency @emotion/styled@"^10.0.14"
-        from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
-          for: prod dependency gatsby-interface@"^0.0.166"
-          from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-            for: prod dependency gatsby-recipes@"^0.2.20"
-            from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-              for: prod dependency gatsby-cli@"^2.12.91"
-              from: gatsby@2.24.53 at node_modules/gatsby
-                for: prod dependency gatsby@""
-                from: the root project
-  and: peer dependency react@">=16.3.0"
-  from: @emotion/styled@10.0.27 at node_modules/@emotion/styled
-    for: prod dependency @emotion/styled@"^10.0.14"
-    from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-      for: prod dependency gatsby-recipes@"^0.2.20"
-      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-        for: prod dependency gatsby-cli@"^2.12.91"
-        from: gatsby@2.24.53 at node_modules/gatsby
-          for: prod dependency gatsby@""
-          from: the root project
-    and: peer dependency @emotion/styled@"^10.0.14"
-    from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
-      for: prod dependency gatsby-interface@"^0.0.166"
-      from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-        for: prod dependency gatsby-recipes@"^0.2.20"
-        from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-          for: prod dependency gatsby-cli@"^2.12.91"
-          from: gatsby@2.24.53 at node_modules/gatsby
-            for: prod dependency gatsby@""
-            from: the root project
-  and: peer dependency react@"^16.13.1"
-  from: @mdx-js/react@2.0.0-next.7 at node_modules/@mdx-js/react
-    for: prod dependency @mdx-js/react@"^2.0.0-next.4"
-    from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-      for: prod dependency gatsby-recipes@"^0.2.20"
-      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-        for: prod dependency gatsby-cli@"^2.12.91"
-        from: gatsby@2.24.53 at node_modules/gatsby
-          for: prod dependency gatsby@""
-          from: the root project
-    and: prod dependency @mdx-js/react@"^2.0.0-next.7"
-    from: @mdx-js/runtime@2.0.0-next.7 at node_modules/@mdx-js/runtime
-      for: prod dependency @mdx-js/runtime@"^2.0.0-next.4"
-      from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-        for: prod dependency gatsby-recipes@"^0.2.20"
-        from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-          for: prod dependency gatsby-cli@"^2.12.91"
-          from: gatsby@2.24.53 at node_modules/gatsby
-            for: prod dependency gatsby@""
-            from: the root project
-  and: peer dependency react@"^16.13.1"
-  from: @mdx-js/runtime@2.0.0-next.7 at node_modules/@mdx-js/runtime
-    for: prod dependency @mdx-js/runtime@"^2.0.0-next.4"
-    from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-      for: prod dependency gatsby-recipes@"^0.2.20"
-      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-        for: prod dependency gatsby-cli@"^2.12.91"
-        from: gatsby@2.24.53 at node_modules/gatsby
-          for: prod dependency gatsby@""
-          from: the root project
-  and: peer dependency react@">=16.8.0"
-  from: formik@2.1.5 at node_modules/formik
-    for: prod dependency formik@"^2.0.8"
-    from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-      for: prod dependency gatsby-recipes@"^0.2.20"
-      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-        for: prod dependency gatsby-cli@"^2.12.91"
-        from: gatsby@2.24.53 at node_modules/gatsby
-          for: prod dependency gatsby@""
-          from: the root project
-    and: peer dependency formik@"^2.0.8"
-    from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
-      for: prod dependency gatsby-interface@"^0.0.166"
-      from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-        for: prod dependency gatsby-recipes@"^0.2.20"
-        from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-          for: prod dependency gatsby-cli@"^2.12.91"
-          from: gatsby@2.24.53 at node_modules/gatsby
-            for: prod dependency gatsby@""
-            from: the root project
-  and: peer dependency react@"^16.4.2"
-  from: gatsby@2.6.0 at node_modules/gatsby-recipes/node_modules/gatsby
-    for: peer dependency gatsby@"2.6.0"
-    from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
-      for: prod dependency gatsby-interface@"^0.0.166"
-      from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-        for: prod dependency gatsby-recipes@"^0.2.20"
-        from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-          for: prod dependency gatsby-cli@"^2.12.91"
-          from: gatsby@2.24.53 at node_modules/gatsby
-            for: prod dependency gatsby@""
-            from: the root project
-  and: peer dependency react@"^16.0.0"
-  from: react-dom@16.8.1 at node_modules/gatsby-recipes/node_modules/react-dom
-    for: peer dependency react-dom@"16.8.1"
-    from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
-      for: prod dependency gatsby-interface@"^0.0.166"
-      from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-        for: prod dependency gatsby-recipes@"^0.2.20"
-        from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-          for: prod dependency gatsby-cli@"^2.12.91"
-          from: gatsby@2.24.53 at node_modules/gatsby
-            for: prod dependency gatsby@""
-            from: the root project
-    and: peer dependency react-dom@"^16.4.2"
-    from: gatsby@2.6.0 at node_modules/gatsby-recipes/node_modules/gatsby
-      for: peer dependency gatsby@"2.6.0"
-      from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
-        for: prod dependency gatsby-interface@"^0.0.166"
-        from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-          for: prod dependency gatsby-recipes@"^0.2.20"
-          from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-            for: prod dependency gatsby-cli@"^2.12.91"
-            from: gatsby@2.24.53 at node_modules/gatsby
-              for: prod dependency gatsby@""
-              from: the root project
-    and: peer dependency react-dom@"^0.14.0 || ^15.0.0 || ^16.0.0"
-    from: gatsby-react-router-scroll@2.3.1 at node_modules/gatsby-recipes/node_modules/gatsby-react-router-scroll
-      for: prod dependency gatsby-react-router-scroll@"^2.0.7"
-      from: gatsby@2.6.0 at node_modules/gatsby-recipes/node_modules/gatsby
-        for: peer dependency gatsby@"2.6.0"
-        from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
-          for: prod dependency gatsby-interface@"^0.0.166"
-          from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-            for: prod dependency gatsby-recipes@"^0.2.20"
-            from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-              for: prod dependency gatsby-cli@"^2.12.91"
-              from: gatsby@2.24.53 at node_modules/gatsby
-                for: prod dependency gatsby@""
-                from: the root project
-  and: peer dependency react@"*"
-  from: react-icons@3.11.0 at node_modules/react-icons
-    for: prod dependency react-icons@"^3.0.1"
-    from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-      for: prod dependency gatsby-recipes@"^0.2.20"
-      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-        for: prod dependency gatsby-cli@"^2.12.91"
-        from: gatsby@2.24.53 at node_modules/gatsby
-          for: prod dependency gatsby@""
-          from: the root project
-    and: peer dependency react-icons@"^3.2.1"
-    from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
-      for: prod dependency gatsby-interface@"^0.0.166"
-      from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-        for: prod dependency gatsby-recipes@"^0.2.20"
-        from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-          for: prod dependency gatsby-cli@"^2.12.91"
-          from: gatsby@2.24.53 at node_modules/gatsby
-            for: prod dependency gatsby@""
-            from: the root project
-  and: peer dependency react@">=16.8.0"
-  from: ink-box@1.0.0 at node_modules/ink-box
-    for: prod dependency ink-box@"^1.0.0"
-    from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-      for: prod dependency gatsby-recipes@"^0.2.20"
-      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-        for: prod dependency gatsby-cli@"^2.12.91"
-        from: gatsby@2.24.53 at node_modules/gatsby
-          for: prod dependency gatsby@""
-          from: the root project
-  and: peer dependency react@"^0.14.0 || ^15.0.0 || ^16.0.0"
-  from: react-circular-progressbar@2.0.3 at node_modules/react-circular-progressbar
-    for: prod dependency react-circular-progressbar@"^2.0.0"
-    from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-      for: prod dependency gatsby-recipes@"^0.2.20"
-      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-        for: prod dependency gatsby-cli@"^2.12.91"
-        from: gatsby@2.24.53 at node_modules/gatsby
-          for: prod dependency gatsby@""
-          from: the root project
-  and: peer dependency react@"^16.13.1"
-  from: react-reconciler@0.25.1 at node_modules/react-reconciler
-    for: prod dependency react-reconciler@"^0.25.1"
-    from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-      for: prod dependency gatsby-recipes@"^0.2.20"
-      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-        for: prod dependency gatsby-cli@"^2.12.91"
-        from: gatsby@2.24.53 at node_modules/gatsby
-          for: prod dependency gatsby@""
-          from: the root project
-  and: peer dependency react@">= 16.8.0"
-  from: urql@1.10.0 at node_modules/urql
-    for: prod dependency urql@"^1.9.7"
-    from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-      for: prod dependency gatsby-recipes@"^0.2.20"
-      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-        for: prod dependency gatsby-cli@"^2.12.91"
-        from: gatsby@2.24.53 at node_modules/gatsby
-          for: prod dependency gatsby@""
-          from: the root project
-  and: peer dependency react@">=16.3.0"
-  from: @emotion/styled-base@10.0.31 at node_modules/@emotion/styled-base
-    for: prod dependency @emotion/styled-base@"^10.0.27"
-    from: @emotion/styled@10.0.27 at node_modules/@emotion/styled
-      for: prod dependency @emotion/styled@"^10.0.14"
-      from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-        for: prod dependency gatsby-recipes@"^0.2.20"
-        from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-          for: prod dependency gatsby-cli@"^2.12.91"
-          from: gatsby@2.24.53 at node_modules/gatsby
-            for: prod dependency gatsby@""
-            from: the root project
-      and: peer dependency @emotion/styled@"^10.0.14"
-      from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
-        for: prod dependency gatsby-interface@"^0.0.166"
-        from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-          for: prod dependency gatsby-recipes@"^0.2.20"
-          from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-            for: prod dependency gatsby-cli@"^2.12.91"
-            from: gatsby@2.24.53 at node_modules/gatsby
-              for: prod dependency gatsby@""
-              from: the root project
-  and: peer dependency react@"^16.0.0"
-  from: react-reconciler@0.24.0 at node_modules/ink/node_modules/react-reconciler
-    for: prod dependency react-reconciler@"^0.24.0"
-    from: ink@2.7.1 at node_modules/ink
-      for: prod dependency ink@"^2.7.1"
-      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-        for: prod dependency gatsby-cli@"^2.12.91"
-        from: gatsby@2.24.53 at node_modules/gatsby
-          for: prod dependency gatsby@""
-          from: the root project
-      and: peer dependency ink@"^2.0.0"
-      from: ink-spinner@3.1.0 at node_modules/ink-spinner
-        for: prod dependency ink-spinner@"^3.1.0"
-        from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-          for: prod dependency gatsby-cli@"^2.12.91"
-          from: gatsby@2.24.53 at node_modules/gatsby
-            for: prod dependency gatsby@""
-            from: the root project
-      and: peer dependency ink@">=2.0.0"
-      from: ink-box@1.0.0 at node_modules/ink-box
-        for: prod dependency ink-box@"^1.0.0"
-        from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-          for: prod dependency gatsby-recipes@"^0.2.20"
-          from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-            for: prod dependency gatsby-cli@"^2.12.91"
-            from: gatsby@2.24.53 at node_modules/gatsby
-              for: prod dependency gatsby@""
-              from: the root project
-  and: peer dependency react@"^0.14.0 || ^15.0.0 || ^16.0.0"
-  from: gatsby-react-router-scroll@2.3.1 at node_modules/gatsby-recipes/node_modules/gatsby-react-router-scroll
-    for: prod dependency gatsby-react-router-scroll@"^2.0.7"
-    from: gatsby@2.6.0 at node_modules/gatsby-recipes/node_modules/gatsby
-      for: peer dependency gatsby@"2.6.0"
-      from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
-        for: prod dependency gatsby-interface@"^0.0.166"
-        from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-          for: prod dependency gatsby-recipes@"^0.2.20"
-          from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-            for: prod dependency gatsby-cli@"^2.12.91"
-            from: gatsby@2.24.53 at node_modules/gatsby
-              for: prod dependency gatsby@""
-              from: the root project
-  and: peer dependency react@"^16.13.1"
-  from: @mdx-js/react@1.6.16 at node_modules/gatsby-recipes/node_modules/gatsby-interface/node_modules/@mdx-js/react
-    for: prod dependency @mdx-js/react@"^1.5.2"
-    from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
-      for: prod dependency gatsby-interface@"^0.0.166"
-      from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-        for: prod dependency gatsby-recipes@"^0.2.20"
-        from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-          for: prod dependency gatsby-cli@"^2.12.91"
-          from: gatsby@2.24.53 at node_modules/gatsby
-            for: prod dependency gatsby@""
-            from: the root project
+Found: react@16.13.1
+node_modules/react
+  peer react@"^16.4.2" from gatsby@2.24.53
+  node_modules/gatsby
+    gatsby@"" from the root project
+  peer react@"^16.13.1" from react-dom@16.13.1
+  node_modules/react-dom
+    peer react-dom@"^16.4.2" from gatsby@2.24.53
+    node_modules/gatsby
+      gatsby@"" from the root project
+    peer react-dom@"15.x || 16.x || 16.4.0-alpha.0911da3" from @reach/router@1.3.4
+    node_modules/@reach/router
+      @reach/router@"^1.3.4" from gatsby@2.24.53
+      node_modules/gatsby
+        gatsby@"" from the root project
+      peer @reach/router@"^1.3.3" from gatsby-link@2.4.13
+      node_modules/gatsby-link
+        gatsby-link@"^2.4.13" from gatsby@2.24.53
+        node_modules/gatsby
+          gatsby@"" from the root project
+      peer @reach/router@"^1.0.0" from gatsby-react-router-scroll@3.0.12
+      node_modules/gatsby-react-router-scroll
+        gatsby-react-router-scroll@"^3.0.12" from gatsby@2.24.53
+        node_modules/gatsby
+          gatsby@"" from the root project
+    peer react-dom@"^16.4.2" from gatsby-link@2.4.13
+    node_modules/gatsby-link
+      gatsby-link@"^2.4.13" from gatsby@2.24.53
+      node_modules/gatsby
+        gatsby@"" from the root project
+    peer react-dom@"^16.4.2" from gatsby-react-router-scroll@3.0.12
+    node_modules/gatsby-react-router-scroll
+      gatsby-react-router-scroll@"^3.0.12" from gatsby@2.24.53
+      node_modules/gatsby
+        gatsby@"" from the root project
+    peer react-dom@"^15.0.0 || ^16.0.0" from react-hot-loader@4.12.21
+    node_modules/react-hot-loader
+      react-hot-loader@"^4.12.21" from gatsby@2.24.53
+      node_modules/gatsby
+        gatsby@"" from the root project
+  peer react@"15.x || 16.x || 16.4.0-alpha.0911da3" from @reach/router@1.3.4
+  node_modules/@reach/router
+    @reach/router@"^1.3.4" from gatsby@2.24.53
+    node_modules/gatsby
+      gatsby@"" from the root project
+    peer @reach/router@"^1.3.3" from gatsby-link@2.4.13
+    node_modules/gatsby-link
+      gatsby-link@"^2.4.13" from gatsby@2.24.53
+      node_modules/gatsby
+        gatsby@"" from the root project
+    peer @reach/router@"^1.0.0" from gatsby-react-router-scroll@3.0.12
+    node_modules/gatsby-react-router-scroll
+      gatsby-react-router-scroll@"^3.0.12" from gatsby@2.24.53
+      node_modules/gatsby
+        gatsby@"" from the root project
+  react@"^16.8.0" from gatsby-cli@2.12.91
+  node_modules/gatsby-cli
+    gatsby-cli@"^2.12.91" from gatsby@2.24.53
+    node_modules/gatsby
+      gatsby@"" from the root project
+  peer react@"^16.4.2" from gatsby-link@2.4.13
+  node_modules/gatsby-link
+    gatsby-link@"^2.4.13" from gatsby@2.24.53
+    node_modules/gatsby
+      gatsby@"" from the root project
+  peer react@"^16.4.2" from gatsby-react-router-scroll@3.0.12
+  node_modules/gatsby-react-router-scroll
+    gatsby-react-router-scroll@"^3.0.12" from gatsby@2.24.53
+    node_modules/gatsby
+      gatsby@"" from the root project
+  peer react@"^15.0.0 || ^16.0.0" from react-hot-loader@4.12.21
+  node_modules/react-hot-loader
+    react-hot-loader@"^4.12.21" from gatsby@2.24.53
+    node_modules/gatsby
+      gatsby@"" from the root project
+  peer react@"^0.14.0 || ^15.0.0 || ^16.0.0" from create-react-context@0.3.0
+  node_modules/create-react-context
+    create-react-context@"0.3.0" from @reach/router@1.3.4
+    node_modules/@reach/router
+      @reach/router@"^1.3.4" from gatsby@2.24.53
+      node_modules/gatsby
+        gatsby@"" from the root project
+      peer @reach/router@"^1.3.3" from gatsby-link@2.4.13
+      node_modules/gatsby-link
+        gatsby-link@"^2.4.13" from gatsby@2.24.53
+        node_modules/gatsby
+          gatsby@"" from the root project
+      peer @reach/router@"^1.0.0" from gatsby-react-router-scroll@3.0.12
+      node_modules/gatsby-react-router-scroll
+        gatsby-react-router-scroll@"^3.0.12" from gatsby@2.24.53
+        node_modules/gatsby
+          gatsby@"" from the root project
+  peer react@"^16.12.0" from gatsby-recipes@0.2.20
+  node_modules/gatsby-recipes
+    gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+    node_modules/gatsby-cli
+      gatsby-cli@"^2.12.91" from gatsby@2.24.53
+      node_modules/gatsby
+        gatsby@"" from the root project
+  peer react@">=16.8.0" from ink@2.7.1
+  node_modules/ink
+    ink@"^2.7.1" from gatsby-cli@2.12.91
+    node_modules/gatsby-cli
+      gatsby-cli@"^2.12.91" from gatsby@2.24.53
+      node_modules/gatsby
+        gatsby@"" from the root project
+    peer ink@"^2.0.0" from ink-spinner@3.1.0
+    node_modules/ink-spinner
+      ink-spinner@"^3.1.0" from gatsby-cli@2.12.91
+      node_modules/gatsby-cli
+        gatsby-cli@"^2.12.91" from gatsby@2.24.53
+        node_modules/gatsby
+          gatsby@"" from the root project
+    peer ink@">=2.0.0" from ink-box@1.0.0
+    node_modules/ink-box
+      ink-box@"^1.0.0" from gatsby-recipes@0.2.20
+      node_modules/gatsby-recipes
+        gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+        node_modules/gatsby-cli
+          gatsby-cli@"^2.12.91" from gatsby@2.24.53
+          node_modules/gatsby
+            gatsby@"" from the root project
+  peer react@"^16.8.2" from ink-spinner@3.1.0
+  node_modules/ink-spinner
+    ink-spinner@"^3.1.0" from gatsby-cli@2.12.91
+    node_modules/gatsby-cli
+      gatsby-cli@"^2.12.91" from gatsby@2.24.53
+      node_modules/gatsby
+        gatsby@"" from the root project
+  peer react@">=16.3.0" from @emotion/core@10.0.35
+  node_modules/@emotion/core
+    @emotion/core@"^10.0.14" from gatsby-recipes@0.2.20
+    node_modules/gatsby-recipes
+      gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+      node_modules/gatsby-cli
+        gatsby-cli@"^2.12.91" from gatsby@2.24.53
+        node_modules/gatsby
+          gatsby@"" from the root project
+    peer @emotion/core@"^10.0.27" from @emotion/styled@10.0.27
+    node_modules/@emotion/styled
+      @emotion/styled@"^10.0.14" from gatsby-recipes@0.2.20
+      node_modules/gatsby-recipes
+        gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+        node_modules/gatsby-cli
+          gatsby-cli@"^2.12.91" from gatsby@2.24.53
+          node_modules/gatsby
+            gatsby@"" from the root project
+      peer @emotion/styled@"^10.0.14" from gatsby-interface@0.0.166
+      node_modules/gatsby-recipes/node_modules/gatsby-interface
+        gatsby-interface@"^0.0.166" from gatsby-recipes@0.2.20
+        node_modules/gatsby-recipes
+          gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+          node_modules/gatsby-cli
+            gatsby-cli@"^2.12.91" from gatsby@2.24.53
+            node_modules/gatsby
+              gatsby@"" from the root project
+    peer @emotion/core@"^10.0.14" from gatsby-interface@0.0.166
+    node_modules/gatsby-recipes/node_modules/gatsby-interface
+      gatsby-interface@"^0.0.166" from gatsby-recipes@0.2.20
+      node_modules/gatsby-recipes
+        gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+        node_modules/gatsby-cli
+          gatsby-cli@"^2.12.91" from gatsby@2.24.53
+          node_modules/gatsby
+            gatsby@"" from the root project
+    peer @emotion/core@"^10.0.28" from @emotion/styled-base@10.0.31
+    node_modules/@emotion/styled-base
+      @emotion/styled-base@"^10.0.27" from @emotion/styled@10.0.27
+      node_modules/@emotion/styled
+        @emotion/styled@"^10.0.14" from gatsby-recipes@0.2.20
+        node_modules/gatsby-recipes
+          gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+          node_modules/gatsby-cli
+            gatsby-cli@"^2.12.91" from gatsby@2.24.53
+            node_modules/gatsby
+              gatsby@"" from the root project
+        peer @emotion/styled@"^10.0.14" from gatsby-interface@0.0.166
+        node_modules/gatsby-recipes/node_modules/gatsby-interface
+          gatsby-interface@"^0.0.166" from gatsby-recipes@0.2.20
+          node_modules/gatsby-recipes
+            gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+            node_modules/gatsby-cli
+              gatsby-cli@"^2.12.91" from gatsby@2.24.53
+              node_modules/gatsby
+                gatsby@"" from the root project
+  peer react@">=16.3.0" from @emotion/styled@10.0.27
+  node_modules/@emotion/styled
+    @emotion/styled@"^10.0.14" from gatsby-recipes@0.2.20
+    node_modules/gatsby-recipes
+      gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+      node_modules/gatsby-cli
+        gatsby-cli@"^2.12.91" from gatsby@2.24.53
+        node_modules/gatsby
+          gatsby@"" from the root project
+    peer @emotion/styled@"^10.0.14" from gatsby-interface@0.0.166
+    node_modules/gatsby-recipes/node_modules/gatsby-interface
+      gatsby-interface@"^0.0.166" from gatsby-recipes@0.2.20
+      node_modules/gatsby-recipes
+        gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+        node_modules/gatsby-cli
+          gatsby-cli@"^2.12.91" from gatsby@2.24.53
+          node_modules/gatsby
+            gatsby@"" from the root project
+  peer react@"^16.13.1" from @mdx-js/react@2.0.0-next.7
+  node_modules/@mdx-js/react
+    @mdx-js/react@"^2.0.0-next.4" from gatsby-recipes@0.2.20
+    node_modules/gatsby-recipes
+      gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+      node_modules/gatsby-cli
+        gatsby-cli@"^2.12.91" from gatsby@2.24.53
+        node_modules/gatsby
+          gatsby@"" from the root project
+    @mdx-js/react@"^2.0.0-next.7" from @mdx-js/runtime@2.0.0-next.7
+    node_modules/@mdx-js/runtime
+      @mdx-js/runtime@"^2.0.0-next.4" from gatsby-recipes@0.2.20
+      node_modules/gatsby-recipes
+        gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+        node_modules/gatsby-cli
+          gatsby-cli@"^2.12.91" from gatsby@2.24.53
+          node_modules/gatsby
+            gatsby@"" from the root project
+  peer react@"^16.13.1" from @mdx-js/runtime@2.0.0-next.7
+  node_modules/@mdx-js/runtime
+    @mdx-js/runtime@"^2.0.0-next.4" from gatsby-recipes@0.2.20
+    node_modules/gatsby-recipes
+      gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+      node_modules/gatsby-cli
+        gatsby-cli@"^2.12.91" from gatsby@2.24.53
+        node_modules/gatsby
+          gatsby@"" from the root project
+  peer react@">=16.8.0" from formik@2.1.5
+  node_modules/formik
+    formik@"^2.0.8" from gatsby-recipes@0.2.20
+    node_modules/gatsby-recipes
+      gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+      node_modules/gatsby-cli
+        gatsby-cli@"^2.12.91" from gatsby@2.24.53
+        node_modules/gatsby
+          gatsby@"" from the root project
+    peer formik@"^2.0.8" from gatsby-interface@0.0.166
+    node_modules/gatsby-recipes/node_modules/gatsby-interface
+      gatsby-interface@"^0.0.166" from gatsby-recipes@0.2.20
+      node_modules/gatsby-recipes
+        gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+        node_modules/gatsby-cli
+          gatsby-cli@"^2.12.91" from gatsby@2.24.53
+          node_modules/gatsby
+            gatsby@"" from the root project
+  peer react@"^16.4.2" from gatsby@2.6.0
+  node_modules/gatsby-recipes/node_modules/gatsby
+    peer gatsby@"2.6.0" from gatsby-interface@0.0.166
+    node_modules/gatsby-recipes/node_modules/gatsby-interface
+      gatsby-interface@"^0.0.166" from gatsby-recipes@0.2.20
+      node_modules/gatsby-recipes
+        gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+        node_modules/gatsby-cli
+          gatsby-cli@"^2.12.91" from gatsby@2.24.53
+          node_modules/gatsby
+            gatsby@"" from the root project
+  peer react@"^16.0.0" from react-dom@16.8.1
+  node_modules/gatsby-recipes/node_modules/react-dom
+    peer react-dom@"16.8.1" from gatsby-interface@0.0.166
+    node_modules/gatsby-recipes/node_modules/gatsby-interface
+      gatsby-interface@"^0.0.166" from gatsby-recipes@0.2.20
+      node_modules/gatsby-recipes
+        gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+        node_modules/gatsby-cli
+          gatsby-cli@"^2.12.91" from gatsby@2.24.53
+          node_modules/gatsby
+            gatsby@"" from the root project
+    peer react-dom@"^16.4.2" from gatsby@2.6.0
+    node_modules/gatsby-recipes/node_modules/gatsby
+      peer gatsby@"2.6.0" from gatsby-interface@0.0.166
+      node_modules/gatsby-recipes/node_modules/gatsby-interface
+        gatsby-interface@"^0.0.166" from gatsby-recipes@0.2.20
+        node_modules/gatsby-recipes
+          gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+          node_modules/gatsby-cli
+            gatsby-cli@"^2.12.91" from gatsby@2.24.53
+            node_modules/gatsby
+              gatsby@"" from the root project
+    peer react-dom@"^0.14.0 || ^15.0.0 || ^16.0.0" from gatsby-react-router-scroll@2.3.1
+    node_modules/gatsby-recipes/node_modules/gatsby-react-router-scroll
+      gatsby-react-router-scroll@"^2.0.7" from gatsby@2.6.0
+      node_modules/gatsby-recipes/node_modules/gatsby
+        peer gatsby@"2.6.0" from gatsby-interface@0.0.166
+        node_modules/gatsby-recipes/node_modules/gatsby-interface
+          gatsby-interface@"^0.0.166" from gatsby-recipes@0.2.20
+          node_modules/gatsby-recipes
+            gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+            node_modules/gatsby-cli
+              gatsby-cli@"^2.12.91" from gatsby@2.24.53
+              node_modules/gatsby
+                gatsby@"" from the root project
+  peer react@"*" from react-icons@3.11.0
+  node_modules/react-icons
+    react-icons@"^3.0.1" from gatsby-recipes@0.2.20
+    node_modules/gatsby-recipes
+      gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+      node_modules/gatsby-cli
+        gatsby-cli@"^2.12.91" from gatsby@2.24.53
+        node_modules/gatsby
+          gatsby@"" from the root project
+    peer react-icons@"^3.2.1" from gatsby-interface@0.0.166
+    node_modules/gatsby-recipes/node_modules/gatsby-interface
+      gatsby-interface@"^0.0.166" from gatsby-recipes@0.2.20
+      node_modules/gatsby-recipes
+        gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+        node_modules/gatsby-cli
+          gatsby-cli@"^2.12.91" from gatsby@2.24.53
+          node_modules/gatsby
+            gatsby@"" from the root project
+  peer react@">=16.8.0" from ink-box@1.0.0
+  node_modules/ink-box
+    ink-box@"^1.0.0" from gatsby-recipes@0.2.20
+    node_modules/gatsby-recipes
+      gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+      node_modules/gatsby-cli
+        gatsby-cli@"^2.12.91" from gatsby@2.24.53
+        node_modules/gatsby
+          gatsby@"" from the root project
+  peer react@"^0.14.0 || ^15.0.0 || ^16.0.0" from react-circular-progressbar@2.0.3
+  node_modules/react-circular-progressbar
+    react-circular-progressbar@"^2.0.0" from gatsby-recipes@0.2.20
+    node_modules/gatsby-recipes
+      gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+      node_modules/gatsby-cli
+        gatsby-cli@"^2.12.91" from gatsby@2.24.53
+        node_modules/gatsby
+          gatsby@"" from the root project
+  peer react@"^16.13.1" from react-reconciler@0.25.1
+  node_modules/react-reconciler
+    react-reconciler@"^0.25.1" from gatsby-recipes@0.2.20
+    node_modules/gatsby-recipes
+      gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+      node_modules/gatsby-cli
+        gatsby-cli@"^2.12.91" from gatsby@2.24.53
+        node_modules/gatsby
+          gatsby@"" from the root project
+  peer react@">= 16.8.0" from urql@1.10.0
+  node_modules/urql
+    urql@"^1.9.7" from gatsby-recipes@0.2.20
+    node_modules/gatsby-recipes
+      gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+      node_modules/gatsby-cli
+        gatsby-cli@"^2.12.91" from gatsby@2.24.53
+        node_modules/gatsby
+          gatsby@"" from the root project
+  peer react@">=16.3.0" from @emotion/styled-base@10.0.31
+  node_modules/@emotion/styled-base
+    @emotion/styled-base@"^10.0.27" from @emotion/styled@10.0.27
+    node_modules/@emotion/styled
+      @emotion/styled@"^10.0.14" from gatsby-recipes@0.2.20
+      node_modules/gatsby-recipes
+        gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+        node_modules/gatsby-cli
+          gatsby-cli@"^2.12.91" from gatsby@2.24.53
+          node_modules/gatsby
+            gatsby@"" from the root project
+      peer @emotion/styled@"^10.0.14" from gatsby-interface@0.0.166
+      node_modules/gatsby-recipes/node_modules/gatsby-interface
+        gatsby-interface@"^0.0.166" from gatsby-recipes@0.2.20
+        node_modules/gatsby-recipes
+          gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+          node_modules/gatsby-cli
+            gatsby-cli@"^2.12.91" from gatsby@2.24.53
+            node_modules/gatsby
+              gatsby@"" from the root project
+  peer react@"^16.0.0" from react-reconciler@0.24.0
+  node_modules/ink/node_modules/react-reconciler
+    react-reconciler@"^0.24.0" from ink@2.7.1
+    node_modules/ink
+      ink@"^2.7.1" from gatsby-cli@2.12.91
+      node_modules/gatsby-cli
+        gatsby-cli@"^2.12.91" from gatsby@2.24.53
+        node_modules/gatsby
+          gatsby@"" from the root project
+      peer ink@"^2.0.0" from ink-spinner@3.1.0
+      node_modules/ink-spinner
+        ink-spinner@"^3.1.0" from gatsby-cli@2.12.91
+        node_modules/gatsby-cli
+          gatsby-cli@"^2.12.91" from gatsby@2.24.53
+          node_modules/gatsby
+            gatsby@"" from the root project
+      peer ink@">=2.0.0" from ink-box@1.0.0
+      node_modules/ink-box
+        ink-box@"^1.0.0" from gatsby-recipes@0.2.20
+        node_modules/gatsby-recipes
+          gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+          node_modules/gatsby-cli
+            gatsby-cli@"^2.12.91" from gatsby@2.24.53
+            node_modules/gatsby
+              gatsby@"" from the root project
+  peer react@"^0.14.0 || ^15.0.0 || ^16.0.0" from gatsby-react-router-scroll@2.3.1
+  node_modules/gatsby-recipes/node_modules/gatsby-react-router-scroll
+    gatsby-react-router-scroll@"^2.0.7" from gatsby@2.6.0
+    node_modules/gatsby-recipes/node_modules/gatsby
+      peer gatsby@"2.6.0" from gatsby-interface@0.0.166
+      node_modules/gatsby-recipes/node_modules/gatsby-interface
+        gatsby-interface@"^0.0.166" from gatsby-recipes@0.2.20
+        node_modules/gatsby-recipes
+          gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+          node_modules/gatsby-cli
+            gatsby-cli@"^2.12.91" from gatsby@2.24.53
+            node_modules/gatsby
+              gatsby@"" from the root project
+  peer react@"^16.13.1" from @mdx-js/react@1.6.16
+  node_modules/gatsby-recipes/node_modules/gatsby-interface/node_modules/@mdx-js/react
+    @mdx-js/react@"^1.5.2" from gatsby-interface@0.0.166
+    node_modules/gatsby-recipes/node_modules/gatsby-interface
+      gatsby-interface@"^0.0.166" from gatsby-recipes@0.2.20
+      node_modules/gatsby-recipes
+        gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+        node_modules/gatsby-cli
+          gatsby-cli@"^2.12.91" from gatsby@2.24.53
+          node_modules/gatsby
+            gatsby@"" from the root project
 
-Could not add conflicting dependency: react@16.8.1 at node_modules/react
-  for: peer dependency react@"16.8.1"
-  from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
-    for: prod dependency gatsby-interface@"^0.0.166"
-    from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-      for: prod dependency gatsby-recipes@"^0.2.20"
-      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-        for: prod dependency gatsby-cli@"^2.12.91"
-        from: gatsby@2.24.53 at node_modules/gatsby
-          for: prod dependency gatsby@""
-          from: the root project
+Could not add conflicting dependency: react@16.8.1
+node_modules/react
+  peer react@"16.8.1" from gatsby-interface@0.0.166
+  node_modules/gatsby-recipes/node_modules/gatsby-interface
+    gatsby-interface@"^0.0.166" from gatsby-recipes@0.2.20
+    node_modules/gatsby-recipes
+      gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+      node_modules/gatsby-cli
+        gatsby-cli@"^2.12.91" from gatsby@2.24.53
+        node_modules/gatsby
+          gatsby@"" from the root project
 
 Fix the upstream dependency conflict, or retry
 this command with --legacy-peer-deps or --force
@@ -746,36 +690,35 @@ Raw JSON explanation object:
 
 exports[`test/lib/utils/explain-eresolve.js TAP gatsby > report with color 1`] = `
 While resolving: [1mgatsby-interface[22m@[1m0.0.166[22m
-Found: [1mreact[22m@[1m16.13.1[22m[2m at node_modules/react[22m
-  for: peer dependency [1mreact[22m@"[1m^16.4.2[22m"
-  from: [1mgatsby[22m@[1m2.24.53[22m[2m at node_modules/gatsby[22m
-    for: prod dependency [1mgatsby[22m@""
-    from: the root project
-  and: peer dependency [1mreact[22m@"[1m^16.13.1[22m"
-  from: [1mreact-dom[22m@[1m16.13.1[22m[2m at node_modules/react-dom[22m
-    for: peer dependency [1mreact-dom[22m@"[1m^16.4.2[22m"
-    from: [1mgatsby[22m@[1m2.24.53[22m[2m at node_modules/gatsby[22m
-      for: prod dependency [1mgatsby[22m@""
-      from: the root project
-    and: peer dependency [1mreact-dom[22m@"[1m15.x || 16.x || 16.4.0-alpha.0911da3[22m"
-    from: [1m@reach/router[22m@[1m1.3.4[22m[2m at node_modules/@reach/router[22m
-      for: prod dependency [1m@reach/router[22m@"[1m^1.3.4[22m"
-      from: [1mgatsby[22m@[1m2.24.53[22m[2m at node_modules/gatsby[22m
-        for: prod dependency [1mgatsby[22m@""
-        from: the root project
-      and: 2 more (gatsby-link, gatsby-react-router-scroll)
-    and: 3 more (gatsby-link, gatsby-react-router-scroll, react-hot-loader)
-  and: 25 more (@reach/router, gatsby-cli, gatsby-link, gatsby-react-router-scroll, react-hot-loader, ...)
+Found: [1mreact[22m@[1m16.13.1[22m[2m[22m
+[2mnode_modules/react[22m
+  [35mpeer[39m [1mreact[22m@"[1m^16.4.2[22m" from [1mgatsby[22m@[1m2.24.53[22m[2m[22m
+  [2mnode_modules/gatsby[22m
+    [1mgatsby[22m@"" from the root project
+  [35mpeer[39m [1mreact[22m@"[1m^16.13.1[22m" from [1mreact-dom[22m@[1m16.13.1[22m[2m[22m
+  [2mnode_modules/react-dom[22m
+    [35mpeer[39m [1mreact-dom[22m@"[1m^16.4.2[22m" from [1mgatsby[22m@[1m2.24.53[22m[2m[22m
+    [2mnode_modules/gatsby[22m
+      [1mgatsby[22m@"" from the root project
+    [35mpeer[39m [1mreact-dom[22m@"[1m15.x || 16.x || 16.4.0-alpha.0911da3[22m" from [1m@reach/router[22m@[1m1.3.4[22m[2m[22m
+    [2mnode_modules/@reach/router[22m
+      [1m@reach/router[22m@"[1m^1.3.4[22m" from [1mgatsby[22m@[1m2.24.53[22m[2m[22m
+      [2mnode_modules/gatsby[22m
+        [1mgatsby[22m@"" from the root project
+      2 more (gatsby-link, gatsby-react-router-scroll)
+    3 more (gatsby-link, gatsby-react-router-scroll, react-hot-loader)
+  25 more (@reach/router, gatsby-cli, gatsby-link, ...)
 
-Could not add conflicting dependency: [1mreact[22m@[1m16.8.1[22m[2m at node_modules/react[22m
-  for: peer dependency [1mreact[22m@"[1m16.8.1[22m"
-  from: [1mgatsby-interface[22m@[1m0.0.166[22m[2m at node_modules/gatsby-recipes/node_modules/gatsby-interface[22m
-    for: prod dependency [1mgatsby-interface[22m@"[1m^0.0.166[22m"
-    from: [1mgatsby-recipes[22m@[1m0.2.20[22m[2m at node_modules/gatsby-recipes[22m
-      for: prod dependency [1mgatsby-recipes[22m@"[1m^0.2.20[22m"
-      from: [1mgatsby-cli[22m@[1m2.12.91[22m[2m at node_modules/gatsby-cli[22m
-        for: prod dependency [1mgatsby-cli[22m@"[1m^2.12.91[22m"
-        from: [1mgatsby[22m@[1m2.24.53[22m[2m at node_modules/gatsby[22m
+Could not add conflicting dependency: [1mreact[22m@[1m16.8.1[22m[2m[22m
+[2mnode_modules/react[22m
+  [35mpeer[39m [1mreact[22m@"[1m16.8.1[22m" from [1mgatsby-interface[22m@[1m0.0.166[22m[2m[22m
+  [2mnode_modules/gatsby-recipes/node_modules/gatsby-interface[22m
+    [1mgatsby-interface[22m@"[1m^0.0.166[22m" from [1mgatsby-recipes[22m@[1m0.2.20[22m[2m[22m
+    [2mnode_modules/gatsby-recipes[22m
+      [1mgatsby-recipes[22m@"[1m^0.2.20[22m" from [1mgatsby-cli[22m@[1m2.12.91[22m[2m[22m
+      [2mnode_modules/gatsby-cli[22m
+        [1mgatsby-cli[22m@"[1m^2.12.91[22m" from [1mgatsby[22m@[1m2.24.53[22m[2m[22m
+        [2mnode_modules/gatsby[22m
 
 Fix the upstream dependency conflict, or retry
 this command with --legacy-peer-deps or --force
@@ -786,18 +729,19 @@ See \${REPORT} for a full report.
 
 exports[`test/lib/utils/explain-eresolve.js TAP gatsby > report with color, depth only 2 1`] = `
 While resolving: [1mgatsby-interface[22m@[1m0.0.166[22m
-Found: [1mreact[22m@[1m16.13.1[22m[2m at node_modules/react[22m
-  for: peer dependency [1mreact[22m@"[1m^16.4.2[22m"
-  from: [1mgatsby[22m@[1m2.24.53[22m[2m at node_modules/gatsby[22m
-    for: prod dependency [1mgatsby[22m@""
-    from: the root project
-  and: 26 more (react-dom, @reach/router, gatsby-cli, gatsby-link, gatsby-react-router-scroll, ...)
+Found: [1mreact[22m@[1m16.13.1[22m[2m[22m
+[2mnode_modules/react[22m
+  [35mpeer[39m [1mreact[22m@"[1m^16.4.2[22m" from [1mgatsby[22m@[1m2.24.53[22m[2m[22m
+  [2mnode_modules/gatsby[22m
+    [1mgatsby[22m@"" from the root project
+  26 more (react-dom, @reach/router, gatsby-cli, ...)
 
-Could not add conflicting dependency: [1mreact[22m@[1m16.8.1[22m[2m at node_modules/react[22m
-  for: peer dependency [1mreact[22m@"[1m16.8.1[22m"
-  from: [1mgatsby-interface[22m@[1m0.0.166[22m[2m at node_modules/gatsby-recipes/node_modules/gatsby-interface[22m
-    for: prod dependency [1mgatsby-interface[22m@"[1m^0.0.166[22m"
-    from: [1mgatsby-recipes[22m@[1m0.2.20[22m[2m at node_modules/gatsby-recipes[22m
+Could not add conflicting dependency: [1mreact[22m@[1m16.8.1[22m[2m[22m
+[2mnode_modules/react[22m
+  [35mpeer[39m [1mreact[22m@"[1m16.8.1[22m" from [1mgatsby-interface[22m@[1m0.0.166[22m[2m[22m
+  [2mnode_modules/gatsby-recipes/node_modules/gatsby-interface[22m
+    [1mgatsby-interface[22m@"[1m^0.0.166[22m" from [1mgatsby-recipes[22m@[1m0.2.20[22m[2m[22m
+    [2mnode_modules/gatsby-recipes[22m
 
 Fix the upstream dependency conflict, or retry
 this command with --legacy-peer-deps or --force
@@ -808,68 +752,61 @@ See \${REPORT} for a full report.
 
 exports[`test/lib/utils/explain-eresolve.js TAP gatsby > report with no color, depth of 6 1`] = `
 While resolving: gatsby-interface@0.0.166
-Found: react@16.13.1 at node_modules/react
-  for: peer dependency react@"^16.4.2"
-  from: gatsby@2.24.53 at node_modules/gatsby
-    for: prod dependency gatsby@""
-    from: the root project
-  and: peer dependency react@"^16.13.1"
-  from: react-dom@16.13.1 at node_modules/react-dom
-    for: peer dependency react-dom@"^16.4.2"
-    from: gatsby@2.24.53 at node_modules/gatsby
-      for: prod dependency gatsby@""
-      from: the root project
-    and: peer dependency react-dom@"15.x || 16.x || 16.4.0-alpha.0911da3"
-    from: @reach/router@1.3.4 at node_modules/@reach/router
-      for: prod dependency @reach/router@"^1.3.4"
-      from: gatsby@2.24.53 at node_modules/gatsby
-        for: prod dependency gatsby@""
-        from: the root project
-      and: peer dependency @reach/router@"^1.3.3"
-      from: gatsby-link@2.4.13 at node_modules/gatsby-link
-        for: prod dependency gatsby-link@"^2.4.13"
-        from: gatsby@2.24.53 at node_modules/gatsby
-          for: prod dependency gatsby@""
-          from: the root project
-      and: 1 more (gatsby-react-router-scroll)
-    and: peer dependency react-dom@"^16.4.2"
-    from: gatsby-link@2.4.13 at node_modules/gatsby-link
-      for: prod dependency gatsby-link@"^2.4.13"
-      from: gatsby@2.24.53 at node_modules/gatsby
-        for: prod dependency gatsby@""
-        from: the root project
-    and: 2 more (gatsby-react-router-scroll, react-hot-loader)
-  and: peer dependency react@"15.x || 16.x || 16.4.0-alpha.0911da3"
-  from: @reach/router@1.3.4 at node_modules/@reach/router
-    for: prod dependency @reach/router@"^1.3.4"
-    from: gatsby@2.24.53 at node_modules/gatsby
-      for: prod dependency gatsby@""
-      from: the root project
-    and: peer dependency @reach/router@"^1.3.3"
-    from: gatsby-link@2.4.13 at node_modules/gatsby-link
-      for: prod dependency gatsby-link@"^2.4.13"
-      from: gatsby@2.24.53 at node_modules/gatsby
-        for: prod dependency gatsby@""
-        from: the root project
-    and: peer dependency @reach/router@"^1.0.0"
-    from: gatsby-react-router-scroll@3.0.12 at node_modules/gatsby-react-router-scroll
-      for: prod dependency gatsby-react-router-scroll@"^3.0.12"
-      from: gatsby@2.24.53 at node_modules/gatsby
-        for: prod dependency gatsby@""
-        from: the root project
-  and: 24 more (gatsby-cli, gatsby-link, gatsby-react-router-scroll, react-hot-loader, create-react-context, ...)
+Found: react@16.13.1
+node_modules/react
+  peer react@"^16.4.2" from gatsby@2.24.53
+  node_modules/gatsby
+    gatsby@"" from the root project
+  peer react@"^16.13.1" from react-dom@16.13.1
+  node_modules/react-dom
+    peer react-dom@"^16.4.2" from gatsby@2.24.53
+    node_modules/gatsby
+      gatsby@"" from the root project
+    peer react-dom@"15.x || 16.x || 16.4.0-alpha.0911da3" from @reach/router@1.3.4
+    node_modules/@reach/router
+      @reach/router@"^1.3.4" from gatsby@2.24.53
+      node_modules/gatsby
+        gatsby@"" from the root project
+      peer @reach/router@"^1.3.3" from gatsby-link@2.4.13
+      node_modules/gatsby-link
+        gatsby-link@"^2.4.13" from gatsby@2.24.53
+        node_modules/gatsby
+          gatsby@"" from the root project
+      1 more (gatsby-react-router-scroll)
+    peer react-dom@"^16.4.2" from gatsby-link@2.4.13
+    node_modules/gatsby-link
+      gatsby-link@"^2.4.13" from gatsby@2.24.53
+      node_modules/gatsby
+        gatsby@"" from the root project
+    2 more (gatsby-react-router-scroll, react-hot-loader)
+  peer react@"15.x || 16.x || 16.4.0-alpha.0911da3" from @reach/router@1.3.4
+  node_modules/@reach/router
+    @reach/router@"^1.3.4" from gatsby@2.24.53
+    node_modules/gatsby
+      gatsby@"" from the root project
+    peer @reach/router@"^1.3.3" from gatsby-link@2.4.13
+    node_modules/gatsby-link
+      gatsby-link@"^2.4.13" from gatsby@2.24.53
+      node_modules/gatsby
+        gatsby@"" from the root project
+    peer @reach/router@"^1.0.0" from gatsby-react-router-scroll@3.0.12
+    node_modules/gatsby-react-router-scroll
+      gatsby-react-router-scroll@"^3.0.12" from gatsby@2.24.53
+      node_modules/gatsby
+        gatsby@"" from the root project
+  24 more (gatsby-cli, gatsby-link, gatsby-react-router-scroll, ...)
 
-Could not add conflicting dependency: react@16.8.1 at node_modules/react
-  for: peer dependency react@"16.8.1"
-  from: gatsby-interface@0.0.166 at node_modules/gatsby-recipes/node_modules/gatsby-interface
-    for: prod dependency gatsby-interface@"^0.0.166"
-    from: gatsby-recipes@0.2.20 at node_modules/gatsby-recipes
-      for: prod dependency gatsby-recipes@"^0.2.20"
-      from: gatsby-cli@2.12.91 at node_modules/gatsby-cli
-        for: prod dependency gatsby-cli@"^2.12.91"
-        from: gatsby@2.24.53 at node_modules/gatsby
-          for: prod dependency gatsby@""
-          from: the root project
+Could not add conflicting dependency: react@16.8.1
+node_modules/react
+  peer react@"16.8.1" from gatsby-interface@0.0.166
+  node_modules/gatsby-recipes/node_modules/gatsby-interface
+    gatsby-interface@"^0.0.166" from gatsby-recipes@0.2.20
+    node_modules/gatsby-recipes
+      gatsby-recipes@"^0.2.20" from gatsby-cli@2.12.91
+      node_modules/gatsby-cli
+        gatsby-cli@"^2.12.91" from gatsby@2.24.53
+        node_modules/gatsby
+          gatsby@"" from the root project
 
 Fix the upstream dependency conflict, or retry
 this command with --legacy-peer-deps or --force
@@ -880,30 +817,31 @@ See \${REPORT} for a full report.
 
 exports[`test/lib/utils/explain-eresolve.js TAP withShrinkwrap > explain with color 1`] = `
 While resolving: [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m
-Found: [1m@isaacs/peer-dep-cycle-c[22m@[1m2.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-c[22m
-  for: prod dependency [1m@isaacs/peer-dep-cycle-c[22m@"[1m2.x[22m"
-  from: the root project
+Found: [1m@isaacs/peer-dep-cycle-c[22m@[1m2.0.0[22m[2m[22m
+[2mnode_modules/@isaacs/peer-dep-cycle-c[22m
+  [1m@isaacs/peer-dep-cycle-c[22m@"[1m2.x[22m" from the root project
 
-Could not add conflicting dependency: [1m@isaacs/peer-dep-cycle-c[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-c[22m
-  for: peer dependency [1m@isaacs/peer-dep-cycle-c[22m@"[1m1[22m"
-  from: [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-b[22m
-    for: peer dependency [1m@isaacs/peer-dep-cycle-b[22m@"[1m1[22m"
-    from: [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-a[22m
+Could not add conflicting dependency: [1m@isaacs/peer-dep-cycle-c[22m@[1m1.0.0[22m[2m[22m
+[2mnode_modules/@isaacs/peer-dep-cycle-c[22m
+  [35mpeer[39m [1m@isaacs/peer-dep-cycle-c[22m@"[1m1[22m" from [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m[2m[22m
+  [2mnode_modules/@isaacs/peer-dep-cycle-b[22m
+    [35mpeer[39m [1m@isaacs/peer-dep-cycle-b[22m@"[1m1[22m" from [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m[2m[22m
+    [2mnode_modules/@isaacs/peer-dep-cycle-a[22m
 `
 
 exports[`test/lib/utils/explain-eresolve.js TAP withShrinkwrap > explain with no color, depth of 6 1`] = `
 While resolving: @isaacs/peer-dep-cycle-b@1.0.0
-Found: @isaacs/peer-dep-cycle-c@2.0.0 at node_modules/@isaacs/peer-dep-cycle-c
-  for: prod dependency @isaacs/peer-dep-cycle-c@"2.x"
-  from: the root project
+Found: @isaacs/peer-dep-cycle-c@2.0.0
+node_modules/@isaacs/peer-dep-cycle-c
+  @isaacs/peer-dep-cycle-c@"2.x" from the root project
 
-Could not add conflicting dependency: @isaacs/peer-dep-cycle-c@1.0.0 at node_modules/@isaacs/peer-dep-cycle-c
-  for: peer dependency @isaacs/peer-dep-cycle-c@"1"
-  from: @isaacs/peer-dep-cycle-b@1.0.0 at node_modules/@isaacs/peer-dep-cycle-b
-    for: peer dependency @isaacs/peer-dep-cycle-b@"1"
-    from: @isaacs/peer-dep-cycle-a@1.0.0 at node_modules/@isaacs/peer-dep-cycle-a
-      for: prod dependency @isaacs/peer-dep-cycle-a@"1.x"
-      from: the root project
+Could not add conflicting dependency: @isaacs/peer-dep-cycle-c@1.0.0
+node_modules/@isaacs/peer-dep-cycle-c
+  peer @isaacs/peer-dep-cycle-c@"1" from @isaacs/peer-dep-cycle-b@1.0.0
+  node_modules/@isaacs/peer-dep-cycle-b
+    peer @isaacs/peer-dep-cycle-b@"1" from @isaacs/peer-dep-cycle-a@1.0.0
+    node_modules/@isaacs/peer-dep-cycle-a
+      @isaacs/peer-dep-cycle-a@"1.x" from the root project
 `
 
 exports[`test/lib/utils/explain-eresolve.js TAP withShrinkwrap > report 1`] = `
@@ -912,17 +850,17 @@ exports[`test/lib/utils/explain-eresolve.js TAP withShrinkwrap > report 1`] = `
 \${TIME}
 
 While resolving: @isaacs/peer-dep-cycle-b@1.0.0
-Found: @isaacs/peer-dep-cycle-c@2.0.0 at node_modules/@isaacs/peer-dep-cycle-c
-  for: prod dependency @isaacs/peer-dep-cycle-c@"2.x"
-  from: the root project
+Found: @isaacs/peer-dep-cycle-c@2.0.0
+node_modules/@isaacs/peer-dep-cycle-c
+  @isaacs/peer-dep-cycle-c@"2.x" from the root project
 
-Could not add conflicting dependency: @isaacs/peer-dep-cycle-c@1.0.0 at node_modules/@isaacs/peer-dep-cycle-c
-  for: peer dependency @isaacs/peer-dep-cycle-c@"1"
-  from: @isaacs/peer-dep-cycle-b@1.0.0 at node_modules/@isaacs/peer-dep-cycle-b
-    for: peer dependency @isaacs/peer-dep-cycle-b@"1"
-    from: @isaacs/peer-dep-cycle-a@1.0.0 at node_modules/@isaacs/peer-dep-cycle-a
-      for: prod dependency @isaacs/peer-dep-cycle-a@"1.x"
-      from: the root project
+Could not add conflicting dependency: @isaacs/peer-dep-cycle-c@1.0.0
+node_modules/@isaacs/peer-dep-cycle-c
+  peer @isaacs/peer-dep-cycle-c@"1" from @isaacs/peer-dep-cycle-b@1.0.0
+  node_modules/@isaacs/peer-dep-cycle-b
+    peer @isaacs/peer-dep-cycle-b@"1" from @isaacs/peer-dep-cycle-a@1.0.0
+    node_modules/@isaacs/peer-dep-cycle-a
+      @isaacs/peer-dep-cycle-a@"1.x" from the root project
 
 Fix the upstream dependency conflict, or retry
 this command with --legacy-peer-deps or --force
@@ -939,17 +877,17 @@ Raw JSON explanation object:
 
 exports[`test/lib/utils/explain-eresolve.js TAP withShrinkwrap > report with color 1`] = `
 While resolving: [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m
-Found: [1m@isaacs/peer-dep-cycle-c[22m@[1m2.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-c[22m
-  for: prod dependency [1m@isaacs/peer-dep-cycle-c[22m@"[1m2.x[22m"
-  from: the root project
+Found: [1m@isaacs/peer-dep-cycle-c[22m@[1m2.0.0[22m[2m[22m
+[2mnode_modules/@isaacs/peer-dep-cycle-c[22m
+  [1m@isaacs/peer-dep-cycle-c[22m@"[1m2.x[22m" from the root project
 
-Could not add conflicting dependency: [1m@isaacs/peer-dep-cycle-c[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-c[22m
-  for: peer dependency [1m@isaacs/peer-dep-cycle-c[22m@"[1m1[22m"
-  from: [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-b[22m
-    for: peer dependency [1m@isaacs/peer-dep-cycle-b[22m@"[1m1[22m"
-    from: [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-a[22m
-      for: prod dependency [1m@isaacs/peer-dep-cycle-a[22m@"[1m1.x[22m"
-      from: the root project
+Could not add conflicting dependency: [1m@isaacs/peer-dep-cycle-c[22m@[1m1.0.0[22m[2m[22m
+[2mnode_modules/@isaacs/peer-dep-cycle-c[22m
+  [35mpeer[39m [1m@isaacs/peer-dep-cycle-c[22m@"[1m1[22m" from [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m[2m[22m
+  [2mnode_modules/@isaacs/peer-dep-cycle-b[22m
+    [35mpeer[39m [1m@isaacs/peer-dep-cycle-b[22m@"[1m1[22m" from [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m[2m[22m
+    [2mnode_modules/@isaacs/peer-dep-cycle-a[22m
+      [1m@isaacs/peer-dep-cycle-a[22m@"[1m1.x[22m" from the root project
 
 Fix the upstream dependency conflict, or retry
 this command with --legacy-peer-deps or --force
@@ -960,15 +898,16 @@ See \${REPORT} for a full report.
 
 exports[`test/lib/utils/explain-eresolve.js TAP withShrinkwrap > report with color, depth only 2 1`] = `
 While resolving: [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m
-Found: [1m@isaacs/peer-dep-cycle-c[22m@[1m2.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-c[22m
-  for: prod dependency [1m@isaacs/peer-dep-cycle-c[22m@"[1m2.x[22m"
-  from: the root project
+Found: [1m@isaacs/peer-dep-cycle-c[22m@[1m2.0.0[22m[2m[22m
+[2mnode_modules/@isaacs/peer-dep-cycle-c[22m
+  [1m@isaacs/peer-dep-cycle-c[22m@"[1m2.x[22m" from the root project
 
-Could not add conflicting dependency: [1m@isaacs/peer-dep-cycle-c[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-c[22m
-  for: peer dependency [1m@isaacs/peer-dep-cycle-c[22m@"[1m1[22m"
-  from: [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-b[22m
-    for: peer dependency [1m@isaacs/peer-dep-cycle-b[22m@"[1m1[22m"
-    from: [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m[2m at node_modules/@isaacs/peer-dep-cycle-a[22m
+Could not add conflicting dependency: [1m@isaacs/peer-dep-cycle-c[22m@[1m1.0.0[22m[2m[22m
+[2mnode_modules/@isaacs/peer-dep-cycle-c[22m
+  [35mpeer[39m [1m@isaacs/peer-dep-cycle-c[22m@"[1m1[22m" from [1m@isaacs/peer-dep-cycle-b[22m@[1m1.0.0[22m[2m[22m
+  [2mnode_modules/@isaacs/peer-dep-cycle-b[22m
+    [35mpeer[39m [1m@isaacs/peer-dep-cycle-b[22m@"[1m1[22m" from [1m@isaacs/peer-dep-cycle-a[22m@[1m1.0.0[22m[2m[22m
+    [2mnode_modules/@isaacs/peer-dep-cycle-a[22m
 
 Fix the upstream dependency conflict, or retry
 this command with --legacy-peer-deps or --force
@@ -979,17 +918,17 @@ See \${REPORT} for a full report.
 
 exports[`test/lib/utils/explain-eresolve.js TAP withShrinkwrap > report with no color, depth of 6 1`] = `
 While resolving: @isaacs/peer-dep-cycle-b@1.0.0
-Found: @isaacs/peer-dep-cycle-c@2.0.0 at node_modules/@isaacs/peer-dep-cycle-c
-  for: prod dependency @isaacs/peer-dep-cycle-c@"2.x"
-  from: the root project
+Found: @isaacs/peer-dep-cycle-c@2.0.0
+node_modules/@isaacs/peer-dep-cycle-c
+  @isaacs/peer-dep-cycle-c@"2.x" from the root project
 
-Could not add conflicting dependency: @isaacs/peer-dep-cycle-c@1.0.0 at node_modules/@isaacs/peer-dep-cycle-c
-  for: peer dependency @isaacs/peer-dep-cycle-c@"1"
-  from: @isaacs/peer-dep-cycle-b@1.0.0 at node_modules/@isaacs/peer-dep-cycle-b
-    for: peer dependency @isaacs/peer-dep-cycle-b@"1"
-    from: @isaacs/peer-dep-cycle-a@1.0.0 at node_modules/@isaacs/peer-dep-cycle-a
-      for: prod dependency @isaacs/peer-dep-cycle-a@"1.x"
-      from: the root project
+Could not add conflicting dependency: @isaacs/peer-dep-cycle-c@1.0.0
+node_modules/@isaacs/peer-dep-cycle-c
+  peer @isaacs/peer-dep-cycle-c@"1" from @isaacs/peer-dep-cycle-b@1.0.0
+  node_modules/@isaacs/peer-dep-cycle-b
+    peer @isaacs/peer-dep-cycle-b@"1" from @isaacs/peer-dep-cycle-a@1.0.0
+    node_modules/@isaacs/peer-dep-cycle-a
+      @isaacs/peer-dep-cycle-a@"1.x" from the root project
 
 Fix the upstream dependency conflict, or retry
 this command with --legacy-peer-deps or --force

--- a/test/lib/explain.js
+++ b/test/lib/explain.js
@@ -1,0 +1,177 @@
+const t = require('tap')
+const requireInject = require('require-inject')
+const npm = {
+  prefix: null,
+  color: true,
+  flatOptions: {}
+}
+const { resolve } = require('path')
+
+const OUTPUT = []
+
+const explain = requireInject('../../lib/explain.js', {
+  '../../lib/npm.js': npm,
+
+  '../../lib/utils/output.js': (...args) => {
+    OUTPUT.push(args)
+  },
+
+  // keep the snapshots pared down a bit, since this has its own tests.
+  '../../lib/utils/explain-dep.js': {
+    explainNode: (expl, depth, color) => {
+      return `${expl.name}@${expl.version} depth=${depth} color=${color}`
+    }
+  }
+})
+
+t.test('no args throws usage', async t => {
+  t.plan(1)
+  try {
+    await explain([], er => {
+      throw er
+    })
+  } catch (er) {
+    t.equal(er, explain.usage)
+  }
+})
+
+t.test('no match throws not found', async t => {
+  npm.prefix = t.testdir()
+  t.plan(1)
+  try {
+    await explain(['foo@1.2.3', 'node_modules/baz'], er => {
+      throw er
+    })
+  } catch (er) {
+    t.equal(er, 'No dependencies found matching foo@1.2.3, node_modules/baz')
+  }
+})
+
+t.test('invalid package name throws not found', async t => {
+  npm.prefix = t.testdir()
+  t.plan(1)
+  const badName = ' not a valid package name '
+  try {
+    await explain([`${badName}@1.2.3`], er => {
+      throw er
+    })
+  } catch (er) {
+    t.equal(er, `No dependencies found matching ${badName}@1.2.3`)
+  }
+})
+
+t.test('explain some nodes', async t => {
+  npm.prefix = t.testdir({
+    node_modules: {
+      foo: {
+        'package.json': JSON.stringify({
+          name: 'foo',
+          version: '1.2.3',
+          dependencies: {
+            bar: '*'
+          }
+        })
+      },
+      bar: {
+        'package.json': JSON.stringify({
+          name: 'bar',
+          version: '1.2.3'
+        })
+      },
+      baz: {
+        'package.json': JSON.stringify({
+          name: 'baz',
+          version: '1.2.3',
+          dependencies: {
+            foo: '*',
+            bar: '2'
+          }
+        }),
+        node_modules: {
+          bar: {
+            'package.json': JSON.stringify({
+              name: 'bar',
+              version: '2.3.4'
+            })
+          },
+          extra: {
+            'package.json': JSON.stringify({
+              name: 'extra',
+              version: '99.9999.999999',
+              description: 'extraneous package'
+            })
+          }
+        }
+      }
+    },
+    'package.json': JSON.stringify({
+      dependencies: {
+        baz: '1'
+      }
+    })
+  })
+
+  // works with either a full actual path or the location
+  const p = 'node_modules/foo'
+  for (const path of [p, resolve(npm.prefix, p)]) {
+    await explain([path], er => {
+      if (er) {
+        throw er
+      }
+    })
+    t.strictSame(OUTPUT, [['foo@1.2.3 depth=Infinity color=true']])
+    OUTPUT.length = 0
+  }
+
+  // finds all nodes by name
+  await explain(['bar'], er => {
+    if (er) {
+      throw er
+    }
+  })
+  t.strictSame(OUTPUT, [[
+    'bar@1.2.3 depth=Infinity color=true\n\n' +
+    'bar@2.3.4 depth=Infinity color=true'
+  ]])
+  OUTPUT.length = 0
+
+  // finds only nodes that match the spec
+  await explain(['bar@1'], er => {
+    if (er) {
+      throw er
+    }
+  })
+  t.strictSame(OUTPUT, [['bar@1.2.3 depth=Infinity color=true']])
+  OUTPUT.length = 0
+
+  // finds extraneous nodes
+  await explain(['extra'], er => {
+    if (er) {
+      throw er
+    }
+  })
+  t.strictSame(OUTPUT, [['extra@99.9999.999999 depth=Infinity color=true']])
+  OUTPUT.length = 0
+
+  npm.flatOptions.json = true
+  await explain(['node_modules/foo'], er => {
+    if (er) {
+      throw er
+    }
+  })
+  t.match(JSON.parse(OUTPUT[0][0]), [{
+    name: 'foo',
+    version: '1.2.3',
+    dependents: Array
+  }])
+  OUTPUT.length = 0
+  npm.flatOptions.json = false
+
+  t.test('report if no nodes found', async t => {
+    t.plan(1)
+    await explain(['asdf/foo/bar', 'quux@1.x'], er => {
+      t.equal(er, 'No dependencies found matching asdf/foo/bar, quux@1.x')
+    })
+  })
+})
+

--- a/test/lib/utils/explain-dep.js
+++ b/test/lib/utils/explain-dep.js
@@ -1,0 +1,185 @@
+const t = require('tap')
+const requireInject = require('require-inject')
+const npm = {}
+const { explainNode, printNode } = requireInject('../../../lib/utils/explain-dep.js', {
+  '../../../lib/npm.js': npm
+})
+
+const cases = {
+  prodDep: {
+    name: 'prod-dep',
+    version: '1.2.3',
+    location: 'node_modules/prod-dep',
+    dependents: [
+      {
+        type: 'prod',
+        spec: '1.x',
+        from: {
+          location: '/path/to/project'
+        }
+      }
+    ]
+  },
+
+  deepDev: {
+    name: 'deep-dev',
+    version: '2.3.4',
+    location: 'node_modules/deep-dev',
+    dev: true,
+    dependents: [
+      {
+        type: 'prod',
+        spec: '2.x',
+        from: {
+          name: 'metadev',
+          version: '3.4.5',
+          location: 'node_modules/dev/node_modules/metadev',
+          dependents: [
+            {
+              type: 'prod',
+              spec: '3.x',
+              from: {
+                name: 'topdev',
+                version: '4.5.6',
+                location: 'node_modules/topdev',
+                dependents: [
+                  {
+                    type: 'dev',
+                    spec: '4.x',
+                    from: {
+                      location: '/path/to/project'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    ]
+  },
+
+  optional: {
+    name: 'optdep',
+    version: '1.0.0',
+    location: 'node_modules/optdep',
+    optional: true,
+    dependents: [
+      {
+        type: 'optdep',
+        spec: '1.0.0',
+        from: {
+          location: '/path/to/project'
+        }
+      }
+    ]
+  },
+
+  peer: {
+    name: 'peer',
+    version: '1.0.0',
+    location: 'node_modules/peer',
+    peer: true,
+    dependents: [
+      {
+        type: 'peer',
+        spec: '1.0.0',
+        from: {
+          location: '/path/to/project'
+        }
+      }
+    ]
+  },
+
+  extraneous: {
+    name: 'extra-neos',
+    version: '1337.420.69-lol',
+    location: 'node_modules/extra-neos',
+    dependents: [],
+    extraneous: true
+  }
+}
+
+cases.manyDeps = {
+  name: 'manydep',
+  version: '1.0.0',
+  dependents: [
+    {
+      type: 'prod',
+      spec: '1.0.0',
+      from: cases.prodDep
+    },
+    {
+      type: 'optional',
+      spec: '1.x',
+      from: cases.optional
+    },
+    {
+      type: 'prod',
+      spec: '1.0.x',
+      from: cases.extraneous
+    },
+    {
+      type: 'dev',
+      spec: '*',
+      from: cases.deepDev
+    },
+    {
+      type: 'peer',
+      spec: '>1.0.0-beta <1.0.1',
+      from: cases.peer
+    },
+    {
+      type: 'prod',
+      spec: '1',
+      from: {
+        name: 'a package with a pretty long name',
+        version: '1.2.3',
+        dependents: {
+          location: '/path/to/project'
+        }
+      }
+    },
+    {
+      type: 'prod',
+      spec: '1',
+      from: {
+        name: 'another package with a pretty long name',
+        version: '1.2.3',
+        dependents: {
+          location: '/path/to/project'
+        }
+      }
+    },
+    {
+      type: 'prod',
+      spec: '1',
+      from: {
+        name: 'yet another a package with a pretty long name',
+        version: '1.2.3',
+        dependents: {
+          location: '/path/to/project'
+        }
+      }
+    },
+  ]
+}
+
+
+for (const [name, expl] of Object.entries(cases)) {
+  t.test(name, t => {
+    npm.color = true
+    t.matchSnapshot(printNode(expl, true), 'print color')
+    t.matchSnapshot(printNode(expl, false), 'print nocolor')
+    t.matchSnapshot(explainNode(expl, Infinity, true), 'explain color deep')
+    t.matchSnapshot(explainNode(expl, 2, false), 'explain nocolor shallow')
+    t.end()
+  })
+}
+
+// make sure that we show the last one if it's the only one that would
+// hit the ...
+cases.manyDeps.dependents.pop()
+t.matchSnapshot(explainNode(cases.manyDeps, 2, false), 'ellipses test one')
+cases.manyDeps.dependents.pop()
+t.matchSnapshot(explainNode(cases.manyDeps, 2, false), 'ellipses test two')


### PR DESCRIPTION
Took the code used to explain ERESOLVE errors, and just made it a top-level command that will explain a given set of nodes.

This is surprisingly handy!  Like, if you noticed that `react` is in the `node_modules` tree, you could do this:

```
$ npm explain node_modules/react
react@16.13.1 dev
node_modules/react
  react@"^16.12.0" from tap@14.10.8
  node_modules/tap
    dev tap@"^14.10.8" from the root project
  peer react@">=16.8.0" from ink@2.7.1
  node_modules/tap/node_modules/ink
    ink@"^2.6.0" from tap@14.10.8
    node_modules/tap
      dev tap@"^14.10.8" from the root project
    ink@"^2.6.0" from treport@1.0.2
    node_modules/tap/node_modules/treport
      treport@"^1.0.2" from tap@14.10.8
      node_modules/tap
        dev tap@"^14.10.8" from the root project
  peer react@"^16.0.0" from react-reconciler@0.24.0
  node_modules/tap/node_modules/react-reconciler
    react-reconciler@"^0.24.0" from ink@2.7.1
    node_modules/tap/node_modules/ink
      ink@"^2.6.0" from tap@14.10.8
      node_modules/tap
        dev tap@"^14.10.8" from the root project
      ink@"^2.6.0" from treport@1.0.2
      node_modules/tap/node_modules/treport
        treport@"^1.0.2" from tap@14.10.8
        node_modules/tap
          dev tap@"^14.10.8" from the root project
  peer react@"^16.8.6" from treport@1.0.2
  node_modules/tap/node_modules/treport
    treport@"^1.0.2" from tap@14.10.8
    node_modules/tap
      dev tap@"^14.10.8" from the root project
```

Or if you want to know why `mkdirp` is being duplicated, you could run:

```
$ npm explain mkdirp
mkdirp@1.0.4
node_modules/mkdirp
  mkdirp@"^1.0.4" from the root project

mkdirp@0.5.5
node_modules/node-gyp/node_modules/mkdirp
  mkdirp@"^0.5.1" from node-gyp@6.1.0
  node_modules/node-gyp
    node-gyp@"^6.1.0" from @npmcli/run-script@1.5.0
    node_modules/@npmcli/run-script
      @npmcli/run-script@"^1.5.0" from the root project
  mkdirp@"^0.5.0" from tar@4.4.13
  node_modules/node-gyp/node_modules/tar
    tar@"^4.4.12" from node-gyp@6.1.0
    node_modules/node-gyp
      node-gyp@"^6.1.0" from @npmcli/run-script@1.5.0
      node_modules/@npmcli/run-script
        @npmcli/run-script@"^1.5.0" from the root project
```

Definitely some overlap in use-cases with `npm ls`, but coming at the data in the other direction, starting with the dependency as the top of the "tree" and then showing each dependent tracking back to the root project, which makes it a better fit for the "why is this here??" questions.

cc: @ljharb I think I promised you this when we were discussing removing the `_`-prefixed fields from `package.json` files in `node_modules`.