### PR TITLE
docs: update some github urls in docs.

### DIFF
--- a/docs/content/cli-commands/npm-init.md
+++ b/docs/content/cli-commands/npm-init.md
@@ -68,7 +68,7 @@ will create a scoped package.
 
 ### See Also
 
-* <https://github.com/isaacs/init-package-json>
+* <https://github.com/npm/init-package-json>
 * [package.json](/configuring-npm/package-json)
 * [npm version](/cli-commands/version)
 * [npm scope](/using-npm/scope)

--- a/docs/content/configuring-npm/package-json.md
+++ b/docs/content/configuring-npm/package-json.md
@@ -58,7 +58,7 @@ Changes to the package should come along with changes to the version. If you don
 plan to publish your package, the name and version fields are optional.
 
 Version must be parseable by
-[node-semver](https://github.com/isaacs/node-semver), which is bundled
+[node-semver](https://github.com/npm/node-semver), which is bundled
 with npm as a dependency.  (`npm install semver` to use it yourself.)
 
 More on version numbers and ranges at [semver](/using-npm/semver).


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

https://github.com/npm/cli/commit/1e4e6e9152bad264ef4c576ae211abcda780ba85#diff-00d457bc2d4eb5bc7994d3fd8fdd0f17e6cd0e2e8512d43fe273de53a72f0fcdL601 updated old github URL to new one.

```diff
- [init-package-json](https://github.com/isaacs/init-package-json) module
+ [init-package-json](https://github.com/npm/init-package-json) module
```

I noticed there are some old URLs in docs. This PR updated remaining old URLs.

* init-package-json is now https://github.com/npm/init-package-json
* node-semver is now https://github.com/npm/node-semver

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

Related to ##1938