### PR TITLE
pass publishConfig through to npm-registry-fetch

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -69,7 +69,8 @@ const publish_ = async (arg, opts) => {
     // The purpose of re-reading the manifest is in case it changed,
     // so that we send the latest and greatest thing to the registry
     manifest = await readJson(`${arg}/package.json`)
-    await otplease(opts, opts => libpub(arg, manifest, opts))
+    const { publishConfig } = manifest
+    await otplease(opts, opts => libpub(arg, manifest, { ...opts, publishConfig }))
   }
 
   // publish

--- a/node_modules/npm-registry-fetch/CHANGELOG.md
+++ b/node_modules/npm-registry-fetch/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [8.1.5](https://github.com/npm/registry-fetch/compare/v8.1.4...v8.1.5) (2020-10-12)
+
+
+### Bug Fixes
+
+* respect publishConfig.registry when specified ([32e36ef](https://github.com/npm/registry-fetch/commit/32e36efe86302ed319973cd5b1e6ccc3f62e557e)), closes [#35](https://github.com/npm/registry-fetch/issues/35)
+
 ### [8.1.4](https://github.com/npm/registry-fetch/compare/v8.1.3...v8.1.4) (2020-08-17)
 
 

--- a/node_modules/npm-registry-fetch/index.js
+++ b/node_modules/npm-registry-fetch/index.js
@@ -29,6 +29,7 @@ function regFetch (uri, /* istanbul ignore next */ opts_ = {}) {
   }
   const registry = opts.registry = (
     (opts.spec && pickRegistry(opts.spec, opts)) ||
+    (opts.publishConfig && opts.publishConfig.registry) ||
     opts.registry ||
     /* istanbul ignore next */
     'https://registry.npmjs.org/'
@@ -153,6 +154,10 @@ function pickRegistry (spec, opts = {}) {
 
   if (!registry && opts.scope) {
     registry = opts[opts.scope.replace(/^@?/, '@') + ':registry']
+  }
+
+  if (!registry && opts.publishConfig) {
+    registry = opts.publishConfig.registry
   }
 
   if (!registry) {

--- a/node_modules/npm-registry-fetch/package.json
+++ b/node_modules/npm-registry-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-registry-fetch",
-  "version": "8.1.4",
+  "version": "8.1.5",
   "description": "Fetch-based http client for use with npm registry APIs",
   "main": "index.js",
   "files": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -4121,9 +4121,9 @@
       }
     },
     "node_modules/npm-registry-fetch": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-8.1.4.tgz",
-      "integrity": "sha512-UaLGFQP7VCuyBsb7S5P5od3av/Zy9JW6K5gbMigjZCYnEpIkWWRiLQTKVpxM4QocfPcsjm+xtyrDNm4jdqwNEg==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-8.1.5.tgz",
+      "integrity": "sha512-yZPNoJK9clx1jhSXU54kU6Aj1SV2p7mXUs1W/6OjQvek3wb1RrjDCrt4iY1+VX9eBQvvSGEpzNmYkRUaTL8rqg==",
       "inBundle": true,
       "dependencies": {
         "@npmcli/ci-detect": "^1.0.0",
@@ -11329,9 +11329,9 @@
       }
     },
     "npm-registry-fetch": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-8.1.4.tgz",
-      "integrity": "sha512-UaLGFQP7VCuyBsb7S5P5od3av/Zy9JW6K5gbMigjZCYnEpIkWWRiLQTKVpxM4QocfPcsjm+xtyrDNm4jdqwNEg==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-8.1.5.tgz",
+      "integrity": "sha512-yZPNoJK9clx1jhSXU54kU6Aj1SV2p7mXUs1W/6OjQvek3wb1RrjDCrt4iY1+VX9eBQvvSGEpzNmYkRUaTL8rqg==",
       "requires": {
         "@npmcli/ci-detect": "^1.0.0",
         "lru-cache": "^6.0.0",

--- a/test/lib/publish.js
+++ b/test/lib/publish.js
@@ -2,10 +2,12 @@ const { test, cleanSnapshot } = require('tap')
 const requireInject = require('require-inject')
 
 test('should publish with libnpmpublish', (t) => {
+  const publishConfig = { registry: 'https://some.registry' }
   const testDir = t.testdir({
     'package.json': JSON.stringify({
       name: 'my-cool-pkg',
-      version: '1.0.0'
+      version: '1.0.0',
+      publishConfig
     }, null, 2)
   })
 
@@ -32,6 +34,7 @@ test('should publish with libnpmpublish', (t) => {
         t.ok(arg, 'gets path')
         t.ok(manifest, 'gets manifest')
         t.ok(opts, 'gets opts object')
+        t.same(opts.publishConfig, publishConfig, 'publishConfig is passed through')
         t.ok(true, 'libnpmpublish is called')
       }
     },


### PR DESCRIPTION
This makes sure that `publishConfig` is passed through to npm-registry-fetch for both publish and unpublish commands, as well as updates npm-registry-fetch to a version that actually cares about that setting.

Closes #1937
