### PR TITLE
fix: listing deps of a linked dep

### DIFF
--- a/lib/ls.js
+++ b/lib/ls.js
@@ -423,7 +423,7 @@ const ls = async (args) => {
         !(node instanceof Arborist.Node) || (node[_depth] > depthToPrint)
       return (shouldSkipChildren)
         ? []
-        : [...node.edgesOut.values()]
+        : [...(node.target || node).edgesOut.values()]
           .filter(filterByEdgesTypes({
             dev,
             development,

--- a/tap-snapshots/test-lib-ls.js-TAP.test.js
+++ b/tap-snapshots/test-lib-ls.js-TAP.test.js
@@ -433,6 +433,7 @@ filter-by-child-of-missing-dep@1.0.0 {CWD}/ls-ls-loading-a-tree-containing-works
 exports[`test/lib/ls.js TAP ls loading a tree containing workspaces > should list workspaces properly 1`] = `
 filter-by-child-of-missing-dep@1.0.0 {CWD}/ls-ls-loading-a-tree-containing-workspaces
 +-- a@1.0.0 -> {CWD}/ls-ls-loading-a-tree-containing-workspaces/a
+| \`-- c@1.0.0
 \`-- b@1.0.0 -> {CWD}/ls-ls-loading-a-tree-containing-workspaces/b
 
 `

--- a/test/lib/ls.js
+++ b/test/lib/ls.js
@@ -1396,12 +1396,21 @@ t.test('ls', (t) => {
       }),
       node_modules: {
         a: t.fixture('symlink', '../a'),
-        b: t.fixture('symlink', '../b')
+        b: t.fixture('symlink', '../b'),
+        c: {
+          'package.json': JSON.stringify({
+            name: 'c',
+            version: '1.0.0'
+          })
+        }
       },
       a: {
         'package.json': JSON.stringify({
           name: 'a',
-          version: '1.0.0'
+          version: '1.0.0',
+          dependencies: {
+            c: '^1.0.0'
+          }
         })
       },
       b: {


### PR DESCRIPTION
`npm ls` was failing to properly follow symlink targets in order to find its dependencies to get printed output.
