### PR TITLE
Support exec auto pick bin when all bin is alias

### DIFF
--- a/docs/content/commands/npm-exec.md
+++ b/docs/content/commands/npm-exec.md
@@ -54,7 +54,8 @@ the package specifier provided as the first positional argument according
 to the following heuristic:
 
 - If the package has a single entry in its `bin` field in `package.json`,
-  then that command will be used.
+  or if all entries are aliases of the same command, then that command
+  will be used.
 - If the package has multiple `bin` entries, and one of them matches the
   unscoped portion of the `name` field, then that command will be used.
 - If this does not result in exactly one option (either because there are

--- a/docs/content/commands/npx.md
+++ b/docs/content/commands/npx.md
@@ -8,9 +8,9 @@ description: Run a command from a local or remote npm package
 
 ```bash
 npm exec -- <pkg>[@<version>] [args...]
-npm exec -p <pkg>[@<version>] -- <cmd> [args...]
+npm exec --package=<pkg>[@<version>] -- <cmd> [args...]
 npm exec -c '<cmd> [args...]'
-npm exec -p foo -c '<cmd> [args...]'
+npm exec --package=foo -c '<cmd> [args...]'
 
 npx <pkg>[@<specifier>] [args...]
 npx -p <pkg>[@<specifier>] <cmd> [args...]
@@ -19,7 +19,8 @@ npx -p <pkg>[@<specifier>] -c '<cmd> [args...]'
 
 alias: npm x, npx
 
--p <pkg> --package=<pkg> (may be specified multiple times)
+--package=<pkg> (may be specified multiple times)
+-p is a shorthand for --package only when using npx executable
 -c <cmd> --call=<cmd> (may not be mixed with positional arguments)
 ```
 
@@ -29,9 +30,9 @@ This command allows you to run an arbitrary command from an npm package
 (either one installed locally, or fetched remotely), in a similar context
 as running it via `npm run`.
 
-Whatever packages are specified by the `--package` or `-p` option will be
+Whatever packages are specified by the `--package` option will be
 provided in the `PATH` of the executed command, along with any locally
-installed package executables.  The `--package` or `-p` option may be
+installed package executables.  The `--package` option may be
 specified multiple times, to execute the supplied command in an environment
 where all specified packages are available.
 
@@ -47,13 +48,14 @@ only be considered a match if they have the exact same name and version as
 the local dependency.
 
 If no `-c` or `--call` option is provided, then the positional arguments
-are used to generate the command string.  If no `-p` or `--package` options
+are used to generate the command string.  If no `--package` options
 are provided, then npm will attempt to determine the executable name from
 the package specifier provided as the first positional argument according
 to the following heuristic:
 
 - If the package has a single entry in its `bin` field in `package.json`,
-  then that command will be used.
+  or if all entries are aliases of the same command, then that command
+  will be used.
 - If the package has multiple `bin` entries, and one of them matches the
   unscoped portion of the `name` field, then that command will be used.
 - If this does not result in exactly one option (either because there are

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -228,10 +228,11 @@ const getBinFromManifest = mani => {
   // if we have a bin matching (unscoped portion of) packagename, use that
   // otherwise if there's 1 bin or all bin value is the same (alias), use that,
   // otherwise fail
-  const bins = Array.from(new Set(Object.values(mani.bin || {})))
-  if (bins.length === 1)
-    return Object.keys(mani.bin || {})[0]
-
+  const maniBin = mani.bin || {}
+  if (Array.from(new Set(Object.values(maniBin))).length === 1) {
+    const binNameList = Object.keys(maniBin)
+    return binNameList[0]
+  }
   // XXX probably a util to parse this better?
   const name = mani.name.replace(/^@[^/]+\//, '')
   if (mani.bin && mani.bin[name])

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -226,11 +226,11 @@ const manifestMissing = (tree, mani) => {
 
 const getBinFromManifest = mani => {
   // if we have a bin matching (unscoped portion of) packagename, use that
-  // otherwise if there's 1 bin, use that,
+  // otherwise if there's 1 bin or all bin value is the same (alias), use that,
   // otherwise fail
-  const bins = Object.entries(mani.bin || {})
+  const bins = Array.from(new Set(Object.values(mani.bin || {})))
   if (bins.length === 1)
-    return bins[0][0]
+    return Object.keys(mani.bin || {})[0]
 
   // XXX probably a util to parse this better?
   const name = mani.name.replace(/^@[^/]+\//, '')

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -228,14 +228,13 @@ const getBinFromManifest = mani => {
   // if we have a bin matching (unscoped portion of) packagename, use that
   // otherwise if there's 1 bin or all bin value is the same (alias), use that,
   // otherwise fail
-  const maniBin = mani.bin || {}
-  if (new Set(Object.values(maniBin)).size === 1) {
-    const binNameList = Object.keys(maniBin)
-    return binNameList[0]
-  }
+  const bin = mani.bin || {}
+  if (new Set(Object.values(bin)).size === 1)
+    return Object.keys(bin)[0]
+
   // XXX probably a util to parse this better?
   const name = mani.name.replace(/^@[^/]+\//, '')
-  if (mani.bin && mani.bin[name])
+  if (bin[name])
     return name
 
   // XXX need better error message

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -229,7 +229,7 @@ const getBinFromManifest = mani => {
   // otherwise if there's 1 bin or all bin value is the same (alias), use that,
   // otherwise fail
   const maniBin = mani.bin || {}
-  if (Array.from(new Set(Object.values(maniBin))).length === 1) {
+  if (new Set(Object.values(maniBin)).size === 1) {
     const binNameList = Object.keys(maniBin)
     return binNameList[0]
   }


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

Some scoped package can not use the unscoped portion of package name as `bin` since it's too common, like `@dr-js/core` or `@dr-js/node`. And put the full name in `bin` will break the auto bin file creation.

This change should allow the package just aliasing bin to skip add bin to `npm exec` command, like:
```json
{
  "bin": {
    "dr-js": "bin/index.js",
    "DR": "bin/index.js"
  }
}
```

TODO: If this change is OK, I can update the doc in later commit if needed.