### PR TITLE
test: fix npm run test

### DIFF
--- a/package.json
+++ b/package.json
@@ -214,6 +214,7 @@
     "Remove the 'files' below once we're done porting old tests over"
   ],
   "tap": {
+    "color": 1,
     "files": "test/{lib,bin}",
     "coverage-map": "test/coverage-map.js",
     "check-coverage": true,

--- a/test/lib/npm.js
+++ b/test/lib/npm.js
@@ -8,11 +8,16 @@ const event = process.env.npm_lifecycle_event
 for (const env of Object.keys(process.env).filter(e => /^npm_/.test(e))) {
   if (env === 'npm_command') {
     // should only be running this in the 'test' or 'run-script' command!
-    // if the lifecycle event is 'test', then it'll be 'test', otherwise
-    // it should always be run-script.  Of course, it'll be missing if this
-    // test is just run directly, which is also acceptable.
-    const cmd = event === 'test' ? 'test' : 'run-script'
-    t.match(process.env[env], cmd)
+    // if the lifecycle event is 'test', then it'll be either 'test' or 'run',
+    // otherwise it should always be run-script. Of course, it'll be missing
+    // if this test is just run directly, which is also acceptable.
+    if (event === 'test') {
+      t.ok(
+        ['test', 'run-script'].some(i => i === event),
+        'should match "npm test" or "npm run test"'
+      )
+    } else
+      t.match(process.env[env], 'run-script')
   }
   delete process.env[env]
 }


### PR DESCRIPTION
Fixes two issues that enable running tests downstream in nodejs:
- Running tests using `npm run-script test` instead of the `npm test` alias will result in a failure since `test/lib/npm.js` have an assertion for "test" being the command only. This changes it so that this particular test also accepts "run-script" as the command.
- Explicitly enable colors for tap output so that running the test suite in a non-tty environment will result in output that matches coloured snapshots.
