### PR TITLE
add .idea/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ npm-debug.log
 .DS_Store
 **/.DS_Store
 .vscode/
+.idea/


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

`.idea/` is a folder containing metadata for Jetbrains IDEs such as PyCharm, WebStorm, and Intellij

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
