### PR TITLE
install: run scripts for global packages

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -40,7 +40,7 @@ const install = async args => {
     ...npm.flatOptions,
     add: args,
   })
-  if (!args.length && !isGlobalInstall && !ignoreScripts) {
+  if (!args.length && !ignoreScripts) {
     const { scriptShell } = npm.flatOptions
     const scripts = [
       'preinstall',


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

This commit enables the behaviour that globally installed packages should run the scripts in their package.json file.

I think this should be a certainly serious bug in npm 7.x. Since v7, globally installed packages won't run scripts any more, unlike what npm v6 does. This causes lots of failures in my development.

I don't know if there's a reason for this breaking change but I couldn't see any information mentioned in either changelogs or blogs. Also, I don't know why there's nobody having asked yet....(Perhaps the [quieter install scripts](https://github.com/npm/rfcs/blob/latest/implemented/0022-quieter-install-scripts.md) makes it less obvious? Someone mentioned it #2194, but later he said it's running actually, which confused me. I think he's not sure either...?)

<!-- Examples:
## References
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
