### PR TITLE
chore: remove 'dist-tags' step from cli release process

### DIFF
--- a/scripts/publish-tag.js
+++ b/scripts/publish-tag.js
@@ -1,3 +1,3 @@
 var semver = require('semver')
 var version = semver.parse(require('../package.json').version)
-console.log('v%s.%s-next', version.major, version.minor)
+console.log('next-%s', version.major)


### PR DESCRIPTION
Why not just publish to `next-7` instead of `7.0-next` and have to update it?