### PR TITLE
Output registry before prompting for login details

### DIFF
--- a/lib/auth/legacy.js
+++ b/lib/auth/legacy.js
@@ -2,6 +2,7 @@
 
 const log = require('npmlog')
 const profile = require('npm-profile')
+const output = require('../utils/output.js')
 
 const openUrl = require('../utils/open-url.js')
 const read = require('../utils/read-user-info.js')
@@ -57,6 +58,7 @@ const login = async (opts) => {
   }
 
   try {
+    output(`Log in on ${opts.registry}`)
     res = await profile.login(openerPromise, loginPrompter, opts)
   } catch (err) {
     const needsMoreInfo = !(opts &&


### PR DESCRIPTION
This change outputs the registry before prompting the user for the login information.

Related to/Resolves: #2071 

Please let me know if any changes are required, wasn't sure if to use console.log or the output util (as it seems most parts of the cli seem to use output instead with a few exceptions).