### PR TITLE
docs: mention nodenv in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ If you're looking to manage multiple versions of **`node`** &/or **`npm`**, cons
 * [**`nave`**](https://github.com/isaacs/nave)
 * [**`n`**](https://github.com/tj/n)
 * [**`volta`**](https://github.com/volta-cli/volta)
+* [**`nodenv`**](https://github.com/nodenv/nodenv)
 
 ### Usage
 


### PR DESCRIPTION
The PR adds [**`nodenv`**](https://github.com/nodenv/nodenv) to [the list of available version managers in README.md](https://github.com/npm/cli/blob/e703362b02d672a14a98af8e2f99ae75c1bab945/README.md#node-version-managers).

The version manager in question has merit for being listed on the repository page due to its maturity and popularity (it has approx. 1.5k stars as of the time of posting).