### PR TITLE
fix empty scripts

### DIFF
--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -46,7 +46,7 @@ const runScript = async (args) => {
 
   pkg.scripts = scripts
 
-  if (!scripts[event] && !(event === 'start' && await isServerPackage(path))) {
+  if (!Object.prototype.hasOwnProperty.call(scripts, event) && !(event === 'start' && await isServerPackage(path))) {
     if (npm.config.get('if-present'))
       return
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
this restores the npm6 behavior where `npm run somescript` where the script is defined as an empty string simply does nothing, rather than throwing an error that the script does not exist

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Fixes #2171 
