### PR TITLE
package.json: fix repo URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/npm/cli"
+    "url": "git+https://github.com/npm/cli.git"
   },
   "bugs": {
     "url": "https://github.com/npm/cli/issues"


### PR DESCRIPTION
BTW something else I noticed is that `json-parse-even-better-errors` should be in the dependencies

https://github.com/npm/cli/blob/eb4f069159f70d7a48a7e41002ab5b9f9e15fc04/lib/set-script.js#L7
https://github.com/npm/cli/blob/eb4f069159f70d7a48a7e41002ab5b9f9e15fc04/lib/view.js#L19