### PR TITLE
deps: float c2ccc1a on node-gyp

### DIFF
--- a/node_modules/node-gyp/gyp/pylib/gyp/generator/msvs.py
+++ b/node_modules/node-gyp/gyp/pylib/gyp/generator/msvs.py
@@ -3614,13 +3614,12 @@ def _AddSources2(
                     extension_to_rule_name,
                     _GetUniquePlatforms(spec),
                 )
-                if group == "compile":
-                    # Always add an <ObjectFileName> value to support duplicate
-                    # source file basenames.
+                if group == "compile" and not os.path.isabs(source):
+                    # Add an <ObjectFileName> value to support duplicate source
+                    # file basenames, except for absolute paths to avoid paths
+                    # with more than 260 characters.
                     file_name = os.path.splitext(source)[0] + ".obj"
-                    if os.path.isabs(file_name):
-                        file_name = os.path.splitdrive(file_name)[1]
-                    elif file_name.startswith("..\\"):
+                    if file_name.startswith("..\\"):
                         file_name = re.sub(r"^(\.\.\\)+", "", file_name)
                     elif file_name.startswith("$("):
                         file_name = re.sub(r"^\$\([^)]+\)\\", "", file_name)


### PR DESCRIPTION
A change to "correctly rename object files for absolute paths"
caused a bug in windows. A fix has already landed upstream in
gyp-next, but has not yet made it's way to a release of gyp-next
or to node-gyp.

Let's float the change until it is fixed upstream.

Refs: https://github.com/nodejs/gyp-next/pull/74