### PR TITLE
feat(preinstall): add preinstall check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -356,6 +356,7 @@
         "wrappy",
         "yallist"
       ],
+      "hasInstallScript": true,
       "license": "Artistic-2.0",
       "dependencies": {
         "@npmcli/arborist": "^2.2.1",
@@ -401,6 +402,7 @@
         "node-gyp": "^7.1.2",
         "nopt": "^5.0.0",
         "npm-audit-report": "^2.1.4",
+        "npm-install-checks": "^4.0.0",
         "npm-package-arg": "^8.1.0",
         "npm-pick-manifest": "^6.1.0",
         "npm-profile": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "node-gyp": "^7.1.2",
     "nopt": "^5.0.0",
     "npm-audit-report": "^2.1.4",
+    "npm-install-checks": "^4.0.0",
     "npm-package-arg": "^8.1.0",
     "npm-pick-manifest": "^6.1.0",
     "npm-profile": "^5.0.2",
@@ -194,6 +195,7 @@
     "yaml": "^1.10.0"
   },
   "scripts": {
+    "preinstall": "node scripts/preinstall.js",
     "dumpconf": "env | grep npm | sort | uniq",
     "preversion": "bash scripts/update-authors.sh && git add AUTHORS && git commit -m \"update AUTHORS\" || true",
     "licenses": "licensee --production --errors-only",

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+/*
+ * Preinstall check
+ *
+ * We don't want to allow npm to install on systems that we know it won't work
+ * on, so we run some preinstall checks to make it bail early and save end
+ * users the hassle of recovering from a broken npm install
+ */
+
+
+const checks = require('npm-install-checks')
+const pkg = require('../package.json')
+
+try {
+  checks.checkEngine(pkg, pkg.version, process.version)
+} catch (e) {
+  if (e.code !== 'EBADENGINE') {
+    throw e
+  }
+  console.log(`Error: ${e.message}`)
+  console.log('Please see "Requirements" on https://www.npmjs.com/package/npm for more information about what versions of node are supported')
+  console.log('')
+  process.exitCode = 1
+}


### PR DESCRIPTION
This will prevent npm from installing itself on versions of node
in which we know it will not run


## References
Closes https://github.com/npm/cli/issues/2612


## Example output

```sh
~/D/npm $ npm install ./cli/npm-7.5.3.tgz

> npm@7.5.3 preinstall /Users/wraithgar/Development/npm/node_modules/npm
> node scripts/preinstall.js

Error: Unsupported engine
Please see "Requirements" on https://www.npmjs.com/package/npm for more information about what versions of node are supported

npm WARN notsup Unsupported engine for npm@7.5.3: wanted: {"node":">=10"} (current: {"node":"8.17.0","npm":"6.14.11"})
npm WARN notsup Not compatible with your version of node/npm: npm@7.5.3
npm WARN enoent ENOENT: no such file or directory, open '/Users/wraithgar/Development/npm/package.json'
npm WARN npm No description
npm WARN npm No repository field.
npm WARN npm No README data
npm WARN npm No license field.

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! npm@7.5.3 preinstall: `node scripts/preinstall.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the npm@7.5.3 preinstall script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/wraithgar/.npm/_logs/2021-02-09T16_56_31_080Z-debug.log
```