### PR TITLE
pack: do not show individual files of bundled deps

### DIFF
--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -1,14 +1,10 @@
-'use strict'
-
 const tar = require('tar')
 const ssri = require('ssri')
 const npmlog = require('npmlog')
 const byteSize = require('byte-size')
 const columnify = require('columnify')
 
-module.exports = { logTar, getContents }
-
-function logTar (tarball, opts = {}) {
+const logTar = (tarball, opts = {}) => {
   const { unicode = false, log = npmlog } = opts
   log.notice('')
   log.notice('', `${unicode ? '📦 ' : 'package:'} ${tarball.name}@${tarball.version}`)
@@ -16,8 +12,9 @@ function logTar (tarball, opts = {}) {
   if (tarball.files.length) {
     log.notice('', columnify(tarball.files.map((f) => {
       const bytes = byteSize(f.size)
-      return { path: f.path, size: `${bytes.value}${bytes.unit}` }
-    }), {
+      return (/^node_modules\//.test(f.path)) ? null
+        : { path: f.path, size: `${bytes.value}${bytes.unit}` }
+    }).filter(f => f), {
       include: ['size', 'path'],
       showHeaders: false,
     }))
@@ -49,7 +46,7 @@ function logTar (tarball, opts = {}) {
   log.notice('', '')
 }
 
-async function getContents (manifest, tarball) {
+const getContents = async (manifest, tarball) => {
   const files = []
   const bundled = new Set()
   let totalEntries = 0
@@ -111,3 +108,5 @@ async function getContents (manifest, tarball) {
     bundled: Array.from(bundled),
   }
 }
+
+module.exports = { logTar, getContents }

--- a/tap-snapshots/test-lib-utils-tar.js-TAP.test.js
+++ b/tap-snapshots/test-lib-utils-tar.js-TAP.test.js
@@ -11,8 +11,7 @@ exports[`test/lib/utils/tar.js TAP should log tarball contents > must match snap
 package: my-cool-pkg@1.0.0
 === Tarball Contents ===
 
-4B  node_modules/bundle-dep
-97B package.json           
+97B package.json
 === Bundled Dependencies ===
 
 bundle-dep


### PR DESCRIPTION
We show a list of bundled dependencies, there's no need to ALSO show
the individual files in each one.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
