### PR TITLE
[fix] node v10.0 lacks `fs.promises`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: ['10.1', 10.x, '12.1', 12.x, '14.1', 14.x]
         platform:
           - os: ubuntu-latest
             shell: bash

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -1,5 +1,7 @@
 const { resolve, basename } = require('path')
-const { promises: { unlink } } = require('fs')
+const util = require('util')
+const fs = require('fs')
+const { unlink } = fs.promises || util.promisify(fs.unlink)
 const Arborist = require('@npmcli/arborist')
 const log = require('npmlog')
 

--- a/lib/utils/reify-finish.js
+++ b/lib/utils/reify-finish.js
@@ -1,7 +1,9 @@
 const reifyOutput = require('./reify-output.js')
 const npm = require('../npm.js')
 const ini = require('ini')
-const {writeFile} = require('fs').promises
+const util = require('util')
+const fs = require('fs')
+const { writeFile } = fs.promises || { writeFile: util.promisify(fs.writeFile) }
 const {resolve} = require('path')
 
 const reifyFinish = async arb => {

--- a/test/lib/shrinkwrap.js
+++ b/test/lib/shrinkwrap.js
@@ -1,4 +1,5 @@
 const t = require('tap')
+const fs = require('fs')
 const requireInject = require('require-inject')
 
 const npm = {
@@ -326,4 +327,11 @@ t.test('shrinkwrap --global', t => {
     t.equal(err.code, 'ESHRINKWRAPGLOBAL', 'should throw expected error code')
     t.end()
   })
+})
+
+t.test('works without fs.promises', async t => {
+  t.doesNotThrow(() => requireInject('../../lib/shrinkwrap.js', {
+    ...mocks,
+    fs: { ...fs, promises: null },
+  }))
 })

--- a/test/lib/utils/reify-finish.js
+++ b/test/lib/utils/reify-finish.js
@@ -20,7 +20,7 @@ let expectWrite = false
 const realFs = require('fs')
 const fs = {
   ...realFs,
-  promises: {
+  promises: realFs.promises && {
     ...realFs.promises,
     writeFile: async (path, data) => {
       if (!expectWrite)
@@ -77,4 +77,12 @@ t.test('should write if everything above passes', async t => {
   // windowwwwwwssss!!!!!
   const data = fs.readFileSync(`${path}/npmrc`, 'utf8').replace(/\r\n/g, '\n')
   t.matchSnapshot(data, 'written config')
+})
+
+t.test('works without fs.promises', async t => {
+  t.doesNotThrow(() => requireInject('../../../lib/utils/reify-finish.js', {
+    fs: { ...fs, promises: null },
+    '../../../lib/npm.js': npm,
+    '../../../lib/utils/reify-output.js': reifyOutput,
+  }))
 })


### PR DESCRIPTION
In this node version, fall back to `util.promisify` of the callback version.

Maybe fixes https://github.com/npm/cli/issues/2623. Maybe fixes https://github.com/npm/cli/issues/2652. Maybe fixes https://github.com/npm/cli/issues/2625.

Updated the tests to run on the `.0`s as well.

This is likely blocked until https://github.com/npm/node-gyp/pull/5 and https://github.com/npm/run-script/pull/21 are landed, released, and updated here.