### PR TITLE
(docs,test): assorted typo fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -977,7 +977,7 @@
     * fix package.json dependencies order
 * [`49b2bf5a7`](https://github.com/npm/cli/commit/49b2bf5a798b49d52166744088a80b8a39ccaeb6)
   `@npmcli/config@1.1.8`
-    * fix unkown envs to be passed through
+    * fix unknown envs to be passed through
     * fix setting correct globalPrefix on load
 * [`f9aac351d`](https://github.com/npm/cli/commit/f9aac351dd36a19d14e1f951a2e8e20b41545822)
   `libnpmversion@1.0.5`

--- a/docs/content/using-npm/scripts.md
+++ b/docs/content/using-npm/scripts.md
@@ -24,7 +24,7 @@ To create "pre" or "post" scripts for any scripts defined in the `"scripts"` sec
 
 ### Life Cycle Scripts
 
-There are some special life cycle scripts that happen only in certain situations. These scripts happen in addtion to the "pre" and "post" script.
+There are some special life cycle scripts that happen only in certain situations. These scripts happen in addition to the "pre" and "post" script.
 * `prepare`, `prepublish`, `prepublishOnly`, `prepack`, `postpack`
 
 **prepare** (since `npm@4.0.0`)

--- a/tap-snapshots/test-lib-config.js-TAP.test.js
+++ b/tap-snapshots/test-lib-config.js-TAP.test.js
@@ -129,7 +129,7 @@ long = false
 ; Run \`npm config ls -l\` to show all defaults.
 `
 
-exports[`test/lib/config.js TAP config list overrides > should list overriden configs 1`] = `
+exports[`test/lib/config.js TAP config list overrides > should list overridden configs 1`] = `
 ; "cli" config from command line options
 
 editor = "vi" 

--- a/tap-snapshots/test-lib-ls.js-TAP.test.js
+++ b/tap-snapshots/test-lib-ls.js-TAP.test.js
@@ -187,7 +187,7 @@ exports[`test/lib/ls.js TAP ls --parseable --production > should output tree con
 {CWD}/ls-ls-parseable--production/node_modules/prod-dep/node_modules/bar
 `
 
-exports[`test/lib/ls.js TAP ls --parseable cycle deps > should print tree output ommiting deduped ref 1`] = `
+exports[`test/lib/ls.js TAP ls --parseable cycle deps > should print tree output omitting deduped ref 1`] = `
 {CWD}/ls-ls-parseable-cycle-deps
 {CWD}/ls-ls-parseable-cycle-deps/node_modules/a
 {CWD}/ls-ls-parseable-cycle-deps/node_modules/b
@@ -287,11 +287,11 @@ exports[`test/lib/ls.js TAP ls --parseable using aliases > should output tree co
 {CWD}/ls-ls-parseable-using-aliases/node_modules/a
 `
 
-exports[`test/lib/ls.js TAP ls --parseable with filter arg > should output parseable contaning only occurences of filtered by package 1`] = `
+exports[`test/lib/ls.js TAP ls --parseable with filter arg > should output parseable contaning only occurrences of filtered by package 1`] = `
 {CWD}/ls-ls-parseable-with-filter-arg/node_modules/lorem
 `
 
-exports[`test/lib/ls.js TAP ls --parseable with filter arg nested dep > should output parseable contaning only occurences of filtered package 1`] = `
+exports[`test/lib/ls.js TAP ls --parseable with filter arg nested dep > should output parseable contaning only occurrences of filtered package 1`] = `
 {CWD}/ls-ls-parseable-with-filter-arg-nested-dep/node_modules/bar
 `
 
@@ -299,7 +299,7 @@ exports[`test/lib/ls.js TAP ls --parseable with missing filter arg > should outp
 
 `
 
-exports[`test/lib/ls.js TAP ls --parseable with multiple filter args > should output parseable contaning only occurences of multiple filtered packages and their ancestors 1`] = `
+exports[`test/lib/ls.js TAP ls --parseable with multiple filter args > should output parseable contaning only occurrences of multiple filtered packages and their ancestors 1`] = `
 {CWD}/ls-ls-parseable-with-multiple-filter-args/node_modules/lorem
 {CWD}/ls-ls-parseable-with-multiple-filter-args/node_modules/bar
 `
@@ -319,8 +319,8 @@ npm-broken-resolved-field-test@1.0.0 {CWD}/ls-ls-broken-resolved-field
 
 `
 
-exports[`test/lib/ls.js TAP ls coloured output > should output tree containing color info 1`] = `
-[0mtest-npm-ls@1.0.0 {CWD}/ls-ls-coloured-output[0m
+exports[`test/lib/ls.js TAP ls colored output > should output tree containing color info 1`] = `
+[0mtest-npm-ls@1.0.0 {CWD}/ls-ls-colored-output[0m
 [0m+-- foo@1.0.0 [31m[40minvalid[49m[39m[0m
 [0m| \`-- bar@1.0.0[0m
 [0m+-- [31m[40mUNMET DEPENDENCY[49m[39m ipsum@^1.0.0[0m
@@ -550,19 +550,19 @@ dedupe-entries@1.0.0 {CWD}/ls-ls-with-args-and-different-order-of-items
 
 `
 
-exports[`test/lib/ls.js TAP ls with dot filter arg > should output tree contaning only occurences of filtered by package and coloured output 1`] = `
+exports[`test/lib/ls.js TAP ls with dot filter arg > should output tree contaning only occurrences of filtered by package and colored output 1`] = `
 test-npm-ls@1.0.0 {CWD}/ls-ls-with-dot-filter-arg
 \`-- (empty)
 
 `
 
-exports[`test/lib/ls.js TAP ls with filter arg > should output tree contaning only occurences of filtered by package and coloured output 1`] = `
+exports[`test/lib/ls.js TAP ls with filter arg > should output tree contaning only occurrences of filtered by package and colored output 1`] = `
 [0mtest-npm-ls@1.0.0 {CWD}/ls-ls-with-filter-arg[0m
 [0m\`-- [33m[40mlorem@1.0.0[49m[39m[0m
 [0m[0m
 `
 
-exports[`test/lib/ls.js TAP ls with filter arg nested dep > should output tree contaning only occurences of filtered package and its ancestors 1`] = `
+exports[`test/lib/ls.js TAP ls with filter arg nested dep > should output tree contaning only occurrences of filtered package and its ancestors 1`] = `
 test-npm-ls@1.0.0 {CWD}/ls-ls-with-filter-arg-nested-dep
 \`-- foo@1.0.0
   \`-- bar@1.0.0
@@ -575,7 +575,7 @@ test-npm-ls@1.0.0 {CWD}/ls-ls-with-missing-filter-arg
 
 `
 
-exports[`test/lib/ls.js TAP ls with multiple filter args > should output tree contaning only occurences of multiple filtered packages and their ancestors 1`] = `
+exports[`test/lib/ls.js TAP ls with multiple filter args > should output tree contaning only occurrences of multiple filtered packages and their ancestors 1`] = `
 test-npm-ls@1.0.0 {CWD}/ls-ls-with-multiple-filter-args
 +-- foo@1.0.0
 | \`-- bar@1.0.0

--- a/test/fixtures/eresolve-explanations.js
+++ b/test/fixtures/eresolve-explanations.js
@@ -1,4 +1,4 @@
-// some real-world examples of ERESOLVE error explaination objects,
+// some real-world examples of ERESOLVE error explanation objects,
 // copied from arborist or generated there.
 module.exports = {
   cycleNested: {

--- a/test/lib/config.js
+++ b/test/lib/config.js
@@ -122,7 +122,7 @@ t.test('config list overrides', t => {
 
   config(['list'], (err) => {
     t.ifError(err, 'npm config list')
-    t.matchSnapshot(result, 'should list overriden configs')
+    t.matchSnapshot(result, 'should list overridden configs')
   })
 })
 

--- a/test/lib/dist-tag.js
+++ b/test/lib/dist-tag.js
@@ -323,6 +323,6 @@ test('completion', t => {
       },
     },
   }, (err) => {
-    t.notOk(err, 'should ignore any unkown name')
+    t.notOk(err, 'should ignore any unknown name')
   })
 })

--- a/test/lib/ls.js
+++ b/test/lib/ls.js
@@ -209,7 +209,7 @@ t.test('ls', (t) => {
     })
     ls(['lorem'], (err) => {
       t.ifError(err, 'npm ls')
-      t.matchSnapshot(redactCwd(result), 'should output tree contaning only occurences of filtered by package and coloured output')
+      t.matchSnapshot(redactCwd(result), 'should output tree contaning only occurrences of filtered by package and colored output')
       _flatOptions.color = false
       t.end()
     })
@@ -231,7 +231,7 @@ t.test('ls', (t) => {
     })
     ls(['.'], (err) => {
       t.ifError(err, 'should not throw on missing dep above current level')
-      t.matchSnapshot(redactCwd(result), 'should output tree contaning only occurences of filtered by package and coloured output')
+      t.matchSnapshot(redactCwd(result), 'should output tree contaning only occurrences of filtered by package and colored output')
       _flatOptions.all = true
       _flatOptions.depth = Infinity
       t.end()
@@ -252,7 +252,7 @@ t.test('ls', (t) => {
     })
     ls(['bar'], (err) => {
       t.ifError(err, 'npm ls')
-      t.matchSnapshot(redactCwd(result), 'should output tree contaning only occurences of filtered package and its ancestors')
+      t.matchSnapshot(redactCwd(result), 'should output tree contaning only occurrences of filtered package and its ancestors')
       t.end()
     })
   })
@@ -280,7 +280,7 @@ t.test('ls', (t) => {
     })
     ls(['bar@*', 'lorem@1.0.0'], (err) => {
       t.ifError(err, 'npm ls')
-      t.matchSnapshot(redactCwd(result), 'should output tree contaning only occurences of multiple filtered packages and their ancestors')
+      t.matchSnapshot(redactCwd(result), 'should output tree contaning only occurrences of multiple filtered packages and their ancestors')
       t.end()
     })
   })
@@ -443,7 +443,7 @@ t.test('ls', (t) => {
     })
   })
 
-  t.test('coloured output', (t) => {
+  t.test('colored output', (t) => {
     _flatOptions.color = true
     prefix = t.testdir({
       'package.json': JSON.stringify({
@@ -1588,7 +1588,7 @@ t.test('ls --parseable', (t) => {
     })
     ls(['lorem'], (err) => {
       t.ifError(err, 'npm ls')
-      t.matchSnapshot(redactCwd(result), 'should output parseable contaning only occurences of filtered by package')
+      t.matchSnapshot(redactCwd(result), 'should output parseable contaning only occurrences of filtered by package')
       t.end()
     })
   })
@@ -1607,7 +1607,7 @@ t.test('ls --parseable', (t) => {
     })
     ls(['bar'], (err) => {
       t.ifError(err, 'npm ls')
-      t.matchSnapshot(redactCwd(result), 'should output parseable contaning only occurences of filtered package')
+      t.matchSnapshot(redactCwd(result), 'should output parseable contaning only occurrences of filtered package')
       t.end()
     })
   })
@@ -1635,7 +1635,7 @@ t.test('ls --parseable', (t) => {
     })
     ls(['bar@*', 'lorem@1.0.0'], (err) => {
       t.ifError(err, 'npm ls')
-      t.matchSnapshot(redactCwd(result), 'should output parseable contaning only occurences of multiple filtered packages and their ancestors')
+      t.matchSnapshot(redactCwd(result), 'should output parseable contaning only occurrences of multiple filtered packages and their ancestors')
       t.end()
     })
   })
@@ -2158,7 +2158,7 @@ t.test('ls --parseable', (t) => {
       },
     })
     ls([], () => {
-      t.matchSnapshot(redactCwd(result), 'should print tree output ommiting deduped ref')
+      t.matchSnapshot(redactCwd(result), 'should print tree output omitting deduped ref')
       t.end()
     })
   })
@@ -2482,7 +2482,7 @@ t.test('ls --json', (t) => {
             },
           },
         },
-        'should output json contaning only occurences of filtered by package'
+        'should output json contaning only occurrences of filtered by package'
       )
       t.equal(
         process.exitCode,
@@ -2523,7 +2523,7 @@ t.test('ls --json', (t) => {
             },
           },
         },
-        'should output json contaning only occurences of filtered by package'
+        'should output json contaning only occurrences of filtered by package'
       )
       t.end()
     })
@@ -2571,7 +2571,7 @@ t.test('ls --json', (t) => {
             },
           },
         },
-        'should output json contaning only occurences of multiple filtered packages and their ancestors'
+        'should output json contaning only occurrences of multiple filtered packages and their ancestors'
       )
       t.end()
     })

--- a/test/lib/owner.js
+++ b/test/lib/owner.js
@@ -119,7 +119,7 @@ t.test('owner ls fails to retrieve packument', t => {
     t.match(
       err,
       /ERR/,
-      'should throw unkown error'
+      'should throw unknown error'
     )
   })
 })

--- a/test/lib/utils/replace-info.js
+++ b/test/lib/utils/replace-info.js
@@ -46,7 +46,7 @@ t.equal(
 t.equal(
   replaceInfo('Something https://user:pass@registry.npmjs.org/ foo bar'),
   'Something https://user:***@registry.npmjs.org/ foo bar',
-  'should replace single item withing a phrase'
+  'should replace single item within a phrase'
 )
 
 t.deepEqual(


### PR DESCRIPTION
Just typo fixes. I also went with the US spelling for "color".

Let me know if I should revert any changes; I recall not bothering with the changelog files in the past :)
