### PR TITLE
fix: pass flatOptions through to Arborist.reify in npm ci

### DIFF
--- a/lib/ci.js
+++ b/lib/ci.js
@@ -34,7 +34,7 @@ const ci = async () => {
     rimraf(`${where}/node_modules/*`, { glob: { dot: true, nosort: true, silent: true } }),
   ])
   // npm ci should never modify the lockfile or package.json
-  await arb.reify({ save: false })
+  await arb.reify({ ...npm.flatOptions, save: false })
   reifyOutput(arb)
 }
 

--- a/test/lib/ci.js
+++ b/test/lib/ci.js
@@ -42,6 +42,25 @@ test('should use Arborist', (t) => {
   })
 })
 
+test('should pass flatOptions to Arborist.reify', (t) => {
+  const ci = requireInject('../../lib/ci.js', {
+    '../../lib/npm.js': {
+      prefix: 'foo',
+      flatOptions: {
+        production: true
+      }
+    },
+    '@npmcli/arborist': function () {
+      this.loadVirtual = () => Promise.resolve(true)
+      this.reify = async (options) => {
+        t.equal(options.production, true, 'should pass flatOptions to Arborist.reify')
+        t.end()
+      }
+    }
+  })
+  ci(null, () => {})
+})
+
 test('should throw if package-lock.json or npm-shrinkwrap missing', (t) => {
   const testDir = t.testdir({
     'index.js': 'some contents',


### PR DESCRIPTION
Fixes: #2017
