### PR TITLE
fix(preinstall): run preinstall before reify

### DIFF
--- a/lib/ci.js
+++ b/lib/ci.js
@@ -47,13 +47,24 @@ const ci = async () => {
     }),
     removeNodeModules(where),
   ])
+
+  if (!ignoreScripts) {
+    await runScript({
+      path: where,
+      args: [],
+      scriptShell,
+      stdio: 'inherit',
+      stdioString: true,
+      event: 'preinstall',
+    })
+  }
+
   // npm ci should never modify the lockfile or package.json
   await arb.reify({ ...npm.flatOptions, save: false })
 
   // run the same set of scripts that `npm install` runs.
   if (!ignoreScripts) {
     const scripts = [
-      'preinstall',
       'install',
       'postinstall',
       'prepublish', // XXX should we remove this finally??

--- a/lib/install.js
+++ b/lib/install.js
@@ -16,7 +16,7 @@ const cmd = async (args, cb) => install(args).then(() => cb()).catch(cb)
 const install = async args => {
   // the /path/to/node_modules/..
   const globalTop = resolve(npm.globalDir, '..')
-  const { ignoreScripts, global: isGlobalInstall } = npm.flatOptions
+  const { global: isGlobalInstall } = npm.flatOptions
   const where = isGlobalInstall ? globalTop : npm.prefix
 
   // don't try to install the prefix into itself
@@ -30,19 +30,36 @@ const install = async args => {
   if (npm.config.get('dev'))
     log.warn('install', 'Usage of the `--dev` option is deprecated. Use `--include=dev` instead.')
 
+  const { scriptShell } = npm.flatOptions
   const arb = new Arborist({
     ...npm.flatOptions,
     path: where,
   })
 
+  const ignoreScripts = (args.length > 0) || isGlobalInstall ||
+    npm.flatOptions.ignoreScripts
+
+  // This is placed after Arborist is initialized but before reify to
+  // match the behavior in lib/ci.js, which has to initialize Arborist,
+  // remove node_modules, then reify again.
+  if (!ignoreScripts) {
+    await runScript({
+      path: where,
+      args: [],
+      scriptShell,
+      stdio: 'inherit',
+      stdioString: true,
+      event: 'preinstall',
+    })
+  }
+
   await arb.reify({
     ...npm.flatOptions,
     add: args,
   })
-  if (!args.length && !isGlobalInstall && !ignoreScripts) {
-    const { scriptShell } = npm.flatOptions
+
+  if (!ignoreScripts) {
     const scripts = [
-      'preinstall',
       'install',
       'postinstall',
       'prepublish', // XXX should we remove this finally??


### PR DESCRIPTION
This puts the preinstall life cycle script where it belongs,
i.e. before the actual installation/reify has taken place.



## References
Found during research for https://github.com/npm/cli/pull/2690