### PR TITLE
Include prerelease versions when deprecating an entire package.

### DIFF
--- a/docs/content/commands/npm-deprecate.md
+++ b/docs/content/commands/npm-deprecate.md
@@ -7,7 +7,7 @@ description: Deprecate a version of a package
 ### Synopsis
 
 ```bash
-npm deprecate <pkg>[@<version>] <message>
+npm deprecate <pkg>[@<version range>] <message>
 ```
 
 ### Description
@@ -22,8 +22,17 @@ versions, so you can do something like this:
 npm deprecate my-thing@"< 0.2.3" "critical bug fixed in v0.2.3"
 ```
 
-Note that you must be the package owner to deprecate something.  See the
-`owner` and `adduser` help topics.
+SemVer ranges passed to this command are interpreted such that they *do*
+include prerelease versions.  For example:
+
+```bash
+npm deprecate my-thing@1.x "1.x is no longer supported"
+```
+
+In this case, a version `my-thing@1.0.0-beta.0` will also be deprecated.
+
+You must be the package owner to deprecate something.  See the `owner` and
+`adduser` help topics.
 
 To un-deprecate a package, specify an empty string (`""`) for the `message` 
 argument. Note that you must use double quotes with no space between them to 

--- a/lib/deprecate.js
+++ b/lib/deprecate.js
@@ -58,7 +58,7 @@ const deprecate = async ([pkg, msg]) => {
   })
 
   Object.keys(packument.versions)
-    .filter(v => semver.satisfies(v, spec))
+    .filter(v => semver.satisfies(v, spec, { includePrerelease: true }))
     .forEach(v => {
       packument.versions[v].deprecated = msg
     })

--- a/test/lib/deprecate.js
+++ b/test/lib/deprecate.js
@@ -13,6 +13,7 @@ npmFetch.json = async (uri, opts) => {
     versions: {
       '1.0.0': {},
       '1.0.1': {},
+      '1.0.1-pre': {},
     },
   }
 }
@@ -124,6 +125,9 @@ test('deprecates all versions when no range is specified', t => {
           deprecated: 'this version is deprecated',
         },
         '1.0.1': {
+          deprecated: 'this version is deprecated',
+        },
+        '1.0.1-pre': {
           deprecated: 'this version is deprecated',
         },
       },


### PR DESCRIPTION
The [NPM docs](https://docs.npmjs.com/deprecating-and-undeprecating-packages-or-package-versions) say:

```
To deprecate an entire package, run the following command, replacing <package-name> 
with  the name of your package, and "<message>" with your deprecation message:

npm deprecate <package-name> "<message>"
```

This **should** mark all versions as deprecated, but it currently excludes any prerelease versions.

The filtering of versions in the deprecate command is done by passing a version range to `semver.satisfies()`. A wildcard `*` is passed as the version range when deprecating an entire package, but wildcards [don't include prereleases by the semver library's rules](https://github.com/npm/node-semver#prerelease-tags), so we need to pass the `includePrerelease: true` option so that all prereleases are included in the deprecated versions.

## References
Fixes https://github.com/npm/cli/issues/1615
