### PR TITLE
fix: don't set exit code to 1 when `ls <filter>` returns results

### DIFF
--- a/lib/ls.js
+++ b/lib/ls.js
@@ -488,7 +488,7 @@ const ls = async (args) => {
   )
 
   // if filtering items, should exit with error code on no results
-  if (!tree[_include] && args.length) {
+  if (!tree[_include] && !args.length) {
     process.exitCode = 1
   }
 

--- a/test/lib/ls.js
+++ b/test/lib/ls.js
@@ -2476,6 +2476,12 @@ t.test('ls --json', (t) => {
         },
         'should output json contaning only occurences of filtered by package'
       )
+      t.equal(
+        process.exitCode,
+        0,
+        'should exit with error code 1'
+      )
+      process.exitCode = 0
       t.end()
     })
   })


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

Currently this is doing the opposite of what the comment says: erroring if there are results when filtering items.

I've chucked an assertion to prevent regression into the first filter test - technically they should all ideally do the check, but I've not worked a lot with tap and this is a simple typo bug that I don't expect would crop up all the time.

Happy to add the assertion to the other tests if desired :)

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

Fixes #1979