### PR TITLE
Fix broken links to package.json documentation

### DIFF
--- a/docs/content/using-npm/workspaces.md
+++ b/docs/content/using-npm/workspaces.md
@@ -18,13 +18,13 @@ order to add references to packages that should be symlinked into the current
 
 We also refer to these packages being auto-symlinked during `npm install` as a
 single **workspace**, meaning it's a nested package within the current local
-file system that is explicitly defined in the [`package.json`](/using-npm/package-json)
+file system that is explicitly defined in the [`package.json`](/configuring-npm/package-json#workspaces)
 `workspaces` configuration.
 
 ### Installing workspaces
 
 Workspaces are usually defined via the `workspaces` property of the
-[`package.json`](/using-npm/package-json) file, e.g:
+[`package.json`](/configuring-npm/package-json#workspaces) file, e.g:
 
 ```json
 {


### PR DESCRIPTION
There are some links in the workspaces documentation that lead to a 404. This fixes them and also jumps straight to the `workspaces` section.