### PR TITLE
Remove --parseable from npm-audit.md

### DIFF
--- a/docs/content/commands/npm-audit.md
+++ b/docs/content/commands/npm-audit.md
@@ -7,7 +7,7 @@ description: Run a security audit
 ### Synopsis
 
 ```bash
-npm audit [--json|--parseable|--audit-level=(low|moderate|high|critical)]
+npm audit [--json|--audit-level=(low|moderate|high|critical)]
 npm audit fix [--force|--package-lock-only|--dry-run]
 
 common options: [--production] [--only=(dev|prod)]


### PR DESCRIPTION
--parseable is left from v6 and is not supported in v7. It was removed from the docs further down and thus should also not be used further up in the Synopsis.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Compare: https://docs.npmjs.com/cli/v6/commands/npm-audit
