### PR TITLE
fix: added count on reify-output

### DIFF
--- a/lib/utils/reify-output.js
+++ b/lib/utils/reify-output.js
@@ -43,7 +43,7 @@ const reifyOutput = arb => {
             summary.removed++
             break
           case 'ADD':
-            summary.added++
+            actualTree.inventory.has(d.ideal) && summary.added++
             break
           case 'CHANGE':
             summary.changed++

--- a/tap-snapshots/test-lib-utils-reify-output.js-TAP.test.js
+++ b/tap-snapshots/test-lib-utils-reify-output.js-TAP.test.js
@@ -5,6 +5,16 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/lib/utils/reify-output.js TAP added packages should be looked up within returned tree has added pkg in inventory > must match snapshot 1`] = `
+
+added 1 package in {TIME}
+`
+
+exports[`test/lib/utils/reify-output.js TAP added packages should be looked up within returned tree missing added pkg in inventory > must match snapshot 1`] = `
+
+up to date in {TIME}
+`
+
 exports[`test/lib/utils/reify-output.js TAP packages changed message > {"added":0,"removed":0,"changed":0,"audited":0,"json":false} 1`] = `
 
 up to date in {TIME}

--- a/test/lib/utils/reify-output.js
+++ b/test/lib/utils/reify-output.js
@@ -238,7 +238,7 @@ t.test('packages changed message', t => {
     settings.json = json
     npmock.command = command
     const mock = {
-      actualTree: { inventory: { size: audited }, children: [] },
+      actualTree: { inventory: { size: audited, has: () => true }, children: [] },
       auditReport: audited ? {
         toJSON: () => mock.auditReport,
         vulnerabilities: {},
@@ -298,5 +298,50 @@ t.test('packages changed message', t => {
     testCase(t, added, removed, changed, audited, json, command)
   }
 
+  t.end()
+})
+
+t.test('added packages should be looked up within returned tree', t => {
+  t.test('has added pkg in inventory', t => {
+    t.plan(1)
+    const reifyOutput = getReifyOutput(
+      out => t.matchSnapshot(out)
+    )
+
+    reifyOutput({
+      actualTree: {
+        name: 'foo',
+        inventory: {
+          has: () => true
+        }
+      },
+      diff: {
+        children: [
+          { action: 'ADD', ideal: { name: 'baz' } }
+        ]
+      }
+    })
+  })
+
+  t.test('missing added pkg in inventory', t => {
+    t.plan(1)
+    const reifyOutput = getReifyOutput(
+      out => t.matchSnapshot(out)
+    )
+
+    reifyOutput({
+      actualTree: {
+        name: 'foo',
+        inventory: {
+          has: () => false
+        }
+      },
+      diff: {
+        children: [
+          { action: 'ADD', ideal: { name: 'baz' } }
+        ]
+      }
+    })
+  })
   t.end()
 })


### PR DESCRIPTION
The added count on lib/utils/reify-output.js only looks up resulting
keys from arb.diff and does not take into account the fact that some of
these pkgs signaled as diff=ADD might in fact not have been installed,
most common scenario are optional deps that could have failed their
install in a given system or opt-out from configs.

This fixes the counting number by looking up at arb.inventory and
confirming it has the node that has been marked as added on diff result.

Fix: #1813