### PR TITLE
elaborate that npm help uses browser

### DIFF
--- a/lib/utils/npm-usage.js
+++ b/lib/utils/npm-usage.js
@@ -16,8 +16,8 @@ npm test           run this project's tests
 npm run <foo>      run the script named <foo>
 npm <command> -h   quick help on <command>
 npm -l             display usage info for all commands
-npm help <term>    search for help on <term>
-npm help npm       more involved overview
+npm help <term>    search for help on <term> (in a browser)
+npm help npm       more involved overview (in a browser)
 
 All commands:
 ${npm.config.get('long') ? usages() : ('\n    ' + wrap(cmdList))}


### PR DESCRIPTION
<!-- What / Why -->
As I mentioned in issue #2501 it is is mildly annoying to me that I forget that the npm help command opens a browser, and probably a few other people.  
<!-- Describe the request in detail. What it does and why it's being changed. -->
I have added "(in a browser)" to the npm usage string at the npm help line. Is this a reasonable change? It makes the output slightly more verbose, but reduces the occasional surprise of opening a browser with a saved session of over 900 tabs just to view a single help page. Yes, really, I do have 1004 tabs open currently, and that's an outlier, but I'm sure this impacts other people in less unusual circumstances.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Fixes #2501 