### PR TITLE
correctly identify already linked packages when global prefix is a symlink

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -45,6 +45,9 @@ const link = async args => {
 // Returns a list of items that can't be fulfilled by
 // things found in the current arborist inventory
 const missingArgsFromTree = (tree, args) => {
+  if (tree.isLink)
+    return missingArgsFromTree(tree.target, args)
+
   const foundNodes = []
   const missing = args.filter(a => {
     const arg = npa(a)

--- a/tap-snapshots/test-lib-link.js-TAP.test.js
+++ b/tap-snapshots/test-lib-link.js-TAP.test.js
@@ -19,6 +19,11 @@ exports[`test/lib/link.js TAP link pkg already in global space > should create a
 
 `
 
+exports[`test/lib/link.js TAP link pkg already in global space when prefix is a symlink > should create a local symlink to global pkg 1`] = `
+{CWD}/test/lib/link-link-pkg-already-in-global-space-when-prefix-is-a-symlink/my-project/node_modules/@myscope/linked -> {CWD}/test/lib/link-link-pkg-already-in-global-space-when-prefix-is-a-symlink/scoped-linked
+
+`
+
 exports[`test/lib/link.js TAP link to globalDir when in current working dir of pkg and no args > should create a global link to current pkg 1`] = `
 {CWD}/test/lib/link-link-to-globalDir-when-in-current-working-dir-of-pkg-and-no-args/global-prefix/lib/node_modules/test-pkg-link -> {CWD}/test/lib/link-link-to-globalDir-when-in-current-working-dir-of-pkg-and-no-args/test-pkg-link
 


### PR DESCRIPTION
the previous behavior caused any linked package to be identified as missing when the global prefix is a symlink.

this in turn caused arborist to attempt to install it even though it was already there, which in the case of a linked package could cause the locally linked copy to be overwritten by a published version from the registry

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Fixes #2104 
