### PR TITLE
fix: in run-script, if loglevel is silent, disable banner option

### DIFF
--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -71,6 +71,7 @@ const runScript = async (args) => {
     stdio: 'inherit',
     stdioString: true,
     pkg,
+    banner: log.level !== 'silent',
   }
 
   for (const [event, args] of events) {

--- a/test/lib/run-script.js
+++ b/test/lib/run-script.js
@@ -253,6 +253,7 @@ t.test('skip pre/post hooks when using ignoreScripts', async t => {
           postenv: 'echo after the env',
           env: 'env'
         } },
+        banner: true,
         event: 'env'
       }
     ])
@@ -295,7 +296,8 @@ t.test('run silent', async t => {
         pkg: { name: 'x', version: '1.2.3', _id: 'x@1.2.3', scripts: {
           env: 'env'
         } },
-        event: 'env'
+        event: 'env',
+        banner: false
       },
       {
         event: 'postenv',


### PR DESCRIPTION
<!-- What / Why -->
This patch restore the previous behaviour when running npm with `-s` flag

Before patch:
```
╰─➤  npm run -s ver

> scl@4.0.0 ver
> echo $npm_package_version

4.0.0
```

After patch:
```
╰─➤  npm run -s ver
4.0.0
```

## References

Related to #2023

<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
