### PR TITLE
fix(docs): clean up `npm token` docs

### DIFF
--- a/docs/content/commands/npm-token.md
+++ b/docs/content/commands/npm-token.md
@@ -16,8 +16,8 @@ description: Manage your authentication tokens
 This lets you list, create and revoke authentication tokens.
 
 * `npm token list`:
-  Shows a table of all active authentication tokens. You can request this as
-  JSON with `--json` or tab-separated values with `--parseable`.
+  Shows a table of all active authentication tokens. You can request
+  this as JSON with `--json` or tab-separated values with `--parseable`.
 
 ```bash
 +--------+---------+------------+----------+----------------+
@@ -40,10 +40,17 @@ This lets you list, create and revoke authentication tokens.
 ```
 
 * `npm token create [--read-only] [--cidr=<cidr-ranges>]`:
-  Create a new authentication token. It can be `--read-only` or accept a list of
-  [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) ranges to
-  limit use of this token to. This will prompt you for your password, and, if you have
-  two-factor authentication enabled, an otp.
+  Create a new authentication token. It can be `--read-only`, or accept
+  a list of
+  [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing)
+  ranges with which to limit use of this token. This will prompt you for
+  your password, and, if you have two-factor authentication enabled, an
+  otp.
+
+  Currently, the cli can not generate automation tokens. Please refer to
+  the [docs
+  website](https://docs.npmjs.com/creating-and-viewing-access-tokens)
+  for more information on generating automation tokens.
 
 ```bash
 +----------------+--------------------------------------+
@@ -58,7 +65,9 @@ This lets you list, create and revoke authentication tokens.
 ```
 
 * `npm token revoke <token|id>`:
-  This removes an authentication token, making it immediately unusable. This can accept
-  both complete tokens (as you get back from `npm token create` and will
-  find in your `.npmrc`) and ids as seen in the `npm token list` output. 
-  This will NOT accept the truncated token found in `npm token list` output.
+  Immediately removes an authentication token from the registry.  You
+  will no longer be able to use it.  This can accept both complete
+  tokens (such as those you get back from `npm token create`, and those
+  found in your `.npmrc`), and ids as seen in the parseable or json
+  output of `npm token list`.  This will NOT accept the truncated token
+  found in the normal `npm token list` output.

--- a/lib/token.js
+++ b/lib/token.js
@@ -17,7 +17,7 @@ token._validateCIDRList = validateCIDRList
 const usageUtil = require('./utils/usage.js')
 token.usage = usageUtil('token',
   'npm token list\n' +
-  'npm token revoke <tokenKey>\n' +
+  'npm token revoke <id|token>\n' +
   'npm token create [--read-only] [--cidr=list]')
 
 const UsageError = (msg) =>


### PR DESCRIPTION
grammar fixes, notes on authentication tokens, match usage
output with readme


## References
Closes https://github.com/npm/statusboard/issues/251