### PR TITLE
Adding update to support urls with "_" and attributes with "_" being …

### DIFF
--- a/lib/config/core.js
+++ b/lib/config/core.js
@@ -349,14 +349,14 @@ Conf.prototype.addEnv = function (env) {
       // leave first char untouched, even if
       // it is a '_' - convert all other to '-'
       var p = k.toLowerCase()
-        .replace(/^npm_config_/, '');
-      const urlIndex = p.indexOf('//');
-      if(urlIndex >= 0) {
-        const base = p.slice(0, urlIndex);
-        const remainder = p.slice(urlIndex);
-        p = base.replace(/(?!^)_/g, '-') + remainder;
+        .replace(/^npm_config_/, '')
+      const urlIndex = p.indexOf('//')
+      if (urlIndex >= 0) {
+        const base = p.slice(0, urlIndex)
+        const remainder = p.slice(urlIndex)
+        p = base.replace(/(?!^)_/g, '-') + remainder
       } else {
-        p = p.replace(/(?!^)_/g, '-');
+        p = p.replace(/(?!^)_/g, '-')
       }
       conf[p] = env[k]
     })

--- a/lib/config/core.js
+++ b/lib/config/core.js
@@ -350,7 +350,7 @@ Conf.prototype.addEnv = function (env) {
       // it is a '_' - convert all other to '-'
       var p = k.toLowerCase()
         .replace(/^npm_config_/, '')
-        .replace(/(?!^)_(?=(.*\/\/))/g, '-')
+        .replace(/(?<!\/\/.*)(?!^)_/g, '-')
       conf[p] = env[k]
     })
   return CC.prototype.addEnv.call(this, '', conf, 'env')

--- a/lib/config/core.js
+++ b/lib/config/core.js
@@ -349,8 +349,15 @@ Conf.prototype.addEnv = function (env) {
       // leave first char untouched, even if
       // it is a '_' - convert all other to '-'
       var p = k.toLowerCase()
-        .replace(/^npm_config_/, '')
-        .replace(/(?<!\/\/.*)(?!^)_/g, '-')
+        .replace(/^npm_config_/, '');
+      const urlIndex = p.indexOf('//');
+      if(urlIndex >= 0) {
+        const base = p.slice(0, urlIndex);
+        const remainder = p.slice(urlIndex);
+        p = base.replace(/(?!^)_/g, '-') + remainder;
+      } else {
+        p = p.replace(/(?!^)_/g, '-');
+      }
       conf[p] = env[k]
     })
   return CC.prototype.addEnv.call(this, '', conf, 'env')

--- a/lib/config/core.js
+++ b/lib/config/core.js
@@ -350,7 +350,7 @@ Conf.prototype.addEnv = function (env) {
       // it is a '_' - convert all other to '-'
       var p = k.toLowerCase()
         .replace(/^npm_config_/, '')
-        .replace(/(?!^)_/g, '-')
+        .replace(/(?!^)_(?=(.*\/\/))/g, '-')
       conf[p] = env[k]
     })
   return CC.prototype.addEnv.call(this, '', conf, 'env')

--- a/test/common-config.js
+++ b/test/common-config.js
@@ -59,18 +59,21 @@ process.env.npm_config_other_env_thing = '1000'
 process.env.random_env_var = 'asdf'
 process.env.npm_config__underbar_env_thing = 'underful'
 process.env.NPM_CONFIG_UPPERCASE_ENV_THING = '42'
+process.env['npm_config_url_//this_is_a_test:_password'] = 'fixes urls and paths'
 
 exports.envData = {
   userconfig: exports.userconfig,
   '_underbar-env-thing': 'underful',
   'uppercase-env-thing': '42',
-  'other-env-thing': '1000'
+  'other-env-thing': '1000',
+  'url-//this_is_a_test:_password': 'fixes urls and paths'
 }
 exports.envDataFix = {
   userconfig: exports.userconfig,
   '_underbar-env-thing': 'underful',
   'uppercase-env-thing': 42,
-  'other-env-thing': 1000
+  'other-env-thing': 1000,
+  'url-//this_is_a_test:_password': 'fixes urls and paths'
 }
 
 var projectConf = path.resolve(__dirname, '..', '.npmrc')


### PR DESCRIPTION
…set in the environment variables.

<!-- What / Why -->
This change makes environment variables used for passwords (where the variable url format has :_password) usable.  Currently using _password will be replaced by -password which will not authenticate with services like JFrog.

<!-- Describe the request in detail. What it does and why it's being changed. -->
this change modifies the general replacement of "\_" to one which replaces all "\_" up until the combination of "//".  After the "//" the remainder of the variable is considered a definitive url and no "\_" are replaced.  In this way both the legacy implementation of the environment variable association will work, as well as being able to extend the urls to contain "_" in their paths.

## References
Fixes #1826 
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
