### PR TITLE
fix: npm init flat-options

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -43,7 +43,6 @@ const init = async args => {
       }
     }
     npm.config.set('package', [])
-    npm.flatOptions = { ...npm.flatOptions, package: [] }
     return new Promise((res, rej) => {
       npm.commands.exec([packageName, ...args.slice(1)], er => er ? rej(er) : res())
     })


### PR DESCRIPTION
The `flatOptions` property exposed by `lib/npm.js` should not be
redefined. This fixes an error in `npm init` by just avoiding trying to
override the property there.

Fixes: #2206
