### PR TITLE
test: replace requireInject with t.mock tap api 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -436,7 +436,7 @@
         "json-parse-even-better-errors": "^2.3.1",
         "marked-man": "^0.7.0",
         "require-inject": "^1.4.4",
-        "tap": "^14.11.0",
+        "tap": "npm:@ruyadorno/tap-with-mocks@^14.10.8-patch.9",
         "yaml": "^1.10.0"
       },
       "engines": {
@@ -6611,114 +6611,14 @@
       }
     },
     "node_modules/tap": {
-      "version": "14.11.0",
-      "resolved": "https://registry.npmjs.org/tap/-/tap-14.11.0.tgz",
-      "integrity": "sha512-z8qnNFVyIjLh/bNoTLFRkEk09XZUDAZbCkz/BjvHHly3ao5H+y60gPnedALfheEjA6dA4tpp/mrKq2NWlMuq0A==",
+      "name": "@ruyadorno/tap-with-mocks",
+      "version": "14.10.8-patch.9",
+      "resolved": "https://registry.npmjs.org/@ruyadorno/tap-with-mocks/-/tap-with-mocks-14.10.8-patch.9.tgz",
+      "integrity": "sha512-K4oo3Hc75eafnNAw2lMDF9HrtqVcvXdcXhslIq2n5Lfw3tsFsqy99+HnW6iUgAL/jykXlCW0SgtuWKM+VslkEw==",
       "bundleDependencies": [
         "ink",
         "treport",
-        "@types/react",
-        "import-jsx",
-        "minipass",
-        "signal-exit",
-        "tap-parser",
-        "tap-yaml",
-        "yaml",
-        "@babel/code-frame",
-        "@babel/core",
-        "@babel/generator",
-        "@babel/helper-annotate-as-pure",
-        "@babel/helper-builder-react-jsx",
-        "@babel/helper-builder-react-jsx-experimental",
-        "@babel/helper-function-name",
-        "@babel/helper-get-function-arity",
-        "@babel/helper-member-expression-to-functions",
-        "@babel/helper-module-imports",
-        "@babel/helper-module-transforms",
-        "@babel/helper-optimise-call-expression",
-        "@babel/helper-plugin-utils",
-        "@babel/helper-replace-supers",
-        "@babel/helper-simple-access",
-        "@babel/helper-split-export-declaration",
-        "@babel/helper-validator-identifier",
-        "@babel/helpers",
-        "@babel/highlight",
-        "@babel/parser",
-        "@babel/plugin-proposal-object-rest-spread",
-        "@babel/plugin-syntax-jsx",
-        "@babel/plugin-syntax-object-rest-spread",
-        "@babel/plugin-transform-destructuring",
-        "@babel/plugin-transform-parameters",
-        "@babel/plugin-transform-react-jsx",
-        "@babel/template",
-        "@babel/traverse",
-        "@babel/types",
-        "@types/color-name",
-        "@types/prop-types",
-        "@types/yoga-layout",
-        "ansi-escapes",
-        "ansi-regex",
-        "ansi-styles",
-        "ansicolors",
-        "arrify",
-        "astral-regex",
-        "auto-bind",
-        "caller-callsite",
-        "caller-path",
-        "callsites",
-        "cardinal",
-        "chalk",
-        "ci-info",
-        "cli-cursor",
-        "cli-truncate",
-        "color-convert",
-        "color-name",
-        "convert-source-map",
-        "csstype",
-        "debug",
-        "emoji-regex",
-        "escape-string-regexp",
-        "esprima",
-        "events-to-array",
-        "gensync",
-        "globals",
-        "has-flag",
-        "is-ci",
-        "is-fullwidth-code-point",
-        "js-tokens",
-        "jsesc",
-        "json5",
-        "lodash",
-        "lodash.throttle",
-        "log-update",
-        "loose-envify",
-        "mimic-fn",
-        "minimist",
-        "ms",
-        "object-assign",
-        "onetime",
-        "path-parse",
-        "prop-types",
-        "punycode",
-        "react-is",
-        "react-reconciler",
-        "redeyed",
-        "resolve",
-        "resolve-from",
-        "restore-cursor",
-        "scheduler",
-        "semver",
-        "slice-ansi",
-        "string-length",
-        "string-width",
-        "strip-ansi",
-        "supports-color",
-        "to-fast-properties",
-        "type-fest",
-        "unicode-length",
-        "widest-line",
-        "wrap-ansi",
-        "yoga-layout-prebuilt"
+        "@types/react"
       ],
       "dev": true,
       "dependencies": {
@@ -6752,7 +6652,7 @@
         "rimraf": "^2.7.1",
         "signal-exit": "^3.0.0",
         "source-map-support": "^0.5.16",
-        "stack-utils": "^1.0.3",
+        "stack-utils": "^1.0.2",
         "tap-mocha-reporter": "^5.0.0",
         "tap-parser": "^10.0.1",
         "tap-yaml": "^1.0.0",
@@ -6826,8 +6726,6 @@
     },
     "node_modules/tap/node_modules/@babel/code-frame": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6837,8 +6735,6 @@
     },
     "node_modules/tap/node_modules/@babel/core": {
       "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.5.tgz",
-      "integrity": "sha512-O34LQooYVDXPl7QWCdW9p4NR+QlzOr7xShPPJz8GsuCU3/8ua/wqTr7gmnxXv+WBESiGU/G5s16i6tUvHkNb+w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6870,8 +6766,6 @@
     },
     "node_modules/tap/node_modules/@babel/core/node_modules/source-map": {
       "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -6881,8 +6775,6 @@
     },
     "node_modules/tap/node_modules/@babel/generator": {
       "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
-      "integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6894,8 +6786,6 @@
     },
     "node_modules/tap/node_modules/@babel/generator/node_modules/source-map": {
       "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -6905,8 +6795,6 @@
     },
     "node_modules/tap/node_modules/@babel/helper-annotate-as-pure": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
-      "integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6916,8 +6804,6 @@
     },
     "node_modules/tap/node_modules/@babel/helper-builder-react-jsx": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.10.4.tgz",
-      "integrity": "sha512-5nPcIZ7+KKDxT1427oBivl9V9YTal7qk0diccnh7RrcgrT/pGFOjgGw1dgryyx1GvHEpXVfoDF6Ak3rTiWh8Rg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6928,8 +6814,6 @@
     },
     "node_modules/tap/node_modules/@babel/helper-builder-react-jsx-experimental": {
       "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.10.5.tgz",
-      "integrity": "sha512-Buewnx6M4ttG+NLkKyt7baQn7ScC/Td+e99G914fRU8fGIUivDDgVIQeDHFa5e4CRSJQt58WpNHhsAZgtzVhsg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6941,8 +6825,6 @@
     },
     "node_modules/tap/node_modules/@babel/helper-function-name": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-      "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6954,8 +6836,6 @@
     },
     "node_modules/tap/node_modules/@babel/helper-get-function-arity": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-      "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6965,8 +6845,6 @@
     },
     "node_modules/tap/node_modules/@babel/helper-member-expression-to-functions": {
       "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.5.tgz",
-      "integrity": "sha512-HiqJpYD5+WopCXIAbQDG0zye5XYVvcO9w/DHp5GsaGkRUaamLj2bEtu6i8rnGGprAhHM3qidCMgp71HF4endhA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6976,8 +6854,6 @@
     },
     "node_modules/tap/node_modules/@babel/helper-module-imports": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-      "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6987,8 +6863,6 @@
     },
     "node_modules/tap/node_modules/@babel/helper-module-transforms": {
       "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.5.tgz",
-      "integrity": "sha512-4P+CWMJ6/j1W915ITJaUkadLObmCRRSC234uctJfn/vHrsLNxsR8dwlcXv9ZhJWzl77awf+mWXSZEKt5t0OnlA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7004,8 +6878,6 @@
     },
     "node_modules/tap/node_modules/@babel/helper-optimise-call-expression": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
-      "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7015,16 +6887,12 @@
     },
     "node_modules/tap/node_modules/@babel/helper-plugin-utils": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-      "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/@babel/helper-replace-supers": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-      "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7037,8 +6905,6 @@
     },
     "node_modules/tap/node_modules/@babel/helper-simple-access": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
-      "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7049,8 +6915,6 @@
     },
     "node_modules/tap/node_modules/@babel/helper-split-export-declaration": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
-      "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7060,16 +6924,12 @@
     },
     "node_modules/tap/node_modules/@babel/helper-validator-identifier": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/@babel/helpers": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
-      "integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7081,8 +6941,6 @@
     },
     "node_modules/tap/node_modules/@babel/highlight": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7094,8 +6952,6 @@
     },
     "node_modules/tap/node_modules/@babel/parser": {
       "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
-      "integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7108,8 +6964,6 @@
     },
     "node_modules/tap/node_modules/@babel/plugin-proposal-object-rest-spread": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.10.4.tgz",
-      "integrity": "sha512-6vh4SqRuLLarjgeOf4EaROJAHjvu9Gl+/346PbDH9yWbJyfnJ/ah3jmYKYtswEyCoWZiidvVHjHshd4WgjB9BA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7124,8 +6978,6 @@
     },
     "node_modules/tap/node_modules/@babel/plugin-syntax-jsx": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.10.4.tgz",
-      "integrity": "sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7138,8 +6990,6 @@
     },
     "node_modules/tap/node_modules/@babel/plugin-syntax-object-rest-spread": {
       "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
-      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7152,8 +7002,6 @@
     },
     "node_modules/tap/node_modules/@babel/plugin-transform-destructuring": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.4.tgz",
-      "integrity": "sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7166,8 +7014,6 @@
     },
     "node_modules/tap/node_modules/@babel/plugin-transform-parameters": {
       "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.5.tgz",
-      "integrity": "sha512-xPHwUj5RdFV8l1wuYiu5S9fqWGM2DrYc24TMvUiRrPVm+SM3XeqU9BcokQX/kEUe+p2RBwy+yoiR1w/Blq6ubw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7181,8 +7027,6 @@
     },
     "node_modules/tap/node_modules/@babel/plugin-transform-react-jsx": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.10.4.tgz",
-      "integrity": "sha512-L+MfRhWjX0eI7Js093MM6MacKU4M6dnCRa/QPDwYMxjljzSCzzlzKzj9Pk4P3OtrPcxr2N3znR419nr3Xw+65A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7198,8 +7042,6 @@
     },
     "node_modules/tap/node_modules/@babel/template": {
       "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-      "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7211,8 +7053,6 @@
     },
     "node_modules/tap/node_modules/@babel/traverse": {
       "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
-      "integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7230,8 +7070,6 @@
     },
     "node_modules/tap/node_modules/@babel/types": {
       "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
-      "integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7243,24 +7081,18 @@
     },
     "node_modules/tap/node_modules/@types/color-name": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/@types/prop-types": {
       "version": "15.7.3",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-      "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/@types/react": {
       "version": "16.9.43",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.43.tgz",
-      "integrity": "sha512-PxshAFcnJqIWYpJbLPriClH53Z2WlJcVZE+NP2etUtWQs2s7yIMj3/LDKZT/5CHJ/F62iyjVCDu2H3jHEXIxSg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7271,16 +7103,12 @@
     },
     "node_modules/tap/node_modules/@types/yoga-layout": {
       "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@types/yoga-layout/-/yoga-layout-1.9.2.tgz",
-      "integrity": "sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/ansi-escapes": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-      "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7296,8 +7124,6 @@
     },
     "node_modules/tap/node_modules/ansi-regex": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7307,8 +7133,6 @@
     },
     "node_modules/tap/node_modules/ansi-styles": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7321,16 +7145,12 @@
     },
     "node_modules/tap/node_modules/ansicolors": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-      "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/arrify": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7340,8 +7160,6 @@
     },
     "node_modules/tap/node_modules/astral-regex": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7351,8 +7169,6 @@
     },
     "node_modules/tap/node_modules/auto-bind": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
-      "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7365,8 +7181,6 @@
     },
     "node_modules/tap/node_modules/caller-callsite": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
-      "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7379,8 +7193,6 @@
     },
     "node_modules/tap/node_modules/caller-path": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
-      "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7393,8 +7205,6 @@
     },
     "node_modules/tap/node_modules/callsites": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7404,8 +7214,6 @@
     },
     "node_modules/tap/node_modules/cardinal": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
-      "integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7419,8 +7227,6 @@
     },
     "node_modules/tap/node_modules/chalk": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7435,16 +7241,12 @@
     },
     "node_modules/tap/node_modules/ci-info": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/cli-cursor": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7457,8 +7259,6 @@
     },
     "node_modules/tap/node_modules/cli-truncate": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
-      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7475,8 +7275,6 @@
     },
     "node_modules/tap/node_modules/color-convert": {
       "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7486,16 +7284,12 @@
     },
     "node_modules/tap/node_modules/color-name": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/convert-source-map": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7505,24 +7299,18 @@
     },
     "node_modules/tap/node_modules/convert-source-map/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/csstype": {
       "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.11.tgz",
-      "integrity": "sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/debug": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7532,16 +7320,12 @@
     },
     "node_modules/tap/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7551,8 +7335,6 @@
     },
     "node_modules/tap/node_modules/esprima": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -7566,16 +7348,12 @@
     },
     "node_modules/tap/node_modules/events-to-array": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
-      "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/tap/node_modules/gensync": {
       "version": "1.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
-      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7585,8 +7363,6 @@
     },
     "node_modules/tap/node_modules/globals": {
       "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7596,8 +7372,6 @@
     },
     "node_modules/tap/node_modules/has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7607,8 +7381,6 @@
     },
     "node_modules/tap/node_modules/import-jsx": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/import-jsx/-/import-jsx-3.1.0.tgz",
-      "integrity": "sha512-lTuMdQ/mRXC+xQSGPDvAg1VkODlX78j5hZv2tneJ+zuo7GH/XhUF/YVKoeF382a4jO4GYw9jgganbMhEcxwb0g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7626,8 +7398,6 @@
     },
     "node_modules/tap/node_modules/ink": {
       "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/ink/-/ink-2.7.1.tgz",
-      "integrity": "sha512-s7lJuQDJEdjqtaIWhp3KYHl6WV3J04U9zoQ6wVc+Xoa06XM27SXUY57qC5DO46xkF0CfgXMKkKNcgvSu/SAEpA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7666,8 +7436,6 @@
     },
     "node_modules/tap/node_modules/ink/node_modules/ansi-styles": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-      "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7684,8 +7452,6 @@
     },
     "node_modules/tap/node_modules/ink/node_modules/chalk": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7699,8 +7465,6 @@
     },
     "node_modules/tap/node_modules/ink/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7713,16 +7477,12 @@
     },
     "node_modules/tap/node_modules/ink/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/ink/node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7732,8 +7492,6 @@
     },
     "node_modules/tap/node_modules/ink/node_modules/supports-color": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-      "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7746,8 +7504,6 @@
     },
     "node_modules/tap/node_modules/is-ci": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7760,8 +7516,6 @@
     },
     "node_modules/tap/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7771,16 +7525,12 @@
     },
     "node_modules/tap/node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/jsesc": {
       "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7793,8 +7543,6 @@
     },
     "node_modules/tap/node_modules/json5": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7810,24 +7558,18 @@
     },
     "node_modules/tap/node_modules/lodash": {
       "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/lodash.throttle": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/log-update": {
       "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-3.4.0.tgz",
-      "integrity": "sha512-ILKe88NeMt4gmDvk/eb615U/IVn7K9KWGkoYbdatQ69Z65nj1ZzjM6fHXfcs0Uge+e+EGnMW7DY4T9yko8vWFg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7845,8 +7587,6 @@
     },
     "node_modules/tap/node_modules/log-update/node_modules/ansi-escapes": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7856,8 +7596,6 @@
     },
     "node_modules/tap/node_modules/log-update/node_modules/ansi-regex": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7867,8 +7605,6 @@
     },
     "node_modules/tap/node_modules/log-update/node_modules/cli-cursor": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7881,16 +7617,12 @@
     },
     "node_modules/tap/node_modules/log-update/node_modules/emoji-regex": {
       "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/log-update/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7900,8 +7632,6 @@
     },
     "node_modules/tap/node_modules/log-update/node_modules/mimic-fn": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7911,8 +7641,6 @@
     },
     "node_modules/tap/node_modules/log-update/node_modules/onetime": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7925,8 +7653,6 @@
     },
     "node_modules/tap/node_modules/log-update/node_modules/restore-cursor": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7940,8 +7666,6 @@
     },
     "node_modules/tap/node_modules/log-update/node_modules/string-width": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7956,8 +7680,6 @@
     },
     "node_modules/tap/node_modules/log-update/node_modules/strip-ansi": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7970,8 +7692,6 @@
     },
     "node_modules/tap/node_modules/log-update/node_modules/wrap-ansi": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7986,8 +7706,6 @@
     },
     "node_modules/tap/node_modules/loose-envify": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8000,8 +7718,6 @@
     },
     "node_modules/tap/node_modules/mimic-fn": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8011,16 +7727,12 @@
     },
     "node_modules/tap/node_modules/minimist": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/minipass": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
-      "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8033,8 +7745,6 @@
     },
     "node_modules/tap/node_modules/minipass/node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
@@ -8053,16 +7763,12 @@
     },
     "node_modules/tap/node_modules/ms": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8072,8 +7778,6 @@
     },
     "node_modules/tap/node_modules/onetime": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-      "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8086,16 +7790,12 @@
     },
     "node_modules/tap/node_modules/path-parse": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/prop-types": {
       "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8107,8 +7807,6 @@
     },
     "node_modules/tap/node_modules/punycode": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8118,16 +7816,12 @@
     },
     "node_modules/tap/node_modules/react-is": {
       "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/react-reconciler": {
       "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.24.0.tgz",
-      "integrity": "sha512-gAGnwWkf+NOTig9oOowqid9O0HjTDC+XVGBCAmJYYJ2A2cN/O4gDdIuuUQjv8A4v6GDwVfJkagpBBLW5OW9HSw==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8146,8 +7840,6 @@
     },
     "node_modules/tap/node_modules/redeyed": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
-      "integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8157,8 +7849,6 @@
     },
     "node_modules/tap/node_modules/resolve": {
       "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8171,8 +7861,6 @@
     },
     "node_modules/tap/node_modules/resolve-from": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8182,8 +7870,6 @@
     },
     "node_modules/tap/node_modules/restore-cursor": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8209,8 +7895,6 @@
     },
     "node_modules/tap/node_modules/scheduler": {
       "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
-      "integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8221,8 +7905,6 @@
     },
     "node_modules/tap/node_modules/semver": {
       "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8232,16 +7914,12 @@
     },
     "node_modules/tap/node_modules/signal-exit": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/tap/node_modules/slice-ansi": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
-      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8256,8 +7934,6 @@
     },
     "node_modules/tap/node_modules/slice-ansi/node_modules/ansi-styles": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-      "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8274,8 +7950,6 @@
     },
     "node_modules/tap/node_modules/slice-ansi/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8288,16 +7962,12 @@
     },
     "node_modules/tap/node_modules/slice-ansi/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/string-length": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-length/-/string-length-3.1.0.tgz",
-      "integrity": "sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8311,8 +7981,6 @@
     },
     "node_modules/tap/node_modules/string-length/node_modules/ansi-regex": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8322,8 +7990,6 @@
     },
     "node_modules/tap/node_modules/string-length/node_modules/astral-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8333,8 +7999,6 @@
     },
     "node_modules/tap/node_modules/string-length/node_modules/strip-ansi": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8347,8 +8011,6 @@
     },
     "node_modules/tap/node_modules/string-width": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8363,8 +8025,6 @@
     },
     "node_modules/tap/node_modules/strip-ansi": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8377,8 +8037,6 @@
     },
     "node_modules/tap/node_modules/supports-color": {
       "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8391,8 +8049,6 @@
     },
     "node_modules/tap/node_modules/tap-parser": {
       "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-10.0.1.tgz",
-      "integrity": "sha512-qdT15H0DoJIi7zOqVXDn9X0gSM68JjNy1w3VemwTJlDnETjbi6SutnqmBfjDJAwkFS79NJ97gZKqie00ZCGmzg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8410,8 +8066,6 @@
     },
     "node_modules/tap/node_modules/tap-yaml": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tap-yaml/-/tap-yaml-1.0.0.tgz",
-      "integrity": "sha512-Rxbx4EnrWkYk0/ztcm5u3/VznbyFJpyXO12dDBHKWiDVxy7O2Qw6MRrwO5H6Ww0U5YhRY/4C/VzWmFPhBQc4qQ==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8421,8 +8075,6 @@
     },
     "node_modules/tap/node_modules/to-fast-properties": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8432,8 +8084,6 @@
     },
     "node_modules/tap/node_modules/treport": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/treport/-/treport-1.0.2.tgz",
-      "integrity": "sha512-QCAbFtzIjQN+9k+alo8e6oo8j0eSLsttdahAgNLoC3U36rls8XRy/R11QOhHmPz7CDcB2ar29eLe4OFJoPnsPA==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8453,8 +8103,6 @@
     },
     "node_modules/tap/node_modules/treport/node_modules/ansi-styles": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-      "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8471,8 +8119,6 @@
     },
     "node_modules/tap/node_modules/treport/node_modules/chalk": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8486,8 +8132,6 @@
     },
     "node_modules/tap/node_modules/treport/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8500,16 +8144,12 @@
     },
     "node_modules/tap/node_modules/treport/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/treport/node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8519,8 +8159,6 @@
     },
     "node_modules/tap/node_modules/treport/node_modules/supports-color": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-      "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8533,8 +8171,6 @@
     },
     "node_modules/tap/node_modules/type-fest": {
       "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-      "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
       "dev": true,
       "inBundle": true,
       "license": "(MIT OR CC0-1.0)",
@@ -8547,8 +8183,6 @@
     },
     "node_modules/tap/node_modules/unicode-length": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-2.0.2.tgz",
-      "integrity": "sha512-Ph/j1VbS3/r77nhoY2WU0GWGjVYOHL3xpKp0y/Eq2e5r0mT/6b649vm7KFO6RdAdrZkYLdxphYVgvODxPB+Ebg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8559,8 +8193,6 @@
     },
     "node_modules/tap/node_modules/unicode-length/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8570,8 +8202,6 @@
     },
     "node_modules/tap/node_modules/unicode-length/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8584,8 +8214,6 @@
     },
     "node_modules/tap/node_modules/widest-line": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
-      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8598,8 +8226,6 @@
     },
     "node_modules/tap/node_modules/wrap-ansi": {
       "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8614,8 +8240,6 @@
     },
     "node_modules/tap/node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-      "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8632,8 +8256,6 @@
     },
     "node_modules/tap/node_modules/wrap-ansi/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8646,16 +8268,12 @@
     },
     "node_modules/tap/node_modules/wrap-ansi/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/tap/node_modules/yaml": {
       "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
-      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8665,8 +8283,6 @@
     },
     "node_modules/tap/node_modules/yoga-layout-prebuilt": {
       "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/yoga-layout-prebuilt/-/yoga-layout-prebuilt-1.9.6.tgz",
-      "integrity": "sha512-Wursw6uqLXLMjBAO4SEShuzj8+EJXhCF71/rJ7YndHTkRAYSU0GY3OghRqfAk9HPUAAFMuqp3U1Wl+01vmGRQQ==",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -14218,9 +13834,9 @@
       }
     },
     "tap": {
-      "version": "14.11.0",
-      "resolved": "https://registry.npmjs.org/tap/-/tap-14.11.0.tgz",
-      "integrity": "sha512-z8qnNFVyIjLh/bNoTLFRkEk09XZUDAZbCkz/BjvHHly3ao5H+y60gPnedALfheEjA6dA4tpp/mrKq2NWlMuq0A==",
+      "version": "npm:@ruyadorno/tap-with-mocks@14.10.8-patch.9",
+      "resolved": "https://registry.npmjs.org/@ruyadorno/tap-with-mocks/-/tap-with-mocks-14.10.8-patch.9.tgz",
+      "integrity": "sha512-K4oo3Hc75eafnNAw2lMDF9HrtqVcvXdcXhslIq2n5Lfw3tsFsqy99+HnW6iUgAL/jykXlCW0SgtuWKM+VslkEw==",
       "dev": true,
       "requires": {
         "@types/react": "^16.9.16",
@@ -14253,7 +13869,7 @@
         "rimraf": "^2.7.1",
         "signal-exit": "^3.0.0",
         "source-map-support": "^0.5.16",
-        "stack-utils": "^1.0.3",
+        "stack-utils": "^1.0.2",
         "tap-mocha-reporter": "^5.0.0",
         "tap-parser": "^10.0.1",
         "tap-yaml": "^1.0.0",
@@ -14270,8 +13886,6 @@
       "dependencies": {
         "@babel/code-frame": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14280,8 +13894,6 @@
         },
         "@babel/core": {
           "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.5.tgz",
-          "integrity": "sha512-O34LQooYVDXPl7QWCdW9p4NR+QlzOr7xShPPJz8GsuCU3/8ua/wqTr7gmnxXv+WBESiGU/G5s16i6tUvHkNb+w==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14305,8 +13917,6 @@
           "dependencies": {
             "source-map": {
               "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
               "bundled": true,
               "dev": true
             }
@@ -14314,8 +13924,6 @@
         },
         "@babel/generator": {
           "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.5.tgz",
-          "integrity": "sha512-3vXxr3FEW7E7lJZiWQ3bM4+v/Vyr9C+hpolQ8BGFr9Y8Ri2tFLWTixmwKBafDujO1WVah4fhZBeU1bieKdghig==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14326,8 +13934,6 @@
           "dependencies": {
             "source-map": {
               "version": "0.5.7",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
               "bundled": true,
               "dev": true
             }
@@ -14335,8 +13941,6 @@
         },
         "@babel/helper-annotate-as-pure": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
-          "integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14345,8 +13949,6 @@
         },
         "@babel/helper-builder-react-jsx": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.10.4.tgz",
-          "integrity": "sha512-5nPcIZ7+KKDxT1427oBivl9V9YTal7qk0diccnh7RrcgrT/pGFOjgGw1dgryyx1GvHEpXVfoDF6Ak3rTiWh8Rg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14356,8 +13958,6 @@
         },
         "@babel/helper-builder-react-jsx-experimental": {
           "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.10.5.tgz",
-          "integrity": "sha512-Buewnx6M4ttG+NLkKyt7baQn7ScC/Td+e99G914fRU8fGIUivDDgVIQeDHFa5e4CRSJQt58WpNHhsAZgtzVhsg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14368,8 +13968,6 @@
         },
         "@babel/helper-function-name": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
-          "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14380,8 +13978,6 @@
         },
         "@babel/helper-get-function-arity": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
-          "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14390,8 +13986,6 @@
         },
         "@babel/helper-member-expression-to-functions": {
           "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.5.tgz",
-          "integrity": "sha512-HiqJpYD5+WopCXIAbQDG0zye5XYVvcO9w/DHp5GsaGkRUaamLj2bEtu6i8rnGGprAhHM3qidCMgp71HF4endhA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14400,8 +13994,6 @@
         },
         "@babel/helper-module-imports": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-          "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14410,8 +14002,6 @@
         },
         "@babel/helper-module-transforms": {
           "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.5.tgz",
-          "integrity": "sha512-4P+CWMJ6/j1W915ITJaUkadLObmCRRSC234uctJfn/vHrsLNxsR8dwlcXv9ZhJWzl77awf+mWXSZEKt5t0OnlA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14426,8 +14016,6 @@
         },
         "@babel/helper-optimise-call-expression": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
