### PR TITLE
fix: shrinkwrap in node v10.0

### DIFF
--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -1,7 +1,7 @@
 const { resolve, basename } = require('path')
 const util = require('util')
 const fs = require('fs')
-const { unlink } = fs.promises || util.promisify(fs.unlink)
+const { unlink } = fs.promises || { unlink: util.promisify(fs.unlink) }
 const Arborist = require('@npmcli/arborist')
 const log = require('npmlog')
 


### PR DESCRIPTION
See https://github.com/npm/cli/pull/2654#discussion_r575549441

Note that this only applies to node 10.0; tests didn't catch it because errorMessage tests don't work in node 10.0 due to a broken Object.entries implementation with error instances.