### PR TITLE
fix(docs): clean up `npm unpublish` docs

### DIFF
--- a/docs/content/commands/npm-unpublish.md
+++ b/docs/content/commands/npm-unpublish.md
@@ -20,22 +20,30 @@ npm unpublish [<@scope>/]<pkg> --force
 
 ### Warning
 
-Consider using the `deprecate` command instead, if your intent is to encourage users to upgrade, or if you no longer want to maintain a package.
+Consider using the [deprecate](/commands/npm-deprecate) command instead,
+if your intent is to encourage users to upgrade, or if you no longer
+want to maintain a package.
 
 ### Description
 
-This removes a package version from the registry, deleting its
-entry and removing the tarball.
+This removes a package version from the registry, deleting its entry and
+removing the tarball.
 
-If no version is specified, or if all versions are removed then
-the root package entry is removed from the registry entirely.
+The npm registry will return an error if you are not [logged
+in](/commands/npm-login).
 
-Even if a package version is unpublished, that specific name and
-version combination can never be reused. In order to publish the
-package again, a new version number must be used. If you unpublish the entire package, you may not publish any new versions of that package until 24 hours have passed.
+If you do not specify a version or if you remove all of a package's
+versions then the registry will remove the root package entry entirely.
 
-To learn more about how unpublish is treated on the npm registry, see our <a href="https://www.npmjs.com/policies/unpublish" target="_blank" rel="noopener noreferrer"> unpublish policies</a>. 
+Even if you unpublish a package version, that specific name and version
+combination can never be reused. In order to publish the package again,
+you must use a new version number. If you unpublish the entire package,
+you may not publish any new versions of that package until 24 hours have
+passed.
 
+To learn more about how the npm registry treats unpublish, see our <a
+href="https://www.npmjs.com/policies/unpublish" target="_blank"
+rel="noopener noreferrer"> unpublish policies</a>
 
 ### See Also
 
@@ -44,3 +52,4 @@ To learn more about how unpublish is treated on the npm registry, see our <a hre
 * [npm registry](/using-npm/registry)
 * [npm adduser](/commands/npm-adduser)
 * [npm owner](/commands/npm-owner)
+* [npm login](/commands/npm-login)

--- a/docs/content/commands/npm-unpublish.md
+++ b/docs/content/commands/npm-unpublish.md
@@ -6,6 +6,10 @@ description: Remove a package from the registry
 
 ### Synopsis
 
+To learn more about how the npm registry treats unpublish, see our <a
+href="https://www.npmjs.com/policies/unpublish" target="_blank"
+rel="noopener noreferrer"> unpublish policies</a>
+
 #### Unpublishing a single version of a package
 
 ```bash
@@ -20,7 +24,7 @@ npm unpublish [<@scope>/]<pkg> --force
 
 ### Warning
 
-Consider using the [deprecate](/commands/npm-deprecate) command instead,
+Consider using the [`deprecate`](/commands/npm-deprecate) command instead,
 if your intent is to encourage users to upgrade, or if you no longer
 want to maintain a package.
 
@@ -40,10 +44,6 @@ combination can never be reused. In order to publish the package again,
 you must use a new version number. If you unpublish the entire package,
 you may not publish any new versions of that package until 24 hours have
 passed.
-
-To learn more about how the npm registry treats unpublish, see our <a
-href="https://www.npmjs.com/policies/unpublish" target="_blank"
-rel="noopener noreferrer"> unpublish policies</a>
 
 ### See Also
 

--- a/lib/unpublish.js
+++ b/lib/unpublish.js
@@ -35,7 +35,7 @@ const completionFn = async (args) => {
   const access = await libaccess.lsPackages(username, opts)
   // do a bit of filtering at this point, so that we don't need
   // to fetch versions for more than one thing, but also don't
-  // accidentally a whole project
+  // accidentally unpublish a whole project
   let pkgs = Object.keys(access || {})
   if (!partialWord || !pkgs.length)
     return pkgs


### PR DESCRIPTION
Mostly grammar fixes, also adds not about needing to
be logged in, as per comment in https://github.com/npm/cli/issues/1880

## References
Closes https://github.com/npm/statusboard/issues/253