### PR TITLE
Add --save-peer as a common option to npm install

### DIFF
--- a/docs/content/cli-commands/npm-install.md
+++ b/docs/content/cli-commands/npm-install.md
@@ -24,7 +24,7 @@ npm install <tarball url>
 npm install <folder>
 
 aliases: npm i, npm add
-common options: [-P|--save-prod|-D|--save-dev|-O|--save-optional] [-E|--save-exact] [-B|--save-bundle] [--no-save] [--dry-run]
+common options: [-P|--save-prod|-D|--save-dev|-O|--save-optional|--save-peer] [-E|--save-exact] [-B|--save-bundle] [--no-save] [--dry-run]
 ```
 
 ### Description

--- a/lib/install.js
+++ b/lib/install.js
@@ -83,7 +83,7 @@ const usage = usageUtil(
   '\nnpm install <tarball url>' +
   '\nnpm install <git:// url>' +
   '\nnpm install <github username>/<github project>',
-  '[--save-prod|--save-dev|--save-optional] [--save-exact] [--no-save]'
+  '[--save-prod|--save-dev|--save-optional|--save-peer] [--save-exact] [--no-save]'
 )
 
 const completion = async (opts, cb) => {


### PR DESCRIPTION
Currently there is no documentation on the website or the manual pages which explains that `--save-peer` is a valid option for `npm install`.