-          "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14436,15 +14024,11 @@
         },
         "@babel/helper-plugin-utils": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-          "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
           "bundled": true,
           "dev": true
         },
         "@babel/helper-replace-supers": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-          "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14456,8 +14040,6 @@
         },
         "@babel/helper-simple-access": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
-          "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14467,8 +14049,6 @@
         },
         "@babel/helper-split-export-declaration": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
-          "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14477,15 +14057,11 @@
         },
         "@babel/helper-validator-identifier": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
           "bundled": true,
           "dev": true
         },
         "@babel/helpers": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
-          "integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14496,8 +14072,6 @@
         },
         "@babel/highlight": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
-          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14508,15 +14082,11 @@
         },
         "@babel/parser": {
           "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.5.tgz",
-          "integrity": "sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ==",
           "bundled": true,
           "dev": true
         },
         "@babel/plugin-proposal-object-rest-spread": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.10.4.tgz",
-          "integrity": "sha512-6vh4SqRuLLarjgeOf4EaROJAHjvu9Gl+/346PbDH9yWbJyfnJ/ah3jmYKYtswEyCoWZiidvVHjHshd4WgjB9BA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14527,8 +14097,6 @@
         },
         "@babel/plugin-syntax-jsx": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.10.4.tgz",
-          "integrity": "sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14537,8 +14105,6 @@
         },
         "@babel/plugin-syntax-object-rest-spread": {
           "version": "7.8.3",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
-          "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14547,8 +14113,6 @@
         },
         "@babel/plugin-transform-destructuring": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.4.tgz",
-          "integrity": "sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14557,8 +14121,6 @@
         },
         "@babel/plugin-transform-parameters": {
           "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.5.tgz",
-          "integrity": "sha512-xPHwUj5RdFV8l1wuYiu5S9fqWGM2DrYc24TMvUiRrPVm+SM3XeqU9BcokQX/kEUe+p2RBwy+yoiR1w/Blq6ubw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14568,8 +14130,6 @@
         },
         "@babel/plugin-transform-react-jsx": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.10.4.tgz",
-          "integrity": "sha512-L+MfRhWjX0eI7Js093MM6MacKU4M6dnCRa/QPDwYMxjljzSCzzlzKzj9Pk4P3OtrPcxr2N3znR419nr3Xw+65A==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14581,8 +14141,6 @@
         },
         "@babel/template": {
           "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
-          "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14593,8 +14151,6 @@
         },
         "@babel/traverse": {
           "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.5.tgz",
-          "integrity": "sha512-yc/fyv2gUjPqzTz0WHeRJH2pv7jA9kA7mBX2tXl/x5iOE81uaVPuGPtaYk7wmkx4b67mQ7NqI8rmT2pF47KYKQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14611,8 +14167,6 @@
         },
         "@babel/types": {
           "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.5.tgz",
-          "integrity": "sha512-ixV66KWfCI6GKoA/2H9v6bQdbfXEwwpOdQ8cRvb4F+eyvhlaHxWFMQB4+3d9QFJXZsiiiqVrewNV0DFEQpyT4Q==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14623,22 +14177,16 @@
         },
         "@types/color-name": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-          "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
           "bundled": true,
           "dev": true
         },
         "@types/prop-types": {
           "version": "15.7.3",
-          "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-          "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
           "bundled": true,
           "dev": true
         },
         "@types/react": {
           "version": "16.9.43",
-          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.43.tgz",
-          "integrity": "sha512-PxshAFcnJqIWYpJbLPriClH53Z2WlJcVZE+NP2etUtWQs2s7yIMj3/LDKZT/5CHJ/F62iyjVCDu2H3jHEXIxSg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14648,15 +14196,11 @@
         },
         "@types/yoga-layout": {
           "version": "1.9.2",
-          "resolved": "https://registry.npmjs.org/@types/yoga-layout/-/yoga-layout-1.9.2.tgz",
-          "integrity": "sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==",
           "bundled": true,
           "dev": true
         },
         "ansi-escapes": {
           "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
-          "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14665,15 +14209,11 @@
         },
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "bundled": true,
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14682,36 +14222,26 @@
         },
         "ansicolors": {
           "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-          "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
           "bundled": true,
           "dev": true
         },
         "arrify": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
           "bundled": true,
           "dev": true
         },
         "astral-regex": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-          "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
           "bundled": true,
           "dev": true
         },
         "auto-bind": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
-          "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
           "bundled": true,
           "dev": true
         },
         "caller-callsite": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
-          "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14720,8 +14250,6 @@
         },
         "caller-path": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
-          "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14730,15 +14258,11 @@
         },
         "callsites": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
           "bundled": true,
           "dev": true
         },
         "cardinal": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
-          "integrity": "sha1-fMEFXYItISlU0HsIXeolHMe8VQU=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14748,8 +14272,6 @@
         },
         "chalk": {
           "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14760,15 +14282,11 @@
         },
         "ci-info": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
           "bundled": true,
           "dev": true
         },
         "cli-cursor": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14777,8 +14295,6 @@
         },
         "cli-truncate": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
-          "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14788,8 +14304,6 @@
         },
         "color-convert": {
           "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14798,15 +14312,11 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "bundled": true,
           "dev": true
         },
         "convert-source-map": {
           "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-          "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14815,8 +14325,6 @@
           "dependencies": {
             "safe-buffer": {
               "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
               "bundled": true,
               "dev": true
             }
@@ -14824,15 +14332,11 @@
         },
         "csstype": {
           "version": "2.6.11",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.11.tgz",
-          "integrity": "sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw==",
           "bundled": true,
           "dev": true
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14841,57 +14345,41 @@
         },
         "emoji-regex": {
           "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
           "bundled": true,
           "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
           "bundled": true,
           "dev": true
         },
         "esprima": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
           "bundled": true,
           "dev": true
         },
         "events-to-array": {
           "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
-          "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=",
           "bundled": true,
           "dev": true
         },
         "gensync": {
           "version": "1.0.0-beta.1",
-          "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
-          "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
           "bundled": true,
           "dev": true
         },
         "globals": {
           "version": "11.12.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
           "bundled": true,
           "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "bundled": true,
           "dev": true
         },
         "import-jsx": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/import-jsx/-/import-jsx-3.1.0.tgz",
-          "integrity": "sha512-lTuMdQ/mRXC+xQSGPDvAg1VkODlX78j5hZv2tneJ+zuo7GH/XhUF/YVKoeF382a4jO4GYw9jgganbMhEcxwb0g==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14905,8 +14393,6 @@
         },
         "ink": {
           "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/ink/-/ink-2.7.1.tgz",
-          "integrity": "sha512-s7lJuQDJEdjqtaIWhp3KYHl6WV3J04U9zoQ6wVc+Xoa06XM27SXUY57qC5DO46xkF0CfgXMKkKNcgvSu/SAEpA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -14932,8 +14418,6 @@
           "dependencies": {
             "ansi-styles": {
               "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -14943,8 +14427,6 @@
             },
             "chalk": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-              "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -14954,8 +14436,6 @@
             },
             "color-convert": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-              "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -14964,22 +14444,16 @@
             },
             "color-name": {
               "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-              "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
               "bundled": true,
               "dev": true
             },
             "has-flag": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-              "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
               "bundled": true,
               "dev": true
             },
             "supports-color": {
               "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -14990,8 +14464,6 @@
         },
         "is-ci": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-          "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -15000,29 +14472,21 @@
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "bundled": true,
           "dev": true
         },
         "js-tokens": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
           "bundled": true,
           "dev": true
         },
         "jsesc": {
           "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-          "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
           "bundled": true,
           "dev": true
         },
         "json5": {
           "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -15031,22 +14495,16 @@
         },
         "lodash": {
           "version": "4.17.19",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
           "bundled": true,
           "dev": true
         },
         "lodash.throttle": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-          "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
           "bundled": true,
           "dev": true
         },
         "log-update": {
           "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/log-update/-/log-update-3.4.0.tgz",
-          "integrity": "sha512-ILKe88NeMt4gmDvk/eb615U/IVn7K9KWGkoYbdatQ69Z65nj1ZzjM6fHXfcs0Uge+e+EGnMW7DY4T9yko8vWFg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -15057,22 +14515,16 @@
           "dependencies": {
             "ansi-escapes": {
               "version": "3.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-              "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
               "bundled": true,
               "dev": true
             },
             "ansi-regex": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
               "bundled": true,
               "dev": true
             },
             "cli-cursor": {
               "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-              "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -15081,29 +14533,21 @@
             },
             "emoji-regex": {
               "version": "7.0.3",
-              "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-              "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
               "bundled": true,
               "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
               "bundled": true,
               "dev": true
             },
             "mimic-fn": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-              "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
               "bundled": true,
               "dev": true
             },
             "onetime": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-              "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -15112,8 +14556,6 @@
             },
             "restore-cursor": {
               "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-              "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -15123,8 +14565,6 @@
             },
             "string-width": {
               "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -15135,8 +14575,6 @@
             },
             "strip-ansi": {
               "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -15145,8 +14583,6 @@
             },
             "wrap-ansi": {
               "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-              "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -15159,8 +14595,6 @@
         },
         "loose-envify": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -15169,22 +14603,16 @@
         },
         "mimic-fn": {
           "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
           "bundled": true,
           "dev": true
         },
         "minimist": {
           "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
           "bundled": true,
           "dev": true
         },
         "minipass": {
           "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
-          "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -15193,8 +14621,6 @@
           "dependencies": {
             "yallist": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-              "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
               "bundled": true,
               "dev": true
             }
@@ -15211,22 +14637,16 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "bundled": true,
           "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "bundled": true,
           "dev": true
         },
         "onetime": {
           "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -15235,15 +14655,11 @@
         },
         "path-parse": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
           "bundled": true,
           "dev": true
         },
         "prop-types": {
           "version": "15.7.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -15254,22 +14670,16 @@
         },
         "punycode": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
           "bundled": true,
           "dev": true
         },
         "react-is": {
           "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
           "bundled": true,
           "dev": true
         },
         "react-reconciler": {
           "version": "0.24.0",
-          "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.24.0.tgz",
-          "integrity": "sha512-gAGnwWkf+NOTig9oOowqid9O0HjTDC+XVGBCAmJYYJ2A2cN/O4gDdIuuUQjv8A4v6GDwVfJkagpBBLW5OW9HSw==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -15281,8 +14691,6 @@
         },
         "redeyed": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
-          "integrity": "sha1-iYS1gV2ZyyIEacme7v/jiRPmzAs=",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -15291,8 +14699,6 @@
         },
         "resolve": {
           "version": "1.17.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -15301,15 +14707,11 @@
         },
         "resolve-from": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
           "bundled": true,
           "dev": true
         },
         "restore-cursor": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -15328,8 +14730,6 @@
         },
         "scheduler": {
           "version": "0.18.0",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
-          "integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -15339,22 +14739,16 @@
         },
         "semver": {
           "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "bundled": true,
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-          "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
           "bundled": true,
           "dev": true
         },
         "slice-ansi": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
-          "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -15365,8 +14759,6 @@
           "dependencies": {
             "ansi-styles": {
               "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -15376,8 +14768,6 @@
             },
             "color-convert": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-              "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -15386,8 +14776,6 @@
             },
             "color-name": {
               "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-              "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
               "bundled": true,
               "dev": true
             }
@@ -15395,8 +14783,6 @@
         },
         "string-length": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-length/-/string-length-3.1.0.tgz",
-          "integrity": "sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -15406,22 +14792,16 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
               "bundled": true,
               "dev": true
             },
             "astral-regex": {
               "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-              "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
               "bundled": true,
               "dev": true
             },
             "strip-ansi": {
               "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -15432,8 +14812,6 @@
         },
         "string-width": {
           "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -15444,8 +14822,6 @@
         },
         "strip-ansi": {
           "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -15454,8 +14830,6 @@
         },
         "supports-color": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -15464,8 +14838,6 @@
         },
         "tap-parser": {
           "version": "10.0.1",
-          "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-10.0.1.tgz",
-          "integrity": "sha512-qdT15H0DoJIi7zOqVXDn9X0gSM68JjNy1w3VemwTJlDnETjbi6SutnqmBfjDJAwkFS79NJ97gZKqie00ZCGmzg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -15476,8 +14848,6 @@
         },
         "tap-yaml": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/tap-yaml/-/tap-yaml-1.0.0.tgz",
-          "integrity": "sha512-Rxbx4EnrWkYk0/ztcm5u3/VznbyFJpyXO12dDBHKWiDVxy7O2Qw6MRrwO5H6Ww0U5YhRY/4C/VzWmFPhBQc4qQ==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -15486,15 +14856,11 @@
         },
         "to-fast-properties": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
           "bundled": true,
           "dev": true
         },
         "treport": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/treport/-/treport-1.0.2.tgz",
