### PR TITLE
docs(readme): add note back about branding/origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,13 @@ npm <command>
 
 * `npm` is configured to use the **npm Public Registry** at [https://registry.npmjs.org](https://registry.npmjs.org) by default; Usage of this registry is subject to **Terms of Use** available at [https://npmjs.com/policies/terms](https://npmjs.com/policies/terms)
 * You can configure `npm` to use any other compatible registry you prefer. You can read more about configuring third-party registries [here](https://docs.npmjs.com/cli/v7/using-npm/registry)
+
+### FAQ on Branding
+
+#### Is it "npm" or "NPM" or "Npm"?
+
+**`npm`** should never be capitalized unless it is being displayed in a location that is customarily all-capitals (ex. titles on `man` pages).
+
+#### Is "npm" an acronym for "Node Package Manager"?
+
+Contrary to popular belief, **`npm`** **is not** in fact an acronym for "Node Package Manager"; It is a recursive bacronymic abbreviation for **"npm is not an acronym"** (if the project was named "ninaa", then it would be an acronym). The precursor to **`npm`** was actually a bash utility named **"pm"**, which was the shortform name of **"pkgmakeinst"** - a bash function that installed various things on various platforms. If **`npm`** were to ever have been considered an acronym, it would be as "node pm" or, potentially "new pm".


### PR DESCRIPTION
Pretty self-explanatory; Getting tired of trying to find the historical reference to this - might as well pull it in.

[Rendered](https://github.com/npm/cli/pull/2685/files?short_path=b335630#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)

[Original FAQ from 2015](https://docs.npmjs.com/misc/faq#if-npm-is-an-acronym-why-is-it-never-capitalized)

![...](https://thumbs.gfycat.com/ImmenseFearlessCockatiel-small.gif)