### PR TITLE
view: directly print to process.stdout

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -407,9 +407,8 @@ async function printData (data, name, opts) {
   // we may have partial lines printed.
   log.disableProgress()
 
-  // print directly to stdout to not unnecessarily add blank lines
-  if (msg === '') process.stdout.write(msg.trim())
-  else console.log(msg.trim())
+  // only log if there is something to log
+  if (msg !== '') console.log(msg.trim())
 }
 
 function cleanup (data) {

--- a/lib/view.js
+++ b/lib/view.js
@@ -408,7 +408,8 @@ async function printData (data, name, opts) {
   log.disableProgress()
 
   // print directly to stdout to not unnecessarily add blank lines
-  process.stdout.write(msg.trim())
+  if (msg === '') process.stdout.write(msg.trim())
+  else console.log(msg.trim())
 }
 
 function cleanup (data) {

--- a/lib/view.js
+++ b/lib/view.js
@@ -408,7 +408,7 @@ async function printData (data, name, opts) {
   log.disableProgress()
 
   // print directly to stdout to not unnecessarily add blank lines
-  console.log(msg.trim())
+  process.stdout.write(msg.trim())
 }
 
 function cleanup (data) {

--- a/test/lib/view.js
+++ b/test/lib/view.js
@@ -332,7 +332,7 @@ t.test('should log package info', t => {
 
   t.test('package with --json and no versions', t => {
     viewJson(['brown'], () => {
-      t.equals(logs, '\n', 'no info to display')
+      t.equals(logs, '', 'no info to display')
       t.end()
     })
   })
@@ -446,7 +446,7 @@ t.test('should log info by field name', t => {
 
   t.test('unknown nested field ', t => {
     view(['yellow@1.0.0', 'dist.foobar'], () => {
-      t.equals(logs, '\n', 'no info to display')
+      t.equals(logs, '', 'no info to display')
       t.end()
     })
   })


### PR DESCRIPTION
Currently in npm 7 output of npm view is being printed
by a call to console.log which is causing an extra newline
on output compared to npm 6. Replace the call to console.log
with process.stdout.write to avoid this.

Fixes: https://github.com/npm/cli/issues/1639