### PR TITLE
Updated the url for RFC 19 so that it isn't a 404.

### DIFF
--- a/lib/update.js
+++ b/lib/update.js
@@ -24,7 +24,7 @@ const update = async args => {
 
   if (npm.flatOptions.depth) {
     log.warn('update', 'The --depth option no longer has any effect. See RFC0019.\n' +
-      'https://github.com/npm/rfcs/blob/latest/accepted/0019-remove-update-depth-option.md')
+      'https://github.com/npm/rfcs/blob/latest/implemented/0019-remove-update-depth-option.md')
   }
 
   const arb = new Arborist({


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

When I tried to use npm --depth 9999 update based on some old documentation, I got an error message: 

`npm WARN update The --depth option no longer has any effect. See RFC0019.
npm WARN update https://github.com/npm/rfcs/blob/latest/accepted/0019-remove-update-depth-option.md`

I noticed that the url mentioned is a 404, so this change updates the url from

https://github.com/npm/rfcs/blob/latest/accepted/0019-remove-update-depth-option.md

to 

https://github.com/npm/rfcs/blob/latest/implemented/0019-remove-update-depth-option.md

Aside: these docs on npm-update still seem to recommend --depth tricks:

https://docs.npmjs.com/cli/v7/commands/npm-update
