### PR TITLE
Fixed: npm publish lifecycle order

### DIFF
--- a/docs/content/using-npm/scripts.md
+++ b/docs/content/using-npm/scripts.md
@@ -76,9 +76,9 @@ The advantage of doing these things at `prepublish` time is that they can be don
 
 #### [`npm publish`](/commands/npm-publish)
 
-* `prepublishOnly`
-* `prepare`
 * `prepublish`
+* `prepare`
+* `prepublishOnly`
 * `publish`
 * `postpublish`
 


### PR DESCRIPTION
The lifecycle order for `npm publish` was corrected to match actual behavior and no longer contradicts the description for prepare .


