### PR TITLE
fix: owner rm at local pkg not work

### DIFF
--- a/lib/owner.js
+++ b/lib/owner.js
@@ -153,7 +153,7 @@ function rm (user, pkg, opts) {
   if (!pkg) {
     return readLocalPkg().then(pkg => {
       if (!pkg) { UsageError() }
-      return add(user, pkg, opts)
+      return rm(user, pkg, opts)
     })
   }
   log.verbose('owner rm', '%s from %s', user, pkg)


### PR DESCRIPTION
when exec `npm owner rm <user>` without package name at local package folder, npm will exec add while it's expected to exec rm

