### PR TITLE
fix: add npm_package_main to the list of environment variables

### DIFF
--- a/node_modules/@npmcli/run-script/lib/package-envs.js
+++ b/node_modules/@npmcli/run-script/lib/package-envs.js
@@ -22,4 +22,5 @@ module.exports = (env, pkg) => packageEnvs({ ...env }, {
   config: pkg.config,
   engines: pkg.engines,
   bin: pkg.bin,
+  main: pkg.main
 }, 'npm_package_')


### PR DESCRIPTION
<!-- What / Why -->
I believe `"start": "node $npm_package_main"` is a very popular script, so missing `main` in the list of variables becomes a breaking change for many projects.

<!-- Describe the request in detail. What it does and why it's being changed. -->
After all, `npm_package_main` was mentioned in the https://github.com/npm/rfcs/pull/183/files

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
