### PR TITLE
npx run existing bins

### DIFF
--- a/lib/completion.js
+++ b/lib/completion.js
@@ -43,6 +43,7 @@ const shorthandNames = Object.keys(shorthands)
 const allConfs = configNames.concat(shorthandNames)
 const isWindowsShell = require('./utils/is-windows-shell.js')
 const output = require('./utils/output.js')
+const fileExists = require('./utils/file-exists.js')
 
 const usageUtil = require('./utils/usage.js')
 const usage = usageUtil('completion', 'source <(npm completion)')
@@ -56,13 +57,10 @@ const completion = async (opts, cb) => {
     return cb()
   }
 
-  const fs = require('fs')
-  const stat = promisify(fs.stat)
-  const exists = f => stat(f).then(() => true).catch(() => false)
   const { resolve } = require('path')
   const [bashExists, zshExists] = await Promise.all([
-    exists(resolve(process.env.HOME, '.bashrc')),
-    exists(resolve(process.env.HOME, '.zshrc'))
+    fileExists(resolve(process.env.HOME, '.bashrc')),
+    fileExists(resolve(process.env.HOME, '.zshrc'))
   ])
   const out = []
   if (zshExists) {

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -59,6 +59,8 @@ const crypto = require('crypto')
 const pacote = require('pacote')
 const npa = require('npm-package-arg')
 const escapeArg = require('./utils/escape-arg.js')
+const fileExists = require('./utils/file-exists.js')
+const PATH = require('./utils/path.js')
 
 const cmd = (args, cb) => exec(args).then(() => cb()).catch(cb)
 
@@ -69,8 +71,38 @@ const exec = async args => {
     throw usage
   }
 
+  const pathArr = [...PATH]
+
   const needPackageCommandSwap = args.length && !packages.length
+  // if there's an argument and no package has been explicitly asked for
+  // check the local and global bin paths for a binary named the same as
+  // the argument and run it if it exists, otherwise fall through to
+  // the behavior of treating the single argument as a package name
   if (needPackageCommandSwap) {
+    let binExists = false
+    if (await fileExists(`${npm.localBin}/${args[0]}`)) {
+      pathArr.unshift(npm.localBin)
+      binExists = true
+    } else if (await fileExists(`${npm.globalBin}/${args[0]}`)) {
+      pathArr.unshift(npm.globalBin)
+      binExists = true
+    }
+
+    if (binExists) {
+      return await runScript({
+        cmd: args.map(escapeArg).join(' ').trim(),
+        banner: false,
+        // we always run in cwd, not --prefix
+        path: process.cwd(),
+        stdioString: true,
+        event: 'npx',
+        env: {
+          PATH: pathArr.join(delimiter)
+        },
+        stdio: 'inherit'
+      })
+    }
+
     packages.push(args[0])
   }
 
@@ -111,7 +143,6 @@ const exec = async args => {
   // do we have all the packages in manifest list?
   const needInstall = manis.some(mani => manifestMissing(tree, mani))
 
-  const pathArr = [process.env.PATH]
   if (needInstall) {
     const installDir = cacheInstallDir(packages)
     await mkdirp(installDir)

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -90,7 +90,7 @@ const exec = async args => {
 
     if (binExists) {
       return await runScript({
-        cmd: args.map(escapeArg).join(' ').trim(),
+        cmd: [args[0], ...args.slice(1).map(escapeArg)].join(' ').trim(),
         banner: false,
         // we always run in cwd, not --prefix
         path: process.cwd(),

--- a/lib/utils/file-exists.js
+++ b/lib/utils/file-exists.js
@@ -1,0 +1,8 @@
+const fs = require('fs')
+const util = require('util')
+
+const stat = util.promisify(fs.stat)
+
+const fileExists = (file) => stat(file).then((stat) => stat.isFile()).catch(() => false)
+
+module.exports = fileExists

--- a/test/lib/utils/file-exists.js
+++ b/test/lib/utils/file-exists.js
@@ -1,0 +1,30 @@
+const { test } = require('tap')
+const fileExists = require('../../../lib/utils/file-exists.js')
+
+test('returns true when arg is a file', async (t) => {
+  const path = t.testdir({
+    foo: 'just some file'
+  })
+
+  const result = await fileExists(`${path}/foo`)
+  t.equal(result, true, 'file exists')
+  t.end()
+})
+
+test('returns false when arg is not a file', async (t) => {
+  const path = t.testdir({
+    foo: {}
+  })
+
+  const result = await fileExists(`${path}/foo`)
+  t.equal(result, false, 'file does not exist')
+  t.end()
+})
+
+test('returns false when arg does not exist', async (t) => {
+  const path = t.testdir()
+
+  const result = await fileExists(`${path}/foo`)
+  t.equal(result, false, 'file does not exist')
+  t.end()
+})


### PR DESCRIPTION
This restores the old `npx foo` behavior of looking for `foo` in the local and global bin paths first, before assuming that it's a package name and attempting to install it.

Related to: https://github.com/npm/cli/issues/1845 and https://github.com/npm/cli/issues/1746
