### PR TITLE
doc: remove doc on obsolete `unsafe-perm` flag

### DIFF
--- a/docs/content/using-npm/scripts.md
+++ b/docs/content/using-npm/scripts.md
@@ -122,10 +122,8 @@ npm will default some script values based on package contents.
 
 ### User
 
-If npm was invoked with root privileges, then it will change the uid
-to the user account or uid specified by the `user` config, which
-defaults to `nobody`.  Set the `unsafe-perm` flag to run scripts with
-root privileges.
+When npm is run as root, scripts are always run with the effective uid
+and gid of the working directory owner.
 
 ### Environment
 


### PR DESCRIPTION
replace obsolete doc about root-privilege with changelog notes @ https://github.com/npm/cli/blob/e1a2837809a76896523cdfcbce7537e46f71d67e/CHANGELOG.md#v700-beta0-2020-08-04

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
the current doc about npm running with root-privilege is incorrect.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
