### PR TITLE
chore(tests): skip coverage for results.sort

### DIFF
--- a/lib/help-search.js
+++ b/lib/help-search.js
@@ -132,11 +132,15 @@ const searchFiles = async (args, data, files) => {
 
   // sort results by number of results found, then by number of hits
   // then by number of matching lines
+
+  // coverage is ignored here because the contents of results are
+  // nondeterministic due to either glob or readFiles or Object.entries
   return results.sort((a, b) =>
     a.found.length > b.found.length ? -1
     : a.found.length < b.found.length ? 1
     : a.totalHits > b.totalHits ? -1
     : a.totalHits < b.totalHits ? 1
+    /* istanbul ignore next */
     : a.lines.length > b.lines.length ? -1
     : a.lines.length < b.lines.length ? 1
     : 0).slice(0, 10)


### PR DESCRIPTION
We finally know why this is happening, and it's because
the array that it is sorting isn't deterministic. Explanation
is in the comments above the function, line is ignored, no
more random CI test failures.