### PR TITLE
Release v7.0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 7.0.14 (2020-11-23)
+
+### DEPENDENCIES
+* [`09d21ab90`](https://github.com/npm/cli/commit/09d21ab903dcfebdfd446b8b29ad46c425b6510e)
+  `@npmcli/run-script@1.8.1`
+    - fix a regression in how scripts are escaped
+
 ## 7.0.13 (2020-11-20)
 
 ### BUG FIXES

--- a/node_modules/@npmcli/run-script/lib/make-spawn-args.js
+++ b/node_modules/@npmcli/run-script/lib/make-spawn-args.js
@@ -34,7 +34,7 @@ const makeSpawnArgs = options => {
   } = options
 
   const isCmd = /(?:^|\\)cmd(?:\.exe)?$/i.test(scriptShell)
-  const args = isCmd ? ['/d', '/s', '/c', escapeCmd(cmd)] : ['-c', escapeCmd(cmd)]
+  const args = isCmd ? ['/d', '/s', '/c', escapeCmd(cmd)] : ['-c', cmd]
 
   const spawnOpts = {
     env: setPATH(path, {

--- a/node_modules/@npmcli/run-script/lib/set-path.js
+++ b/node_modules/@npmcli/run-script/lib/set-path.js
@@ -1,6 +1,8 @@
 const {resolve, dirname} = require('path')
 const isWindows = require('./is-windows.js')
-const nodeGypPath = resolve(__dirname, 'node-gyp-bin')
+// the path here is relative, even though it does not need to be
+// in order to make the posix tests pass in windows
+const nodeGypPath = resolve(__dirname, '../lib/node-gyp-bin')
 
 // Windows typically calls its PATH environ 'Path', but this is not
 // guaranteed, nor is it guaranteed to be the only one.  Merge them

--- a/node_modules/@npmcli/run-script/package.json
+++ b/node_modules/@npmcli/run-script/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@npmcli/run-script",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Run a lifecycle script for a package (descendant of npm-lifecycle)",
   "author": "Isaac Z. Schlueter <i@izs.me> (https://izs.me)",
   "license": "ISC",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm",
-  "version": "7.0.13",
+  "version": "7.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "npm",
-      "version": "7.0.13",
+      "version": "7.0.14",
       "bundleDependencies": [
         "@npmcli/arborist",
         "@npmcli/ci-detect",

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "@npmcli/arborist": "^1.0.12",
         "@npmcli/ci-detect": "^1.2.0",
         "@npmcli/config": "^1.2.1",
-        "@npmcli/run-script": "^1.8.0",
+        "@npmcli/run-script": "^1.8.1",
         "abbrev": "~1.1.1",
         "ansicolors": "~0.3.2",
         "ansistyles": "~0.1.3",
@@ -525,9 +525,9 @@
       }
     },
     "node_modules/@npmcli/run-script": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.8.0.tgz",
-      "integrity": "sha512-ljPLRbQM5byhqacWl9kIjt/yPMee0heaTskaMBFaFvYzOXNJ64h27xV96Sr+LnjJpqR0qJejG36QzJkXILvghQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.8.1.tgz",
+      "integrity": "sha512-G8c86g9cQHyRINosIcpovzv0BkXQc3urhL1ORf3KTe4TS4UBsg2O4Z2feca/W3pfzdHEJzc83ETBW4aKbb3SaA==",
       "inBundle": true,
       "dependencies": {
         "@npmcli/node-gyp": "^1.0.0",
@@ -9211,9 +9211,9 @@
       }
     },
     "@npmcli/run-script": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.8.0.tgz",
-      "integrity": "sha512-ljPLRbQM5byhqacWl9kIjt/yPMee0heaTskaMBFaFvYzOXNJ64h27xV96Sr+LnjJpqR0qJejG36QzJkXILvghQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/run-script/-/run-script-1.8.1.tgz",
+      "integrity": "sha512-G8c86g9cQHyRINosIcpovzv0BkXQc3urhL1ORf3KTe4TS4UBsg2O4Z2feca/W3pfzdHEJzc83ETBW4aKbb3SaA==",
       "requires": {
         "@npmcli/node-gyp": "^1.0.0",
         "@npmcli/promise-spawn": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.0.13",
+  "version": "7.0.14",
   "name": "npm",
   "description": "a package manager for JavaScript",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@npmcli/arborist": "^1.0.12",
     "@npmcli/ci-detect": "^1.2.0",
     "@npmcli/config": "^1.2.1",
-    "@npmcli/run-script": "^1.8.0",
+    "@npmcli/run-script": "^1.8.1",
     "abbrev": "~1.1.1",
     "ansicolors": "~0.3.2",
     "ansistyles": "~0.1.3",


### PR DESCRIPTION
## 7.0.14 (2020-11-23)

### DEPENDENCIES
* [`09d21ab90`](https://github.com/npm/cli/commit/09d21ab903dcfebdfd446b8b29ad46c425b6510e) `@npmcli/run-script@1.8.1`
    - fix a regression in how scripts are escaped


