### PR TITLE
throw an error when trying to dedupe in global mode

### DIFF
--- a/lib/dedupe.js
+++ b/lib/dedupe.js
@@ -10,6 +10,12 @@ const completion = require('./utils/completion/none.js')
 const cmd = (args, cb) => dedupe(args).then(() => cb()).catch(cb)
 
 const dedupe = async (args) => {
+  if (npm.flatOptions.global) {
+    const er = new Error('`npm dedupe` does not work in global mode.')
+    er.code = 'EDEDUPEGLOBAL'
+    throw er
+  }
+
   const dryRun = (args && args.dryRun) || npm.flatOptions.dryRun
   const where = npm.prefix
   const arb = new Arborist({

--- a/test/lib/dedupe.js
+++ b/test/lib/dedupe.js
@@ -1,6 +1,21 @@
 const { test } = require('tap')
 const requireInject = require('require-inject')
 
+test('should throw in global mode', (t) => {
+  const dedupe = requireInject('../../lib/dedupe.js', {
+    '../../lib/npm.js': {
+      flatOptions: {
+        global: true,
+      },
+    },
+  })
+
+  dedupe([], er => {
+    t.match(er, { code: 'EDEDUPEGLOBAL' }, 'throws EDEDUPEGLOBAL')
+    t.end()
+  })
+})
+
 test('should remove dupes using Arborist', (t) => {
   const dedupe = requireInject('../../lib/dedupe.js', {
     '../../lib/npm.js': {


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
as described in #2620 it doesn't make much sense to globally dedupe, and clearly the wrong thing happens. let's just fail immediately instead of potentially breaking global packages.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Closes #2620