### PR TITLE
fix: publish --dry-run require login & publishConfig loaded after registry check

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -35,22 +35,7 @@ const publish = async args => {
   log.verbose('publish', args)
 
   const opts = { ...npm.flatOptions }
-  const { json, defaultTag, registry } = opts
-
-  if (!registry) {
-    throw Object.assign(new Error('No registry specified.'), {
-      code: 'ENOREGISTRY',
-    })
-  }
-
-  if (!opts.dryRun) {
-    const creds = npm.config.getCredentialsByURI(registry)
-    if (!creds.token && !creds.username) {
-      throw Object.assign(new Error('This command requires you to be logged in.'), {
-        code: 'ENEEDAUTH',
-      })
-    }
-  }
+  const { json, defaultTag } = opts
 
   if (semver.validRange(defaultTag))
     throw new Error('Tag name must not be a valid SemVer range: ' + defaultTag.trim())
@@ -90,6 +75,22 @@ const publish_ = async (arg, opts) => {
 
   if (manifest.publishConfig)
     Object.assign(opts, publishConfigToOpts(manifest.publishConfig))
+
+  const { registry } = opts
+  if (!registry) {
+    throw Object.assign(new Error('No registry specified.'), {
+      code: 'ENOREGISTRY',
+    })
+  }
+
+  if (!dryRun) {
+    const creds = npm.config.getCredentialsByURI(registry)
+    if (!creds.token && !creds.username) {
+      throw Object.assign(new Error('This command requires you to be logged in.'), {
+        code: 'ENEEDAUTH',
+      })
+    }
+  }
 
   // only run scripts for directory type publishes
   if (spec.type === 'directory') {

--- a/test/lib/publish.js
+++ b/test/lib/publish.js
@@ -369,3 +369,44 @@ t.test('throw if not logged in', async t => {
     }, 'throws when not logged in')
   })
 })
+
+t.test('read registry only from publishConfig', t => {
+  t.plan(3)
+
+  const publishConfig = { registry: 'https://some.registry' }
+  const testDir = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'my-cool-pkg',
+      version: '1.0.0',
+      publishConfig,
+    }, null, 2),
+  })
+
+  const publish = requireInject('../../lib/publish.js', {
+    '../../lib/npm.js': {
+      flatOptions: {
+        json: false,
+      },
+      config,
+    },
+    '../../lib/utils/tar.js': {
+      getContents: () => ({
+        id: 'someid',
+      }),
+      logTar: () => {},
+    },
+    '../../lib/utils/output.js': () => {},
+    libnpmpublish: {
+      publish: (manifest, tarData, opts) => {
+        t.match(manifest, { name: 'my-cool-pkg', version: '1.0.0' }, 'gets manifest')
+        t.same(opts.registry, publishConfig.registry, 'publishConfig is passed through')
+      },
+    },
+  })
+
+  return publish([testDir], (er) => {
+    if (er)
+      throw er
+    t.pass('got to callback')
+  })
+})

--- a/test/lib/publish.js
+++ b/test/lib/publish.js
@@ -329,7 +329,6 @@ t.test('throw if no registry', async t => {
     '../../lib/npm.js': {
       flatOptions: {
         json: false,
-        defaultTag: '0.0.13',
         registry: null,
       },
       config,
@@ -350,7 +349,6 @@ t.test('throw if not logged in', async t => {
     '../../lib/npm.js': {
       flatOptions: {
         json: false,
-        defaultTag: '0.0.13',
         registry: 'https://registry.npmjs.org/',
       },
       config: {


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

~~Fix `publish --dry-run` with v7.3.0 will require login (ENEEDAUTH).~~ (already fixed)
Fix `publishConfig` from `package.json` loaded after the registry check.

This PR delayed publish login check till config merge (from the code should wait for 1 more file read or pacote manifest load), and added publish read registry only from publishConfig test.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

Fixes https://github.com/npm/cli/issues/2411
Related PR also fix dry-run https://github.com/npm/cli/pull/2422
