### PR TITLE
Grammatical Fix in npm-ls Documentation

### DIFF
--- a/docs/content/commands/npm-ls.md
+++ b/docs/content/commands/npm-ls.md
@@ -62,7 +62,7 @@ this gets even more curious, as `peerDependencies` are logically
 physically at or above their location on disk.
 
 Also, in the years since npm got an `ls` command (in version 0.0.2!),
-dependency graphs have gotten much larger as a general rule.  Therefor, in
+dependency graphs have gotten much larger as a general rule.  Therefore, in
 order to avoid dumping an excessive amount of content to the terminal, `npm
 ls` now only shows the _top_ level dependencies, unless `--all` is
 provided.


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Fixed a small spelling mistake in [npm-ls](https://github.com/npm/cli/blob/latest/docs/content/commands/npm-ls.md) documentation. 
'Therefore' was spelled 'Therefor'.


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #2400 
  Closes #2400 
-->
