### PR TITLE
Stop linking to an archived forum as the way to submit issues

### DIFF
--- a/docs/src/components/FoundTypo.js
+++ b/docs/src/components/FoundTypo.js
@@ -13,8 +13,8 @@ const FoundTypo = () => {
       <p><span role='img' aria-label='eyes-emoji'>👀</span> Found a typo? <a href='https://github.com/npm/cli/'>Let us know!</a></p>
       <p>The current stable version of npm is <a href='https://github.com/npm/cli/'>here</a>. To upgrade, run: <code className='language-text'>npm install npm@latest -g</code></p>
       <p>
-        To report bugs or submit feature requests for the docs, please post <a href='https://npm.community/c/support/docs-needed'>here</a>.
-        Submit npm issues <a href='https://npm.community/c/bugs'>here.</a>
+        To report bugs or submit feature requests for the docs, please post <a href='https://github.com/npm/cli/issues'>here</a>.
+        Submit npm issues <a href='https://github.com/npm/cli/issues'>here.</a>
       </p>
     </Container>
   )


### PR DESCRIPTION
I don't know if the links I've suggested are "correct", but they're surely better than the current ones.

