### PR TITLE
Fix post-install script name

### DIFF
--- a/docs/content/using-npm/scripts.md
+++ b/docs/content/using-npm/scripts.md
@@ -228,7 +228,7 @@ For example, if your package.json contains this:
 { 
   "scripts" : { 
     "install" : "scripts/install.js", 
-    "postinstall" : "scripts/install.js", 
+    "postinstall" : "scripts/postinstall.js", 
     "uninstall" : "scripts/uninstall.js"
   }
 }


### PR DESCRIPTION
fix a typo in documentations : using-npm -> scripts. 

correct the 'postinstall' script file.