### PR TITLE
fix casing of javascript

### DIFF
--- a/docs/src/components/home/Terminal.js
+++ b/docs/src/components/home/Terminal.js
@@ -105,7 +105,7 @@ const Terminal = ({onClose, top, left}) => {
       <Bottom>
         <SiteName py={3}><Bracket />npm cli <Cursor>_</Cursor></SiteName>
         <Text>
-          The intelligent package manager for the Node Javascript Platform. Install stuff and get coding!
+          The intelligent package manager for the Node JavaScript platform. Install stuff and get coding!
         </Text>
         <Box mx={'auto'} my={4}>
           <LinkButton to='/cli-commands/npm'>


### PR DESCRIPTION
## What
* rename "Javascript" to "JavaScript" in terminal.js component of npm docs homepage
* rename platform from "Platform" to "platform"

## What
* JavaScript is written with the `s` in capitals.
* To be consistent with the phrase "Node JavaScript platform", the "p" in platform was renamed to lowercase
