### PR TITLE
fix: npm exec on folders missing package.json

### DIFF
--- a/lib/exec.js
+++ b/lib/exec.js
@@ -65,6 +65,41 @@ const PATH = require('./utils/path.js')
 
 const cmd = (args, cb) => exec(args).then(() => cb()).catch(cb)
 
+const run = async ({ args, call, pathArr }) => {
+  // turn list of args into command string
+  const script = call || args.map(escapeArg).join(' ').trim()
+
+  // do the fakey runScript dance
+  // still should work if no package.json in cwd
+  const realPkg = await readPackageJson(`${npm.localPrefix}/package.json`)
+    .catch(() => ({}))
+  const pkg = {
+    ...realPkg,
+    scripts: {
+      ...(realPkg.scripts || {}),
+      npx: script,
+    },
+  }
+
+  npm.log.disableProgress()
+  try {
+    return await runScript({
+      pkg,
+      banner: false,
+      // we always run in cwd, not --prefix
+      path: process.cwd(),
+      stdioString: true,
+      event: 'npx',
+      env: {
+        PATH: pathArr.join(delimiter),
+      },
+      stdio: 'inherit',
+    })
+  } finally {
+    npm.log.enableProgress()
+  }
+}
+
 const exec = async args => {
   const { package: packages, call } = npm.flatOptions
 
@@ -89,17 +124,10 @@ const exec = async args => {
     }
 
     if (binExists) {
-      return await runScript({
-        cmd: [args[0], ...args.slice(1).map(escapeArg)].join(' ').trim(),
-        banner: false,
-        // we always run in cwd, not --prefix
-        path: process.cwd(),
-        stdioString: true,
-        event: 'npx',
-        env: {
-          PATH: pathArr.join(delimiter),
-        },
-        stdio: 'inherit',
+      return await run({
+        args,
+        call: [args[0], ...args.slice(1).map(escapeArg)].join(' ').trim(),
+        pathArr,
       })
     }
 
@@ -128,9 +156,6 @@ const exec = async args => {
 
   if (needPackageCommandSwap)
     args[0] = getBinFromManifest(manis[0])
-
-  // turn list of args into command string
-  const script = call || args.map(escapeArg).join(' ').trim()
 
   // figure out whether we need to install stuff, or if local is fine
   const localArb = new Arborist({
@@ -180,35 +205,7 @@ const exec = async args => {
     pathArr.unshift(resolve(installDir, 'node_modules/.bin'))
   }
 
-  // do the fakey runScript dance
-  // still should work if no package.json in cwd
-  const realPkg = await readPackageJson(`${npm.localPrefix}/package.json`)
-    .catch(() => ({}))
-  const pkg = {
-    ...realPkg,
-    scripts: {
-      ...(realPkg.scripts || {}),
-      npx: script,
-    },
-  }
-
-  npm.log.disableProgress()
-  try {
-    return await runScript({
-      pkg,
-      banner: false,
-      // we always run in cwd, not --prefix
-      path: process.cwd(),
-      stdioString: true,
-      event: 'npx',
-      env: {
-        PATH: pathArr.join(delimiter),
-      },
-      stdio: 'inherit',
-    })
-  } finally {
-    npm.log.enableProgress()
-  }
+  return await run({ args, call, pathArr })
 }
 
 const manifestMissing = (tree, mani) => {

--- a/test/lib/exec.js
+++ b/test/lib/exec.js
@@ -82,7 +82,7 @@ const PATH = require('../../lib/utils/path.js')
 
 let CI_NAME = 'travis-ci'
 
-const exec = requireInject('../../lib/exec.js', {
+const mocks = {
   '@npmcli/arborist': Arborist,
   '@npmcli/run-script': runScript,
   '@npmcli/ci-detect': () => CI_NAME,
@@ -90,7 +90,8 @@ const exec = requireInject('../../lib/exec.js', {
   pacote,
   read,
   'mkdirp-infer-owner': mkdirp
-})
+}
+const exec = requireInject('../../lib/exec.js', mocks)
 
 t.afterEach(cb => {
   MKDIRPS.length = 0
@@ -122,7 +123,7 @@ t.test('npx foo, bin already exists locally', async t => {
     t.ifError(er, 'npm exec')
   })
   t.strictSame(RUN_SCRIPTS, [{
-    cmd: 'foo',
+    pkg: { scripts: { npx: 'foo' }},
     banner: false,
     path: process.cwd(),
     stdioString: true,
@@ -146,7 +147,7 @@ t.test('npx foo, bin already exists globally', async t => {
     t.ifError(er, 'npm exec')
   })
   t.strictSame(RUN_SCRIPTS, [{
-    cmd: 'foo',
+    pkg: { scripts: { npx: 'foo' }},
     banner: false,
     path: process.cwd(),
     stdioString: true,


### PR DESCRIPTION
This fixes running `npm exec` in folders that does not have a `package.json` file.

Fixes: #1975
Fixes: #2078