### PR TITLE
fix(docs): clean up `npm start` docs

### DIFF
--- a/docs/content/commands/npm-start.md
+++ b/docs/content/commands/npm-start.md
@@ -12,12 +12,38 @@ npm start [-- <args>]
 
 ### Description
 
-This runs an arbitrary command specified in the package's `"start"` property of
-its `"scripts"` object. If no `"start"` property is specified on the
-`"scripts"` object, it will run `node server.js`.
+This runs a predefined command specified in the `"start"` property of
+a package's `"scripts"` object.
+
+If the `"scripts"` object does not define a  `"start"` property, npm
+will run `node server.js`.
+
+Note that this is different from the default node behavior of running
+the file specified in a package's `"main"` attribute when evoking with
+`node .`
 
 As of [`npm@2.0.0`](https://blog.npmjs.org/post/98131109725/npm-2-0-0), you can
 use custom arguments when executing scripts. Refer to [`npm run-script`](/commands/npm-run-script) for more details.
+
+### Example
+
+```json
+{
+  "scripts": {
+    "start": "node foo.js"
+  }
+}
+```
+
+```bash
+npm start
+
+> npm@x.x.x start
+> node foo.js
+
+(foo.js output would be here)
+
+```
 
 ### See Also
 


### PR DESCRIPTION
Adds an example, and a note about how this differs than node's default
behavior

## References
Closes https://github.com/npm/statusboard/issues/247