### PR TITLE
add process title to npm cli

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -254,14 +254,8 @@
         process.installPrefix = path.resolve(node, '..', '..')
       }
 
-      var t = [ process.title ]
-      t.push(path.relative(process.cwd(), process.argv[1]))
-      for(var index=2; index < process.argv.length; index++ ) {
-        var val = process.argv[index];
-        t.push( val );
-      }
-      // set process title
-      process.title = t.join(' ');
+      process.title = [ process.title, path.relative(process.cwd(), process.argv[1]) ]
+        .concat(process.argv.slice(2)).join(' ');
 
       // look up configs
       var builtin = path.resolve(__dirname, '..', 'npmrc')

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -255,7 +255,7 @@
       }
 
       process.title = [ process.title, path.relative(process.cwd(), process.argv[1]) ]
-        .concat(process.argv.slice(2)).join(' ');
+        .concat(process.argv.slice(2)).join(' ')
 
       // look up configs
       var builtin = path.resolve(__dirname, '..', 'npmrc')

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -254,6 +254,15 @@
         process.installPrefix = path.resolve(node, '..', '..')
       }
 
+      var t = [ process.title ]
+      t.push(path.relative(process.cwd(), process.argv[1]))
+      for(var index=2; index < process.argv.length; index++ ) {
+        var val = process.argv[index];
+        t.push( val );
+      }
+      // set process title
+      process.title = t.join(' ');
+
       // look up configs
       var builtin = path.resolve(__dirname, '..', 'npmrc')
       npmconf.load(cli, builtin, function (er, config) {


### PR DESCRIPTION
<!-- What / Why -->

See 
https://npm.community/t/why-does-the-cli-override-process-title/8400
https://github.com/tmux-plugins/tmux-resurrect/issues/201

Code from http://broken-by.me/node-js-change-visible-process-name

Not a huge number of tmux resurrect users out there, but there are many reasons for setting the process title. For example, it would make it easier to identify an npm process inside `top`, `htop`, `ps`. We would simply like to give npm the ability to set the title. 

<!-- Describe the request in detail. What it does and why it's being changed. -->

This just adds simple code to report the npm command being run in the process title. 

I am expecting this to be closed because I suspect that the reason why the shell command that is being run is not shown in the title is done for security reasons (in case an npm command is constructed with passwords right in the command). 

I think that even if this is grounds for rejection, we could at least have a discussion about whether we could add a flag to the CLI to allow the title to be manually specified or maybe a flag that can be configured to let it run this code?

Basically this will allow npm cli to report itself as `npm start` or `npm run lint` etc.  rather than just always `npm`.

Thanks
