### PR TITLE
Fix typeof comparison with undefined

### DIFF
--- a/node_modules/json-schema/lib/validate.js
+++ b/node_modules/json-schema/lib/validate.js
@@ -170,11 +170,11 @@ var validate = exports._validate = function(/*Any*/instance,/*Object*/schema,/*O
 				if(schema.minLength && typeof value == 'string' && value.length < schema.minLength){
 					addError("must be at least " + schema.minLength + " characters long");
 				}
-				if(typeof schema.minimum !== undefined && typeof value == typeof schema.minimum &&
+				if(typeof schema.minimum !== "undefined" && typeof value == typeof schema.minimum &&
 						schema.minimum > value){
 					addError("must have a minimum value of " + schema.minimum);
 				}
-				if(typeof schema.maximum !== undefined && typeof value == typeof schema.maximum &&
+				if(typeof schema.maximum !== "undefined" && typeof value == typeof schema.maximum &&
 						schema.maximum < value){
 					addError("must have a maximum value of " + schema.maximum);
 				}


### PR DESCRIPTION
Probably intended fix for #1851 

Signed-off-by: Martin Röbke <martin.roebke@web.de>

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Propose a fix for the invalid comparison in json-schema validate.js

## References

  Related to #1851 

