### PR TITLE
skip exec confirmation prompt in ci

### DIFF
--- a/lib/exec.js
+++ b/lib/exec.js
@@ -55,6 +55,7 @@ const readPackageJson = require('read-package-json-fast')
 const Arborist = require('@npmcli/arborist')
 const runScript = require('@npmcli/run-script')
 const { resolve, delimiter } = require('path')
+const ciDetect = require('@npmcli/ci-detect')
 const crypto = require('crypto')
 const pacote = require('pacote')
 const npa = require('npm-package-arg')
@@ -161,7 +162,7 @@ const exec = async args => {
         if (npm.flatOptions.yes === false)
           throw 'canceled'
 
-        if (!isTTY)
+        if (!isTTY || ciDetect())
           npm.log.warn('exec', `The following package${add.length === 1 ? ' was' : 's were'} not found and will be installed: ${add.map((pkg) => pkg.replace(/@$/, '')).join(', ')}`)
         else {
           const addList = add.map(a => `  ${a.replace(/@$/, '')}`)

--- a/tap-snapshots/test-lib-utils-flat-options.js-TAP.test.js
+++ b/tap-snapshots/test-lib-utils-flat-options.js-TAP.test.js
@@ -75,7 +75,7 @@ Object {
   "omit": Array [],
   "otp": "otp",
   "package": "package",
-  "packageLock": "package-lock",
+  "packageLock": true,
   "packageLockOnly": "package-lock-only",
   "parseable": undefined,
   "preferDedupe": undefined,

--- a/test/lib/exec.js
+++ b/test/lib/exec.js
@@ -528,12 +528,15 @@ t.test('positional args and --call together is an error', t => {
 t.test('prompt when installs are needed if not already present and shell is a TTY', async t => {
   const stdoutTTY = process.stdout.isTTY
   const stdinTTY = process.stdin.isTTY
+  const travisEnv = process.env.TRAVIS
   t.teardown(() => {
     process.stdout.isTTY = stdoutTTY
     process.stdin.isTTY = stdinTTY
+    process.env.TRAVIS = travisEnv
   })
   process.stdout.isTTY = true
   process.stdin.isTTY = true
+  delete process.env.TRAVIS
 
   const packages = ['foo', 'bar']
   READ_RESULT = 'yolo'
@@ -595,12 +598,15 @@ t.test('prompt when installs are needed if not already present and shell is a TT
 t.test('skip prompt when installs are needed if not already present and shell is not a tty (multiple packages)', async t => {
   const stdoutTTY = process.stdout.isTTY
   const stdinTTY = process.stdin.isTTY
+  const travisEnv = process.env.TRAVIS
   t.teardown(() => {
     process.stdout.isTTY = stdoutTTY
     process.stdin.isTTY = stdinTTY
+    process.env.TRAVIS = travisEnv
   })
   process.stdout.isTTY = false
   process.stdin.isTTY = false
+  delete process.env.TRAVIS
 
   const packages = ['foo', 'bar']
   READ_RESULT = 'yolo'
@@ -660,12 +666,15 @@ t.test('skip prompt when installs are needed if not already present and shell is
 t.test('skip prompt when installs are needed if not already present and shell is not a tty (single package)', async t => {
   const stdoutTTY = process.stdout.isTTY
   const stdinTTY = process.stdin.isTTY
+  const travisEnv = process.env.TRAVIS
   t.teardown(() => {
     process.stdout.isTTY = stdoutTTY
     process.stdin.isTTY = stdinTTY
+    process.env.TRAVIS = travisEnv
   })
   process.stdout.isTTY = false
   process.stdin.isTTY = false
+  delete process.env.TRAVIS
 
   const packages = ['foo']
   READ_RESULT = 'yolo'
@@ -717,12 +726,15 @@ t.test('skip prompt when installs are needed if not already present and shell is
 t.test('abort if prompt rejected', async t => {
   const stdoutTTY = process.stdout.isTTY
   const stdinTTY = process.stdin.isTTY
+  const travisEnv = process.env.TRAVIS
   t.teardown(() => {
     process.stdout.isTTY = stdoutTTY
     process.stdin.isTTY = stdinTTY
+    process.env.TRAVIS = travisEnv
   })
   process.stdout.isTTY = true
   process.stdin.isTTY = true
+  delete process.env.TRAVIS
 
   const packages = ['foo', 'bar']
   READ_RESULT = 'no, why would I want such a thing??'
@@ -773,12 +785,15 @@ t.test('abort if prompt rejected', async t => {
 t.test('abort if prompt false', async t => {
   const stdoutTTY = process.stdout.isTTY
   const stdinTTY = process.stdin.isTTY
+  const travisEnv = process.env.TRAVIS
   t.teardown(() => {
     process.stdout.isTTY = stdoutTTY
     process.stdin.isTTY = stdinTTY
+    process.env.TRAVIS = travisEnv
   })
   process.stdout.isTTY = true
   process.stdin.isTTY = true
+  delete process.env.TRAVIS
 
   const packages = ['foo', 'bar']
   READ_ERROR = 'canceled'
@@ -829,12 +844,15 @@ t.test('abort if prompt false', async t => {
 t.test('abort if -n provided', async t => {
   const stdoutTTY = process.stdout.isTTY
   const stdinTTY = process.stdin.isTTY
+  const travisEnv = process.env.TRAVIS
   t.teardown(() => {
     process.stdout.isTTY = stdoutTTY
     process.stdin.isTTY = stdinTTY
+    process.env.TRAVIS = travisEnv
   })
   process.stdout.isTTY = true
   process.stdin.isTTY = true
+  delete process.env.TRAVIS
 
   const packages = ['foo', 'bar']
 

--- a/test/lib/exec.js
+++ b/test/lib/exec.js
@@ -80,9 +80,12 @@ const read = (options, cb) => {
 
 const PATH = require('../../lib/utils/path.js')
 
+let CI_NAME = 'travis-ci'
+
 const exec = requireInject('../../lib/exec.js', {
   '@npmcli/arborist': Arborist,
   '@npmcli/run-script': runScript,
+  '@npmcli/ci-detect': () => CI_NAME,
   '../../lib/npm.js': npm,
   pacote,
   read,
@@ -528,15 +531,14 @@ t.test('positional args and --call together is an error', t => {
 t.test('prompt when installs are needed if not already present and shell is a TTY', async t => {
   const stdoutTTY = process.stdout.isTTY
   const stdinTTY = process.stdin.isTTY
-  const travisEnv = process.env.TRAVIS
   t.teardown(() => {
     process.stdout.isTTY = stdoutTTY
     process.stdin.isTTY = stdinTTY
-    process.env.TRAVIS = travisEnv
+    CI_NAME = 'travis-ci'
   })
   process.stdout.isTTY = true
   process.stdin.isTTY = true
-  delete process.env.TRAVIS
+  CI_NAME = false
 
   const packages = ['foo', 'bar']
   READ_RESULT = 'yolo'
@@ -598,15 +600,14 @@ t.test('prompt when installs are needed if not already present and shell is a TT
 t.test('skip prompt when installs are needed if not already present and shell is not a tty (multiple packages)', async t => {
   const stdoutTTY = process.stdout.isTTY
   const stdinTTY = process.stdin.isTTY
-  const travisEnv = process.env.TRAVIS
   t.teardown(() => {
     process.stdout.isTTY = stdoutTTY
     process.stdin.isTTY = stdinTTY
-    process.env.TRAVIS = travisEnv
+    CI_NAME = 'travis-ci'
   })
   process.stdout.isTTY = false
   process.stdin.isTTY = false
-  delete process.env.TRAVIS
+  CI_NAME = false
 
   const packages = ['foo', 'bar']
   READ_RESULT = 'yolo'
@@ -666,15 +667,14 @@ t.test('skip prompt when installs are needed if not already present and shell is
 t.test('skip prompt when installs are needed if not already present and shell is not a tty (single package)', async t => {
   const stdoutTTY = process.stdout.isTTY
   const stdinTTY = process.stdin.isTTY
-  const travisEnv = process.env.TRAVIS
   t.teardown(() => {
     process.stdout.isTTY = stdoutTTY
     process.stdin.isTTY = stdinTTY
-    process.env.TRAVIS = travisEnv
+    CI_NAME = 'travis-ci'
   })
   process.stdout.isTTY = false
   process.stdin.isTTY = false
-  delete process.env.TRAVIS
+  CI_NAME = false
 
   const packages = ['foo']
   READ_RESULT = 'yolo'
@@ -726,15 +726,14 @@ t.test('skip prompt when installs are needed if not already present and shell is
 t.test('abort if prompt rejected', async t => {
   const stdoutTTY = process.stdout.isTTY
   const stdinTTY = process.stdin.isTTY
-  const travisEnv = process.env.TRAVIS
   t.teardown(() => {
     process.stdout.isTTY = stdoutTTY
     process.stdin.isTTY = stdinTTY
-    process.env.TRAVIS = travisEnv
+    CI_NAME = 'travis-ci'
   })
   process.stdout.isTTY = true
   process.stdin.isTTY = true
-  delete process.env.TRAVIS
+  CI_NAME = false
 
   const packages = ['foo', 'bar']
   READ_RESULT = 'no, why would I want such a thing??'
@@ -785,15 +784,14 @@ t.test('abort if prompt rejected', async t => {
 t.test('abort if prompt false', async t => {
   const stdoutTTY = process.stdout.isTTY
   const stdinTTY = process.stdin.isTTY
-  const travisEnv = process.env.TRAVIS
   t.teardown(() => {
     process.stdout.isTTY = stdoutTTY
     process.stdin.isTTY = stdinTTY
-    process.env.TRAVIS = travisEnv
+    CI_NAME = 'travis-ci'
   })
   process.stdout.isTTY = true
   process.stdin.isTTY = true
-  delete process.env.TRAVIS
+  CI_NAME = false
 
   const packages = ['foo', 'bar']
   READ_ERROR = 'canceled'
@@ -844,15 +842,14 @@ t.test('abort if prompt false', async t => {
 t.test('abort if -n provided', async t => {
   const stdoutTTY = process.stdout.isTTY
   const stdinTTY = process.stdin.isTTY
-  const travisEnv = process.env.TRAVIS
   t.teardown(() => {
     process.stdout.isTTY = stdoutTTY
     process.stdin.isTTY = stdinTTY
-    process.env.TRAVIS = travisEnv
+    CI_NAME = 'travis-ci'
   })
   process.stdout.isTTY = true
   process.stdin.isTTY = true
-  delete process.env.TRAVIS
+  CI_NAME = false
 
   const packages = ['foo', 'bar']
 


### PR DESCRIPTION
this extends the previous test that skips the prompt when a tty is not present to also skip the prompt if it looks like we're running in a CI environment at all, which _should_ hopefully fully resolve #1935 
