### PR TITLE
Set process.title a bit more usefully

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,5 +1,7 @@
 // Separated out for easier unit testing
 module.exports = (process) => {
+  // set it here so that regardless of what happens later, we don't
+  // leak any private CLI configs to other programs
   process.title = 'npm'
 
   const {


### PR DESCRIPTION
This includes all positional args (ie, not anything that is a config),
except for the third positional arg when running `npm token revoke ...`,
since that is also a secret.

Makes the `ps` entry a bit more useful than just "npm", so users can at
least get some clue what npm is doing, while minimizing the degree to
which we leak anything secret.

Closes: #1927
Fixes: https://npm.community/t/8400
Related: tmux-plugins/tmux-resurrect#201

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
