### PR TITLE
deps: float 856a47b on node-gyp

### DIFF
--- a/gyp/.github/workflows/release-please.yml
+++ b/gyp/.github/workflows/release-please.yml
@@ -1,0 +1,16 @@
+on:
+  push:
+    branches:
+      - master
+
+name: release-please
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v2.5.6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: python
+          package-name: gyp-next
+          bump-minor-pre-major: Yes

--- a/node_modules/node-gyp/gyp/CHANGELOG.md
+++ b/node_modules/node-gyp/gyp/CHANGELOG.md
@@ -1,67 +1,70 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+### [0.6.2](https://www.github.com/nodejs/gyp-next/compare/v0.6.1...v0.6.2) (2020-10-16)
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+### Bug Fixes
 
-## [0.6.1] - 2020-10-14
+* do not rewrite absolute paths to avoid long paths ([#74](https://www.github.com/nodejs/gyp-next/issues/74)) ([c2ccc1a](https://www.github.com/nodejs/gyp-next/commit/c2ccc1a81f7f94433a94f4d01a2e820db4c4331a))
+* only include MARMASM when toolset is target ([5a2794a](https://www.github.com/nodejs/gyp-next/commit/5a2794aefb58f0c00404ff042b61740bc8b8d5cd))
 
-### Fixed
-- Correctly rename object files for absolute paths in MSVS generator.
+### [0.6.1](https://github.com/nodejs/gyp-next/compare/v0.6.0...v0.6.1) (2020-10-14)
 
-## [0.6.0] - 2020-10-13
 
-### Added
-- The Makefile generator will now output shared libraries directly to the product
-  directory on all platforms (previously only macOS).
+### Bug Fixes
 
-## [0.5.0] - 2020-09-30
+* Correctly rename object files for absolute paths in MSVS generator.
 
-### Added
-- Extended compile_commands_json generator to consider more file extensions than
-  just `c` and `cc`. `cpp` and `cxx` are now supported.
-- Source files with duplicate basenames are now supported.
+## [0.6.0](https://github.com/nodejs/gyp-next/compare/v0.5.0...v0.6.0) (2020-10-13)
+
+
+### Features
+
+* The Makefile generator will now output shared libraries directly to the product directory on all platforms (previously only macOS).
+
+## [0.5.0](https://github.com/nodejs/gyp-next/compare/v0.4.0...v0.5.0) (2020-09-30)
+
+
+### Features
+
+* Extended compile_commands_json generator to consider more file extensions than just `c` and `cc`. `cpp` and `cxx` are now supported.
+* Source files with duplicate basenames are now supported.
 
 ### Removed
-- The `--no-duplicate-basename-check` option was removed.
-- The `msvs_enable_marmasm` configuration option was removed in favor of
-  auto-inclusion of the "marmasm" sections for Windows on ARM.
 
-## [0.4.0] - 2020-07-14
+* The `--no-duplicate-basename-check` option was removed.
+* The `msvs_enable_marmasm` configuration option was removed in favor of auto-inclusion of the "marmasm" sections for Windows on ARM.
 
-### Added
-- Added support for passing arbitrary architectures to Xcode builds, enables `arm64` builds.
+## [0.4.0](https://github.com/nodejs/gyp-next/compare/v0.3.0...v0.4.0) (2020-07-14)
 
-### Fixed
-- Fixed a bug on Solaris where copying archives failed.
 
-## [0.3.0] - 2020-06-06
+### Features
 
-### Added
-- Added support for MSVC cross-compilation. This allows compilation on x64 for
-  a Windows ARM target.
+* Added support for passing arbitrary architectures to Xcode builds, enables `arm64` builds.
 
-### Fixed
-- Fixed XCode CLT version detection on macOS Catalina.
+### Bug Fixes
 
-## [0.2.1] - 2020-05-05
+* Fixed a bug on Solaris where copying archives failed.
 
-### Fixed
-- Relicensed to Node.js contributors.
-- Fixed Windows bug introduced in v0.2.0.
+## [0.3.0](https://github.com/nodejs/gyp-next/compare/v0.2.1...v0.3.0) (2020-06-06)
 
-## [0.2.0] - 2020-04-06
 
-This is the first release of this project, based on https://chromium.googlesource.com/external/gyp
-with changes made over the years in Node.js and node-gyp.
+### Features
 
-[Unreleased]: https://github.com/nodejs/gyp-next/compare/v0.6.1...HEAD
-[0.6.1]: https://github.com/nodejs/gyp-next/compare/v0.6.0...v0.6.1
-[0.6.0]: https://github.com/nodejs/gyp-next/compare/v0.5.0...v0.6.0
-[0.5.0]: https://github.com/nodejs/gyp-next/compare/v0.4.0...v0.5.0
-[0.4.0]: https://github.com/nodejs/gyp-next/compare/v0.3.0...v0.4.0
-[0.3.0]: https://github.com/nodejs/gyp-next/compare/v0.2.1...v0.3.0
-[0.2.1]: https://github.com/nodejs/gyp-next/compare/v0.2.0...v0.2.1
-[0.2.0]: https://github.com/nodejs/gyp-next/releases/tag/v0.2.0
+* Added support for MSVC cross-compilation. This allows compilation on x64 for a Windows ARM target.
+
+### Bug Fixes
+
+* Fixed XCode CLT version detection on macOS Catalina.
+
+### [0.2.1](https://github.com/nodejs/gyp-next/compare/v0.2.0...v0.2.1) (2020-05-05)
+
+
+### Bug Fixes
+
+* Relicensed to Node.js contributors.
+* Fixed Windows bug introduced in v0.2.0.
+
+## [0.2.0](https://github.com/nodejs/gyp-next/releases/tag/v0.2.0) (2020-04-06)
+
+This is the first release of this project, based on https://chromium.googlesource.com/external/gyp with changes made over the years in Node.js and node-gyp.

--- a/node_modules/node-gyp/gyp/pylib/gyp/generator/msvs.py
+++ b/node_modules/node-gyp/gyp/pylib/gyp/generator/msvs.py
@@ -2177,7 +2177,12 @@ def GenerateOutput(target_list, target_dicts, data, params):
 
 
 def _GenerateMSBuildFiltersFile(
-    filters_path, source_files, rule_dependencies, extension_to_rule_name, platforms
+    filters_path,
+    source_files,
+    rule_dependencies,
+    extension_to_rule_name,
+    platforms,
+    toolset,
 ):
     """Generate the filters file.
 
@@ -2197,6 +2202,7 @@ def _GenerateMSBuildFiltersFile(
         rule_dependencies,
         extension_to_rule_name,
         platforms,
+        toolset,
         filter_group,
         source_group,
     )
@@ -2222,6 +2228,7 @@ def _AppendFiltersForMSBuild(
     rule_dependencies,
     extension_to_rule_name,
     platforms,
+    toolset,
     filter_group,
     source_group,
 ):
@@ -2257,13 +2264,14 @@ def _AppendFiltersForMSBuild(
                 rule_dependencies,
                 extension_to_rule_name,
                 platforms,
+                toolset,
                 filter_group,
                 source_group,
             )
         else:
             # It's a source.  Create a source entry.
             _, element = _MapFileToMsBuildSourceType(
-                source, rule_dependencies, extension_to_rule_name, platforms
+                source, rule_dependencies, extension_to_rule_name, platforms, toolset
             )
             source_entry = [element, {"Include": source}]
             # Specify the filter it is part of, if any.
@@ -2273,7 +2281,7 @@ def _AppendFiltersForMSBuild(
 
 
 def _MapFileToMsBuildSourceType(
-    source, rule_dependencies, extension_to_rule_name, platforms
+    source, rule_dependencies, extension_to_rule_name, platforms, toolset
 ):
     """Returns the group and element type of the source file.
 
@@ -2301,9 +2309,8 @@ def _MapFileToMsBuildSourceType(
     elif ext in [".s", ".asm"]:
         group = "masm"
         element = "MASM"
-        for platform in platforms:
-            if platform.lower() in ["arm", "arm64"]:
-                element = "MARMASM"
+        if "arm64" in platforms and toolset == "target":
+            element = "MARMASM"
     elif ext == ".idl":
         group = "midl"
         element = "Midl"
@@ -3613,14 +3620,14 @@ def _AddSources2(
                     rule_dependencies,
                     extension_to_rule_name,
                     _GetUniquePlatforms(spec),
+                    spec["toolset"],
                 )
-                if group == "compile":
-                    # Always add an <ObjectFileName> value to support duplicate
-                    # source file basenames.
+                if group == "compile" and not os.path.isabs(source):
+                    # Add an <ObjectFileName> value to support duplicate source
+                    # file basenames, except for absolute paths to avoid paths
+                    # with more than 260 characters.
                     file_name = os.path.splitext(source)[0] + ".obj"
-                    if os.path.isabs(file_name):
-                        file_name = os.path.splitdrive(file_name)[1]
-                    elif file_name.startswith("..\\"):
+                    if file_name.startswith("..\\"):
                         file_name = re.sub(r"^(\.\.\\)+", "", file_name)
                     elif file_name.startswith("$("):
                         file_name = re.sub(r"^\$\([^)]+\)\\", "", file_name)
@@ -3730,6 +3737,7 @@ def _GenerateMSBuildProject(project, options, version, generator_flags, spec):
         rule_dependencies,
         extension_to_rule_name,
         platforms,
+        toolset,
     )
     missing_sources = _VerifySourcesExist(sources, project_dir)
 

--- a/node_modules/node-gyp/gyp/setup.py
+++ b/node_modules/node-gyp/gyp/setup.py
@@ -15,7 +15,7 @@ with open(path.join(here, "README.md")) as in_file:
 
 setup(
     name="gyp-next",
-    version="0.6.1",
+    version="0.6.2",
     description="A fork of the GYP build system for use in the Node.js projects",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
A change to "correctly rename object files for absolute paths"
caused a bug in windows. A fix has already landed upstream in
gyp-next and been release as 0.6.2, but has not yet made it's
way to a release of node-gyp.

This float the upgrade to 0.6.2 in node-gyp

Closes: https://github.com/npm/cli/pull/1974

Refs: https://github.com/nodejs/gyp-next/releases/tag/v0.6.2
Refs: https://github.com/nodejs/node-gyp/pull/2241
Signed-off-by: Myles Borins <mylesborins@github.com>
