### PR TITLE
fix(docs): clean up `npm prefix` docs

### DIFF
--- a/docs/content/commands/npm-prefix.md
+++ b/docs/content/commands/npm-prefix.md
@@ -12,12 +12,24 @@ npm prefix [-g]
 
 ### Description
 
-Print the local prefix to standard out. This is the closest parent directory
+Print the local prefix to standard output. This is the closest parent directory
 to contain a `package.json` file or `node_modules` directory, unless `-g` is
 also specified.
 
 If `-g` is specified, this will be the value of the global prefix. See
 [`npm config`](/commands/npm-config) for more detail.
+
+### Example
+
+```bash
+npm prefix
+/usr/local/projects/foo
+```
+
+```bash
+npm prefix -g
+/usr/local
+```
 
 ### See Also
 


### PR DESCRIPTION
Adds an example and slightly changes wording


## References
Closes https://github.com/npm/statusboard/issues/234