### PR TITLE
pass all settings through to pacote.packument in outdated

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -108,6 +108,7 @@ async function outdated_ (tree, deps, opts) {
 
   async function getPackument (spec) {
     const packument = await pacote.packument(spec, {
+      ...npm.flatOptions,
       fullMetadata: npm.flatOptions.long,
       preferOnline: true,
     })


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
this was another spot where we missed passing flatOptions downstream

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Fixes #2060
