### PR TITLE
Release/v7.0.0 rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## v7.0.0-rc.1 (2020-10-02)
+
+* [`281a7f39a`](https://github.com/npm/cli/commit/281a7f39ac314bd7657ce2bcd7918b21eee99210)
+  `@npmcli/arborist@0.0.31`
+    * Allow `npm update` to update bundled root dependencies
+    * Only do implicit node-gyp build for gyp files named `binding.gyp`
+* [`384f5ec47`](https://github.com/npm/cli/commit/384f5ec47091eed66c2a47f2c98df3ba7506ec9f)
+  update minipass-fetch to fix many 'cb() never called' errors
+* [`7b1e75906`](https://github.com/npm/cli/commit/7b1e75906351bd73cde2f745ccaf63b9ad7de435)
+  `@npmcli/run-script@1.7.1`
+    * Only do implicit node-gyp build for gyp files named `binding.gyp`
+* [`c20e2f0c7`](https://github.com/npm/cli/commit/c20e2f0c7766a04f999fdc64faad29277904c2d3)
+  [#1892](https://github.com/npm/cli/pull/1892)
+  Support `--omit` options in npm outdated
+
 ## v7.0.0-rc.0 (2020-10-01)
 
 * [`3b417055c`](https://github.com/npm/cli/commit/3b417055cf07c4ef8e4c5063f00d3c24b5f5cbd2)

--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -130,6 +130,12 @@ async function outdated_ (tree, deps, opts) {
       : edge.dev ? 'devDependencies'
       : 'dependencies'
 
+    for (const omitType of opts.omit || []) {
+      if (node[omitType]) {
+        return
+      }
+    }
+
     // deps different from prod not currently
     // on disk are not included in the output
     if (edge.error === 'MISSING' && type !== 'dependencies') return

--- a/node_modules/@npmcli/arborist/lib/arborist/build-ideal-tree.js
+++ b/node_modules/@npmcli/arborist/lib/arborist/build-ideal-tree.js
@@ -545,7 +545,7 @@ module.exports = cls => class IdealTreeBuilder extends cls {
   [_shouldUpdateNode] (node) {
     return this[_updateNames].includes(node.name) &&
       !node.isTop &&
-      !node.inBundle &&
+      !node.inDepBundle &&
       !node.inShrinkwrap
   }
 

--- a/node_modules/@npmcli/arborist/package.json
+++ b/node_modules/@npmcli/arborist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@npmcli/arborist",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "Manage node_modules trees",
   "dependencies": {
     "@npmcli/installed-package-contents": "^1.0.5",

--- a/node_modules/@npmcli/node-gyp/lib/index.js
+++ b/node_modules/@npmcli/node-gyp/lib/index.js
@@ -1,10 +1,10 @@
 const util = require('util')
-const fs = require('fs')
-const readdir = util.promisify(fs.readdir)
+const {stat} = require('fs').promises
 
 async function isNodeGypPackage(path) {
-  const files = await readdir(path)
-  return files.some(f => /.*\.gyp$/.test(f))
+  return await stat(`${path}/binding.gyp`)
+    .then(st => st.isFile())
+    .catch(() => false)
 }
 
 module.exports = {

--- a/node_modules/@npmcli/node-gyp/package.json
+++ b/node_modules/@npmcli/node-gyp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@npmcli/node-gyp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Tools for dealing with node-gyp packages",
   "scripts": {
     "test": "tap",

--- a/node_modules/@npmcli/run-script/lib/run-script-pkg.js
+++ b/node_modules/@npmcli/run-script/lib/run-script-pkg.js
@@ -29,13 +29,14 @@ const runScriptPkg = async options => {
     event === 'install' &&
     ! pkg.scripts.install &&
     ! pkg.scripts.preinstall &&
+    pkg.gypfile !== false &&
     await isNodeGypPackage(path)
   ) {
     cmd = defaultGypInstallScript
   }
 
   if (!cmd)
-    return Promise.resolve({ code: 0, signal: null })
+    return { code: 0, signal: null }
 
   if (stdio === 'inherit' && banner !== false) {
     // we're dumping to the parent's stdout, so print the banner

--- a/node_modules/@npmcli/run-script/package.json
+++ b/node_modules/@npmcli/run-script/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@npmcli/run-script",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Run a lifecycle script for a package (descendant of npm-lifecycle)",
   "author": "Isaac Z. Schlueter <i@izs.me> (https://izs.me)",
   "license": "ISC",

--- a/node_modules/minipass-fetch/lib/index.js
+++ b/node_modules/minipass-fetch/lib/index.js
@@ -205,7 +205,9 @@ const fetch = (url, opts) => {
       const body = new Minipass()
       // exceedingly rare that the stream would have an error,
       // but just in case we proxy it to the stream in use.
-      res.on('error', /* istanbul ignore next */ er => body.emit('error', er)).pipe(body)
+      res.on('error', /* istanbul ignore next */ er => body.emit('error', er))
+      res.on('data', (chunk) => body.write(chunk))
+      res.on('end', () => body.end())
 
       const responseOptions = {
         url: request.url,

--- a/node_modules/minipass-fetch/package.json
+++ b/node_modules/minipass-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minipass-fetch",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "An implementation of window.fetch in Node.js using Minipass streams",
   "license": "MIT",
   "main": "lib/index.js",
@@ -26,10 +26,10 @@
     "whatwg-url": "^7.0.0"
   },
   "dependencies": {
+    "encoding": "^0.1.12",
     "minipass": "^3.1.0",
     "minipass-sized": "^1.0.3",
-    "minizlib": "^2.0.0",
-    "encoding": "^0.1.12"
+    "minizlib": "^2.0.0"
   },
   "optionalDependencies": {
     "encoding": "^0.1.12"

--- a/package-lock.json
+++ b/package-lock.json
@@ -526,9 +526,9 @@
       }
     },
     "node_modules/@npmcli/run-script": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.7.0.tgz",
-      "integrity": "sha512-GaWLYT88H6NzOVGyXeCigijJ+eo2sdBfI67VqgkBDcR/5vElpXQH3crdfLYySPuOMZQSQXh0EsW+gC5LciFsMQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.7.1.tgz",
+      "integrity": "sha512-16GKM0Zyw1cSfQPbBN7cwrLMneM0QhAYYiamae5w8802VKK7HT7Gd5AkJHVljsL/BYLxhTV3I5FxAjwJa7S+RA==",
       "inBundle": true,
       "dependencies": {
         "@npmcli/node-gyp": "^1.0.0",
@@ -8632,9 +8632,9 @@
       }
     },
     "@npmcli/run-script": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.7.0.tgz",
-      "integrity": "sha512-GaWLYT88H6NzOVGyXeCigijJ+eo2sdBfI67VqgkBDcR/5vElpXQH3crdfLYySPuOMZQSQXh0EsW+gC5LciFsMQ==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.7.1.tgz",
+      "integrity": "sha512-16GKM0Zyw1cSfQPbBN7cwrLMneM0QhAYYiamae5w8802VKK7HT7Gd5AkJHVljsL/BYLxhTV3I5FxAjwJa7S+RA==",
       "requires": {
         "@npmcli/node-gyp": "^1.0.0",
         "@npmcli/promise-spawn": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm",
-  "version": "7.0.0-rc.0",
+  "version": "7.0.0-rc.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "npm",
-      "version": "7.0.0-rc.0",
+      "version": "7.0.0-rc.1",
       "bundleDependencies": [
         "@npmcli/arborist",
         "@npmcli/ci-detect",

--- a/package-lock.json
+++ b/package-lock.json
@@ -511,9 +511,9 @@
       "inBundle": true
     },
     "node_modules/@npmcli/node-gyp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-1.0.0.tgz",
-      "integrity": "sha512-BBlx5ZCPCmTrPI2BpynmWpL1hQTRVXSIZ0zI/a9AQsIDXUReA8V/WRJo85TF6Wf0YVBtLibKH3OHrxnbxilthw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-1.0.1.tgz",
+      "integrity": "sha512-pBqoKPWmuk9iaEcXlLBVRIA6I1kG9JiICU+sG0NuD6NAR461F+02elHJS4WkQxHW2W5rnsfvP/ClKwmsZ9RaaA==",
       "inBundle": true
     },
     "node_modules/@npmcli/promise-spawn": {
@@ -8619,9 +8619,9 @@
       "integrity": "sha512-qq3oEfcLFwNfEYOQ8HLimRGKlD8WSeGEdtUa7hmzpR8Sa7haL1KVQrvgO6wqMjhWFFVjgtrh1gIxDz+P8sjUaA=="
     },
     "@npmcli/node-gyp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-1.0.0.tgz",
-      "integrity": "sha512-BBlx5ZCPCmTrPI2BpynmWpL1hQTRVXSIZ0zI/a9AQsIDXUReA8V/WRJo85TF6Wf0YVBtLibKH3OHrxnbxilthw=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/node-gyp/-/node-gyp-1.0.1.tgz",
+      "integrity": "sha512-pBqoKPWmuk9iaEcXlLBVRIA6I1kG9JiICU+sG0NuD6NAR461F+02elHJS4WkQxHW2W5rnsfvP/ClKwmsZ9RaaA=="
     },
     "@npmcli/promise-spawn": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3780,9 +3780,9 @@
       }
     },
     "node_modules/minipass-fetch": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.3.1.tgz",
-      "integrity": "sha512-N0ddPAD8OZnoAHUYj1ZH4ZJVna+ucy7if777LrdeIV1ko8f46af4jbyM5EC1gN4xc9Wq5c3C38GnxRJ2gneXRA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.3.2.tgz",
+      "integrity": "sha512-/i4fX1ss+Dtwyk++OsAI6SEV+eE1dvI6W+0hORdjfruQ7VD5uYTetJIHcEMjWiEiszWjn2aAtP1CB/Q4KfeoYA==",
       "inBundle": true,
       "dependencies": {
         "encoding": "^0.1.12",
@@ -11090,9 +11090,9 @@
       }
     },
     "minipass-fetch": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.3.1.tgz",
-      "integrity": "sha512-N0ddPAD8OZnoAHUYj1ZH4ZJVna+ucy7if777LrdeIV1ko8f46af4jbyM5EC1gN4xc9Wq5c3C38GnxRJ2gneXRA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.3.2.tgz",
+      "integrity": "sha512-/i4fX1ss+Dtwyk++OsAI6SEV+eE1dvI6W+0hORdjfruQ7VD5uYTetJIHcEMjWiEiszWjn2aAtP1CB/Q4KfeoYA==",
       "requires": {
         "encoding": "^0.1.12",
         "minipass": "^3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
       ],
       "license": "Artistic-2.0",
       "dependencies": {
-        "@npmcli/arborist": "^0.0.30",
+        "@npmcli/arborist": "^0.0.31",
         "@npmcli/ci-detect": "^1.2.0",
         "@npmcli/config": "^1.1.8",
         "@npmcli/run-script": "^1.7.0",
@@ -379,9 +379,9 @@
       }
     },
     "node_modules/@npmcli/arborist": {
-      "version": "0.0.30",
-      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-0.0.30.tgz",
-      "integrity": "sha512-L2xeTh6ca0RU/J57YZb/etKDsaRdUl+O7NrObIhgg5KaqF+IxOc6+QcDznnmN6swdZcxR0wX7o/VJqEyTv657w==",
+      "version": "0.0.31",
+      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-0.0.31.tgz",
+      "integrity": "sha512-BO5mCagGFv2szVhdAoZj2RcyjgOFxf1B+KpBTJvJYnYWwj/v4dDpzh5BixNrvDRcrCVZUq+kOOL/l53d5MHPjA==",
       "inBundle": true,
       "dependencies": {
         "@npmcli/installed-package-contents": "^1.0.5",
@@ -8511,9 +8511,9 @@
       }
     },
     "@npmcli/arborist": {
-      "version": "0.0.30",
-      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-0.0.30.tgz",
-      "integrity": "sha512-L2xeTh6ca0RU/J57YZb/etKDsaRdUl+O7NrObIhgg5KaqF+IxOc6+QcDznnmN6swdZcxR0wX7o/VJqEyTv657w==",
+      "version": "0.0.31",
+      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-0.0.31.tgz",
+      "integrity": "sha512-BO5mCagGFv2szVhdAoZj2RcyjgOFxf1B+KpBTJvJYnYWwj/v4dDpzh5BixNrvDRcrCVZUq+kOOL/l53d5MHPjA==",
       "requires": {
         "@npmcli/installed-package-contents": "^1.0.5",
         "@npmcli/map-workspaces": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.0.0-rc.0",
+  "version": "7.0.0-rc.1",
   "name": "npm",
   "description": "a package manager for JavaScript",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@npmcli/arborist": "^0.0.30",
+    "@npmcli/arborist": "^0.0.31",
     "@npmcli/ci-detect": "^1.2.0",
     "@npmcli/config": "^1.1.8",
     "@npmcli/run-script": "^1.7.0",

--- a/tap-snapshots/test-lib-outdated.js-TAP.test.js
+++ b/tap-snapshots/test-lib-outdated.js-TAP.test.js
@@ -91,6 +91,31 @@ gamma      1.0.1   1.0.1   2.0.0  node_modules/gamma  outdated-should-display-ou
 theta    MISSING   1.0.1   1.0.1  -                   outdated-should-display-outdated-deps  dependencies
 `
 
+exports[`test/lib/outdated.js TAP should display outdated deps outdated --omit=dev --omit=peer > must match snapshot 1`] = `
+
+[4mPackage[24m  [4mCurrent[24m  [4mWanted[24m  [4mLatest[24m  [4mLocation[24m            [4mDepended by[24m
+[31malpha[39m      1.0.0   [32m1.0.1[39m   [35m1.0.1[39m  node_modules/alpha  outdated-should-display-outdated-deps
+[33mgamma[39m      1.0.1   [32m1.0.1[39m   [35m2.0.0[39m  node_modules/gamma  outdated-should-display-outdated-deps
+[31mtheta[39m    MISSING   [32m1.0.1[39m   [35m1.0.1[39m  -                   outdated-should-display-outdated-deps
+`
+
+exports[`test/lib/outdated.js TAP should display outdated deps outdated --omit=dev > must match snapshot 1`] = `
+
+[4mPackage[24m  [4mCurrent[24m  [4mWanted[24m  [4mLatest[24m  [4mLocation[24m            [4mDepended by[24m
+[31malpha[39m      1.0.0   [32m1.0.1[39m   [35m1.0.1[39m  node_modules/alpha  outdated-should-display-outdated-deps
+[31mbeta[39m       1.0.0   [32m1.0.1[39m   [35m1.0.1[39m  node_modules/beta   outdated-should-display-outdated-deps
+[33mgamma[39m      1.0.1   [32m1.0.1[39m   [35m2.0.0[39m  node_modules/gamma  outdated-should-display-outdated-deps
+[31mtheta[39m    MISSING   [32m1.0.1[39m   [35m1.0.1[39m  -                   outdated-should-display-outdated-deps
+`
+
+exports[`test/lib/outdated.js TAP should display outdated deps outdated --omit=prod > must match snapshot 1`] = `
+
+[4mPackage[24m  [4mCurrent[24m  [4mWanted[24m  [4mLatest[24m  [4mLocation[24m            [4mDepended by[24m
+[31malpha[39m      1.0.0   [32m1.0.1[39m   [35m1.0.1[39m  node_modules/alpha  outdated-should-display-outdated-deps
+[31mbeta[39m       1.0.0   [32m1.0.1[39m   [35m1.0.1[39m  node_modules/beta   outdated-should-display-outdated-deps
+[33mgamma[39m      1.0.1   [32m1.0.1[39m   [35m2.0.0[39m  node_modules/gamma  outdated-should-display-outdated-deps
+`
+
 exports[`test/lib/outdated.js TAP should display outdated deps outdated --parseable --long > must match snapshot 1`] = `
 
 {CWD}/test/lib/outdated-should-display-outdated-deps/node_modules/alpha:alpha@1.0.1:alpha@1.0.0:alpha@1.0.1:outdated-should-display-outdated-deps:dependencies:

--- a/test/lib/outdated.js
+++ b/test/lib/outdated.js
@@ -194,6 +194,39 @@ t.test('should display outdated deps', t => {
     })
   })
 
+  t.test('outdated --omit=dev', t => {
+    outdated(testDir, {
+      global: false,
+      color: true,
+      omit: ['dev']
+    })([], () => {
+      t.matchSnapshot(logs)
+      t.end()
+    })
+  })
+
+  t.test('outdated --omit=dev --omit=peer', t => {
+    outdated(testDir, {
+      global: false,
+      color: true,
+      omit: ['dev', 'peer']
+    })([], () => {
+      t.matchSnapshot(logs)
+      t.end()
+    })
+  })
+
+  t.test('outdated --omit=prod', t => {
+    outdated(testDir, {
+      global: false,
+      color: true,
+      omit: ['prod']
+    })([], () => {
+      t.matchSnapshot(logs)
+      t.end()
+    })
+  })
+
   t.test('outdated --long', t => {
     outdated(testDir, {
       global: false,


### PR DESCRIPTION
## v7.0.0-rc.1 (2020-10-02)

* [`281a7f39a`](https://github.com/npm/cli/commit/281a7f39ac314bd7657ce2bcd7918b21eee99210) `@npmcli/arborist@0.0.31`
    * Allow `npm update` to update bundled root dependencies
    * Only do implicit node-gyp build for gyp files named `binding.gyp`
* [`384f5ec47`](https://github.com/npm/cli/commit/384f5ec47091eed66c2a47f2c98df3ba7506ec9f) update minipass-fetch to fix many 'cb() never called' errors
* [`7b1e75906`](https://github.com/npm/cli/commit/7b1e75906351bd73cde2f745ccaf63b9ad7de435) `@npmcli/run-script@1.7.1`
    * Only do implicit node-gyp build for gyp files named `binding.gyp`
* [`c20e2f0c7`](https://github.com/npm/cli/commit/c20e2f0c7766a04f999fdc64faad29277904c2d3) [#1892](https://github.com/npm/cli/pull/1892) Support `--omit` options in npm outdated

