### PR TITLE
tools: properly remove pycache in release script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -7,8 +7,8 @@ unset CDPATH
 set -e
 
 rm -rf release *.tgz || true
-rm node_modules/node-gyp/gyp/pylib/gyp/*.pyc || true
-rm node_modules/node-gyp/gyp/pylib/gyp/generator/*.pyc || true
+rm node_modules/node-gyp/gyp/pylib/gyp/__pycache__/*.pyc || true
+rm node_modules/node-gyp/gyp/pylib/gyp/generator/__pycache__/*.pyc || true
 mkdir release
 node ./bin/npm-cli.js pack --loglevel error >/dev/null
 mv *.tgz release


### PR DESCRIPTION
Looks like the latest version of node-gyp has the .pyc in a
__pycache__ directory rather than with the other python files.
There is currently a non-exiting error when running the release
script due to this.
