### PR TITLE
fix: npm publish --dry-run should not check login status

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -43,11 +43,13 @@ const publish = async args => {
     })
   }
 
-  const creds = npm.config.getCredentialsByURI(registry)
-  if (!creds.token && !creds.username) {
-    throw Object.assign(new Error('This command requires you to be logged in.'), {
-      code: 'ENEEDAUTH',
-    })
+  if (!opts.dryRun) {
+    const creds = npm.config.getCredentialsByURI(registry)
+    if (!creds.token && !creds.username) {
+      throw Object.assign(new Error('This command requires you to be logged in.'), {
+        code: 'ENEEDAUTH',
+      })
+    }
   }
 
   if (semver.validRange(defaultTag))

--- a/test/lib/publish.js
+++ b/test/lib/publish.js
@@ -193,7 +193,11 @@ t.test('should log tarball contents', (t) => {
         dryRun: true,
         registry: 'https://registry.npmjs.org/',
       },
-      config,
+      config: {
+        ...config,
+        getCredentialsByURI: () => {
+          throw new Error('should not call getCredentialsByURI!')
+        }},
     },
     '../../lib/utils/tar.js': {
       getContents: () => ({


### PR DESCRIPTION
npm7 should not check login status when executing `npm publish --dry-run`.

See [--dry-run](https://docs.npmjs.com/cli/v7/commands/npm-publish). Just keep the same behavior with npm6.

## References

  Fixes #2411 

## Test result

![image](https://user-images.githubusercontent.com/73812919/103279426-b2822700-4a08-11eb-9a1d-694cb8e32b2d.png)


