### PR TITLE
Documentation update for `install`

### DIFF
--- a/docs/content/commands/npm-install.md
+++ b/docs/content/commands/npm-install.md
@@ -34,8 +34,8 @@ following order of precedence:
 * `package-lock.json`
 * `yarn.lock`
 
-See [package-lock.json](/configuring-npm/package-lock-json) and [`npm
-shrinkwrap`](/commands/npm-shrinkwrap).
+See [package-lock.json](/configuring-npm/package-lock-json) and
+[`npm shrinkwrap`](/commands/npm-shrinkwrap).
 
 A `package` is:
 

--- a/docs/content/commands/npm-install.md
+++ b/docs/content/commands/npm-install.md
@@ -43,6 +43,8 @@ A `package` is:
   [`package.json`](/configuring-npm/package-json) file
 * b) a gzipped tarball containing (a)
 * c) a url that resolves to (b)
+* d) a `<name>@<version>` that is published on the registry (see
+  [`registry`](/using-npm/registry)) with (c)
 * e) a `<name>@<tag>` (see [`npm dist-tag`](/commands/npm-dist-tag)) that
   points to (d)
 * f) a `<name>` that has a "latest" tag satisfying (e)


### PR DESCRIPTION
Minor update to the `npm install` docs

- Add clause `(d)` back to the documentation.  I that was erroneously removed in some conflict resolution.  Probably my fault - but the `(e)` clause refers back to it so I think it was not meant to be removed.
- Don't split an inline code block over two lines.  Some markdown parsers have trouble with this, in particular, Gatsby's.  Although the CLI doesn't use Gatsby, we pull these docs up other places - like the registry docs - which do.