### PR TITLE
ignore the sort in help-search more broadly

### DIFF
--- a/lib/help-search.js
+++ b/lib/help-search.js
@@ -135,12 +135,11 @@ const searchFiles = async (args, data, files) => {
 
   // coverage is ignored here because the contents of results are
   // nondeterministic due to either glob or readFiles or Object.entries
-  return results.sort((a, b) =>
+  return results.sort(/* istanbul ignore next */ (a, b) =>
     a.found.length > b.found.length ? -1
     : a.found.length < b.found.length ? 1
     : a.totalHits > b.totalHits ? -1
     : a.totalHits < b.totalHits ? 1
-    /* istanbul ignore next */
     : a.lines.length > b.lines.length ? -1
     : a.lines.length < b.lines.length ? 1
     : 0).slice(0, 10)


### PR DESCRIPTION
It turns out that the other stuff in those objects might also be in
random order, so this is still triggering CI coverage failures, albeit
more rarely than it used to.

Just ignore the whole sort function.  It's fine, we implicitly assert on
the sortedness in the test, so we know that it is doing its job.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
