### PR TITLE
fix: don't suppress run output when `--silent` is passed

### DIFF
--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -69,7 +69,7 @@ const runScript = async (args) => {
     path,
     args,
     scriptShell,
-    stdio: log.level === 'silent' ? 'pipe' : 'inherit',
+    stdio: 'inherit',
     stdioString: true,
     pkg
   }

--- a/test/lib/run-script.js
+++ b/test/lib/run-script.js
@@ -284,13 +284,13 @@ t.test('run silent', async t => {
     t.match(RUN_SCRIPTS, [
       {
         event: 'preenv',
-        stdio: 'pipe'
+        stdio: 'inherit'
       },
       {
         path: npm.localPrefix,
         args: [],
         scriptShell: undefined,
-        stdio: 'pipe',
+        stdio: 'inherit',
         stdioString: true,
         pkg: { name: 'x', version: '1.2.3', _id: 'x@1.2.3', scripts: {
           env: 'env'
@@ -299,7 +299,7 @@ t.test('run silent', async t => {
       },
       {
         event: 'postenv',
-        stdio: 'pipe'
+        stdio: 'inherit'
       }
     ])
   })


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

Restores the output of the command being run when using `run-script`, restoring the ability to use `--silent` to prevent showing `npm ERR!` output, as per the docs:

> You can use the --silent flag to prevent showing npm ERR! output on error.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

Fixes #1958