-          "integrity": "sha512-QCAbFtzIjQN+9k+alo8e6oo8j0eSLsttdahAgNLoC3U36rls8XRy/R11QOhHmPz7CDcB2ar29eLe4OFJoPnsPA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -15510,8 +14876,6 @@
           "dependencies": {
             "ansi-styles": {
               "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -15521,8 +14885,6 @@
             },
             "chalk": {
               "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-              "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -15532,8 +14894,6 @@
             },
             "color-convert": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-              "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -15542,22 +14902,16 @@
             },
             "color-name": {
               "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-              "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
               "bundled": true,
               "dev": true
             },
             "has-flag": {
               "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-              "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
               "bundled": true,
               "dev": true
             },
             "supports-color": {
               "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -15568,15 +14922,11 @@
         },
         "type-fest": {
           "version": "0.11.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
-          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
           "bundled": true,
           "dev": true
         },
         "unicode-length": {
           "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-2.0.2.tgz",
-          "integrity": "sha512-Ph/j1VbS3/r77nhoY2WU0GWGjVYOHL3xpKp0y/Eq2e5r0mT/6b649vm7KFO6RdAdrZkYLdxphYVgvODxPB+Ebg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -15586,15 +14936,11 @@
           "dependencies": {
             "ansi-regex": {
               "version": "2.1.1",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "bundled": true,
               "dev": true
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -15605,8 +14951,6 @@
         },
         "widest-line": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
-          "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -15615,8 +14959,6 @@
         },
         "wrap-ansi": {
           "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -15627,8 +14969,6 @@
           "dependencies": {
             "ansi-styles": {
               "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -15638,8 +14978,6 @@
             },
             "color-convert": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-              "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
               "bundled": true,
               "dev": true,
               "requires": {
@@ -15648,8 +14986,6 @@
             },
             "color-name": {
               "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-              "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
               "bundled": true,
               "dev": true
             }
@@ -15657,15 +14993,11 @@
         },
         "yaml": {
           "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
-          "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
           "bundled": true,
           "dev": true
         },
         "yoga-layout-prebuilt": {
           "version": "1.9.6",
-          "resolved": "https://registry.npmjs.org/yoga-layout-prebuilt/-/yoga-layout-prebuilt-1.9.6.tgz",
-          "integrity": "sha512-Wursw6uqLXLMjBAO4SEShuzj8+EJXhCF71/rJ7YndHTkRAYSU0GY3OghRqfAk9HPUAAFMuqp3U1Wl+01vmGRQQ==",
           "bundled": true,
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "json-parse-even-better-errors": "^2.3.1",
     "marked-man": "^0.7.0",
     "require-inject": "^1.4.4",
-    "tap": "^14.11.0",
+    "tap": "npm:@ruyadorno/tap-with-mocks@^14.10.8-patch.9",
     "yaml": "^1.10.0"
   },
   "scripts": {

--- a/test/bin/npm-cli.js
+++ b/test/bin/npm-cli.js
@@ -1,7 +1,7 @@
 const t = require('tap')
-const requireInject = require('require-inject')
+
 t.test('loading the bin calls the implementation', t => {
-  requireInject('../../bin/npm-cli.js', {
+  t.mock('../../bin/npm-cli.js', {
     '../../lib/cli.js': proc => {
       t.equal(proc, process, 'called implementation with process object')
       t.end()

--- a/test/bin/npx-cli.js
+++ b/test/bin/npx-cli.js
@@ -1,5 +1,4 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 const npx = require.resolve('../../bin/npx-cli.js')
 const cli = require.resolve('../../lib/cli.js')
 const npm = require.resolve('../../bin/npm-cli.js')
@@ -14,35 +13,35 @@ t.afterEach(cb => {
 
 t.test('npx foo -> npm exec -- foo', t => {
   process.argv = ['node', npx, 'foo']
-  requireInject(npx, { [cli]: () => {} })
+  t.mock(npx, { [cli]: () => {} })
   t.strictSame(process.argv, ['node', npm, 'exec', '--', 'foo'])
   t.end()
 })
 
 t.test('npx -- foo -> npm exec -- foo', t => {
   process.argv = ['node', npx, '--', 'foo']
-  requireInject(npx, { [cli]: () => {} })
+  t.mock(npx, { [cli]: () => {} })
   t.strictSame(process.argv, ['node', npm, 'exec', '--', 'foo'])
   t.end()
 })
 
 t.test('npx -x y foo -z -> npm exec -x y -- foo -z', t => {
   process.argv = ['node', npx, '-x', 'y', 'foo', '-z']
-  requireInject(npx, { [cli]: () => {} })
+  t.mock(npx, { [cli]: () => {} })
   t.strictSame(process.argv, ['node', npm, 'exec', '-x', 'y', '--', 'foo', '-z'])
   t.end()
 })
 
 t.test('npx --x=y --no-install foo -z -> npm exec --x=y -- foo -z', t => {
   process.argv = ['node', npx, '--x=y', '--no-install', 'foo', '-z']
-  requireInject(npx, { [cli]: () => {} })
+  t.mock(npx, { [cli]: () => {} })
   t.strictSame(process.argv, ['node', npm, 'exec', '--x=y', '--yes=false', '--', 'foo', '-z'])
   t.end()
 })
 
 t.test('transform renamed options into proper values', t => {
   process.argv = ['node', npx, '-y', '--shell=bash', '-p', 'foo', '-c', 'asdf']
-  requireInject(npx, { [cli]: () => {} })
+  t.mock(npx, { [cli]: () => {} })
   t.strictSame(process.argv, ['node', npm, 'exec', '--yes', '--script-shell=bash', '--package', 'foo', '--call', 'asdf'])
   t.end()
 })
@@ -80,7 +79,7 @@ t.test('use a bunch of deprecated switches and options', t => {
     '--',
     'foobar',
   ]
-  requireInject(npx, { [cli]: () => {} })
+  t.mock(npx, { [cli]: () => {} })
   t.strictSame(process.argv, expect)
   t.strictSame(logs, [
     ['npx: the --npm argument has been removed.'],

--- a/test/lib/access.js
+++ b/test/lib/access.js
@@ -1,13 +1,12 @@
-const { test } = require('tap')
-const requireInject = require('require-inject')
+const t = require('tap')
 
-const emptyMock = requireInject('../../lib/access.js', {
+const emptyMock = t.mock('../../lib/access.js', {
   '../../lib/npm.js': {
     flatOptions: {},
   },
 })
 
-test('completion', t => {
+t.test('completion', t => {
   const { completion } = emptyMock
 
   const testComp = (argv, expect) => {
@@ -49,7 +48,7 @@ test('completion', t => {
   t.end()
 })
 
-test('subcommand required', t => {
+t.test('subcommand required', t => {
   const access = emptyMock
   access([], (err) => {
     t.equal(err, '\nUsage: Subcommand is required.\n\n' + access.usage)
@@ -57,7 +56,7 @@ test('subcommand required', t => {
   })
 })
 
-test('unrecognized subcommand', (t) => {
+t.test('unrecognized subcommand', (t) => {
   const access = emptyMock
 
   access(['blerg'], (err) => {
@@ -70,7 +69,7 @@ test('unrecognized subcommand', (t) => {
   })
 })
 
-test('edit', (t) => {
+t.test('edit', (t) => {
   const access = emptyMock
 
   access([
@@ -86,13 +85,13 @@ test('edit', (t) => {
   })
 })
 
-test('access public on unscoped package', (t) => {
+t.test('access public on unscoped package', (t) => {
   const prefix = t.testdir({
     'package.json': JSON.stringify({
       name: 'npm-access-public-pkg',
     }),
   })
-  const access = requireInject('../../lib/access.js', {
+  const access = t.mock('../../lib/access.js', {
     '../../lib/npm.js': { prefix },
   })
   access([
@@ -107,13 +106,13 @@ test('access public on unscoped package', (t) => {
   })
 })
 
-test('access public on scoped package', (t) => {
+t.test('access public on scoped package', (t) => {
   t.plan(4)
   const name = '@scoped/npm-access-public-pkg'
   const prefix = t.testdir({
     'package.json': JSON.stringify({ name }),
   })
-  const access = requireInject('../../lib/access.js', {
+  const access = t.mock('../../lib/access.js', {
     libnpmaccess: {
       public: (pkg, { registry }) => {
         t.equal(pkg, name, 'should use pkg name ref')
@@ -140,11 +139,11 @@ test('access public on scoped package', (t) => {
   })
 })
 
-test('access public on missing package.json', (t) => {
+t.test('access public on missing package.json', (t) => {
   const prefix = t.testdir({
     node_modules: {},
   })
-  const access = requireInject('../../lib/access.js', {
+  const access = t.mock('../../lib/access.js', {
     '../../lib/npm.js': { prefix },
   })
   access([
@@ -159,12 +158,12 @@ test('access public on missing package.json', (t) => {
   })
 })
 
-test('access public on invalid package.json', (t) => {
+t.test('access public on invalid package.json', (t) => {
   const prefix = t.testdir({
     'package.json': '{\n',
     node_modules: {},
   })
-  const access = requireInject('../../lib/access.js', {
+  const access = t.mock('../../lib/access.js', {
     '../../lib/npm.js': { prefix },
   })
   access([
@@ -179,13 +178,13 @@ test('access public on invalid package.json', (t) => {
   })
 })
 
-test('access restricted on unscoped package', (t) => {
+t.test('access restricted on unscoped package', (t) => {
   const prefix = t.testdir({
     'package.json': JSON.stringify({
       name: 'npm-access-restricted-pkg',
     }),
   })
-  const access = requireInject('../../lib/access.js', {
+  const access = t.mock('../../lib/access.js', {
     '../../lib/npm.js': { prefix },
   })
   access([
@@ -200,13 +199,13 @@ test('access restricted on unscoped package', (t) => {
   })
 })
 
-test('access restricted on scoped package', (t) => {
+t.test('access restricted on scoped package', (t) => {
   t.plan(4)
   const name = '@scoped/npm-access-restricted-pkg'
   const prefix = t.testdir({
     'package.json': JSON.stringify({ name }),
   })
-  const access = requireInject('../../lib/access.js', {
+  const access = t.mock('../../lib/access.js', {
     libnpmaccess: {
       restricted: (pkg, { registry }) => {
         t.equal(pkg, name, 'should use pkg name ref')
@@ -233,11 +232,11 @@ test('access restricted on scoped package', (t) => {
   })
 })
 
-test('access restricted on missing package.json', (t) => {
+t.test('access restricted on missing package.json', (t) => {
   const prefix = t.testdir({
     node_modules: {},
   })
-  const access = requireInject('../../lib/access.js', {
+  const access = t.mock('../../lib/access.js', {
     '../../lib/npm.js': { prefix },
   })
   access([
@@ -252,12 +251,12 @@ test('access restricted on missing package.json', (t) => {
   })
 })
 
-test('access restricted on invalid package.json', (t) => {
+t.test('access restricted on invalid package.json', (t) => {
   const prefix = t.testdir({
     'package.json': '{\n',
     node_modules: {},
   })
-  const access = requireInject('../../lib/access.js', {
+  const access = t.mock('../../lib/access.js', {
     '../../lib/npm.js': { prefix },
   })
   access([
@@ -272,9 +271,9 @@ test('access restricted on invalid package.json', (t) => {
   })
 })
 
-test('access grant read-only', (t) => {
+t.test('access grant read-only', (t) => {
   t.plan(5)
-  const access = requireInject('../../lib/access.js', {
+  const access = t.mock('../../lib/access.js', {
     libnpmaccess: {
       grant: (spec, team, permissions) => {
         t.equal(spec, '@scoped/another', 'should use expected spec')
@@ -296,9 +295,9 @@ test('access grant read-only', (t) => {
   })
 })
 
-test('access grant read-write', (t) => {
+t.test('access grant read-write', (t) => {
   t.plan(5)
-  const access = requireInject('../../lib/access.js', {
+  const access = t.mock('../../lib/access.js', {
     libnpmaccess: {
       grant: (spec, team, permissions) => {
         t.equal(spec, '@scoped/another', 'should use expected spec')
@@ -320,14 +319,14 @@ test('access grant read-write', (t) => {
   })
 })
 
-test('access grant current cwd', (t) => {
+t.test('access grant current cwd', (t) => {
   t.plan(5)
   const prefix = t.testdir({
     'package.json': JSON.stringify({
       name: 'yargs',
     }),
   })
-  const access = requireInject('../../lib/access.js', {
+  const access = t.mock('../../lib/access.js', {
     libnpmaccess: {
       grant: (spec, team, permissions) => {
         t.equal(spec, 'yargs', 'should use expected spec')
@@ -348,7 +347,7 @@ test('access grant current cwd', (t) => {
   })
 })
 
-test('access grant others', (t) => {
+t.test('access grant others', (t) => {
   const access = emptyMock
 
   access([
@@ -366,7 +365,7 @@ test('access grant others', (t) => {
   })
 })
 
-test('access grant missing team args', (t) => {
+t.test('access grant missing team args', (t) => {
   const access = emptyMock
 
   access([
@@ -384,7 +383,7 @@ test('access grant missing team args', (t) => {
   })
 })
 
-test('access grant malformed team arg', (t) => {
+t.test('access grant malformed team arg', (t) => {
   const access = emptyMock
 
   access([
@@ -402,9 +401,9 @@ test('access grant malformed team arg', (t) => {
   })
 })
 
-test('access 2fa-required/2fa-not-required', t => {
+t.test('access 2fa-required/2fa-not-required', t => {
   t.plan(2)
-  const access = requireInject('../../lib/access.js', {
+  const access = t.mock('../../lib/access.js', {
     libnpmaccess: {
       tfaRequired: (spec) => {
         t.equal(spec, '@scope/pkg', 'should use expected spec')
@@ -429,9 +428,9 @@ test('access 2fa-required/2fa-not-required', t => {
   })
 })
 
-test('access revoke', (t) => {
+t.test('access revoke', (t) => {
   t.plan(4)
-  const access = requireInject('../../lib/access.js', {
+  const access = t.mock('../../lib/access.js', {
     libnpmaccess: {
       revoke: (spec, team) => {
         t.equal(spec, '@scoped/another', 'should use expected spec')
@@ -451,7 +450,7 @@ test('access revoke', (t) => {
   })
 })
 
-test('access revoke missing team args', (t) => {
+t.test('access revoke missing team args', (t) => {
   const access = emptyMock
 
   access([
@@ -468,7 +467,7 @@ test('access revoke missing team args', (t) => {
   })
 })
 
-test('access revoke malformed team arg', (t) => {
+t.test('access revoke malformed team arg', (t) => {
   const access = emptyMock
 
   access([
@@ -485,9 +484,9 @@ test('access revoke malformed team arg', (t) => {
   })
 })
 
-test('npm access ls-packages with no team', (t) => {
+t.test('npm access ls-packages with no team', (t) => {
   t.plan(3)
-  const access = requireInject('../../lib/access.js', {
+  const access = t.mock('../../lib/access.js', {
     libnpmaccess: {
       lsPackages: (entity) => {
         t.equal(entity, 'foo', 'should use expected entity')
@@ -506,9 +505,9 @@ test('npm access ls-packages with no team', (t) => {
   })
 })
 
-test('access ls-packages on team', (t) => {
+t.test('access ls-packages on team', (t) => {
   t.plan(3)
-  const access = requireInject('../../lib/access.js', {
+  const access = t.mock('../../lib/access.js', {
     libnpmaccess: {
       lsPackages: (entity) => {
         t.equal(entity, 'myorg:myteam', 'should use expected entity')
@@ -527,14 +526,14 @@ test('access ls-packages on team', (t) => {
   })
 })
 
-test('access ls-collaborators on current', (t) => {
+t.test('access ls-collaborators on current', (t) => {
   t.plan(3)
   const prefix = t.testdir({
     'package.json': JSON.stringify({
       name: 'yargs',
     }),
   })
-  const access = requireInject('../../lib/access.js', {
+  const access = t.mock('../../lib/access.js', {
     libnpmaccess: {
       lsCollaborators: (spec) => {
         t.equal(spec, 'yargs', 'should use expected spec')
@@ -552,9 +551,9 @@ test('access ls-collaborators on current', (t) => {
   })
 })
 
-test('access ls-collaborators on spec', (t) => {
+t.test('access ls-collaborators on spec', (t) => {
   t.plan(3)
-  const access = requireInject('../../lib/access.js', {
+  const access = t.mock('../../lib/access.js', {
     libnpmaccess: {
       lsCollaborators: (spec) => {
         t.equal(spec, 'yargs', 'should use expected spec')

--- a/test/lib/adduser.js
+++ b/test/lib/adduser.js
@@ -1,5 +1,4 @@
-const requireInject = require('require-inject')
-const { test } = require('tap')
+const t = require('tap')
 const { getCredentialsByURI, setCredentialsByURI } =
   require('@npmcli/config').prototype
 
@@ -31,7 +30,7 @@ const deleteMock = (key, where) => {
     [key]: where,
   }
 }
-const adduser = requireInject('../../lib/adduser.js', {
+const adduser = t.mock('../../lib/adduser.js', {
   npmlog: {
     disableProgress: () => null,
     notice: (_, msg) => {
@@ -69,7 +68,7 @@ const adduser = requireInject('../../lib/adduser.js', {
   '../../lib/auth/legacy.js': authDummy,
 })
 
-test('simple login', (t) => {
+t.test('simple login', (t) => {
   adduser([], (err) => {
     t.ifError(err, 'npm adduser')
 
@@ -120,7 +119,7 @@ test('simple login', (t) => {
   })
 })
 
-test('bad auth type', (t) => {
+t.test('bad auth type', (t) => {
   _flatOptions.authType = 'foo'
 
   adduser([], (err) => {
@@ -138,7 +137,7 @@ test('bad auth type', (t) => {
   })
 })
 
-test('scoped login', (t) => {
+t.test('scoped login', (t) => {
   _flatOptions.scope = '@myscope'
 
   adduser([], (err) => {
@@ -158,7 +157,7 @@ test('scoped login', (t) => {
   })
 })
 
-test('scoped login with valid scoped registry config', (t) => {
+t.test('scoped login with valid scoped registry config', (t) => {
   _flatOptions['@myscope:registry'] = 'https://diff-registry.npmjs.com/'
   _flatOptions.scope = '@myscope'
 
@@ -180,7 +179,7 @@ test('scoped login with valid scoped registry config', (t) => {
   })
 })
 
-test('save config failure', (t) => {
+t.test('save config failure', (t) => {
   failSave = true
 
   adduser([], (err) => {

--- a/test/lib/audit.js
+++ b/test/lib/audit.js
@@ -1,5 +1,4 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 const audit = require('../../lib/audit.js')
 
 t.test('should audit using Arborist', t => {
@@ -10,7 +9,7 @@ t.test('should audit using Arborist', t => {
   let OUTPUT_CALLED = false
   let ARB_OBJ = null
 
-  const audit = requireInject('../../lib/audit.js', {
+  const audit = t.mock('../../lib/audit.js', {
     '../../lib/npm.js': {
       prefix: 'foo',
       flatOptions: {
@@ -64,7 +63,7 @@ t.test('should audit using Arborist', t => {
 })
 
 t.test('should audit - json', t => {
-  const audit = requireInject('../../lib/audit.js', {
+  const audit = t.mock('../../lib/audit.js', {
     '../../lib/npm.js': {
       prefix: 'foo',
       flatOptions: {
@@ -132,8 +131,8 @@ t.test('report endpoint error', t => {
         },
       }
       // have to pass mocks to both to get the npm and output set right
-      const auditError = requireInject('../../lib/utils/audit-error.js', mocks)
-      const audit = requireInject('../../lib/audit.js', {
+      const auditError = t.mock('../../lib/utils/audit-error.js', mocks)
+      const audit = t.mock('../../lib/audit.js', {
         ...mocks,
         '../../lib/utils/audit-error.js': auditError,
       })

--- a/test/lib/auth/legacy.js
+++ b/test/lib/auth/legacy.js
@@ -1,12 +1,11 @@
-const requireInject = require('require-inject')
-const { test } = require('tap')
+const t = require('tap')
 
 let log = ''
 
 const token = '24528a24f240'
 const profile = {}
 const read = {}
-const legacy = requireInject('../../../lib/auth/legacy.js', {
+const legacy = t.mock('../../../lib/auth/legacy.js', {
   npmlog: {
     info: (...msgs) => {
       log += msgs.join(' ')
@@ -26,7 +25,7 @@ const legacy = requireInject('../../../lib/auth/legacy.js', {
   '../../../lib/utils/read-user-info.js': read,
 })
 
-test('login using username/password with token result', async (t) => {
+t.test('login using username/password with token result', async (t) => {
   profile.login = () => {
     return { token }
   }
@@ -67,7 +66,7 @@ test('login using username/password with token result', async (t) => {
   delete profile.login
 })
 
-test('login using username/password with user info result', async (t) => {
+t.test('login using username/password with user info result', async (t) => {
   profile.login = () => {
     return null
   }
@@ -107,7 +106,7 @@ test('login using username/password with user info result', async (t) => {
   delete profile.login
 })
 
-test('login otp requested', async (t) => {
+t.test('login otp requested', async (t) => {
   t.plan(5)
 
   profile.login = () => Promise.reject(Object.assign(
@@ -155,7 +154,7 @@ test('login otp requested', async (t) => {
   delete read.otp
 })
 
-test('login missing basic credential info', async (t) => {
+t.test('login missing basic credential info', async (t) => {
   profile.login = () => Promise.reject(Object.assign(
     new Error('missing info'),
     { code: 'ERROR' }
@@ -178,7 +177,7 @@ test('login missing basic credential info', async (t) => {
   delete profile.login
 })
 
-test('create new user when user not found', async (t) => {
+t.test('create new user when user not found', async (t) => {
   t.plan(6)
 
   profile.login = () => Promise.reject(Object.assign(
@@ -230,7 +229,7 @@ test('create new user when user not found', async (t) => {
   delete profile.login
 })
 
-test('prompts for user info if required', async (t) => {
+t.test('prompts for user info if required', async (t) => {
   t.plan(4)
 
   profile.login = async (opener, prompt, opts) => {
@@ -284,7 +283,7 @@ test('prompts for user info if required', async (t) => {
   delete read.email
 })
 
-test('request otp when creating new user', async (t) => {
+t.test('request otp when creating new user', async (t) => {
   t.plan(3)
 
   profile.login = () => Promise.reject(Object.assign(
@@ -322,7 +321,7 @@ test('request otp when creating new user', async (t) => {
   delete read.otp
 })
 
-test('unknown error during user creation', async (t) => {
+t.test('unknown error during user creation', async (t) => {
   profile.login = () => Promise.reject(Object.assign(
     new Error('missing info'),
     { code: 'ERROR' }
@@ -352,7 +351,7 @@ test('unknown error during user creation', async (t) => {
   delete profile.login
 })
 
-test('open url error', async (t) => {
+t.test('open url error', async (t) => {
   profile.login = async (opener, prompt, opts) => {
     await opener()
   }
@@ -374,7 +373,7 @@ test('open url error', async (t) => {
   delete profile.login
 })
 
-test('login no credentials provided', async (t) => {
+t.test('login no credentials provided', async (t) => {
   profile.login = () => ({ token })
 
   await legacy({
@@ -398,7 +397,7 @@ test('login no credentials provided', async (t) => {
   delete profile.login
 })
 
-test('scoped login', async (t) => {
+t.test('scoped login', async (t) => {
   profile.login = () => ({ token })
 
   const { message } = await legacy({

--- a/test/lib/auth/oauth.js
+++ b/test/lib/auth/oauth.js
@@ -1,7 +1,6 @@
-const requireInject = require('require-inject')
-const { test } = require('tap')
+const t = require('tap')
 
-test('oauth login', (t) => {
+t.test('oauth login', (t) => {
   t.plan(3)
   const oauthOpts = {
     creds: {},
@@ -9,7 +8,7 @@ test('oauth login', (t) => {
     scope: 'myscope',
   }
 
-  const oauth = requireInject('../../../lib/auth/oauth.js', {
+  const oauth = t.mock('../../../lib/auth/oauth.js', {
     '../../../lib/auth/sso.js': (opts) => {
       t.equal(opts, oauthOpts, 'should forward opts')
     },

--- a/test/lib/auth/saml.js
+++ b/test/lib/auth/saml.js
@@ -1,4 +1,3 @@
-const requireInject = require('require-inject')
 const { test } = require('tap')
 
 test('saml login', (t) => {
@@ -9,7 +8,7 @@ test('saml login', (t) => {
     scope: 'myscope',
   }
 
-  const saml = requireInject('../../../lib/auth/saml.js', {
+  const saml = t.mock('../../../lib/auth/saml.js', {
     '../../../lib/auth/sso.js': (opts) => {
       t.equal(opts, samlOpts, 'should forward opts')
     },

--- a/test/lib/auth/sso.js
+++ b/test/lib/auth/sso.js
@@ -1,5 +1,4 @@
-const requireInject = require('require-inject')
-const { test } = require('tap')
+const t = require('tap')
 
 let log = ''
 let warn = ''
@@ -11,7 +10,7 @@ const token = '24528a24f240'
 const SSO_URL = 'https://registry.npmjs.org/{SSO_URL}'
 const profile = {}
 const npmFetch = {}
-const sso = requireInject('../../../lib/auth/sso.js', {
+const sso = t.mock('../../../lib/auth/sso.js', {
   npmlog: {
     info: (...msgs) => {
       log += msgs.join(' ') + '\n'
@@ -47,7 +46,7 @@ const sso = requireInject('../../../lib/auth/sso.js', {
   },
 })
 
-test('empty login', async (t) => {
+t.test('empty login', async (t) => {
   _flatOptions.ssoType = false
 
   await t.rejects(
@@ -67,7 +66,7 @@ test('empty login', async (t) => {
   warn = ''
 })
 
-test('simple login', async (t) => {
+t.test('simple login', async (t) => {
   t.plan(6)
 
   profile.loginCouch = (username, password, opts) => {
@@ -122,7 +121,7 @@ test('simple login', async (t) => {
   delete npmFetch.json
 })
 
-test('polling retry', async (t) => {
+t.test('polling retry', async (t) => {
   t.plan(3)
 
   profile.loginCouch = () => ({ token, sso: SSO_URL })
@@ -169,7 +168,7 @@ test('polling retry', async (t) => {
   delete npmFetch.json
 })
 
-test('polling error', async (t) => {
+t.test('polling error', async (t) => {
   profile.loginCouch = () => ({ token, sso: SSO_URL })
   npmFetch.json = () => Promise.reject(Object.assign(
     new Error('unknown error'),
@@ -192,7 +191,7 @@ test('polling error', async (t) => {
   delete npmFetch.json
 })
 
-test('no token retrieved from loginCouch', async (t) => {
+t.test('no token retrieved from loginCouch', async (t) => {
   profile.loginCouch = () => ({})
 
   await t.rejects(
@@ -210,7 +209,7 @@ test('no token retrieved from loginCouch', async (t) => {
   delete profile.loginCouch
 })
 
-test('no sso url retrieved from loginCouch', async (t) => {
+t.test('no sso url retrieved from loginCouch', async (t) => {
   profile.loginCouch = () => Promise.resolve({ token })
 
   await t.rejects(
@@ -228,7 +227,7 @@ test('no sso url retrieved from loginCouch', async (t) => {
   delete profile.loginCouch
 })
 
-test('scoped login', async (t) => {
+t.test('scoped login', async (t) => {
   profile.loginCouch = () => ({ token, sso: SSO_URL })
   npmFetch.json = () => Promise.resolve({ username: 'foo' })
 

--- a/test/lib/bin.js
+++ b/test/lib/bin.js
@@ -1,11 +1,10 @@
 const { test } = require('tap')
-const requireInject = require('require-inject')
 
 test('bin', (t) => {
   t.plan(3)
   const dir = '/bin/dir'
 
-  const bin = requireInject('../../lib/bin.js', {
+  const bin = t.mock('../../lib/bin.js', {
     '../../lib/npm.js': { bin: dir, flatOptions: { global: false } },
     '../../lib/utils/output.js': (output) => {
       t.equal(output, dir, 'prints the correct directory')
@@ -30,7 +29,7 @@ test('bin -g', (t) => {
   }
   const dir = '/bin/dir'
 
-  const bin = requireInject('../../lib/bin.js', {
+  const bin = t.mock('../../lib/bin.js', {
     '../../lib/npm.js': { bin: dir, flatOptions: { global: true } },
     '../../lib/utils/path.js': [dir],
     '../../lib/utils/output.js': (output) => {
@@ -56,7 +55,7 @@ test('bin -g (not in path)', (t) => {
   }
   const dir = '/bin/dir'
 
-  const bin = requireInject('../../lib/bin.js', {
+  const bin = t.mock('../../lib/bin.js', {
     '../../lib/npm.js': { bin: dir, flatOptions: { global: true } },
     '../../lib/utils/path.js': ['/not/my/dir'],
     '../../lib/utils/output.js': (output) => {

--- a/test/lib/birthday.js
+++ b/test/lib/birthday.js
@@ -1,7 +1,6 @@
-const { test } = require('tap')
-const requireInject = require('require-inject')
+const t = require('tap')
 
-test('birthday (nope)', (t) => {
+t.test('birthday (nope)', (t) => {
   t.plan(1)
   const B = global[Buffer.from([66, 117, 102, 102, 101, 114])]
   const f = B.from([102, 114, 111, 109])
@@ -20,13 +19,13 @@ test('birthday (nope)', (t) => {
     global[B[f]([68, 97, 116, 101])] = D
     console.log = consoleLog
   })
-  const birthday = requireInject('../../lib/birthday', {})
+  const birthday = t.mock('../../lib/birthday', {})
   birthday([], (err) => {
     t.match(err, 'try again', 'not telling you the secret that easily are we?')
   })
 })
 
-test('birthday (nope again)', (t) => {
+t.test('birthday (nope again)', (t) => {
   t.plan(1)
   const B = global[Buffer.from([66, 117, 102, 102, 101, 114])]
   const f = B.from([102, 114, 111, 109])
@@ -50,13 +49,13 @@ test('birthday (nope again)', (t) => {
     global[B[f]([68, 97, 116, 101])] = D
     console.log = consoleLog
   })
-  const birthday = requireInject('../../lib/birthday', {})
+  const birthday = t.mock('../../lib/birthday', {})
   birthday([], (err) => {
     t.match(err, 'try again', 'not telling you the secret that easily are we?')
   })
 })
 
-test('birthday (yup)', (t) => {
+t.test('birthday (yup)', (t) => {
   t.plan(1)
   const B = global[Buffer.from([66, 117, 102, 102, 101, 114])]
   const f = B.from([102, 114, 111, 109])
@@ -79,7 +78,7 @@ test('birthday (yup)', (t) => {
     global[B[f]([68, 97, 116, 101])] = D
     console.log = consoleLog
   })
-  const birthday = requireInject('../../lib/birthday', {})
+  const birthday = t.mock('../../lib/birthday', {})
   birthday([], (err) => {
     t.ifError(err, 'npm birthday')
   })

--- a/test/lib/bugs.js
+++ b/test/lib/bugs.js
@@ -1,6 +1,5 @@
 const t = require('tap')
 
-const requireInject = require('require-inject')
 const pacote = {
   manifest: async (spec, options) => {
     return spec === 'nobugs' ? {
@@ -49,7 +48,7 @@ const openUrl = (url, errMsg, cb) => {
   process.nextTick(cb)
 }
 
-const bugs = requireInject('../../lib/bugs.js', {
+const bugs = t.mock('../../lib/bugs.js', {
   pacote,
   '../../lib/utils/open-url.js': openUrl,
 })

--- a/test/lib/cache.js
+++ b/test/lib/cache.js
@@ -1,5 +1,4 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 const path = require('path')
 
 const usageUtil = () => 'usage instructions'
@@ -68,7 +67,7 @@ const mocks = {
   '../../lib/utils/usage.js': usageUtil,
 }
 
-const cache = requireInject('../../lib/cache.js', mocks)
+const cache = t.mock('../../lib/cache.js', mocks)
 
 t.test('cache no args', t => {
   cache([], err => {

--- a/test/lib/ci.js
+++ b/test/lib/ci.js
@@ -2,11 +2,9 @@ const fs = require('fs')
 const util = require('util')
 const readdir = util.promisify(fs.readdir)
 
-const { test } = require('tap')
+const t = require('tap')
 
-const requireInject = require('require-inject')
-
-test('should use Arborist and run-script', (t) => {
+t.test('should use Arborist and run-script', (t) => {
   const scripts = [
     'preinstall',
     'install',
@@ -16,7 +14,7 @@ test('should use Arborist and run-script', (t) => {
     'prepare',
     'postprepare',
   ]
-  const ci = requireInject('../../lib/ci.js', {
+  const ci = t.mock('../../lib/ci.js', {
     '../../lib/npm.js': {
       prefix: 'foo',
       flatOptions: {
@@ -57,8 +55,8 @@ test('should use Arborist and run-script', (t) => {
   })
 })
 
-test('should pass flatOptions to Arborist.reify', (t) => {
-  const ci = requireInject('../../lib/ci.js', {
+t.test('should pass flatOptions to Arborist.reify', (t) => {
+  const ci = t.mock('../../lib/ci.js', {
     '../../lib/npm.js': {
       prefix: 'foo',
       flatOptions: {
@@ -81,13 +79,13 @@ test('should pass flatOptions to Arborist.reify', (t) => {
   })
 })
 
-test('should throw if package-lock.json or npm-shrinkwrap missing', (t) => {
+t.test('should throw if package-lock.json or npm-shrinkwrap missing', (t) => {
   const testDir = t.testdir({
     'index.js': 'some contents',
     'package.json': 'some info',
   })
 
-  const ci = requireInject('../../lib/ci.js', {
+  const ci = t.mock('../../lib/ci.js', {
     '../../lib/npm.js': {
       prefix: testDir,
       flatOptions: {
@@ -109,8 +107,8 @@ test('should throw if package-lock.json or npm-shrinkwrap missing', (t) => {
   })
 })
 
-test('should throw ECIGLOBAL', (t) => {
-  const ci = requireInject('../../lib/ci.js', {
+t.test('should throw ECIGLOBAL', (t) => {
+  const ci = t.mock('../../lib/ci.js', {
     '../../lib/npm.js': {
       prefix: 'foo',
       flatOptions: {
@@ -127,14 +125,14 @@ test('should throw ECIGLOBAL', (t) => {
   })
 })
 
-test('should remove existing node_modules before installing', (t) => {
+t.test('should remove existing node_modules before installing', (t) => {
   const testDir = t.testdir({
     node_modules: {
       'some-file': 'some contents',
     },
   })
 
-  const ci = requireInject('../../lib/ci.js', {
+  const ci = t.mock('../../lib/ci.js', {
     '../../lib/npm.js': {
       prefix: testDir,
       flatOptions: {

--- a/test/lib/cli.js
+++ b/test/lib/cli.js
@@ -36,8 +36,7 @@ const npmlogMock = {
   info: (...msg) => logs.push(['info', ...msg]),
 }
 
-const requireInject = require('require-inject')
-const cli = requireInject.installGlobally('../../lib/cli.js', {
+const cli = t.mock('../../lib/cli.js', {
   '../../lib/npm.js': npmock,
   '../../lib/utils/unsupported.js': unsupportedMock,
   '../../lib/utils/error-handler.js': errorHandlerMock,

--- a/test/lib/completion.js
+++ b/test/lib/completion.js
@@ -1,5 +1,4 @@
-const { test } = require('tap')
-const requireInject = require('require-inject')
+const t = require('tap')
 const fs = require('fs')
 const path = require('path')
 
@@ -75,7 +74,7 @@ const deref = (cmd) => {
   return cmd
 }
 
-const completion = requireInject('../../lib/completion.js', {
+const completion = t.mock('../../lib/completion.js', {
   '../../lib/npm.js': npm,
   '../../lib/utils/cmd-list.js': cmdList,
   '../../lib/utils/config.js': config,
@@ -86,7 +85,7 @@ const completion = requireInject('../../lib/completion.js', {
   },
 })
 
-test('completion completion', t => {
+t.test('completion completion', t => {
   const home = process.env.HOME
   t.teardown(() => {
     process.env.HOME = home
@@ -109,7 +108,7 @@ test('completion completion', t => {
   })
 })
 
-test('completion completion no known shells', t => {
+t.test('completion completion no known shells', t => {
   const home = process.env.HOME
   t.teardown(() => {
     process.env.HOME = home
@@ -126,7 +125,7 @@ test('completion completion no known shells', t => {
   })
 })
 
-test('completion completion wrong word count', t => {
+t.test('completion completion wrong word count', t => {
   completion.completion({ w: 3 }, (err, res) => {
     if (err)
       throw err
@@ -136,8 +135,8 @@ test('completion completion wrong word count', t => {
   })
 })
 
-test('completion errors in windows without bash', t => {
-  const compl = requireInject('../../lib/completion.js', {
+t.test('completion errors in windows without bash', t => {
+  const compl = t.mock('../../lib/completion.js', {
     '../../lib/utils/is-windows-shell.js': true,
   })
 
@@ -150,7 +149,7 @@ test('completion errors in windows without bash', t => {
   })
 })
 
-test('dump script when completion is not being attempted', t => {
+t.test('dump script when completion is not being attempted', t => {
   const _write = process.stdout.write
   const _on = process.stdout.on
   t.teardown(() => {
@@ -183,7 +182,7 @@ test('dump script when completion is not being attempted', t => {
   })
 })
 
-test('dump script exits correctly when EPIPE is emitted on stdout', t => {
+t.test('dump script exits correctly when EPIPE is emitted on stdout', t => {
   const _write = process.stdout.write
   const _on = process.stdout.on
   t.teardown(() => {
@@ -216,7 +215,7 @@ test('dump script exits correctly when EPIPE is emitted on stdout', t => {
   })
 })
 
-test('non EPIPE errors cause failures', t => {
+t.test('non EPIPE errors cause failures', t => {
   const _write = process.stdout.write
   const _on = process.stdout.on
   t.teardown(() => {
@@ -247,7 +246,7 @@ test('non EPIPE errors cause failures', t => {
   })
 })
 
-test('completion completes single command name', t => {
+t.test('completion completes single command name', t => {
   process.env.COMP_CWORD = 1
   process.env.COMP_LINE = 'npm c'
   process.env.COMP_POINT = process.env.COMP_LINE.length
@@ -269,7 +268,7 @@ test('completion completes single command name', t => {
   })
 })
 
-test('completion completes command names', t => {
+t.test('completion completes command names', t => {
   process.env.COMP_CWORD = 1
   process.env.COMP_LINE = 'npm a'
   process.env.COMP_POINT = process.env.COMP_LINE.length
@@ -291,7 +290,7 @@ test('completion completes command names', t => {
   })
 })
 
-test('completion of invalid command name does nothing', t => {
+t.test('completion of invalid command name does nothing', t => {
   process.env.COMP_CWORD = 1
   process.env.COMP_LINE = 'npm compute'
   process.env.COMP_POINT = process.env.COMP_LINE.length
@@ -313,7 +312,7 @@ test('completion of invalid command name does nothing', t => {
   })
 })
 
-test('completion triggers command completions', t => {
+t.test('completion triggers command completions', t => {
   process.env.COMP_CWORD = 2
   process.env.COMP_LINE = 'npm access '
   process.env.COMP_POINT = process.env.COMP_LINE.length
@@ -342,7 +341,7 @@ test('completion triggers command completions', t => {
   })
 })
 
-test('completion triggers filtered command completions', t => {
+t.test('completion triggers filtered command completions', t => {
   process.env.COMP_CWORD = 2
   process.env.COMP_LINE = 'npm access p'
   process.env.COMP_POINT = process.env.COMP_LINE.length
@@ -371,7 +370,7 @@ test('completion triggers filtered command completions', t => {
   })
 })
 
-test('completions for commands that return nested arrays are joined', t => {
+t.test('completions for commands that return nested arrays are joined', t => {
   process.env.COMP_CWORD = 2
   process.env.COMP_LINE = 'npm completion '
   process.env.COMP_POINT = process.env.COMP_LINE.length
@@ -400,7 +399,7 @@ test('completions for commands that return nested arrays are joined', t => {
   })
 })
 
-test('completions for commands that return nothing work correctly', t => {
+t.test('completions for commands that return nothing work correctly', t => {
   process.env.COMP_CWORD = 2
   process.env.COMP_LINE = 'npm donothing '
   process.env.COMP_POINT = process.env.COMP_LINE.length
@@ -429,7 +428,7 @@ test('completions for commands that return nothing work correctly', t => {
   })
 })
 
-test('completions for commands that return a single item work correctly', t => {
+t.test('completions for commands that return a single item work correctly', t => {
   process.env.COMP_CWORD = 2
   process.env.COMP_LINE = 'npm driveaboat '
   process.env.COMP_POINT = process.env.COMP_LINE.length
@@ -458,7 +457,7 @@ test('completions for commands that return a single item work correctly', t => {
   })
 })
 
-test('command completion for commands with no completion return no results', t => {
+t.test('command completion for commands with no completion return no results', t => {
   process.env.COMP_CWORD = 2
   process.env.COMP_LINE = 'npm adduser '
   process.env.COMP_POINT = process.env.COMP_LINE.length
@@ -488,7 +487,7 @@ test('command completion for commands with no completion return no results', t =
   })
 })
 
-test('command completion errors propagate', t => {
+t.test('command completion errors propagate', t => {
   process.env.COMP_CWORD = 2
   process.env.COMP_LINE = 'npm access '
   process.env.COMP_POINT = process.env.COMP_LINE.length
@@ -517,7 +516,7 @@ test('command completion errors propagate', t => {
   })
 })
 
-test('completion can complete flags', t => {
+t.test('completion can complete flags', t => {
   process.env.COMP_CWORD = 2
   process.env.COMP_LINE = 'npm install --'
   process.env.COMP_POINT = process.env.COMP_LINE.length
@@ -540,7 +539,7 @@ test('completion can complete flags', t => {
   })
 })
 
-test('double dashes escape from flag completion', t => {
+t.test('double dashes escape from flag completion', t => {
   process.env.COMP_CWORD = 2
   process.env.COMP_LINE = 'npm -- install --'
   process.env.COMP_POINT = process.env.COMP_LINE.length
@@ -563,7 +562,7 @@ test('double dashes escape from flag completion', t => {
   })
 })
 
-test('completion cannot complete options that take a value in mid-command', t => {
+t.test('completion cannot complete options that take a value in mid-command', t => {
   process.env.COMP_CWORD = 2
   process.env.COMP_LINE = 'npm --registry install'
   process.env.COMP_POINT = process.env.COMP_LINE.length

--- a/test/lib/config.js
+++ b/test/lib/config.js
@@ -1,5 +1,4 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 const { EventEmitter } = require('events')
 
 const redactCwd = (path) => {
@@ -75,7 +74,7 @@ const mocks = {
   '../../lib/utils/usage.js': usageUtil,
 }
 
-const config = requireInject('../../lib/config.js', mocks)
+const config = t.mock('../../lib/config.js', mocks)
 
 t.test('config no args', t => {
   config([], (err) => {
@@ -450,7 +449,7 @@ sign-git-commit=true`
       },
     },
   }
-  const config = requireInject('../../lib/config.js', editMocks)
+  const config = t.mock('../../lib/config.js', editMocks)
   config(['edit'], (err) => {
     t.ifError(err, 'npm config edit')
 
@@ -458,7 +457,7 @@ sign-git-commit=true`
     editMocks.fs.readFile = (p, e, cb) => {
       cb(new Error('ERR'))
     }
-    const config = requireInject('../../lib/config.js', editMocks)
+    const config = t.mock('../../lib/config.js', editMocks)
     config(['edit'], (err) => {
       t.ifError(err, 'npm config edit')
     })
@@ -506,7 +505,7 @@ t.test('config edit --global', t => {
       },
     },
   }
-  const config = requireInject('../../lib/config.js', editMocks)
+  const config = t.mock('../../lib/config.js', editMocks)
   config(['edit'], (err) => {
     t.match(err, /exited with code: 137/, 'propagated exit code from editor')
   })

--- a/test/lib/dedupe.js
+++ b/test/lib/dedupe.js
@@ -1,8 +1,7 @@
 const { test } = require('tap')
-const requireInject = require('require-inject')
 
 test('should remove dupes using Arborist', (t) => {
-  const dedupe = requireInject('../../lib/dedupe.js', {
+  const dedupe = t.mock('../../lib/dedupe.js', {
     '../../lib/npm.js': {
       prefix: 'foo',
       flatOptions: {
@@ -30,7 +29,7 @@ test('should remove dupes using Arborist', (t) => {
 })
 
 test('should remove dupes using Arborist - no arguments', (t) => {
-  const dedupe = requireInject('../../lib/dedupe.js', {
+  const dedupe = t.mock('../../lib/dedupe.js', {
     '../../lib/npm.js': {
       prefix: 'foo',
       flatOptions: {

--- a/test/lib/deprecate.js
+++ b/test/lib/deprecate.js
@@ -1,5 +1,4 @@
-const { test } = require('tap')
-const requireInject = require('require-inject')
+const t = require('tap')
 
 let getIdentityImpl = () => 'someperson'
 let npmFetchBody = null
@@ -17,7 +16,7 @@ npmFetch.json = async (uri, opts) => {
   }
 }
 
-const deprecate = requireInject('../../lib/deprecate.js', {
+const deprecate = t.mock('../../lib/deprecate.js', {
   '../../lib/npm.js': {
     flatOptions: { registry: 'https://registry.npmjs.org' },
   },
@@ -29,7 +28,7 @@ const deprecate = requireInject('../../lib/deprecate.js', {
   'npm-registry-fetch': npmFetch,
 })
 
-test('completion', async t => {
+t.test('completion', async t => {
   const defaultIdentityImpl = getIdentityImpl
   t.teardown(() => {
     getIdentityImpl = defaultIdentityImpl
@@ -62,28 +61,28 @@ test('completion', async t => {
   t.rejects(testComp([], []), /unknown failure/)
 })
 
-test('no args', t => {
+t.test('no args', t => {
   deprecate([], (err) => {
     t.match(err, /Usage: npm deprecate/, 'logs usage')
     t.end()
   })
 })
 
-test('only one arg', t => {
+t.test('only one arg', t => {
   deprecate(['foo'], (err) => {
     t.match(err, /Usage: npm deprecate/, 'logs usage')
     t.end()
   })
 })
 
-test('invalid semver range', t => {
+t.test('invalid semver range', t => {
   deprecate(['foo@notaversion', 'this will fail'], (err) => {
     t.match(err, /invalid version range/, 'logs semver error')
     t.end()
   })
 })
 
-test('deprecates given range', t => {
+t.test('deprecates given range', t => {
   t.teardown(() => {
     npmFetchBody = null
   })
@@ -109,7 +108,7 @@ test('deprecates given range', t => {
   })
 })
 
-test('deprecates all versions when no range is specified', t => {
+t.test('deprecates all versions when no range is specified', t => {
   t.teardown(() => {
     npmFetchBody = null
   })

--- a/test/lib/dist-tag.js
+++ b/test/lib/dist-tag.js
@@ -1,5 +1,4 @@
-const requireInject = require('require-inject')
-const { test } = require('tap')
+const t = require('tap')
 
 let prefix
 let result = ''
@@ -48,7 +47,15 @@ const logger = (...msgs) => {
   log += '\n'
 }
 
-const distTag = requireInject('../../lib/dist-tag.js', {
+const npm = {
+  flatOptions: _flatOptions,
+  config: {
+    get (key) {
+      return _flatOptions[key]
+    },
+  },
+}
+const distTag = t.mock('../../lib/dist-tag.js', {
   npmlog: {
     error: logger,
     info: logger,
@@ -58,20 +65,13 @@ const distTag = requireInject('../../lib/dist-tag.js', {
   get 'npm-registry-fetch' () {
     return npmRegistryFetchMock
   },
-  '../../lib/npm.js': {
-    flatOptions: _flatOptions,
-    config: {
-      get (key) {
-        return _flatOptions[key]
-      },
-    },
-  },
+  '../../lib/npm.js': npm,
   '../../lib/utils/output.js': msg => {
     result = msg
   },
 })
 
-test('ls in current package', (t) => {
+t.test('ls in current package', (t) => {
   prefix = t.testdir({
     'package.json': JSON.stringify({
       name: '@scoped/pkg',
@@ -89,7 +89,7 @@ test('ls in current package', (t) => {
   })
 })
 
-test('no args in current package', (t) => {
+t.test('no args in current package', (t) => {
   prefix = t.testdir({
     'package.json': JSON.stringify({
       name: '@scoped/pkg',
@@ -107,7 +107,7 @@ test('no args in current package', (t) => {
   })
 })
 
-test('borked cmd usage', (t) => {
+t.test('borked cmd usage', (t) => {
   prefix = t.testdir({})
   distTag(['borked', '@scoped/pkg'], (err) => {
     t.matchSnapshot(err, 'should show usage error')
@@ -117,7 +117,7 @@ test('borked cmd usage', (t) => {
   })
 })
 
-test('ls on named package', (t) => {
+t.test('ls on named package', (t) => {
   prefix = t.testdir({})
   distTag(['ls', '@scoped/another'], (err) => {
     t.ifError(err, 'npm dist-tags ls')
@@ -131,7 +131,7 @@ test('ls on named package', (t) => {
   })
 })
 
-test('ls on missing package', (t) => {
+t.test('ls on missing package', (t) => {
   prefix = t.testdir({})
   distTag(['ls', 'foo'], (err) => {
     t.matchSnapshot(
@@ -148,7 +148,7 @@ test('ls on missing package', (t) => {
   })
 })
 
-test('ls on missing name in current package', (t) => {
+t.test('ls on missing name in current package', (t) => {
   prefix = t.testdir({
     'package.json': JSON.stringify({
       version: '1.0.0',
@@ -165,7 +165,7 @@ test('ls on missing name in current package', (t) => {
   })
 })
 
-test('only named package arg', (t) => {
+t.test('only named package arg', (t) => {
   prefix = t.testdir({})
   distTag(['@scoped/another'], (err) => {
     t.ifError(err, 'npm dist-tags ls')
@@ -179,7 +179,7 @@ test('only named package arg', (t) => {
   })
 })
 
-test('add new tag', (t) => {
+t.test('add new tag', (t) => {
   const _nrf = npmRegistryFetchMock
   npmRegistryFetchMock = async (url, opts) => {
     t.equal(opts.method, 'PUT', 'should trigger request to add new tag')
@@ -199,7 +199,7 @@ test('add new tag', (t) => {
   })
 })
 
-test('add using valid semver range as name', (t) => {
+t.test('add using valid semver range as name', (t) => {
   prefix = t.testdir({})
   distTag(['add', '@scoped/another@7.7.7', '1.0.0'], (err) => {
     t.match(
@@ -217,7 +217,7 @@ test('add using valid semver range as name', (t) => {
   })
 })
 
-test('add missing args', (t) => {
+t.test('add missing args', (t) => {
   prefix = t.testdir({})
   distTag(['add', '@scoped/another@7.7.7'], (err) => {
     t.matchSnapshot(err, 'should exit usage error message')
@@ -227,7 +227,7 @@ test('add missing args', (t) => {
   })
 })
 
-test('add missing pkg name', (t) => {
+t.test('add missing pkg name', (t) => {
   prefix = t.testdir({})
   distTag(['add', null], (err) => {
     t.matchSnapshot(err, 'should exit usage error message')
@@ -237,7 +237,7 @@ test('add missing pkg name', (t) => {
   })
 })
 
-test('set existing version', (t) => {
+t.test('set existing version', (t) => {
   prefix = t.testdir({})
   distTag(['set', '@scoped/another@0.6.0', 'b'], (err) => {
     t.ifError(err, 'npm dist-tags set')
@@ -250,7 +250,7 @@ test('set existing version', (t) => {
   })
 })
 
-test('remove existing tag', (t) => {
+t.test('remove existing tag', (t) => {
   const _nrf = npmRegistryFetchMock
   npmRegistryFetchMock = async (url, opts) => {
     t.equal(opts.method, 'DELETE', 'should trigger request to remove tag')
@@ -267,7 +267,7 @@ test('remove existing tag', (t) => {
   })
 })
 
-test('remove non-existing tag', (t) => {
+t.test('remove non-existing tag', (t) => {
   prefix = t.testdir({})
   distTag(['rm', '@scoped/another', 'nonexistent'], (err) => {
     t.match(
@@ -282,7 +282,7 @@ test('remove non-existing tag', (t) => {
   })
 })
 
-test('remove missing pkg name', (t) => {
+t.test('remove missing pkg name', (t) => {
   prefix = t.testdir({})
   distTag(['rm', null], (err) => {
     t.matchSnapshot(err, 'should exit usage error message')
@@ -292,7 +292,7 @@ test('remove missing pkg name', (t) => {
   })
 })
 
-test('completion', t => {
+t.test('completion', t => {
   const { completion } = distTag
   t.plan(3)
 

--- a/test/lib/docs.js
+++ b/test/lib/docs.js
@@ -1,6 +1,5 @@
 const t = require('tap')
 
-const requireInject = require('require-inject')
 const pacote = {
   manifest: async (spec, options) => {
     return spec === 'nodocs' ? {
@@ -39,7 +38,7 @@ const openUrl = (url, errMsg, cb) => {
   process.nextTick(cb)
 }
 
-const docs = requireInject('../../lib/docs.js', {
+const docs = t.mock('../../lib/docs.js', {
   pacote,
   '../../lib/utils/open-url.js': openUrl,
 })

--- a/test/lib/doctor.js
+++ b/test/lib/doctor.js
@@ -1,5 +1,4 @@
-const { test } = require('tap')
-const requireInject = require('require-inject')
+const t = require('tap')
 
 const { join } = require('path')
 const fs = require('fs')
@@ -120,7 +119,7 @@ const cacache = {
   },
 }
 
-const doctor = requireInject('../../lib/doctor.js', {
+const doctor = t.mock('../../lib/doctor.js', {
   '../../lib/utils/is-windows.js': false,
   '../../lib/utils/ping.js': ping,
   '../../lib/utils/output.js': (data) => {
@@ -133,7 +132,7 @@ const doctor = requireInject('../../lib/doctor.js', {
   which,
 })
 
-test('npm doctor checks ok', t => {
+t.test('npm doctor checks ok', t => {
   const dir = t.testdir()
   npm.cache = npm.flatOptions.cache = dir
   npm.localDir = dir
@@ -180,7 +179,7 @@ test('npm doctor checks ok', t => {
   })
 })
 
-test('npm doctor supports silent', t => {
+t.test('npm doctor supports silent', t => {
   const dir = t.testdir()
   npm.cache = npm.flatOptions.cache = dir
   npm.localDir = dir
@@ -219,7 +218,7 @@ test('npm doctor supports silent', t => {
   })
 })
 
-test('npm doctor supports color', t => {
+t.test('npm doctor supports color', t => {
   const dir = t.testdir()
   npm.cache = npm.flatOptions.cache = dir
   npm.localDir = dir
@@ -270,8 +269,8 @@ test('npm doctor supports color', t => {
   })
 })
 
-test('npm doctor skips some tests in windows', t => {
-  const winDoctor = requireInject('../../lib/doctor.js', {
+t.test('npm doctor skips some tests in windows', t => {
+  const winDoctor = t.mock('../../lib/doctor.js', {
     '../../lib/utils/is-windows.js': true,
     '../../lib/utils/ping.js': ping,
     '../../lib/utils/output.js': (data) => {
@@ -325,7 +324,7 @@ test('npm doctor skips some tests in windows', t => {
   })
 })
 
-test('npm doctor ping error E{3}', t => {
+t.test('npm doctor ping error E{3}', t => {
   const dir = t.testdir()
   npm.cache = npm.flatOptions.cache = dir
   npm.localDir = dir
@@ -374,7 +373,7 @@ test('npm doctor ping error E{3}', t => {
   })
 })
 
-test('npm doctor generic ping error', t => {
+t.test('npm doctor generic ping error', t => {
   const dir = t.testdir()
   npm.cache = npm.flatOptions.cache = dir
   npm.localDir = dir
@@ -423,7 +422,7 @@ test('npm doctor generic ping error', t => {
   })
 })
 
-test('npm doctor outdated npm version', t => {
+t.test('npm doctor outdated npm version', t => {
   const dir = t.testdir()
   npm.cache = npm.flatOptions.cache = dir
   npm.localDir = dir
@@ -472,7 +471,7 @@ test('npm doctor outdated npm version', t => {
   })
 })
 
-test('npm doctor outdated nodejs version', t => {
+t.test('npm doctor outdated nodejs version', t => {
   const dir = t.testdir()
   npm.cache = npm.flatOptions.cache = dir
   npm.localDir = dir
@@ -521,7 +520,7 @@ test('npm doctor outdated nodejs version', t => {
   })
 })
 
-test('npm doctor file permission checks', t => {
+t.test('npm doctor file permission checks', t => {
   const dir = t.testdir({
     cache: {
       one: 'one',
@@ -601,7 +600,7 @@ test('npm doctor file permission checks', t => {
     }
   }
 
-  const doctor = requireInject('../../lib/doctor.js', {
+  const doctor = t.mock('../../lib/doctor.js', {
     '../../lib/utils/is-windows.js': false,
     '../../lib/utils/ping.js': ping,
     '../../lib/utils/output.js': (data) => {
@@ -667,7 +666,7 @@ test('npm doctor file permission checks', t => {
   })
 })
 
-test('npm doctor missing git', t => {
+t.test('npm doctor missing git', t => {
   const dir = t.testdir()
   npm.cache = npm.flatOptions.cache = dir
   npm.localDir = dir
@@ -716,7 +715,7 @@ test('npm doctor missing git', t => {
   })
 })
 
-test('npm doctor cache verification showed bad content', t => {
+t.test('npm doctor cache verification showed bad content', t => {
   const dir = t.testdir()
   npm.cache = npm.flatOptions.cache = dir
   npm.localDir = dir
@@ -774,7 +773,7 @@ test('npm doctor cache verification showed bad content', t => {
   })
 })
 
-test('npm doctor cache verification showed reclaimed content', t => {
+t.test('npm doctor cache verification showed reclaimed content', t => {
   const dir = t.testdir()
   npm.cache = npm.flatOptions.cache = dir
   npm.localDir = dir
@@ -833,7 +832,7 @@ test('npm doctor cache verification showed reclaimed content', t => {
   })
 })
 
-test('npm doctor cache verification showed missing content', t => {
+t.test('npm doctor cache verification showed missing content', t => {
   const dir = t.testdir()
   npm.cache = npm.flatOptions.cache = dir
   npm.localDir = dir
@@ -891,7 +890,7 @@ test('npm doctor cache verification showed missing content', t => {
   })
 })
 
-test('npm doctor not using default registry', t => {
+t.test('npm doctor not using default registry', t => {
   const dir = t.testdir()
   npm.cache = npm.flatOptions.cache = dir
   npm.localDir = dir

--- a/test/lib/edit.js
+++ b/test/lib/edit.js
@@ -1,6 +1,5 @@
-const { test } = require('tap')
+const t = require('tap')
 const { resolve } = require('path')
-const requireInject = require('require-inject')
 const { EventEmitter } = require('events')
 
 let editorBin = null
@@ -38,13 +37,13 @@ const npm = {
 }
 
 const gracefulFs = require('graceful-fs')
-const edit = requireInject('../../lib/edit.js', {
+const edit = t.mock('../../lib/edit.js', {
   '../../lib/npm.js': npm,
   child_process: childProcess,
   'graceful-fs': gracefulFs,
 })
 
-test('npm edit', t => {
+t.test('npm edit', t => {
   t.teardown(() => {
     rebuildArgs = null
     editorBin = null
@@ -65,7 +64,7 @@ test('npm edit', t => {
   })
 })
 
-test('npm edit editor has flags', t => {
+t.test('npm edit editor has flags', t => {
   EDITOR = 'code -w'
   t.teardown(() => {
     rebuildArgs = null
@@ -88,14 +87,14 @@ test('npm edit editor has flags', t => {
   })
 })
 
-test('npm edit no args', t => {
+t.test('npm edit no args', t => {
   return edit([], (err) => {
     t.match(err, /npm edit/, 'throws usage error')
     t.end()
   })
 })
 
-test('npm edit lstat error propagates', t => {
+t.test('npm edit lstat error propagates', t => {
   const _lstat = gracefulFs.lstat
   gracefulFs.lstat = (dir, cb) => {
     return cb(new Error('lstat failed'))
@@ -110,7 +109,7 @@ test('npm edit lstat error propagates', t => {
   })
 })
 
-test('npm edit editor exit code error propagates', t => {
+t.test('npm edit editor exit code error propagates', t => {
   EDITOR_CODE = 137
   t.teardown(() => {
     EDITOR_CODE = 0

--- a/test/lib/exec.js
+++ b/test/lib/exec.js
@@ -1,5 +1,4 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 const { resolve, delimiter } = require('path')
 const OUTPUT = []
 const output = (...msg) => OUTPUT.push(msg)
@@ -96,7 +95,7 @@ const mocks = {
   'mkdirp-infer-owner': mkdirp,
   '../../lib/utils/output.js': output,
 }
-const exec = requireInject('../../lib/exec.js', mocks)
+const exec = t.mock('../../lib/exec.js', mocks)
 
 t.afterEach(cb => {
   MKDIRPS.length = 0

--- a/test/lib/explain.js
+++ b/test/lib/explain.js
@@ -1,5 +1,4 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 const npm = {
   prefix: null,
   color: true,
@@ -9,7 +8,7 @@ const { resolve } = require('path')
 
 const OUTPUT = []
 
-const explain = requireInject('../../lib/explain.js', {
+const explain = t.mock('../../lib/explain.js', {
   '../../lib/npm.js': npm,
 
   '../../lib/utils/output.js': (...args) => {

--- a/test/lib/explore.js
+++ b/test/lib/explore.js
@@ -1,5 +1,4 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 
 let RPJ_ERROR = null
 let RPJ_CALLED = ''
@@ -46,7 +45,7 @@ const mockRunScript = ({ pkg, banner, path, event, stdio }) => {
 const output = []
 let ERROR_HANDLER_CALLED = null
 const logs = []
-const getExplore = windows => requireInject('../../lib/explore.js', {
+const getExplore = windows => t.mock('../../lib/explore.js', {
   '../../lib/utils/is-windows.js': windows,
   path: require('path')[windows ? 'win32' : 'posix'],
   '../../lib/utils/error-handler.js': er => {

--- a/test/lib/find-dupes.js
+++ b/test/lib/find-dupes.js
@@ -1,8 +1,7 @@
-const { test } = require('tap')
-const requireInject = require('require-inject')
+const t = require('tap')
 
-test('should run dedupe in dryRun mode', (t) => {
-  const findDupes = requireInject('../../lib/find-dupes.js', {
+t.test('should run dedupe in dryRun mode', (t) => {
+  const findDupes = t.mock('../../lib/find-dupes.js', {
     '../../lib/dedupe.js': function (args, cb) {
       t.ok(args.dryRun, 'dryRun is true')
       cb()

--- a/test/lib/fund.js
+++ b/test/lib/fund.js
@@ -1,5 +1,4 @@
-const { test } = require('tap')
-const requireInject = require('require-inject')
+const t = require('tap')
 
 const version = '1.0.0'
 const funding = {
@@ -203,13 +202,14 @@ const openUrl = (url, msg, cb) => {
 
   cb()
 }
-const fund = requireInject('../../lib/fund.js', {
-  '../../lib/npm.js': {
-    flatOptions: _flatOptions,
-    get prefix () {
-      return _flatOptions.prefix
-    },
+const npm = {
+  flatOptions: _flatOptions,
+  get prefix () {
+    return _flatOptions.prefix
   },
+}
+const fund = t.mock('../../lib/fund.js', {
+  '../../lib/npm.js': npm,
   '../../lib/utils/open-url.js': openUrl,
   '../../lib/utils/output.js': msg => {
     result += msg + '\n'
@@ -223,7 +223,7 @@ const fund = requireInject('../../lib/fund.js', {
   },
 })
 
-test('fund with no package containing funding', t => {
+t.test('fund with no package containing funding', t => {
   _flatOptions.prefix = t.testdir({
     'package.json': JSON.stringify({
       name: 'no-funding-package',
@@ -239,7 +239,7 @@ test('fund with no package containing funding', t => {
   })
 })
 
-test('fund in which same maintainer owns all its deps', t => {
+t.test('fund in which same maintainer owns all its deps', t => {
   _flatOptions.prefix = t.testdir(maintainerOwnsAllDeps)
 
   fund([], (err) => {
@@ -250,7 +250,7 @@ test('fund in which same maintainer owns all its deps', t => {
   })
 })
 
-test('fund in which same maintainer owns all its deps, using --json option', t => {
+t.test('fund in which same maintainer owns all its deps, using --json option', t => {
   _flatOptions.json = true
   _flatOptions.prefix = t.testdir(maintainerOwnsAllDeps)
 
@@ -289,7 +289,7 @@ test('fund in which same maintainer owns all its deps, using --json option', t =
   })
 })
 
-test('fund containing multi-level nested deps with no funding', t => {
+t.test('fund containing multi-level nested deps with no funding', t => {
   _flatOptions.prefix = t.testdir(nestedNoFundingPackages)
 
   fund([], (err) => {
@@ -304,7 +304,7 @@ test('fund containing multi-level nested deps with no funding', t => {
   })
 })
 
-test('fund containing multi-level nested deps with no funding, using --json option', t => {
+t.test('fund containing multi-level nested deps with no funding, using --json option', t => {
   _flatOptions.prefix = t.testdir(nestedNoFundingPackages)
   _flatOptions.json = true
 
@@ -336,7 +336,7 @@ test('fund containing multi-level nested deps with no funding, using --json opti
   })
 })
 
-test('fund containing multi-level nested deps with no funding, using --json option', t => {
+t.test('fund containing multi-level nested deps with no funding, using --json option', t => {
   _flatOptions.prefix = t.testdir(nestedMultipleFundingPackages)
   _flatOptions.json = true
 
@@ -393,7 +393,7 @@ test('fund containing multi-level nested deps with no funding, using --json opti
   })
 })
 
-test('fund does not support global', t => {
+t.test('fund does not support global', t => {
   _flatOptions.prefix = t.testdir({})
   _flatOptions.global = true
 
@@ -406,7 +406,7 @@ test('fund does not support global', t => {
   })
 })
 
-test('fund using package argument', t => {
+t.test('fund using package argument', t => {
   _flatOptions.prefix = t.testdir(maintainerOwnsAllDeps)
 
   fund(['.'], (err) => {
@@ -418,7 +418,7 @@ test('fund using package argument', t => {
   })
 })
 
-test('fund does not support global, using --json option', t => {
+t.test('fund does not support global, using --json option', t => {
   _flatOptions.prefix = t.testdir({})
   _flatOptions.global = true
   _flatOptions.json = true
@@ -437,7 +437,7 @@ test('fund does not support global, using --json option', t => {
   })
 })
 
-test('fund using string shorthand', t => {
+t.test('fund using string shorthand', t => {
   _flatOptions.prefix = t.testdir({
     'package.json': JSON.stringify({
       name: 'funding-string-shorthand',
@@ -455,7 +455,7 @@ test('fund using string shorthand', t => {
   })
 })
 
-test('fund using nested packages with multiple sources', t => {
+t.test('fund using nested packages with multiple sources', t => {
   _flatOptions.prefix = t.testdir(nestedMultipleFundingPackages)
 
   fund(['.'], (err) => {
@@ -467,7 +467,7 @@ test('fund using nested packages with multiple sources', t => {
   })
 })
 
-test('fund using symlink ref', t => {
+t.test('fund using symlink ref', t => {
   _flatOptions.prefix = t.testdir({
     'package.json': JSON.stringify({
       name: 'using-symlink-ref',
@@ -513,7 +513,7 @@ test('fund using symlink ref', t => {
   })
 })
 
-test('fund using data from actual tree', t => {
+t.test('fund using data from actual tree', t => {
   _flatOptions.prefix = t.testdir({
     'package.json': JSON.stringify({
       name: 'using-actual-tree',
@@ -560,7 +560,7 @@ test('fund using data from actual tree', t => {
   })
 })
 
-test('fund using nested packages with multiple sources, with a source number', t => {
+t.test('fund using nested packages with multiple sources, with a source number', t => {
   _flatOptions.prefix = t.testdir(nestedMultipleFundingPackages)
   _flatOptions.which = '1'
 
@@ -574,7 +574,7 @@ test('fund using nested packages with multiple sources, with a source number', t
   })
 })
 
-test('fund using pkg name while having conflicting versions', t => {
+t.test('fund using pkg name while having conflicting versions', t => {
   _flatOptions.prefix = t.testdir(conflictingFundingPackages)
   _flatOptions.which = '1'
 
@@ -587,7 +587,7 @@ test('fund using pkg name while having conflicting versions', t => {
   })
 })
 
-test('fund using package argument with no browser, using --json option', t => {
+t.test('fund using package argument with no browser, using --json option', t => {
   _flatOptions.prefix = t.testdir(maintainerOwnsAllDeps)
   _flatOptions.json = true
 
@@ -608,7 +608,7 @@ test('fund using package argument with no browser, using --json option', t => {
   })
 })
 
-test('fund using package info fetch from registry', t => {
+t.test('fund using package info fetch from registry', t => {
   _flatOptions.prefix = t.testdir({})
 
   fund(['ntl'], (err) => {
@@ -624,7 +624,7 @@ test('fund using package info fetch from registry', t => {
   })
 })
 
-test('fund tries to use package info fetch from registry but registry has nothing', t => {
+t.test('fund tries to use package info fetch from registry but registry has nothing', t => {
   _flatOptions.prefix = t.testdir({})
 
   fund(['foo'], (err) => {
@@ -640,7 +640,7 @@ test('fund tries to use package info fetch from registry but registry has nothin
   })
 })
 
-test('fund but target module has no funding info', t => {
+t.test('fund but target module has no funding info', t => {
   _flatOptions.prefix = t.testdir(nestedNoFundingPackages)
 
   fund(['foo'], (err) => {
@@ -656,7 +656,7 @@ test('fund but target module has no funding info', t => {
   })
 })
 
-test('fund using bad which value', t => {
+t.test('fund using bad which value', t => {
   _flatOptions.prefix = t.testdir(nestedMultipleFundingPackages)
   _flatOptions.which = 3
 
@@ -674,7 +674,7 @@ test('fund using bad which value', t => {
   })
 })
 
-test('fund pkg missing version number', t => {
+t.test('fund pkg missing version number', t => {
   _flatOptions.prefix = t.testdir({
     'package.json': JSON.stringify({
       name: 'foo',
@@ -690,7 +690,7 @@ test('fund pkg missing version number', t => {
   })
 })
 
-test('fund a package throws on openUrl', t => {
+t.test('fund a package throws on openUrl', t => {
   _flatOptions.prefix = t.testdir({
     'package.json': JSON.stringify({
       name: 'foo',
@@ -706,7 +706,7 @@ test('fund a package throws on openUrl', t => {
   })
 })
 
-test('fund a package with type and multiple sources', t => {
+t.test('fund a package with type and multiple sources', t => {
   _flatOptions.prefix = t.testdir({
     'package.json': JSON.stringify({
       name: 'foo',
@@ -732,7 +732,7 @@ test('fund a package with type and multiple sources', t => {
   })
 })
 
-test('fund colors', t => {
+t.test('fund colors', t => {
   _flatOptions.prefix = t.testdir({
     'package.json': JSON.stringify({
       name: 'test-fund-colors',
@@ -797,7 +797,7 @@ test('fund colors', t => {
   })
 })
 
-test('sub dep with fund info and a parent with no funding info', t => {
+t.test('sub dep with fund info and a parent with no funding info', t => {
   _flatOptions.prefix = t.testdir({
     'package.json': JSON.stringify({
       name: 'test-multiple-funding-sources',

--- a/test/lib/get.js
+++ b/test/lib/get.js
@@ -1,8 +1,7 @@
-const { test } = require('tap')
-const requireInject = require('require-inject')
+const t = require('tap')
 
-test('should retrieve values from npm.commands.config', (t) => {
-  const get = requireInject('../../lib/get.js', {
+t.test('should retrieve values from npm.commands.config', (t) => {
+  const get = t.mock('../../lib/get.js', {
     '../../lib/npm.js': {
       commands: {
         config: ([action, arg]) => {

--- a/test/lib/help-search.js
+++ b/test/lib/help-search.js
@@ -1,6 +1,5 @@
-const { test } = require('tap')
+const t = require('tap')
 const { join } = require('path')
-const requireInject = require('require-inject')
 const ansicolors = require('ansicolors')
 
 const OUTPUT = []
@@ -42,14 +41,14 @@ const globDir = {
 }
 const glob = (p, cb) => cb(null, Object.keys(globDir).map((file) => join(globRoot, file)))
 
-const helpSearch = requireInject('../../lib/help-search.js', {
+const helpSearch = t.mock('../../lib/help-search.js', {
   '../../lib/npm.js': npm,
   '../../lib/utils/npm-usage.js': npmUsage,
   '../../lib/utils/output.js': output,
   glob,
 })
 
-test('npm help-search', t => {
+t.test('npm help-search', t => {
   globRoot = t.testdir(globDir)
   t.teardown(() => {
     OUTPUT.length = 0
@@ -66,7 +65,7 @@ test('npm help-search', t => {
   })
 })
 
-test('npm help-search multiple terms', t => {
+t.test('npm help-search multiple terms', t => {
   globRoot = t.testdir(globDir)
   t.teardown(() => {
     OUTPUT.length = 0
@@ -83,7 +82,7 @@ test('npm help-search multiple terms', t => {
   })
 })
 
-test('npm help-search single result prints full section', t => {
+t.test('npm help-search single result prints full section', t => {
   globRoot = t.testdir(globDir)
   t.teardown(() => {
     OUTPUT.length = 0
@@ -100,7 +99,7 @@ test('npm help-search single result prints full section', t => {
   })
 })
 
-test('npm help-search single result propagates error', t => {
+t.test('npm help-search single result propagates error', t => {
   globRoot = t.testdir(globDir)
   npmHelpErr = new Error('help broke')
   t.teardown(() => {
@@ -117,7 +116,7 @@ test('npm help-search single result propagates error', t => {
   })
 })
 
-test('npm help-search long output', t => {
+t.test('npm help-search long output', t => {
   globRoot = t.testdir(globDir)
   npm.flatOptions.long = true
   t.teardown(() => {
@@ -135,7 +134,7 @@ test('npm help-search long output', t => {
   })
 })
 
-test('npm help-search long output with color', t => {
+t.test('npm help-search long output with color', t => {
   globRoot = t.testdir(globDir)
   npm.flatOptions.long = true
   npm.color = true
@@ -156,14 +155,14 @@ test('npm help-search long output with color', t => {
   })
 })
 
-test('npm help-search no args', t => {
+t.test('npm help-search no args', t => {
   return helpSearch([], (err) => {
     t.match(err, /npm help-search/, 'throws usage')
     t.end()
   })
 })
 
-test('npm help-search no matches', t => {
+t.test('npm help-search no matches', t => {
   globRoot = t.testdir(globDir)
   t.teardown(() => {
     OUTPUT.length = 0

--- a/test/lib/help.js
+++ b/test/lib/help.js
@@ -1,5 +1,4 @@
-const { test } = require('tap')
-const requireInject = require('require-inject')
+const t = require('tap')
 const { EventEmitter } = require('events')
 
 let npmUsageArg = null
@@ -71,7 +70,7 @@ const openUrl = (url, msg, cb) => {
   return cb()
 }
 
-const help = requireInject('../../lib/help.js', {
+const help = t.mock('../../lib/help.js', {
   '../../lib/npm.js': npm,
   '../../lib/utils/npm-usage.js': npmUsage,
   '../../lib/utils/open-url.js': openUrl,
@@ -80,7 +79,7 @@ const help = requireInject('../../lib/help.js', {
   glob,
 })
 
-test('npm help', t => {
+t.test('npm help', t => {
   t.teardown(() => {
     npmUsageArg = null
   })
@@ -94,7 +93,7 @@ test('npm help', t => {
   })
 })
 
-test('npm help completion', async t => {
+t.test('npm help completion', async t => {
   t.teardown(() => {
     globErr = null
   })
@@ -114,7 +113,7 @@ test('npm help completion', async t => {
   t.rejects(completion({ conf: { argv: { remain: [] } } }), /glob failed/, 'glob errors propagate')
 })
 
-test('npm help -h', t => {
+t.test('npm help -h', t => {
   npmConfig.usage = true
   t.teardown(() => {
     npmConfig.usage = false
@@ -130,7 +129,7 @@ test('npm help -h', t => {
   })
 })
 
-test('npm help multiple args calls search', t => {
+t.test('npm help multiple args calls search', t => {
   t.teardown(() => {
     helpSearchArgs = null
   })
@@ -144,7 +143,7 @@ test('npm help multiple args calls search', t => {
   })
 })
 
-test('npm help no matches calls search', t => {
+t.test('npm help no matches calls search', t => {
   globResult = []
   t.teardown(() => {
     helpSearchArgs = null
@@ -160,7 +159,7 @@ test('npm help no matches calls search', t => {
   })
 })
 
-test('npm help glob errors propagate', t => {
+t.test('npm help glob errors propagate', t => {
   globErr = new Error('glob failed')
   t.teardown(() => {
     globErr = null
@@ -174,7 +173,7 @@ test('npm help glob errors propagate', t => {
   })
 })
 
-test('npm help whoami', t => {
+t.test('npm help whoami', t => {
   globResult = ['/root/man/man1/npm-whoami.1.xz']
   t.teardown(() => {
     globResult = globDefaults
@@ -192,7 +191,7 @@ test('npm help whoami', t => {
   })
 })
 
-test('npm help 1 install', t => {
+t.test('npm help 1 install', t => {
   npmConfig.viewer = 'browser'
   globResult = [
     '/root/man/man5/install.5',
@@ -215,7 +214,7 @@ test('npm help 1 install', t => {
   })
 })
 
-test('npm help 5 install', t => {
+t.test('npm help 5 install', t => {
   npmConfig.viewer = 'browser'
   globResult = [
     '/root/man/man5/install.5',
@@ -238,7 +237,7 @@ test('npm help 5 install', t => {
   })
 })
 
-test('npm help 7 config', t => {
+t.test('npm help 7 config', t => {
   npmConfig.viewer = 'browser'
   globResult = [
     '/root/man/man1/npm-config.1',
@@ -260,7 +259,7 @@ test('npm help 7 config', t => {
   })
 })
 
-test('npm help with browser viewer and invalid section throws', t => {
+t.test('npm help with browser viewer and invalid section throws', t => {
   npmConfig.viewer = 'browser'
   globResult = [
     '/root/man/man1/npm-config.1',
@@ -280,7 +279,7 @@ test('npm help with browser viewer and invalid section throws', t => {
   })
 })
 
-test('npm help global redirects to folders', t => {
+t.test('npm help global redirects to folders', t => {
   globResult = ['/root/man/man5/folders.5']
   t.teardown(() => {
     globResult = globDefaults
@@ -298,7 +297,7 @@ test('npm help global redirects to folders', t => {
   })
 })
 
-test('npm help package.json redirects to package-json', t => {
+t.test('npm help package.json redirects to package-json', t => {
   globResult = ['/root/man/man5/package-json.5']
   t.teardown(() => {
     globResult = globDefaults
@@ -316,7 +315,7 @@ test('npm help package.json redirects to package-json', t => {
   })
 })
 
-test('npm help ?(un)star', t => {
+t.test('npm help ?(un)star', t => {
   npmConfig.viewer = 'woman'
   globResult = [
     '/root/man/man1/npm-star.1',
@@ -339,7 +338,7 @@ test('npm help ?(un)star', t => {
   })
 })
 
-test('npm help un*', t => {
+t.test('npm help un*', t => {
   globResult = [
     '/root/man/man1/npm-unstar.1',
     '/root/man/man1/npm-uninstall.1',

--- a/test/lib/hook.js
+++ b/test/lib/hook.js
@@ -1,5 +1,4 @@
-const { test } = require('tap')
-const requireInject = require('require-inject')
+const t = require('tap')
 
 const npm = {
   flatOptions: {
@@ -52,7 +51,7 @@ const libnpmhook = {
 }
 
 const output = []
-const hook = requireInject('../../lib/hook.js', {
+const hook = t.mock('../../lib/hook.js', {
   '../../lib/npm.js': npm,
   '../../lib/utils/otplease.js': async (opts, fn) => fn(opts),
   '../../lib/utils/output.js': (msg) => {
@@ -61,14 +60,14 @@ const hook = requireInject('../../lib/hook.js', {
   libnpmhook,
 })
 
-test('npm hook no args', t => {
+t.test('npm hook no args', t => {
   return hook([], (err) => {
     t.match(err, /npm hook add/, 'throws usage with no arguments')
     t.end()
   })
 })
 
-test('npm hook add', t => {
+t.test('npm hook add', t => {
   t.teardown(() => {
     hookArgs = null
     output.length = 0
@@ -89,7 +88,7 @@ test('npm hook add', t => {
   })
 })
 
-test('npm hook add - unicode output', t => {
+t.test('npm hook add - unicode output', t => {
   npm.flatOptions.unicode = true
   t.teardown(() => {
     npm.flatOptions.unicode = false
@@ -112,7 +111,7 @@ test('npm hook add - unicode output', t => {
   })
 })
 
-test('npm hook add - json output', t => {
+t.test('npm hook add - json output', t => {
   npm.flatOptions.json = true
   t.teardown(() => {
     npm.flatOptions.json = false
@@ -140,7 +139,7 @@ test('npm hook add - json output', t => {
   })
 })
 
-test('npm hook add - parseable output', t => {
+t.test('npm hook add - parseable output', t => {
   npm.flatOptions.parseable = true
   t.teardown(() => {
     npm.flatOptions.parseable = false
@@ -168,7 +167,7 @@ test('npm hook add - parseable output', t => {
   })
 })
 
-test('npm hook add - silent output', t => {
+t.test('npm hook add - silent output', t => {
   npm.flatOptions.silent = true
   t.teardown(() => {
     npm.flatOptions.silent = false
@@ -191,7 +190,7 @@ test('npm hook add - silent output', t => {
   })
 })
 
-test('npm hook ls', t => {
+t.test('npm hook ls', t => {
   t.teardown(() => {
     hookArgs = null
     output.length = 0
@@ -214,7 +213,7 @@ test('npm hook ls', t => {
   })
 })
 
-test('npm hook ls, no results', t => {
+t.test('npm hook ls, no results', t => {
   hookResponse = []
   t.teardown(() => {
     hookResponse = null
@@ -235,7 +234,7 @@ test('npm hook ls, no results', t => {
   })
 })
 
-test('npm hook ls, single result', t => {
+t.test('npm hook ls, single result', t => {
   hookResponse = [{
     id: 1,
     name: 'semver',
@@ -264,7 +263,7 @@ test('npm hook ls, single result', t => {
   })
 })
 
-test('npm hook ls - json output', t => {
+t.test('npm hook ls - json output', t => {
   npm.flatOptions.json = true
   t.teardown(() => {
     npm.flatOptions.json = false
@@ -301,7 +300,7 @@ test('npm hook ls - json output', t => {
   })
 })
 
-test('npm hook ls - parseable output', t => {
+t.test('npm hook ls - parseable output', t => {
   npm.flatOptions.parseable = true
   t.teardown(() => {
     npm.flatOptions.parseable = false
@@ -327,7 +326,7 @@ test('npm hook ls - parseable output', t => {
   })
 })
 
-test('npm hook ls - silent output', t => {
+t.test('npm hook ls - silent output', t => {
   npm.flatOptions.silent = true
   t.teardown(() => {
     npm.flatOptions.silent = false
@@ -348,7 +347,7 @@ test('npm hook ls - silent output', t => {
   })
 })
 
-test('npm hook rm', t => {
+t.test('npm hook rm', t => {
   t.teardown(() => {
     hookArgs = null
     output.length = 0
@@ -369,7 +368,7 @@ test('npm hook rm', t => {
   })
 })
 
-test('npm hook rm - unicode output', t => {
+t.test('npm hook rm - unicode output', t => {
   npm.flatOptions.unicode = true
   t.teardown(() => {
     npm.flatOptions.unicode = false
@@ -392,7 +391,7 @@ test('npm hook rm - unicode output', t => {
   })
 })
 
-test('npm hook rm - silent output', t => {
+t.test('npm hook rm - silent output', t => {
   npm.flatOptions.silent = true
   t.teardown(() => {
     npm.flatOptions.silent = false
@@ -413,7 +412,7 @@ test('npm hook rm - silent output', t => {
   })
 })
 
-test('npm hook rm - json output', t => {
+t.test('npm hook rm - json output', t => {
   npm.flatOptions.json = true
   t.teardown(() => {
     npm.flatOptions.json = false
@@ -439,7 +438,7 @@ test('npm hook rm - json output', t => {
   })
 })
 
-test('npm hook rm - parseable output', t => {
+t.test('npm hook rm - parseable output', t => {
   npm.flatOptions.parseable = true
   t.teardown(() => {
     npm.flatOptions.parseable = false
@@ -463,7 +462,7 @@ test('npm hook rm - parseable output', t => {
   })
 })
 
-test('npm hook update', t => {
+t.test('npm hook update', t => {
   t.teardown(() => {
     hookArgs = null
     output.length = 0
@@ -486,7 +485,7 @@ test('npm hook update', t => {
   })
 })
 
-test('npm hook update - unicode', t => {
+t.test('npm hook update - unicode', t => {
   npm.flatOptions.unicode = true
   t.teardown(() => {
     npm.flatOptions.unicode = false
@@ -511,7 +510,7 @@ test('npm hook update - unicode', t => {
   })
 })
 
-test('npm hook update - json output', t => {
+t.test('npm hook update - json output', t => {
   npm.flatOptions.json = true
   t.teardown(() => {
     npm.flatOptions.json = false
@@ -539,7 +538,7 @@ test('npm hook update - json output', t => {
   })
 })
 
-test('npm hook update - parseable output', t => {
+t.test('npm hook update - parseable output', t => {
   npm.flatOptions.parseable = true
   t.teardown(() => {
     npm.flatOptions.parseable = false
@@ -565,7 +564,7 @@ test('npm hook update - parseable output', t => {
   })
 })
 
-test('npm hook update - silent output', t => {
+t.test('npm hook update - silent output', t => {
   npm.flatOptions.silent = true
   t.teardown(() => {
     npm.flatOptions.silent = false

--- a/test/lib/init.js
+++ b/test/lib/init.js
@@ -1,5 +1,4 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 
 let result = ''
 const npmLog = {
@@ -23,7 +22,7 @@ const mocks = {
     result += msg.join('\n')
   },
 }
-const init = requireInject('../../lib/init.js', mocks)
+const init = t.mock('../../lib/init.js', mocks)
 
 t.afterEach(cb => {
   result = ''
@@ -206,7 +205,7 @@ t.test('should not rewrite flatOptions', t => {
 
 t.test('npm init cancel', t => {
   t.plan(3)
-  const init = requireInject('../../lib/init.js', {
+  const init = t.mock('../../lib/init.js', {
     ...mocks,
     'init-package-json': (dir, initFile, config, cb) => cb(
       new Error('canceled')
@@ -223,7 +222,7 @@ t.test('npm init cancel', t => {
 })
 
 t.test('npm init error', t => {
-  const init = requireInject('../../lib/init.js', {
+  const init = t.mock('../../lib/init.js', {
     ...mocks,
     'init-package-json': (dir, initFile, config, cb) => cb(
       new Error('Unknown Error')

--- a/test/lib/install.js
+++ b/test/lib/install.js
@@ -1,15 +1,14 @@
-const { test } = require('tap')
+const t = require('tap')
 
 const install = require('../../lib/install.js')
-const requireInject = require('require-inject')
 
-test('should install using Arborist', (t) => {
+t.test('should install using Arborist', (t) => {
   const SCRIPTS = []
   let ARB_ARGS = null
   let REIFY_CALLED = false
   let ARB_OBJ = null
 
-  const install = requireInject('../../lib/install.js', {
+  const install = t.mock('../../lib/install.js', {
     '../../lib/npm.js': {
       globalDir: 'path/to/node_modules/',
       prefix: 'foo',
@@ -72,9 +71,8 @@ test('should install using Arborist', (t) => {
   t.end()
 })
 
-test('should install globally using Arborist', (t) => {
-  const install = requireInject('../../lib/install.js', {
-    '../../lib/utils/reify-finish.js': async () => {},
+t.test('should install globally using Arborist', (t) => {
+  const install = t.mock('../../lib/install.js', {
     '../../lib/npm.js': {
       globalDir: 'path/to/node_modules/',
       prefix: 'foo',
@@ -85,6 +83,7 @@ test('should install globally using Arborist', (t) => {
         get: () => false,
       },
     },
+    '../../lib/utils/reify-finish.js': async () => {},
     '@npmcli/arborist': function () {
       this.reify = () => {}
     },
@@ -96,13 +95,13 @@ test('should install globally using Arborist', (t) => {
   })
 })
 
-test('completion to folder', (t) => {
-  const install = requireInject('../../lib/install.js', {
-    '../../lib/utils/reify-finish.js': async () => {},
+t.test('completion to folder', (t) => {
+  const install = t.mock('../../lib/install.js', {
     util: {
       promisify: (fn) => fn,
     },
     fs: {
+      ...require('fs'),
       readdir: (path) => {
         if (path === '/')
           return ['arborist']
@@ -121,13 +120,13 @@ test('completion to folder', (t) => {
   })
 })
 
-test('completion to folder - invalid dir', (t) => {
-  const install = requireInject('../../lib/install.js', {
-    '../../lib/utils/reify-finish.js': async () => {},
+t.test('completion to folder - invalid dir', (t) => {
+  const install = t.mock('../../lib/install.js', {
     util: {
       promisify: (fn) => fn,
     },
     fs: {
+      ...require('fs'),
       readdir: () => {
         throw new Error('EONT')
       },
@@ -142,13 +141,13 @@ test('completion to folder - invalid dir', (t) => {
   })
 })
 
-test('completion to folder - no matches', (t) => {
-  const install = requireInject('../../lib/install.js', {
-    '../../lib/utils/reify-finish.js': async () => {},
+t.test('completion to folder - no matches', (t) => {
+  const install = t.mock('../../lib/install.js', {
     util: {
       promisify: (fn) => fn,
     },
     fs: {
+      ...require('fs'),
       readdir: (path) => {
         return ['foobar']
       },
@@ -163,13 +162,13 @@ test('completion to folder - no matches', (t) => {
   })
 })
 
-test('completion to folder - match is not a package', (t) => {
-  const install = requireInject('../../lib/install.js', {
-    '../../lib/utils/reify-finish.js': async () => {},
+t.test('completion to folder - match is not a package', (t) => {
+  const install = t.mock('../../lib/install.js', {
     util: {
       promisify: (fn) => fn,
     },
     fs: {
+      ...require('fs'),
       readdir: (path) => {
         if (path === '/')
           return ['arborist']
@@ -187,7 +186,7 @@ test('completion to folder - match is not a package', (t) => {
   })
 })
 
-test('completion to url', (t) => {
+t.test('completion to url', (t) => {
   install.completion({
     partialWord: 'http://path/to/url',
   }, (er, res) => {
@@ -197,7 +196,7 @@ test('completion to url', (t) => {
   })
 })
 
-test('completion', (t) => {
+t.test('completion', (t) => {
   install.completion({
     partialWord: 'toto',
   }, (er, res) => {

--- a/test/lib/link.js
+++ b/test/lib/link.js
@@ -2,7 +2,6 @@ const { resolve } = require('path')
 
 const Arborist = require('@npmcli/arborist')
 const t = require('tap')
-const requireInject = require('require-inject')
 
 const redactCwd = (path) => {
   const normalizePath = p => p
@@ -14,7 +13,7 @@ const redactCwd = (path) => {
 
 t.cleanSnapshot = (str) => redactCwd(str)
 
-let reifyOutput
+let reifyFinish
 const npm = {
   globalDir: null,
   prefix: null,
@@ -41,10 +40,10 @@ const printLinks = async (opts) => {
 
 const mocks = {
   '../../lib/npm.js': npm,
-  '../../lib/utils/reify-output.js': () => reifyOutput(),
+  '../../lib/utils/reify-finish.js': () => reifyFinish(),
 }
 
-const link = requireInject('../../lib/link.js', mocks)
+const link = t.mock('../../lib/link.js', mocks)
 
 t.test('link to globalDir when in current working dir of pkg and no args', (t) => {
   t.plan(2)
@@ -72,8 +71,8 @@ t.test('link to globalDir when in current working dir of pkg and no args', (t) =
   npm.globalDir = resolve(testdir, 'global-prefix', 'lib', 'node_modules')
   npm.prefix = resolve(testdir, 'test-pkg-link')
 
-  reifyOutput = async () => {
-    reifyOutput = undefined
+  reifyFinish = async () => {
+    reifyFinish = undefined
 
     const links = await printLinks({
       path: resolve(npm.globalDir, '..'),
@@ -168,8 +167,8 @@ t.test('link global linked pkg to local nm when using args', (t) => {
   const _cwd = process.cwd()
   process.chdir(npm.prefix)
 
-  reifyOutput = async () => {
-    reifyOutput = undefined
+  reifyFinish = async () => {
+    reifyFinish = undefined
     process.chdir(_cwd)
 
     const links = await printLinks({
@@ -230,8 +229,8 @@ t.test('link pkg already in global space', (t) => {
   const _cwd = process.cwd()
   process.chdir(npm.prefix)
 
-  reifyOutput = async () => {
-    reifyOutput = undefined
+  reifyFinish = async () => {
+    reifyFinish = undefined
     process.chdir(_cwd)
     npm.config.find = () => null
 

--- a/test/lib/ll.js
+++ b/test/lib/ll.js
@@ -1,8 +1,7 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 const configs = {}
 let lsCalled = false
-const ll = requireInject('../../lib/ll.js', {
+const ll = t.mock('../../lib/ll.js', {
   '../../lib/npm.js': {
     config: {
       set: (k, v) => {

--- a/test/lib/logout.js
+++ b/test/lib/logout.js
@@ -1,5 +1,4 @@
-const requireInject = require('require-inject')
-const { test } = require('tap')
+const t = require('tap')
 
 const _flatOptions = {
   registry: 'https://registry.npmjs.org/',
@@ -23,9 +22,9 @@ const mocks = {
   },
 }
 
-const logout = requireInject('../../lib/logout.js', mocks)
+const logout = t.mock('../../lib/logout.js', mocks)
 
-test('token logout', async (t) => {
+t.test('token logout', async (t) => {
   t.plan(6)
 
   _flatOptions.token = '@foo/'
@@ -83,7 +82,7 @@ test('token logout', async (t) => {
   })
 })
 
-test('token scoped logout', async (t) => {
+t.test('token scoped logout', async (t) => {
   t.plan(8)
 
   _flatOptions.token = '@foo/'
@@ -155,7 +154,7 @@ test('token scoped logout', async (t) => {
   })
 })
 
-test('user/pass logout', async (t) => {
+t.test('user/pass logout', async (t) => {
   t.plan(3)
 
   _flatOptions.username = 'foo'
@@ -188,7 +187,7 @@ test('user/pass logout', async (t) => {
   })
 })
 
-test('missing credentials', (t) => {
+t.test('missing credentials', (t) => {
   logout([], (err) => {
     t.match(
       err.message,
@@ -200,7 +199,7 @@ test('missing credentials', (t) => {
   })
 })
 
-test('ignore invalid scoped registry config', async (t) => {
+t.test('ignore invalid scoped registry config', async (t) => {
   t.plan(5)
 
   _flatOptions.token = '@foo/'

--- a/test/lib/ls.js
+++ b/test/lib/ls.js
@@ -1,7 +1,6 @@
 const { resolve } = require('path')
 
 const t = require('tap')
-const requireInject = require('require-inject')
 
 t.cleanSnapshot = str => str.split(/\r\n/).join('\n')
 
@@ -100,24 +99,25 @@ const _flatOptions = {
   },
   production: false,
 }
-const ls = requireInject('../../lib/ls.js', {
-  '../../lib/npm.js': {
-    flatOptions: _flatOptions,
-    limit: {
-      fetch: 3,
-    },
-    get prefix () {
-      return _flatOptions.prefix
-    },
-    get globalDir () {
-      return globalDir
-    },
-    config: {
-      get (key) {
-        return _flatOptions[key]
-      },
+const npm = {
+  flatOptions: _flatOptions,
+  limit: {
+    fetch: 3,
+  },
+  get prefix () {
+    return _flatOptions.prefix
+  },
+  get globalDir () {
+    return globalDir
+  },
+  config: {
+    get (key) {
+      return _flatOptions[key]
     },
   },
+}
+const ls = t.mock('../../lib/ls.js', {
+  '../../lib/npm.js': npm,
   '../../lib/utils/output.js': msg => {
     result = msg
   },

--- a/test/lib/org.js
+++ b/test/lib/org.js
@@ -1,5 +1,4 @@
-const { test } = require('tap')
-const requireInject = require('require-inject')
+const t = require('tap')
 const ansiTrim = require('../../lib/utils/ansi-trim.js')
 
 const npm = {
@@ -39,7 +38,7 @@ const libnpmorg = {
   },
 }
 
-const org = requireInject('../../lib/org.js', {
+const org = t.mock('../../lib/org.js', {
   '../../lib/npm.js': npm,
   '../../lib/utils/otplease.js': async (opts, fn) => fn(opts),
   '../../lib/utils/output.js': (msg) => {
@@ -48,7 +47,7 @@ const org = requireInject('../../lib/org.js', {
   libnpmorg,
 })
 
-test('completion', async t => {
+t.test('completion', async t => {
   const completion = (argv) => new Promise((resolve, reject) => {
     org.completion({ conf: { argv: { remain: argv } } }, (err, res) => {
       if (err)
@@ -71,14 +70,14 @@ test('completion', async t => {
   t.rejects(completion(['npm', 'org', 'flurb']), /flurb not recognized/, 'errors for unknown subcommand')
 })
 
-test('npm org - invalid subcommand', t => {
+t.test('npm org - invalid subcommand', t => {
   return org(['foo'], (err) => {
     t.match(err, /npm org set/, 'prints usage information')
     t.end()
   })
 })
 
-test('npm org add', t => {
+t.test('npm org add', t => {
   t.teardown(() => {
     orgSetArgs = null
     output.length = 0
@@ -99,7 +98,7 @@ test('npm org add', t => {
   })
 })
 
-test('npm org add - no org', t => {
+t.test('npm org add - no org', t => {
   t.teardown(() => {
     orgSetArgs = null
     output.length = 0
@@ -111,7 +110,7 @@ test('npm org add - no org', t => {
   })
 })
 
-test('npm org add - no user', t => {
+t.test('npm org add - no user', t => {
   t.teardown(() => {
     orgSetArgs = null
     output.length = 0
@@ -123,7 +122,7 @@ test('npm org add - no user', t => {
   })
 })
 
-test('npm org add - invalid role', t => {
+t.test('npm org add - invalid role', t => {
   t.teardown(() => {
     orgSetArgs = null
     output.length = 0
@@ -135,7 +134,7 @@ test('npm org add - invalid role', t => {
   })
 })
 
-test('npm org add - more users', t => {
+t.test('npm org add - more users', t => {
   orgSize = 5
   t.teardown(() => {
     orgSize = 1
@@ -158,7 +157,7 @@ test('npm org add - more users', t => {
   })
 })
 
-test('npm org add - json output', t => {
+t.test('npm org add - json output', t => {
   npm.flatOptions.json = true
   t.teardown(() => {
     npm.flatOptions.json = false
@@ -188,7 +187,7 @@ test('npm org add - json output', t => {
   })
 })
 
-test('npm org add - parseable output', t => {
+t.test('npm org add - parseable output', t => {
   npm.flatOptions.parseable = true
   t.teardown(() => {
     npm.flatOptions.parseable = false
@@ -214,7 +213,7 @@ test('npm org add - parseable output', t => {
   })
 })
 
-test('npm org add - silent output', t => {
+t.test('npm org add - silent output', t => {
   npm.flatOptions.silent = true
   t.teardown(() => {
     npm.flatOptions.silent = false
@@ -237,7 +236,7 @@ test('npm org add - silent output', t => {
   })
 })
 
-test('npm org rm', t => {
+t.test('npm org rm', t => {
   t.teardown(() => {
     orgRmArgs = null
     orgLsArgs = null
@@ -262,7 +261,7 @@ test('npm org rm', t => {
   })
 })
 
-test('npm org rm - no org', t => {
+t.test('npm org rm - no org', t => {
   t.teardown(() => {
     orgRmArgs = null
     orgLsArgs = null
@@ -275,7 +274,7 @@ test('npm org rm - no org', t => {
   })
 })
 
-test('npm org rm - no user', t => {
+t.test('npm org rm - no user', t => {
   t.teardown(() => {
     orgRmArgs = null
     orgLsArgs = null
@@ -288,7 +287,7 @@ test('npm org rm - no user', t => {
   })
 })
 
-test('npm org rm - one user left', t => {
+t.test('npm org rm - one user left', t => {
   orgList = {
     one: 'developer',
   }
@@ -318,7 +317,7 @@ test('npm org rm - one user left', t => {
   })
 })
 
-test('npm org rm - json output', t => {
+t.test('npm org rm - json output', t => {
   npm.flatOptions.json = true
   t.teardown(() => {
     npm.flatOptions.json = false
@@ -350,7 +349,7 @@ test('npm org rm - json output', t => {
   })
 })
 
-test('npm org rm - parseable output', t => {
+t.test('npm org rm - parseable output', t => {
   npm.flatOptions.parseable = true
   t.teardown(() => {
     npm.flatOptions.parseable = false
@@ -380,7 +379,7 @@ test('npm org rm - parseable output', t => {
   })
 })
 
-test('npm org rm - silent output', t => {
+t.test('npm org rm - silent output', t => {
   npm.flatOptions.silent = true
   t.teardown(() => {
     npm.flatOptions.silent = false
@@ -407,7 +406,7 @@ test('npm org rm - silent output', t => {
   })
 })
 
-test('npm org ls', t => {
+t.test('npm org ls', t => {
   orgList = {
     one: 'developer',
     two: 'admin',
@@ -435,7 +434,7 @@ test('npm org ls', t => {
   })
 })
 
-test('npm org ls - user filter', t => {
+t.test('npm org ls - user filter', t => {
   orgList = {
     username: 'admin',
     missing: 'admin',
@@ -461,7 +460,7 @@ test('npm org ls - user filter', t => {
   })
 })
 
-test('npm org ls - user filter, missing user', t => {
+t.test('npm org ls - user filter, missing user', t => {
   orgList = {
     missing: 'admin',
   }
@@ -486,7 +485,7 @@ test('npm org ls - user filter, missing user', t => {
   })
 })
 
-test('npm org ls - no org', t => {
+t.test('npm org ls - no org', t => {
   t.teardown(() => {
     orgLsArgs = null
     output.length = 0
@@ -498,7 +497,7 @@ test('npm org ls - no org', t => {
   })
 })
 
-test('npm org ls - json output', t => {
+t.test('npm org ls - json output', t => {
   npm.flatOptions.json = true
   orgList = {
     one: 'developer',
@@ -525,7 +524,7 @@ test('npm org ls - json output', t => {
   })
 })
 
-test('npm org ls - parseable output', t => {
+t.test('npm org ls - parseable output', t => {
   npm.flatOptions.parseable = true
   orgList = {
     one: 'developer',
@@ -557,7 +556,7 @@ test('npm org ls - parseable output', t => {
   })
 })
 
-test('npm org ls - silent output', t => {
+t.test('npm org ls - silent output', t => {
   npm.flatOptions.silent = true
   orgList = {
     one: 'developer',

--- a/test/lib/outdated.js
+++ b/test/lib/outdated.js
@@ -1,5 +1,4 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 
 const packument = spec => {
   const mocks = {
@@ -92,7 +91,7 @@ const globalDir = t.testdir({
   },
 })
 
-const outdated = (dir, opts) => requireInject(
+const outdated = (dir, opts) => t.mock(
   '../../lib/outdated.js',
   {
     '../../lib/npm.js': {

--- a/test/lib/owner.js
+++ b/test/lib/owner.js
@@ -1,4 +1,3 @@
-const requireInject = require('require-inject')
 const t = require('tap')
 
 let result = ''
@@ -31,7 +30,7 @@ const npmcliMaintainers = [
   { email: 'i@izs.me', name: 'isaacs' },
 ]
 
-const owner = requireInject('../../lib/owner.js', mocks)
+const owner = t.mock('../../lib/owner.js', mocks)
 
 t.test('owner no args', t => {
   result = ''

--- a/test/lib/pack.js
+++ b/test/lib/pack.js
@@ -1,5 +1,4 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 
 const OUTPUT = []
 const output = (...msg) => OUTPUT.push(msg)
@@ -17,7 +16,7 @@ t.afterEach(cb => {
 })
 
 t.test('should pack current directory with no arguments', (t) => {
-  const pack = requireInject('../../lib/pack.js', {
+  const pack = t.mock('../../lib/pack.js', {
     '../../lib/utils/output.js': output,
     '../../lib/npm.js': {
       flatOptions: {
@@ -51,7 +50,7 @@ t.test('should pack given directory', (t) => {
     }, null, 2),
   })
 
-  const pack = requireInject('../../lib/pack.js', {
+  const pack = t.mock('../../lib/pack.js', {
     '../../lib/utils/output.js': output,
     '../../lib/npm.js': {
       flatOptions: {
@@ -85,7 +84,7 @@ t.test('should pack given directory for scoped package', (t) => {
     }, null, 2),
   })
 
-  const pack = requireInject('../../lib/pack.js', {
+  const pack = t.mock('../../lib/pack.js', {
     '../../lib/utils/output.js': output,
     '../../lib/npm.js': {
       flatOptions: {
@@ -112,7 +111,7 @@ t.test('should pack given directory for scoped package', (t) => {
 })
 
 t.test('should log pack contents', (t) => {
-  const pack = requireInject('../../lib/pack.js', {
+  const pack = t.mock('../../lib/pack.js', {
     '../../lib/utils/output.js': output,
     '../../lib/utils/tar.js': {
       ...require('../../lib/utils/tar.js'),

--- a/test/lib/ping.js
+++ b/test/lib/ping.js
@@ -1,12 +1,11 @@
-const { test } = require('tap')
-const requireInject = require('require-inject')
+const t = require('tap')
 
-test('pings', (t) => {
+t.test('pings', (t) => {
   t.plan(8)
 
   const flatOptions = { registry: 'https://registry.npmjs.org' }
   let noticeCalls = 0
-  const ping = requireInject('../../lib/ping.js', {
+  const ping = t.mock('../../lib/ping.js', {
     '../../lib/npm.js': { flatOptions },
     '../../lib/utils/ping.js': function (spec) {
       t.equal(spec, flatOptions, 'passes flatOptions')
@@ -33,13 +32,13 @@ test('pings', (t) => {
   })
 })
 
-test('pings and logs details', (t) => {
+t.test('pings and logs details', (t) => {
   t.plan(10)
 
   const flatOptions = { registry: 'https://registry.npmjs.org' }
   const details = { extra: 'data' }
   let noticeCalls = 0
-  const ping = requireInject('../../lib/ping.js', {
+  const ping = t.mock('../../lib/ping.js', {
     '../../lib/npm.js': { flatOptions },
     '../../lib/utils/ping.js': function (spec) {
       t.equal(spec, flatOptions, 'passes flatOptions')
@@ -70,13 +69,13 @@ test('pings and logs details', (t) => {
   })
 })
 
-test('pings and returns json', (t) => {
+t.test('pings and returns json', (t) => {
   t.plan(11)
 
   const flatOptions = { registry: 'https://registry.npmjs.org', json: true }
   const details = { extra: 'data' }
   let noticeCalls = 0
-  const ping = requireInject('../../lib/ping.js', {
+  const ping = t.mock('../../lib/ping.js', {
     '../../lib/npm.js': { flatOptions },
     '../../lib/utils/ping.js': function (spec) {
       t.equal(spec, flatOptions, 'passes flatOptions')

--- a/test/lib/prefix.js
+++ b/test/lib/prefix.js
@@ -1,11 +1,10 @@
-const { test } = require('tap')
-const requireInject = require('require-inject')
+const t = require('tap')
 
-test('prefix', (t) => {
+t.test('prefix', (t) => {
   t.plan(3)
   const dir = '/prefix/dir'
 
-  const prefix = requireInject('../../lib/prefix.js', {
+  const prefix = t.mock('../../lib/prefix.js', {
     '../../lib/npm.js': { prefix: dir },
     '../../lib/utils/output.js': (output) => {
       t.equal(output, dir, 'prints the correct directory')

--- a/test/lib/prune.js
+++ b/test/lib/prune.js
@@ -1,8 +1,7 @@
-const { test } = require('tap')
-const requireInject = require('require-inject')
+const t = require('tap')
 
-test('should prune using Arborist', (t) => {
-  const prune = requireInject('../../lib/prune.js', {
+t.test('should prune using Arborist', (t) => {
+  const prune = t.mock('../../lib/prune.js', {
     '../../lib/npm.js': {
       prefix: 'foo',
       flatOptions: {

--- a/test/lib/publish.js
+++ b/test/lib/publish.js
@@ -1,5 +1,4 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 
 // mock config
 const {defaults} = require('../../lib/utils/config.js')
@@ -18,7 +17,7 @@ t.test('should publish with libnpmpublish, respecting publishConfig', (t) => {
     }, null, 2),
   })
 
-  const publish = requireInject('../../lib/publish.js', {
+  const publish = t.mock('../../lib/publish.js', {
     '../../lib/npm.js': {
       flatOptions: {
         json: true,
@@ -72,7 +71,7 @@ t.test('re-loads publishConfig if added during script process', (t) => {
     }, null, 2),
   })
 
-  const publish = requireInject('../../lib/publish.js', {
+  const publish = t.mock('../../lib/publish.js', {
     '../../lib/npm.js': {
       flatOptions: {
         json: true,
@@ -125,7 +124,7 @@ t.test('should not log if silent', (t) => {
     }, null, 2),
   })
 
-  const publish = requireInject('../../lib/publish.js', {
+  const publish = t.mock('../../lib/publish.js', {
     '../../lib/npm.js': {
       flatOptions: {
         json: false,
@@ -175,7 +174,7 @@ t.test('should log tarball contents', (t) => {
     }, null, 2),
   })
 
-  const publish = requireInject('../../lib/publish.js', {
+  const publish = t.mock('../../lib/publish.js', {
     '../../lib/npm.js': {
       flatOptions: {
         json: false,
@@ -215,7 +214,7 @@ t.test('should log tarball contents', (t) => {
 
 t.test('shows usage with wrong set of arguments', (t) => {
   t.plan(1)
-  const publish = requireInject('../../lib/publish.js', {
+  const publish = t.mock('../../lib/publish.js', {
     '../../lib/npm.js': {
       flatOptions: {
         json: false,
@@ -230,7 +229,7 @@ t.test('shows usage with wrong set of arguments', (t) => {
 
 t.test('throws when invalid tag', (t) => {
   t.plan(1)
-  const publish = requireInject('../../lib/publish.js', {
+  const publish = t.mock('../../lib/publish.js', {
     '../../lib/npm.js': {
       flatOptions: {
         json: false,
@@ -269,7 +268,7 @@ t.test('can publish a tarball', t => {
   fs.rmdirSync(`${testDir}/package`)
 
   const tarFile = fs.readFileSync(`${testDir}/package.tgz`)
-  const publish = requireInject('../../lib/publish.js', {
+  const publish = t.mock('../../lib/publish.js', {
     '../../lib/npm.js': {
       flatOptions: {
         json: true,

--- a/test/lib/rebuild.js
+++ b/test/lib/rebuild.js
@@ -1,7 +1,6 @@
 const fs = require('fs')
 const { resolve } = require('path')
 const t = require('tap')
-const requireInject = require('require-inject')
 
 let result = ''
 
@@ -20,7 +19,7 @@ const mocks = {
   '../../lib/utils/usage.js': () => 'usage instructions',
 }
 
-const rebuild = requireInject('../../lib/rebuild.js', mocks)
+const rebuild = t.mock('../../lib/rebuild.js', mocks)
 
 t.afterEach(cb => {
   npm.prefix = ''

--- a/test/lib/repo.js
+++ b/test/lib/repo.js
@@ -1,6 +1,5 @@
 const t = require('tap')
 
-const requireInject = require('require-inject')
 const pacote = {
   manifest: async (spec, options) => {
     return spec === 'norepo' ? {
@@ -114,7 +113,7 @@ const openUrl = (url, errMsg, cb) => {
   process.nextTick(cb)
 }
 
-const repo = requireInject('../../lib/repo.js', {
+const repo = t.mock('../../lib/repo.js', {
   pacote,
   '../../lib/utils/open-url.js': openUrl,
 })

--- a/test/lib/root.js
+++ b/test/lib/root.js
@@ -1,11 +1,10 @@
-const { test } = require('tap')
-const requireInject = require('require-inject')
+const t = require('tap')
 
-test('root', (t) => {
+t.test('root', (t) => {
   t.plan(3)
   const dir = '/root/dir'
 
-  const root = requireInject('../../lib/root.js', {
+  const root = t.mock('../../lib/root.js', {
     '../../lib/npm.js': { dir },
     '../../lib/utils/output.js': (output) => {
       t.equal(output, dir, 'prints the correct directory')

--- a/test/lib/run-script.js
+++ b/test/lib/run-script.js
@@ -1,5 +1,4 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 
 const RUN_SCRIPTS = []
 const npm = {
@@ -23,7 +22,7 @@ const npm = {
 const output = []
 
 const npmlog = { level: 'warn' }
-const getRS = windows => requireInject('../../lib/run-script.js', {
+const getRS = windows => t.mock('../../lib/run-script.js', {
   '@npmcli/run-script': Object.assign(async opts => {
     RUN_SCRIPTS.push(opts)
   }, {

--- a/test/lib/search.js
+++ b/test/lib/search.js
@@ -1,6 +1,5 @@
 const Minipass = require('minipass')
 const t = require('tap')
-const requireInject = require('require-inject')
 const libnpmsearchResultFixture =
   require('../fixtures/libnpmsearch-stream-result.js')
 
@@ -37,7 +36,7 @@ t.afterEach(cb => {
   cb()
 })
 
-const search = requireInject('../../lib/search.js', mocks)
+const search = t.mock('../../lib/search.js', mocks)
 
 t.test('no args', t => {
   search([], err => {
@@ -59,7 +58,7 @@ t.test('search <name>', t => {
     },
   }
 
-  const search = requireInject('../../lib/search.js', {
+  const search = t.mock('../../lib/search.js', {
     ...mocks,
     libnpmsearch,
   })
@@ -93,7 +92,7 @@ t.test('search <name> --searchexclude --searchopts', t => {
     },
   }
 
-  const search = requireInject('../../lib/search.js', {
+  const search = t.mock('../../lib/search.js', {
     ...mocks,
     libnpmsearch,
   })
@@ -146,7 +145,7 @@ t.test('empty search results', t => {
     },
   }
 
-  const search = requireInject('../../lib/search.js', {
+  const search = t.mock('../../lib/search.js', {
     ...mocks,
     libnpmsearch,
   })
@@ -172,7 +171,7 @@ t.test('search api response error', t => {
     },
   }
 
-  const search = requireInject('../../lib/search.js', {
+  const search = t.mock('../../lib/search.js', {
     ...mocks,
     libnpmsearch,
   })

--- a/test/lib/set-script.js
+++ b/test/lib/set-script.js
@@ -1,13 +1,12 @@
-const test = require('tap')
-const requireInject = require('require-inject')
+const t = require('tap')
 const setScriptDefault = require('../../lib/set-script.js')
 const parseJSON = require('json-parse-even-better-errors')
 
-test.type(setScriptDefault, 'function', 'command is function')
-test.equal(setScriptDefault.completion, require('../../lib/utils/completion/none.js'), 'empty completion')
-test.equal(setScriptDefault.usage, 'npm set-script [<script>] [<command>]', 'usage matches')
-test.test('fails on invalid arguments', (t) => {
-  const setScript = requireInject('../../lib/set-script.js', {
+t.type(setScriptDefault, 'function', 'command is function')
+t.equal(setScriptDefault.completion, require('../../lib/utils/completion/none.js'), 'empty completion')
+t.equal(setScriptDefault.usage, 'npm set-script [<script>] [<command>]', 'usage matches')
+t.test('fails on invalid arguments', (t) => {
+  const setScript = t.mock('../../lib/set-script.js', {
     fs: {},
     npmlog: {},
   })
@@ -16,10 +15,10 @@ test.test('fails on invalid arguments', (t) => {
   setScript(['arg1', 'arg2', 'arg3'], (fail) => t.match(fail, /Expected 2 arguments: got 3/))
   setScript(['arg1', 'arg2', 'arg3', 'arg4'], (fail) => t.match(fail, /Expected 2 arguments: got 4/))
 })
-test.test('fails if run in postinstall script', (t) => {
+t.test('fails if run in postinstall script', (t) => {
   var originalVar = process.env.npm_lifecycle_event
   process.env.npm_lifecycle_event = 'postinstall'
-  const setScript = requireInject('../../lib/set-script.js', {
+  const setScript = t.mock('../../lib/set-script.js', {
     fs: {},
     npmlog: {},
   })
@@ -27,8 +26,8 @@ test.test('fails if run in postinstall script', (t) => {
   setScript(['arg1', 'arg2'], (fail) => t.equal(fail.toString(), 'Error: Scripts can’t set from the postinstall script'))
   process.env.npm_lifecycle_event = originalVar
 })
-test.test('fails when package.json not found', (t) => {
-  const setScript = requireInject('../../lib/set-script.js', {
+t.test('fails when package.json not found', (t) => {
+  const setScript = t.mock('../../lib/set-script.js', {
     '../../lib/npm.js': {
       localPrefix: 'IDONTEXIST',
     },
@@ -36,8 +35,8 @@ test.test('fails when package.json not found', (t) => {
   t.plan(1)
   setScript(['arg1', 'arg2'], (fail) => t.match(fail, /package.json not found/))
 })
-test.test('fails on invalid JSON', (t) => {
-  const setScript = requireInject('../../lib/set-script.js', {
+t.test('fails on invalid JSON', (t) => {
+  const setScript = t.mock('../../lib/set-script.js', {
     fs: {
       readFileSync: (name, charcode) => {
         return 'iamnotjson'
@@ -47,9 +46,9 @@ test.test('fails on invalid JSON', (t) => {
   t.plan(1)
   setScript(['arg1', 'arg2'], (fail) => t.match(fail, /Invalid package.json: JSONParseError/))
 })
-test.test('creates scripts object', (t) => {
+t.test('creates scripts object', (t) => {
   var mockFile = ''
-  const setScript = requireInject('../../lib/set-script.js', {
+  const setScript = t.mock('../../lib/set-script.js', {
     fs: {
       readFileSync: (name, charcode) => {
         return '{}'
@@ -71,9 +70,9 @@ test.test('creates scripts object', (t) => {
     t.assert(parseJSON(mockFile), {scripts: {arg1: 'arg2'}})
   })
 })
-test.test('warns before overwriting', (t) => {
+t.test('warns before overwriting', (t) => {
   var warningListened = ''
-  const setScript = requireInject('../../lib/set-script.js', {
+  const setScript = t.mock('../../lib/set-script.js', {
     fs: {
       readFileSync: (name, charcode) => {
         return JSON.stringify({
@@ -102,9 +101,9 @@ test.test('warns before overwriting', (t) => {
     t.equal(warningListened, 'Script "arg1" was overwritten')
   })
 })
-test.test('provided indentation and eol is used', (t) => {
+t.test('provided indentation and eol is used', (t) => {
   var mockFile = ''
-  const setScript = requireInject('../../lib/set-script.js', {
+  const setScript = t.mock('../../lib/set-script.js', {
     fs: {
       readFileSync: (name, charcode) => {
         return '{}'
@@ -127,9 +126,9 @@ test.test('provided indentation and eol is used', (t) => {
     t.equal(mockFile.split('\r\n').every((value) => !value.startsWith(' ') || value.startsWith(' '.repeat(6))), true)
   })
 })
-test.test('goes to default when undefined indent and eol provided', (t) => {
+t.test('goes to default when undefined indent and eol provided', (t) => {
   var mockFile = ''
-  const setScript = requireInject('../../lib/set-script.js', {
+  const setScript = t.mock('../../lib/set-script.js', {
     fs: {
       readFileSync: (name, charcode) => {
         return '{}'

--- a/test/lib/set.js
+++ b/test/lib/set.js
@@ -1,5 +1,4 @@
-const { test } = require('tap')
-const requireInject = require('require-inject')
+const t = require('tap')
 
 let configArgs = null
 const npm = {
@@ -11,18 +10,18 @@ const npm = {
   },
 }
 
-const set = requireInject('../../lib/set.js', {
+const set = t.mock('../../lib/set.js', {
   '../../lib/npm.js': npm,
 })
 
-test('npm set - no args', t => {
+t.test('npm set - no args', t => {
   return set([], (err) => {
     t.match(err, /npm set/, 'prints usage')
     t.end()
   })
 })
 
-test('npm set', t => {
+t.test('npm set', t => {
   return set(['email', 'me@me.me'], (err) => {
     if (err)
       throw err

--- a/test/lib/shrinkwrap.js
+++ b/test/lib/shrinkwrap.js
@@ -1,5 +1,4 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 
 const npm = {
   lockfileVersion: 2,
@@ -79,7 +78,7 @@ t.test('no args', t => {
     },
   }
 
-  const shrinkwrap = requireInject('../../lib/shrinkwrap.js', {
+  const shrinkwrap = t.mock('../../lib/shrinkwrap.js', {
     ...mocks,
     npmlog,
     '@npmcli/arborist': Arborist,
@@ -133,7 +132,7 @@ t.test('no virtual tree', t => {
     },
   }
 
-  const shrinkwrap = requireInject('../../lib/shrinkwrap.js', {
+  const shrinkwrap = t.mock('../../lib/shrinkwrap.js', {
     ...mocks,
     npmlog,
     '@npmcli/arborist': Arborist,
@@ -193,7 +192,7 @@ t.test('existing package-json file', t => {
     },
   }
 
-  const shrinkwrap = requireInject('../../lib/shrinkwrap.js', {
+  const shrinkwrap = t.mock('../../lib/shrinkwrap.js', {
     ...mocks,
     fs,
     npmlog,
@@ -247,7 +246,7 @@ t.test('update shrinkwrap file version', t => {
     },
   }
 
-  const shrinkwrap = requireInject('../../lib/shrinkwrap.js', {
+  const shrinkwrap = t.mock('../../lib/shrinkwrap.js', {
     ...mocks,
     npmlog,
     '@npmcli/arborist': Arborist,
@@ -300,7 +299,7 @@ t.test('update to date shrinkwrap file', t => {
     },
   }
 
-  const shrinkwrap = requireInject('../../lib/shrinkwrap.js', {
+  const shrinkwrap = t.mock('../../lib/shrinkwrap.js', {
     ...mocks,
     npmlog,
     '@npmcli/arborist': Arborist,
@@ -313,7 +312,7 @@ t.test('update to date shrinkwrap file', t => {
 })
 
 t.test('shrinkwrap --global', t => {
-  const shrinkwrap = requireInject('../../lib/shrinkwrap.js', mocks)
+  const shrinkwrap = t.mock('../../lib/shrinkwrap.js', mocks)
 
   npm.flatOptions.global = true
 

--- a/test/lib/star.js
+++ b/test/lib/star.js
@@ -1,4 +1,3 @@
-const requireInject = require('require-inject')
 const t = require('tap')
 
 let result = ''
@@ -18,7 +17,7 @@ const mocks = {
   '../../lib/utils/usage.js': () => 'usage instructions',
 }
 
-const star = requireInject('../../lib/star.js', mocks)
+const star = t.mock('../../lib/star.js', mocks)
 
 t.afterEach(cb => {
   npm.config = { get () {} }
@@ -129,7 +128,7 @@ t.test('unicode', async t => {
 })
 
 t.test('logged out user', t => {
-  const star = requireInject('../../lib/star.js', {
+  const star = t.mock('../../lib/star.js', {
     ...mocks,
     '../../lib/utils/get-identity.js': async () => undefined,
   })

--- a/test/lib/stars.js
+++ b/test/lib/stars.js
@@ -1,4 +1,3 @@
-const requireInject = require('require-inject')
 const t = require('tap')
 
 let result = ''
@@ -18,7 +17,7 @@ const mocks = {
   '../../lib/utils/usage.js': () => 'usage instructions',
 }
 
-const stars = requireInject('../../lib/stars.js', mocks)
+const stars = t.mock('../../lib/stars.js', mocks)
 
 t.afterEach(cb => {
   npm.config = { get () {} }

--- a/test/lib/team.js
+++ b/test/lib/team.js
@@ -1,5 +1,4 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 
 let result = ''
 const libnpmteam = {
@@ -28,7 +27,7 @@ t.afterEach(cb => {
   cb()
 })
 
-const team = requireInject('../../lib/team.js', mocks)
+const team = t.mock('../../lib/team.js', mocks)
 
 t.test('no args', t => {
   team([], err => {
@@ -230,7 +229,7 @@ t.test('team ls <scope>', t => {
     },
   }
 
-  const team = requireInject('../../lib/team.js', {
+  const team = t.mock('../../lib/team.js', {
     ...mocks,
     libnpmteam,
   })
@@ -296,7 +295,7 @@ t.test('team ls <scope>', t => {
       },
     }
 
-    const team = requireInject('../../lib/team.js', {
+    const team = t.mock('../../lib/team.js', {
       ...mocks,
       libnpmteam,
     })
@@ -317,7 +316,7 @@ t.test('team ls <scope>', t => {
       },
     }
 
-    const team = requireInject('../../lib/team.js', {
+    const team = t.mock('../../lib/team.js', {
       ...mocks,
       libnpmteam,
     })
@@ -340,7 +339,7 @@ t.test('team ls <scope:team>', t => {
       return ['nlf', 'ruyadorno', 'darcyclarke', 'isaacs']
     },
   }
-  const team = requireInject('../../lib/team.js', {
+  const team = t.mock('../../lib/team.js', {
     ...mocks,
     libnpmteam,
   })
@@ -407,7 +406,7 @@ t.test('team ls <scope:team>', t => {
       },
     }
 
-    const team = requireInject('../../lib/team.js', {
+    const team = t.mock('../../lib/team.js', {
       ...mocks,
       libnpmteam,
     })
@@ -428,7 +427,7 @@ t.test('team ls <scope:team>', t => {
       },
     }
 
-    const team = requireInject('../../lib/team.js', {
+    const team = t.mock('../../lib/team.js', {
       ...mocks,
       libnpmteam,
     })

--- a/test/lib/test.js
+++ b/test/lib/test.js
@@ -1,5 +1,4 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 let RUN_ARGS = null
 const npmock = {
   commands: {
@@ -9,7 +8,7 @@ const npmock = {
     },
   },
 }
-const test = requireInject('../../lib/test.js', {
+const test = t.mock('../../lib/test.js', {
   '../../lib/npm.js': npmock,
 })
 

--- a/test/lib/token.js
+++ b/test/lib/token.js
@@ -1,5 +1,4 @@
-const { test } = require('tap')
-const requireInject = require('require-inject')
+const t = require('tap')
 
 const mocks = {
   npm: {},
@@ -9,7 +8,7 @@ const mocks = {
   readUserInfo: {},
 }
 
-const tokenMock = requireInject('../../lib/token.js', {
+const tokenMock = t.mock('../../lib/token.js', {
   '../../lib/npm.js': mocks.npm,
   '../../lib/utils/output.js': (...args) => mocks.output(...args),
   '../../lib/utils/otplease.js': (opts, fn) => {
@@ -44,7 +43,7 @@ const tokenWithMocks = (mockRequests) => {
   return [tokenMock, reset]
 }
 
-test('completion', (t) => {
+t.test('completion', (t) => {
   t.plan(5)
 
   const testComp = (argv, expect) => {
@@ -71,7 +70,7 @@ test('completion', (t) => {
   })
 })
 
-test('token foobar', (t) => {
+t.test('token foobar', (t) => {
   t.plan(2)
 
   const [, reset] = tokenWithMocks({
@@ -91,7 +90,7 @@ test('token foobar', (t) => {
   })
 })
 
-test('token list', (t) => {
+t.test('token list', (t) => {
   t.plan(15)
 
   const now = new Date().toISOString()
@@ -159,7 +158,7 @@ test('token list', (t) => {
   })
 })
 
-test('token list json output', (t) => {
+t.test('token list json output', (t) => {
   t.plan(8)
 
   const now = new Date().toISOString()
@@ -213,7 +212,7 @@ test('token list json output', (t) => {
   })
 })
 
-test('token list parseable output', (t) => {
+t.test('token list parseable output', (t) => {
   t.plan(12)
 
   const now = new Date().toISOString()
@@ -281,7 +280,7 @@ test('token list parseable output', (t) => {
   })
 })
 
-test('token revoke', (t) => {
+t.test('token revoke', (t) => {
   t.plan(10)
 
   const [token, reset] = tokenWithMocks({
@@ -334,7 +333,7 @@ test('token revoke', (t) => {
   })
 })
 
-test('token revoke multiple tokens', (t) => {
+t.test('token revoke multiple tokens', (t) => {
   t.plan(10)
 
   const [token, reset] = tokenWithMocks({
@@ -386,7 +385,7 @@ test('token revoke multiple tokens', (t) => {
   })
 })
 
-test('token revoke json output', (t) => {
+t.test('token revoke json output', (t) => {
   t.plan(10)
 
   const [token, reset] = tokenWithMocks({
@@ -438,7 +437,7 @@ test('token revoke json output', (t) => {
   })
 })
 
-test('token revoke parseable output', (t) => {
+t.test('token revoke parseable output', (t) => {
   t.plan(9)
 
   const [token, reset] = tokenWithMocks({
@@ -488,7 +487,7 @@ test('token revoke parseable output', (t) => {
   })
 })
 
-test('token revoke by token', (t) => {
+t.test('token revoke by token', (t) => {
   t.plan(9)
 
   const [token, reset] = tokenWithMocks({
@@ -538,7 +537,7 @@ test('token revoke by token', (t) => {
   })
 })
 
-test('token revoke requires an id', (t) => {
+t.test('token revoke requires an id', (t) => {
   t.plan(2)
 
   const [token, reset] = tokenWithMocks({
@@ -558,7 +557,7 @@ test('token revoke requires an id', (t) => {
   })
 })
 
-test('token revoke ambiguous id errors', (t) => {
+t.test('token revoke ambiguous id errors', (t) => {
   t.plan(7)
 
   const [token, reset] = tokenWithMocks({
@@ -603,7 +602,7 @@ test('token revoke ambiguous id errors', (t) => {
   })
 })
 
-test('token revoke unknown id errors', (t) => {
+t.test('token revoke unknown id errors', (t) => {
   t.plan(7)
 
   const [token, reset] = tokenWithMocks({
@@ -647,7 +646,7 @@ test('token revoke unknown id errors', (t) => {
   })
 })
 
-test('token create', (t) => {
+t.test('token create', (t) => {
   t.plan(15)
 
   const now = new Date().toISOString()
@@ -711,7 +710,7 @@ test('token create', (t) => {
   })
 })
 
-test('token create json output', (t) => {
+t.test('token create json output', (t) => {
   t.plan(10)
 
   const now = new Date().toISOString()
@@ -770,7 +769,7 @@ test('token create json output', (t) => {
   })
 })
 
-test('token create parseable output', (t) => {
+t.test('token create parseable output', (t) => {
   t.plan(12)
 
   const now = new Date().toISOString()
@@ -836,7 +835,7 @@ test('token create parseable output', (t) => {
   })
 })
 
-test('token create ipv6 cidr', (t) => {
+t.test('token create ipv6 cidr', (t) => {
   t.plan(4)
 
   const password = 'thisisnotreallyapassword'
@@ -871,7 +870,7 @@ test('token create ipv6 cidr', (t) => {
   })
 })
 
-test('token create invalid cidr', (t) => {
+t.test('token create invalid cidr', (t) => {
   t.plan(4)
 
   const password = 'thisisnotreallyapassword'

--- a/test/lib/uninstall.js
+++ b/test/lib/uninstall.js
@@ -1,7 +1,6 @@
 const fs = require('fs')
 const { resolve } = require('path')
 const t = require('tap')
-const requireInject = require('require-inject')
 
 const npm = {
   globalDir: '',
@@ -17,7 +16,7 @@ const mocks = {
   '../../lib/utils/usage.js': () => 'usage instructions',
 }
 
-const uninstall = requireInject('../../lib/uninstall.js', mocks)
+const uninstall = t.mock('../../lib/uninstall.js', mocks)
 
 t.afterEach(cb => {
   npm.globalDir = ''
@@ -232,7 +231,7 @@ t.test('no args global but no package.json', t => {
 t.test('unknown error reading from localPrefix package.json', t => {
   const path = t.testdir({})
 
-  const uninstall = requireInject('../../lib/uninstall.js', {
+  const uninstall = t.mock('../../lib/uninstall.js', {
     ...mocks,
     'read-package-json-fast': () => Promise.reject(new Error('ERR')),
   })

--- a/test/lib/unpublish.js
+++ b/test/lib/unpublish.js
@@ -1,5 +1,4 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 
 let result = ''
 const noop = () => null
@@ -78,7 +77,7 @@ t.test('no args --force', t => {
     },
   }
 
-  const unpublish = requireInject('../../lib/unpublish.js', {
+  const unpublish = t.mock('../../lib/unpublish.js', {
     ...mocks,
     npmlog,
     libnpmpublish,
@@ -104,7 +103,7 @@ t.test('no args --force', t => {
 t.test('no args --force missing package.json', t => {
   npm.flatOptions.force = true
 
-  const unpublish = requireInject('../../lib/unpublish.js', {
+  const unpublish = t.mock('../../lib/unpublish.js', {
     ...mocks,
     'read-package-json': (path, cb) => cb(Object.assign(
       new Error('ENOENT'),
@@ -125,7 +124,7 @@ t.test('no args --force missing package.json', t => {
 t.test('no args --force unknown error reading package.json', t => {
   npm.flatOptions.force = true
 
-  const unpublish = requireInject('../../lib/unpublish.js', {
+  const unpublish = t.mock('../../lib/unpublish.js', {
     ...mocks,
     'read-package-json': (path, cb) => cb(new Error('ERR')),
   })
@@ -141,7 +140,7 @@ t.test('no args --force unknown error reading package.json', t => {
 })
 
 t.test('no args', t => {
-  const unpublish = requireInject('../../lib/unpublish.js', {
+  const unpublish = t.mock('../../lib/unpublish.js', {
     ...mocks,
   })
 
@@ -156,7 +155,7 @@ t.test('no args', t => {
 })
 
 t.test('too many args', t => {
-  const unpublish = requireInject('../../lib/unpublish.js', {
+  const unpublish = t.mock('../../lib/unpublish.js', {
     ...mocks,
   })
 
@@ -206,7 +205,7 @@ t.test('unpublish <pkg>@version', t => {
     },
   }
 
-  const unpublish = requireInject('../../lib/unpublish.js', {
+  const unpublish = t.mock('../../lib/unpublish.js', {
     ...mocks,
     npmlog,
     libnpmpublish,
@@ -235,7 +234,7 @@ t.test('no version found in package.json', t => {
 
   npa.resolve = () => ''
 
-  const unpublish = requireInject('../../lib/unpublish.js', {
+  const unpublish = t.mock('../../lib/unpublish.js', {
     ...mocks,
     'npm-package-arg': npa,
     'read-package-json': (path, cb) => cb(null, {
@@ -259,7 +258,7 @@ t.test('no version found in package.json', t => {
 t.test('unpublish <pkg> --force no version set', t => {
   npm.flatOptions.force = true
 
-  const unpublish = requireInject('../../lib/unpublish.js', {
+  const unpublish = t.mock('../../lib/unpublish.js', {
     ...mocks,
     'npm-package-arg': () => ({
       name: 'pkg',
@@ -292,7 +291,7 @@ t.test('silent', t => {
 
   npa.resolve = () => ''
 
-  const unpublish = requireInject('../../lib/unpublish.js', {
+  const unpublish = t.mock('../../lib/unpublish.js', {
     ...mocks,
     'npm-package-arg': npa,
   })
@@ -322,7 +321,7 @@ t.test('completion', t => {
     })
 
   t.test('completing with multiple versions from the registry', async t => {
-    const { completion } = requireInject('../../lib/unpublish.js', {
+    const { completion } = t.mock('../../lib/unpublish.js', {
       ...mocks,
       libnpmaccess: {
         async lsPackages () {
@@ -359,7 +358,7 @@ t.test('completion', t => {
   })
 
   t.test('no versions retrieved', async t => {
-    const { completion } = requireInject('../../lib/unpublish.js', {
+    const { completion } = t.mock('../../lib/unpublish.js', {
       ...mocks,
       libnpmaccess: {
         async lsPackages () {
@@ -391,7 +390,7 @@ t.test('completion', t => {
   })
 
   t.test('packages starting with same letters', async t => {
-    const { completion } = requireInject('../../lib/unpublish.js', {
+    const { completion } = t.mock('../../lib/unpublish.js', {
       ...mocks,
       libnpmaccess: {
         async lsPackages () {
@@ -418,7 +417,7 @@ t.test('completion', t => {
   })
 
   t.test('no packages retrieved', async t => {
-    const { completion } = requireInject('../../lib/unpublish.js', {
+    const { completion } = t.mock('../../lib/unpublish.js', {
       ...mocks,
       libnpmaccess: {
         async lsPackages () {
@@ -437,7 +436,7 @@ t.test('completion', t => {
   })
 
   t.test('no pkg name to complete', async t => {
-    const { completion } = requireInject('../../lib/unpublish.js', {
+    const { completion } = t.mock('../../lib/unpublish.js', {
       ...mocks,
       libnpmaccess: {
         async lsPackages () {
@@ -459,7 +458,7 @@ t.test('completion', t => {
   })
 
   t.test('no pkg names retrieved from user account', async t => {
-    const { completion } = requireInject('../../lib/unpublish.js', {
+    const { completion } = t.mock('../../lib/unpublish.js', {
       ...mocks,
       libnpmaccess: {
         async lsPackages () {
@@ -478,7 +477,7 @@ t.test('completion', t => {
   })
 
   t.test('logged out user', async t => {
-    const { completion } = requireInject('../../lib/unpublish.js', {
+    const { completion } = t.mock('../../lib/unpublish.js', {
       ...mocks,
       '../../lib/utils/get-identity.js': () => Promise.reject(new Error('ERR')),
     })
@@ -492,7 +491,7 @@ t.test('completion', t => {
   })
 
   t.test('too many args', async t => {
-    const { completion } = requireInject('../../lib/unpublish.js', mocks)
+    const { completion } = t.mock('../../lib/unpublish.js', mocks)
 
     await testComp(t, {
       completion,

--- a/test/lib/unstar.js
+++ b/test/lib/unstar.js
@@ -1,10 +1,9 @@
-const requireInject = require('require-inject')
 const t = require('tap')
 
 t.test('unstar', t => {
   t.plan(3)
 
-  const unstar = requireInject('../../lib/unstar.js', {
+  const unstar = t.mock('../../lib/unstar.js', {
     '../../lib/npm.js': {
       config: {
         set: (key, value) => {

--- a/test/lib/update.js
+++ b/test/lib/update.js
@@ -1,6 +1,5 @@
 const { resolve } = require('path')
 const t = require('tap')
-const requireInject = require('require-inject')
 
 const noop = () => null
 const npm = {
@@ -47,7 +46,7 @@ t.test('no args', t => {
     }
   }
 
-  const update = requireInject('../../lib/update.js', {
+  const update = t.mock('../../lib/update.js', {
     ...mocks,
     '../../lib/utils/reify-finish.js': (arb) => {
       t.isLike(arb, Arborist, 'should reify-finish with arborist instance')
@@ -80,7 +79,7 @@ t.test('with args', t => {
     }
   }
 
-  const update = requireInject('../../lib/update.js', {
+  const update = t.mock('../../lib/update.js', {
     ...mocks,
     '../../lib/utils/reify-finish.js': (arb) => {
       t.isLike(arb, Arborist, 'should reify-finish with arborist instance')
@@ -100,7 +99,7 @@ t.test('update --depth=<number>', t => {
   npm.prefix = '/project/a'
   npm.flatOptions.depth = 1
 
-  const update = requireInject('../../lib/update.js', {
+  const update = t.mock('../../lib/update.js', {
     ...mocks,
     npmlog: {
       warn: (title, msg) => {
@@ -150,7 +149,7 @@ t.test('update --global', t => {
     reify () {}
   }
 
-  const update = requireInject('../../lib/update.js', {
+  const update = t.mock('../../lib/update.js', {
     ...mocks,
     '@npmcli/arborist': Arborist,
   })

--- a/test/lib/utils/audit-error.js
+++ b/test/lib/utils/audit-error.js
@@ -1,5 +1,4 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 
 const LOGS = []
 const npm = {
@@ -11,7 +10,7 @@ const npm = {
 }
 const OUTPUT = []
 const output = (...msg) => OUTPUT.push(msg)
-const auditError = requireInject('../../../lib/utils/audit-error.js', {
+const auditError = t.mock('../../../lib/utils/audit-error.js', {
   '../../../lib/npm.js': npm,
   '../../../lib/utils/output.js': output,
 })

--- a/test/lib/utils/cleanup-log-files.js
+++ b/test/lib/utils/cleanup-log-files.js
@@ -1,10 +1,9 @@
 const t = require('tap')
 
-const requireInject = require('require-inject')
 const glob = require('glob')
 const rimraf = require('rimraf')
 const mocks = { glob, rimraf }
-const cleanup = requireInject('../../../lib/utils/cleanup-log-files.js', {
+const cleanup = t.mock('../../../lib/utils/cleanup-log-files.js', {
   glob: (...args) => mocks.glob(...args),
   rimraf: (...args) => mocks.rimraf(...args),
 })

--- a/test/lib/utils/completion/installed-deep.js
+++ b/test/lib/utils/completion/installed-deep.js
@@ -1,6 +1,5 @@
 const { resolve } = require('path')
-const { test } = require('tap')
-const requireInject = require('require-inject')
+const t = require('tap')
 
 let prefix
 let globalDir = 'MISSING_GLOBAL_DIR'
@@ -11,7 +10,7 @@ const _flatOptions = {
     return prefix
   },
 }
-const installedDeep = requireInject('../../../../lib/utils/completion/installed-deep.js', {
+const installedDeep = t.mock('../../../../lib/utils/completion/installed-deep.js', {
   '../../../../lib/npm.js': {
     flatOptions: _flatOptions,
     get prefix () {
@@ -144,7 +143,7 @@ const globalFixture = {
   },
 }
 
-test('get list of package names', (t) => {
+t.test('get list of package names', (t) => {
   const fix = t.testdir({
     local: fixture,
     global: globalFixture,
@@ -171,7 +170,7 @@ test('get list of package names', (t) => {
   })
 })
 
-test('get list of package names as global', (t) => {
+t.test('get list of package names as global', (t) => {
   const fix = t.testdir({
     local: fixture,
     global: globalFixture,
@@ -198,7 +197,7 @@ test('get list of package names as global', (t) => {
   })
 })
 
-test('limit depth', (t) => {
+t.test('limit depth', (t) => {
   const fix = t.testdir({
     local: fixture,
     global: globalFixture,
@@ -228,7 +227,7 @@ test('limit depth', (t) => {
   })
 })
 
-test('limit depth as global', (t) => {
+t.test('limit depth as global', (t) => {
   const fix = t.testdir({
     local: fixture,
     global: globalFixture,

--- a/test/lib/utils/completion/installed-shallow.js
+++ b/test/lib/utils/completion/installed-shallow.js
@@ -1,11 +1,10 @@
-const requireInject = require('require-inject')
 const flatOptions = { global: false }
 const npm = { flatOptions }
 const t = require('tap')
 const { resolve } = require('path')
 
 const p = '../../../../lib/utils/completion/installed-shallow.js'
-const installed = requireInject(p, {
+const installed = t.mock(p, {
   '../../../../lib/npm.js': npm,
 })
 

--- a/test/lib/utils/config.js
+++ b/test/lib/utils/config.js
@@ -1,5 +1,4 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 Object.defineProperty(process, 'umask', {
   value: () => 0o26,
   writable: true,
@@ -72,7 +71,7 @@ const os = { networkInterfaces, tmpdir }
 const pkg = { version: '7.0.0' }
 
 t.test('working network interfaces, not windows', t => {
-  const config = requireInject('../../../lib/utils/config.js', {
+  const config = t.mock('../../../lib/utils/config.js', {
     os,
     '@npmcli/ci-detect': () => false,
     '../../../lib/utils/is-windows.js': false,
@@ -83,7 +82,7 @@ t.test('working network interfaces, not windows', t => {
 })
 
 t.test('no working network interfaces, on windows', t => {
-  const config = requireInject('../../../lib/utils/config.js', {
+  const config = t.mock('../../../lib/utils/config.js', {
     os: { tmpdir, networkInterfaces: networkInterfacesThrow },
     '@npmcli/ci-detect': () => false,
     '../../../lib/utils/is-windows.js': true,
@@ -108,7 +107,7 @@ t.test('no process.umask() method', t => {
       enumerable: true,
     })
   })
-  const config = requireInject('../../../lib/utils/config.js', {
+  const config = t.mock('../../../lib/utils/config.js', {
     os: { tmpdir, networkInterfaces: networkInterfacesThrow },
     '@npmcli/ci-detect': () => false,
     '../../../lib/utils/is-windows.js': true,
@@ -121,7 +120,7 @@ t.test('no process.umask() method', t => {
 
 t.test('no comspec on windows', t => {
   delete process.env.ComSpec
-  const config = requireInject('../../../lib/utils/config.js', {
+  const config = t.mock('../../../lib/utils/config.js', {
     os: { tmpdir, networkInterfaces: networkInterfacesThrow },
     '@npmcli/ci-detect': () => false,
     '../../../lib/utils/is-windows.js': true,
@@ -132,7 +131,7 @@ t.test('no comspec on windows', t => {
 
 t.test('no shell on posix', t => {
   delete process.env.SHELL
-  const config = requireInject('../../../lib/utils/config.js', {
+  const config = t.mock('../../../lib/utils/config.js', {
     os,
     '@npmcli/ci-detect': () => false,
     '../../../lib/utils/is-windows.js': false,
@@ -143,7 +142,7 @@ t.test('no shell on posix', t => {
 
 t.test('no EDITOR env, use VISUAL', t => {
   delete process.env.EDITOR
-  const config = requireInject('../../../lib/utils/config.js', {
+  const config = t.mock('../../../lib/utils/config.js', {
     os,
     '@npmcli/ci-detect': () => false,
     '../../../lib/utils/is-windows.js': false,
@@ -154,7 +153,7 @@ t.test('no EDITOR env, use VISUAL', t => {
 
 t.test('no VISUAL, use system default, not windows', t => {
   delete process.env.VISUAL
-  const config = requireInject('../../../lib/utils/config.js', {
+  const config = t.mock('../../../lib/utils/config.js', {
     os,
     '@npmcli/ci-detect': () => false,
     '../../../lib/utils/is-windows.js': false,
@@ -165,7 +164,7 @@ t.test('no VISUAL, use system default, not windows', t => {
 
 t.test('no VISUAL, use system default, not windows', t => {
   delete process.env.VISUAL
-  const config = requireInject('../../../lib/utils/config.js', {
+  const config = t.mock('../../../lib/utils/config.js', {
     os,
     '@npmcli/ci-detect': () => false,
     '../../../lib/utils/is-windows.js': true,

--- a/test/lib/utils/error-handler.js
+++ b/test/lib/utils/error-handler.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-extend-native */
 /* eslint-disable no-global-assign */
 const EventEmitter = require('events')
-const requireInject = require('require-inject')
 const t = require('tap')
 
 // NOTE: Although these unit tests may look like the rest on the surface,
@@ -128,8 +127,7 @@ const mocks = {
   '../../../lib/utils/cache-file.js': cacheFile,
 }
 
-requireInject.installGlobally('../../../lib/utils/error-handler.js', mocks)
-let errorHandler = require('../../../lib/utils/error-handler.js')
+const errorHandler = t.mock('../../../lib/utils/error-handler.js', mocks)
 
 t.test('default exit code', (t) => {
   t.plan(1)
@@ -376,9 +374,7 @@ t.test('it worked', (t) => {
 t.test('uses code from errno', (t) => {
   t.plan(1)
 
-  // RESET MODULE INTERNAL VARS AND GLOBAL REFS
-  requireInject.installGlobally.andClearCache('../../../lib/utils/error-handler.js', mocks)
-  errorHandler = require('../../../lib/utils/error-handler.js')
+  const errorHandler = t.mock('../../../lib/utils/error-handler.js', mocks)
 
   npmlog.level = 'silent'
   const _exit = process.exit
@@ -402,12 +398,7 @@ t.test('uses code from errno', (t) => {
 t.test('uses exitCode as code if using a number', (t) => {
   t.plan(1)
 
-  // RESET MODULE INTERNAL VARS AND GLOBAL REFS
-  requireInject.installGlobally.andClearCache(
-    '../../../lib/utils/error-handler.js',
-    mocks
-  )
-  errorHandler = require('../../../lib/utils/error-handler.js')
+  const errorHandler = t.mock('../../../lib/utils/error-handler.js', mocks)
 
   npmlog.level = 'silent'
   const _exit = process.exit
@@ -431,12 +422,7 @@ t.test('uses exitCode as code if using a number', (t) => {
 t.test('call errorHandler with no error', (t) => {
   t.plan(1)
 
-  // RESET MODULE INTERNAL VARS AND GLOBAL REFS
-  requireInject.installGlobally.andClearCache(
-    '../../../lib/utils/error-handler.js',
-    mocks
-  )
-  errorHandler = require('../../../lib/utils/error-handler.js')
+  const errorHandler = t.mock('../../../lib/utils/error-handler.js', mocks)
 
   const _exit = process.exit
   process.exit = (code) => {
@@ -494,12 +480,7 @@ t.test('defaults to log error msg if stack is missing', (t) => {
 t.test('set it worked', (t) => {
   t.plan(1)
 
-  // RESET MODULE INTERNAL VARS AND GLOBAL REFS
-  requireInject.installGlobally.andClearCache(
-    '../../../lib/utils/error-handler.js',
-    mocks
-  )
-  errorHandler = require('../../../lib/utils/error-handler.js')
+  const errorHandler = t.mock('../../../lib/utils/error-handler.js', mocks)
 
   const _exit = process.exit
   process.exit = () => {

--- a/test/lib/utils/explain-dep.js
+++ b/test/lib/utils/explain-dep.js
@@ -1,7 +1,6 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 const npm = {}
-const { explainNode, printNode } = requireInject('../../../lib/utils/explain-dep.js', {
+const { explainNode, printNode } = t.mock('../../../lib/utils/explain-dep.js', {
   '../../../lib/npm.js': npm,
 })
 

--- a/test/lib/utils/explain-eresolve.js
+++ b/test/lib/utils/explain-eresolve.js
@@ -1,7 +1,6 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 const npm = {}
-const { explain, report } = requireInject('../../../lib/utils/explain-eresolve.js', {
+const { explain, report } = t.mock('../../../lib/utils/explain-eresolve.js', {
   '../../../lib/npm.js': npm,
 })
 const { statSync, readFileSync, unlinkSync } = require('fs')

--- a/test/lib/utils/file-exists.js
+++ b/test/lib/utils/file-exists.js
@@ -1,7 +1,7 @@
-const { test } = require('tap')
+const t = require('tap')
 const fileExists = require('../../../lib/utils/file-exists.js')
 
-test('returns true when arg is a file', async (t) => {
+t.test('returns true when arg is a file', async (t) => {
   const path = t.testdir({
     foo: 'just some file',
   })
@@ -11,7 +11,7 @@ test('returns true when arg is a file', async (t) => {
   t.end()
 })
 
-test('returns false when arg is not a file', async (t) => {
+t.test('returns false when arg is not a file', async (t) => {
   const path = t.testdir({
     foo: {},
   })
@@ -21,7 +21,7 @@ test('returns false when arg is not a file', async (t) => {
   t.end()
 })
 
-test('returns false when arg does not exist', async (t) => {
+t.test('returns false when arg does not exist', async (t) => {
   const path = t.testdir()
 
   const result = await fileExists(`${path}/foo`)

--- a/test/lib/utils/get-identity.js
+++ b/test/lib/utils/get-identity.js
@@ -1,9 +1,8 @@
-const { test } = require('tap')
-const requireInject = require('require-inject')
+const t = require('tap')
 
-test('throws ENOREGISTRY when no registry option is provided', async (t) => {
+t.test('throws ENOREGISTRY when no registry option is provided', async (t) => {
   t.plan(2)
-  const getIdentity = requireInject('../../../lib/utils/get-identity.js', {
+  const getIdentity = t.mock('../../../lib/utils/get-identity.js', {
     '../../../lib/npm.js': {},
   })
 
@@ -15,10 +14,10 @@ test('throws ENOREGISTRY when no registry option is provided', async (t) => {
   }
 })
 
-test('returns username from uri when provided', async (t) => {
+t.test('returns username from uri when provided', async (t) => {
   t.plan(1)
 
-  const getIdentity = requireInject('../../../lib/utils/get-identity.js', {
+  const getIdentity = t.mock('../../../lib/utils/get-identity.js', {
     '../../../lib/npm.js': {
       config: {
         getCredentialsByURI: () => {
@@ -32,7 +31,7 @@ test('returns username from uri when provided', async (t) => {
   t.equal(identity, 'foo', 'returns username from uri')
 })
 
-test('calls registry whoami when token is provided', async (t) => {
+t.test('calls registry whoami when token is provided', async (t) => {
   t.plan(3)
 
   const options = {
@@ -40,7 +39,7 @@ test('calls registry whoami when token is provided', async (t) => {
     token: 'thisisnotreallyatoken',
   }
 
-  const getIdentity = requireInject('../../../lib/utils/get-identity.js', {
+  const getIdentity = t.mock('../../../lib/utils/get-identity.js', {
     '../../../lib/npm.js': {
       config: {
         getCredentialsByURI: () => options,
@@ -59,7 +58,7 @@ test('calls registry whoami when token is provided', async (t) => {
   t.equal(identity, 'foo', 'fetched username from registry')
 })
 
-test('throws ENEEDAUTH when response does not include a username', async (t) => {
+t.test('throws ENEEDAUTH when response does not include a username', async (t) => {
   t.plan(3)
 
   const options = {
@@ -67,7 +66,7 @@ test('throws ENEEDAUTH when response does not include a username', async (t) => 
     token: 'thisisnotreallyatoken',
   }
 
-  const getIdentity = requireInject('../../../lib/utils/get-identity.js', {
+  const getIdentity = t.mock('../../../lib/utils/get-identity.js', {
     '../../../lib/npm.js': {
       config: {
         getCredentialsByURI: () => options,
@@ -89,9 +88,9 @@ test('throws ENEEDAUTH when response does not include a username', async (t) => 
   }
 })
 
-test('throws ENEEDAUTH when neither username nor token is configured', async (t) => {
+t.test('throws ENEEDAUTH when neither username nor token is configured', async (t) => {
   t.plan(1)
-  const getIdentity = requireInject('../../../lib/utils/get-identity.js', {
+  const getIdentity = t.mock('../../../lib/utils/get-identity.js', {
     '../../../lib/npm.js': {
       config: {
         getCredentialsByURI: () => ({}),

--- a/test/lib/utils/lifecycle-cmd.js
+++ b/test/lib/utils/lifecycle-cmd.js
@@ -1,16 +1,17 @@
 const t = require('tap')
-const requireInject = require('require-inject')
-const lifecycleCmd = requireInject('../../../lib/utils/lifecycle-cmd.js', {
+const none = {}
+const lifecycleCmd = t.mock('../../../lib/utils/lifecycle-cmd.js', {
   '../../../lib/npm.js': {
     commands: {
       run: (args, cb) => cb(null, 'called npm.commands.run'),
     },
   },
+  '../../../lib/utils/completion/none.js': none,
 })
 
 t.test('create a lifecycle command', t => {
   const cmd = lifecycleCmd('asdf')
-  t.equal(cmd.completion, require('../../../lib/utils/completion/none.js'), 'empty completion')
+  t.equal(cmd.completion, none, 'empty completion')
   cmd(['some', 'args'], (er, result) => {
     t.strictSame(result, 'called npm.commands.run')
     t.end()

--- a/test/lib/utils/path.js
+++ b/test/lib/utils/path.js
@@ -1,13 +1,12 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 const mod = '../../../lib/utils/path.js'
 const delim = require('../../../lib/utils/is-windows.js') ? ';' : ':'
 Object.defineProperty(process, 'env', {
   value: {},
 })
 process.env.path = ['foo', 'bar', 'baz'].join(delim)
-t.strictSame(requireInject(mod), ['foo', 'bar', 'baz'])
+t.strictSame(t.mock(mod, {}), ['foo', 'bar', 'baz'])
 process.env.Path = ['a', 'b', 'c'].join(delim)
-t.strictSame(requireInject(mod), ['a', 'b', 'c'])
+t.strictSame(t.mock(mod, {}), ['a', 'b', 'c'])
 process.env.PATH = ['x', 'y', 'z'].join(delim)
-t.strictSame(requireInject(mod), ['x', 'y', 'z'])
+t.strictSame(t.mock(mod, {}), ['x', 'y', 'z'])

--- a/test/lib/utils/ping.js
+++ b/test/lib/utils/ping.js
@@ -1,12 +1,11 @@
-const { test } = require('tap')
-const requireInject = require('require-inject')
+const t = require('tap')
 
-test('pings', async (t) => {
+t.test('pings', async (t) => {
   t.plan(3)
 
   const options = { fake: 'options' }
   const response = { some: 'details' }
-  const ping = requireInject('../../../lib/utils/ping.js', {
+  const ping = t.mock('../../../lib/utils/ping.js', {
     'npm-registry-fetch': (url, opts) => {
       t.equal(url, '/-/ping?write=true', 'calls the correct url')
       t.equal(opts, options, 'passes through options')
@@ -18,12 +17,12 @@ test('pings', async (t) => {
   t.match(res, response, 'returns json response')
 })
 
-test('catches errors and returns empty json', async (t) => {
+t.test('catches errors and returns empty json', async (t) => {
   t.plan(3)
 
   const options = { fake: 'options' }
   const response = { some: 'details' }
-  const ping = requireInject('../../../lib/utils/ping.js', {
+  const ping = t.mock('../../../lib/utils/ping.js', {
     'npm-registry-fetch': (url, opts) => {
       t.equal(url, '/-/ping?write=true', 'calls the correct url')
       t.equal(opts, options, 'passes through options')

--- a/test/lib/utils/proc-log-listener.js
+++ b/test/lib/utils/proc-log-listener.js
@@ -1,5 +1,4 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 const { inspect } = require('util')
 
 const logs = []
@@ -8,7 +7,7 @@ const npmlog = {
   verbose: (...args) => logs.push(['verbose', ...args]),
 }
 
-requireInject('../../../lib/utils/proc-log-listener.js', {
+t.mock('../../../lib/utils/proc-log-listener.js', {
   npmlog,
 })()
 

--- a/test/lib/utils/read-local-package.js
+++ b/test/lib/utils/read-local-package.js
@@ -1,5 +1,4 @@
-const requireInject = require('require-inject')
-const { test } = require('tap')
+const t = require('tap')
 
 let prefix
 const _flatOptions = {
@@ -10,13 +9,13 @@ const _flatOptions = {
   },
 }
 
-const readLocalPackageName = requireInject('../../../lib/utils/read-local-package.js', {
+const readLocalPackageName = t.mock('../../../lib/utils/read-local-package.js', {
   '../../../lib/npm.js': {
     flatOptions: _flatOptions,
   },
 })
 
-test('read local package.json', async (t) => {
+t.test('read local package.json', async (t) => {
   prefix = t.testdir({
     'package.json': JSON.stringify({
       name: 'my-local-package',
@@ -31,7 +30,7 @@ test('read local package.json', async (t) => {
   )
 })
 
-test('read local scoped-package.json', async (t) => {
+t.test('read local scoped-package.json', async (t) => {
   prefix = t.testdir({
     'package.json': JSON.stringify({
       name: '@my-scope/my-local-package',
@@ -46,7 +45,7 @@ test('read local scoped-package.json', async (t) => {
   )
 })
 
-test('read using --global', async (t) => {
+t.test('read using --global', async (t) => {
   prefix = t.testdir({})
   _flatOptions.global = true
   const packageName = await readLocalPackageName()

--- a/test/lib/utils/reify-finish.js
+++ b/test/lib/utils/reify-finish.js
@@ -1,5 +1,4 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 
 const npm = {
   config: {
@@ -30,7 +29,7 @@ const fs = {
   },
 }
 
-const reifyFinish = requireInject('../../../lib/utils/reify-finish.js', {
+const reifyFinish = t.mock('../../../lib/utils/reify-finish.js', {
   fs,
   '../../../lib/npm.js': npm,
   '../../../lib/utils/reify-output.js': reifyOutput,

--- a/test/lib/utils/reify-output.js
+++ b/test/lib/utils/reify-output.js
@@ -1,5 +1,4 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 
 const log = require('npmlog')
 log.level = 'warn'
@@ -14,7 +13,7 @@ const npmock = {
   flatOptions: settings,
 }
 const getReifyOutput = tester =>
-  requireInject(
+  t.mock(
     '../../../lib/utils/reify-output.js',
     {
       '../../../lib/npm.js': npmock,

--- a/test/lib/utils/setup-log.js
+++ b/test/lib/utils/setup-log.js
@@ -1,5 +1,4 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 
 const settings = {
   level: 'warn',
@@ -61,7 +60,7 @@ const npmlog = {
 }
 
 const EXPLAIN_CALLED = []
-const setupLog = requireInject('../../../lib/utils/setup-log.js', {
+const setupLog = t.mock('../../../lib/utils/setup-log.js', {
   '../../../lib/utils/explain-eresolve.js': {
     explain: (...args) => {
       EXPLAIN_CALLED.push(args)

--- a/test/lib/utils/tar.js
+++ b/test/lib/utils/tar.js
@@ -1,7 +1,6 @@
 const { test } = require('tap')
 const pack = require('libnpmpack')
 const ssri = require('ssri')
-const requireInject = require('require-inject')
 
 const { logTar, getContents } = require('../../../lib/utils/tar.js')
 
@@ -43,7 +42,7 @@ test('should log tarball contents', async (t) => {
 })
 
 test('should log tarball contents with unicode', async (t) => {
-  const { logTar } = requireInject('../../../lib/utils/tar.js', {
+  const { logTar } = t.mock('../../../lib/utils/tar.js', {
     npmlog: {
       notice: (str) => {
         t.ok(true, 'defaults to npmlog')
@@ -61,7 +60,7 @@ test('should log tarball contents with unicode', async (t) => {
 })
 
 test('should default to npmlog', async (t) => {
-  const { logTar } = requireInject('../../../lib/utils/tar.js', {
+  const { logTar } = t.mock('../../../lib/utils/tar.js', {
     npmlog: {
       notice: (str) => {
         t.ok(true, 'defaults to npmlog')

--- a/test/lib/utils/update-notifier.js
+++ b/test/lib/utils/update-notifier.js
@@ -1,5 +1,4 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 let ciMock = null
 const flatOptions = { global: false, cache: t.testdir() + '/_cacache' }
 
@@ -72,7 +71,7 @@ const fs = {
   },
 }
 
-const updateNotifier = requireInject('../../../lib/utils/update-notifier.js', {
+const updateNotifier = t.mock('../../../lib/utils/update-notifier.js', {
   '@npmcli/ci-detect': () => ciMock,
   pacote,
   fs,

--- a/test/lib/version.js
+++ b/test/lib/version.js
@@ -1,5 +1,4 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 
 let result = []
 
@@ -21,7 +20,7 @@ const mocks = {
   '../../lib/utils/usage.js': () => 'usage instructions',
 }
 
-const version = requireInject('../../lib/version.js', mocks)
+const version = t.mock('../../lib/version.js', mocks)
 
 const _processVersions = process.versions
 t.afterEach(cb => {
@@ -137,7 +136,7 @@ t.test('--json option', t => {
 })
 
 t.test('with one arg', t => {
-  const version = requireInject('../../lib/version.js', {
+  const version = t.mock('../../lib/version.js', {
     ...mocks,
     libnpmversion: (arg, opts) => {
       t.equal(arg, 'major', 'should forward expected value')

--- a/test/lib/view.js
+++ b/test/lib/view.js
@@ -1,5 +1,4 @@
 const t = require('tap')
-const requireInject = require('require-inject')
 
 let logs
 const cleanLogs = (done) => {
@@ -238,7 +237,7 @@ const packument = (nv, opts) => {
 
 t.beforeEach(cleanLogs)
 t.test('should log package info', t => {
-  const view = requireInject('../../lib/view.js', {
+  const view = t.mock('../../lib/view.js', {
     '../../lib/npm.js': {
       flatOptions: {
         global: false,
@@ -249,7 +248,7 @@ t.test('should log package info', t => {
     },
   })
 
-  const viewJson = requireInject('../../lib/view.js', {
+  const viewJson = t.mock('../../lib/view.js', {
     '../../lib/npm.js': {
       flatOptions: {
         json: true,
@@ -260,7 +259,7 @@ t.test('should log package info', t => {
     },
   })
 
-  const viewUnicode = requireInject('../../lib/view.js', {
+  const viewUnicode = t.mock('../../lib/view.js', {
     '../../lib/npm.js': {
       flatOptions: {
         global: false,
@@ -346,7 +345,7 @@ t.test('should log info of package in current working dir', t => {
     }, null, 2),
   })
 
-  const view = requireInject('../../lib/view.js', {
+  const view = t.mock('../../lib/view.js', {
     '../../lib/npm.js': {
       prefix: testDir,
       flatOptions: {
@@ -377,7 +376,7 @@ t.test('should log info of package in current working dir', t => {
 })
 
 t.test('should log info by field name', t => {
-  const viewJson = requireInject('../../lib/view.js', {
+  const viewJson = t.mock('../../lib/view.js', {
     '../../lib/npm.js': {
       flatOptions: {
         json: true,
@@ -389,7 +388,7 @@ t.test('should log info by field name', t => {
     },
   })
 
-  const view = requireInject('../../lib/view.js', {
+  const view = t.mock('../../lib/view.js', {
     '../../lib/npm.js': {
       flatOptions: {
         global: false,
@@ -467,7 +466,7 @@ t.test('should log info by field name', t => {
 })
 
 t.test('throw error if global mode', (t) => {
-  const view = requireInject('../../lib/view.js', {
+  const view = t.mock('../../lib/view.js', {
     '../../lib/npm.js': {
       flatOptions: {
         global: true,
@@ -483,7 +482,7 @@ t.test('throw error if global mode', (t) => {
 t.test('throw ENOENT error if package.json misisng', (t) => {
   const testDir = t.testdir({})
 
-  const view = requireInject('../../lib/view.js', {
+  const view = t.mock('../../lib/view.js', {
     '../../lib/npm.js': {
       prefix: testDir,
       flatOptions: {
@@ -502,7 +501,7 @@ t.test('throw EJSONPARSE error if package.json not json', (t) => {
     'package.json': 'not json, nope, not even a little bit!',
   })
 
-  const view = requireInject('../../lib/view.js', {
+  const view = t.mock('../../lib/view.js', {
     '../../lib/npm.js': {
       prefix: testDir,
       flatOptions: {
@@ -521,7 +520,7 @@ t.test('throw error if package.json has no name', (t) => {
     'package.json': '{}',
   })
 
-  const view = requireInject('../../lib/view.js', {
+  const view = t.mock('../../lib/view.js', {
     '../../lib/npm.js': {
       prefix: testDir,
       flatOptions: {
@@ -536,7 +535,7 @@ t.test('throw error if package.json has no name', (t) => {
 })
 
 t.test('throws when unpublished', (t) => {
-  const view = requireInject('../../lib/view.js', {
+  const view = t.mock('../../lib/view.js', {
     '../../lib/npm.js': {
       flatOptions: {
         defaultTag: '1.0.1',
@@ -554,7 +553,7 @@ t.test('throws when unpublished', (t) => {
 })
 
 t.test('completion', (t) => {
-  const view = requireInject('../../lib/view.js', {
+  const view = t.mock('../../lib/view.js', {
     '../../lib/npm.js': {
       flatOptions: {
         defaultTag: '1.0.1',
@@ -576,7 +575,7 @@ t.test('completion', (t) => {
 })
 
 t.test('no registry completion', (t) => {
-  const view = requireInject('../../lib/view.js', {
+  const view = t.mock('../../lib/view.js', {
     '../../lib/npm.js': {
       flatOptions: {
         defaultTag: '1.0.1',

--- a/test/lib/whoami.js
+++ b/test/lib/whoami.js
@@ -1,9 +1,8 @@
-const { test } = require('tap')
-const requireInject = require('require-inject')
+const t = require('tap')
 
-test('whoami', (t) => {
+t.test('whoami', (t) => {
   t.plan(3)
-  const whoami = requireInject('../../lib/whoami.js', {
+  const whoami = t.mock('../../lib/whoami.js', {
     '../../lib/utils/get-identity.js': () => Promise.resolve('foo'),
     '../../lib/npm.js': { flatOptions: {} },
     '../../lib/utils/output.js': (output) => {
@@ -17,9 +16,9 @@ test('whoami', (t) => {
   })
 })
 
-test('whoami json', (t) => {
+t.test('whoami json', (t) => {
   t.plan(3)
-  const whoami = requireInject('../../lib/whoami.js', {
+  const whoami = t.mock('../../lib/whoami.js', {
     '../../lib/utils/get-identity.js': () => Promise.resolve('foo'),
     '../../lib/npm.js': { flatOptions: { json: true } },
     '../../lib/utils/output.js': (output) => {


### PR DESCRIPTION
- Replaces all usage of `requireInject` with `t.mock`
- Standardizes usage of tap as: `const t = require('tap')`
- Fixes some rare cases in which mocks were relying in the fact that
`requireInject` placed mocks within the `require.cache` and made mocks
available for nested files, this type of scenario now requires an extra
`t.mock` declaration in order to define mocks to that nested file.
- Requires a new release of `tap`, since currently this PR is just relying in a fork to run all tests, ref: https://github.com/tapjs/node-tap/pull/698