### PR TITLE
Release v7.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## v7.5.2 (2021-02-02)
+
+### BUG FIXES
+
+* [`37613e4e6`](https://github.com/npm/cli/commit/37613e4e686e4891210acaabc9c23f41456eda3f)
+[#2395](https://github.com/npm/cli/issues/2395)
+[#2329](https://github.com/npm/cli/issues/2329)
+fix(exec): use latest version when possible
+([@wraithgar](https://github.com/wraithgar))
+* [`567c9bd03`](https://github.com/npm/cli/commit/567c9bd03a7669111fbba6eb6d1f12ed7cad5a1b)
+fix(lib/npm): do not clobber config.execPath
+([@wraithgar](https://github.com/wraithgar))
+
+### DEPENDENCIES
+
+* [`643709706`](https://github.com/npm/cli/commit/64370970653af5c8d7a2be2c2144e355aa6431b0)
+`@npmcli/config@1.2.9` ([@isaacs](https://github.com/isaacs))
+  * [`4c6be4a`](https://github.com/npm/config/commit/4c6be4a66a3e89ae607e08172b8543b588a95fb5) Restore npm v6 behavior with `INIT_CWD`
+  * [`bbebc66`](https://github.com/npm/config/commit/bbebc668888f71dba57959682364b6ff26ff4fac) Do not set the `PREFIX` environment variable
+
 ## v7.5.1 (2021-02-01
 
 ### BUG FIXES

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -173,8 +173,8 @@ const npm = module.exports = new class extends EventEmitter {
     if (node && node.toUpperCase() !== process.execPath.toUpperCase()) {
       log.verbose('node symlink', node)
       process.execPath = node
+      this.config.execPath = node
     }
-    this.config.execPath = node
 
     await this.config.load()
     this.argv = this.config.parsedArgv.remain

--- a/node_modules/@npmcli/config/lib/set-envs.js
+++ b/node_modules/@npmcli/config/lib/set-envs.js
@@ -53,13 +53,7 @@ const setEnvs = (config) => {
     list: [cliConf, envConf],
   } = config
 
-  const { DESTDIR } = env
-  if (platform !== 'win32' && DESTDIR && globalPrefix.indexOf(DESTDIR) === 0)
-    env.PREFIX = globalPrefix.substr(DESTDIR.length)
-  else
-    env.PREFIX = globalPrefix
-
-  env.INIT_CWD = env.INIT_CWD || process.cwd()
+  env.INIT_CWD = process.cwd()
 
   // if the key is the default value,
   //   if the environ is NOT the default value,

--- a/node_modules/@npmcli/config/package.json
+++ b/node_modules/@npmcli/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@npmcli/config",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "files": [
     "lib"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm",
-  "version": "7.5.1",
+  "version": "7.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "npm",
-      "version": "7.5.1",
+      "version": "7.5.2",
       "bundleDependencies": [
         "@npmcli/arborist",
         "@npmcli/ci-detect",

--- a/package-lock.json
+++ b/package-lock.json
@@ -360,7 +360,7 @@
       "dependencies": {
         "@npmcli/arborist": "^2.1.1",
         "@npmcli/ci-detect": "^1.2.0",
-        "@npmcli/config": "^1.2.8",
+        "@npmcli/config": "^1.2.9",
         "@npmcli/run-script": "^1.8.1",
         "abbrev": "~1.1.1",
         "ansicolors": "~0.3.2",
@@ -727,9 +727,9 @@
       "inBundle": true
     },
     "node_modules/@npmcli/config": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@npmcli/config/-/config-1.2.8.tgz",
-      "integrity": "sha512-XFqg1uxUhEiy73hT1Z66xrMojgUOzAaCCYm12bEYBbi3wxmaer8MDRQ8ZViCacHFSZhkLVLqt/osPwKKJPduPw==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@npmcli/config/-/config-1.2.9.tgz",
+      "integrity": "sha512-d7mx35ju9HFg0gNHiwMU0HXCJk1esAeRdMktLeD+K2K2awkZyEm1FyX+g8iuZbmWGAaFP/aGiXo7a0lKlmp6Xg==",
       "inBundle": true,
       "dependencies": {
         "ini": "^2.0.0",
@@ -9962,9 +9962,9 @@
       "integrity": "sha512-oN3y7FAROHhrAt7Rr7PnTSwrHrZVRTS2ZbyxeQwSSYD0ifwM3YNgQqbaRmjcWoPyq77MjchusjJDspbzMmip1Q=="
     },
     "@npmcli/config": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@npmcli/config/-/config-1.2.8.tgz",
-      "integrity": "sha512-XFqg1uxUhEiy73hT1Z66xrMojgUOzAaCCYm12bEYBbi3wxmaer8MDRQ8ZViCacHFSZhkLVLqt/osPwKKJPduPw==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@npmcli/config/-/config-1.2.9.tgz",
+      "integrity": "sha512-d7mx35ju9HFg0gNHiwMU0HXCJk1esAeRdMktLeD+K2K2awkZyEm1FyX+g8iuZbmWGAaFP/aGiXo7a0lKlmp6Xg==",
       "requires": {
         "ini": "^2.0.0",
         "mkdirp-infer-owner": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.5.1",
+  "version": "7.5.2",
   "name": "npm",
   "description": "a package manager for JavaScript",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@npmcli/arborist": "^2.1.1",
     "@npmcli/ci-detect": "^1.2.0",
-    "@npmcli/config": "^1.2.8",
+    "@npmcli/config": "^1.2.9",
     "@npmcli/run-script": "^1.8.1",
     "abbrev": "~1.1.1",
     "ansicolors": "~0.3.2",


### PR DESCRIPTION
## v7.5.2 (2021-02-02)

### BUG FIXES

* [`37613e4e6`](https://github.com/npm/cli/commit/37613e4e686e4891210acaabc9c23f41456eda3f) [#2395](https://github.com/npm/cli/issues/2395) [#2329](https://github.com/npm/cli/issues/2329) fix(exec): use latest version when possible ([@wraithgar](https://github.com/wraithgar))
* [`567c9bd03`](https://github.com/npm/cli/commit/567c9bd03a7669111fbba6eb6d1f12ed7cad5a1b) fix(lib/npm): do not clobber config.execPath ([@wraithgar](https://github.com/wraithgar))

### DEPENDENCIES

* [`643709706`](https://github.com/npm/cli/commit/64370970653af5c8d7a2be2c2144e355aa6431b0) `@npmcli/config@1.2.9` ([@isaacs](https://github.com/isaacs))
  * [`4c6be4a`](https://github.com/npm/config/commit/4c6be4a66a3e89ae607e08172b8543b588a95fb5) Restore npm v6 behavior with `INIT_CWD`
  * [`bbebc66`](https://github.com/npm/config/commit/bbebc668888f71dba57959682364b6ff26ff4fac) Do not set the `PREFIX` environment variable