### PR TITLE
ci: delete the contents of node_modules only, not the directory

### DIFF
--- a/lib/ci.js
+++ b/lib/ci.js
@@ -31,7 +31,7 @@ const ci = async () => {
         'later to generate a package-lock.json file, then try again.'
       throw new Error(msg)
     }),
-    rimraf(`${where}/node_modules/`),
+    rimraf(`${where}/node_modules/*`, { glob: { dot: true, nosort: true, silent: true } }),
   ])
   // npm ci should never modify the lockfile or package.json
   await arb.reify({ save: false })

--- a/test/lib/ci.js
+++ b/test/lib/ci.js
@@ -104,7 +104,8 @@ test('should remove existing node_modules before installing', (t) => {
         t.equal(options.save, false, 'npm ci should never save')
         // check if node_modules was removed before reifying
         const contents = await readdir(testDir)
-        t.equals(contents.indexOf('node_modules'), -1, 'node_modules does not exist')
+        const nodeModules = contents.filter((path) => path.startsWith('node_modules'))
+        t.same(nodeModules, ['node_modules'], 'should only have the node_modules directory')
         t.end()
       }
     }


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

this makes it so that instead of deleting the entire node_modules directory, we instead delete only its contents. this used to be the case in npm 6 and the current state of things is a regression.
