### PR TITLE
restore the prefix on output from `npm version <inc>`

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -37,13 +37,19 @@ const version = async args => {
     case 0:
       return list()
     case 1:
-      return output(await libversion(args[0], {
-        ...npm.flatOptions,
-        path: npm.prefix,
-      }))
+      return version_(args)
     default:
       throw usage
   }
+}
+
+const version_ = async (args) => {
+  const prefix = npm.flatOptions.tagVersionPrefix
+  const version = await libversion(args[0], {
+    ...npm.flatOptions,
+    path: npm.prefix,
+  })
+  return output(`${prefix}${version}`)
 }
 
 const list = async () => {

--- a/test/lib/version.js
+++ b/test/lib/version.js
@@ -6,6 +6,7 @@ let result = []
 const noop = () => null
 const npm = {
   flatOptions: {
+    tagVersionPrefix: 'v',
     json: false,
   },
   prefix: '',
@@ -144,17 +145,20 @@ t.test('with one arg', t => {
       t.deepEqual(
         opts,
         {
+          tagVersionPrefix: 'v',
           json: false,
           path: '',
         },
         'should forward expected options'
       )
-      t.end()
+      return '4.0.0'
     },
   })
 
   version(['major'], err => {
     if (err)
       throw err
+    t.same(result, ['v4.0.0'], 'outputs the new version prefixed by the tagVersionPrefix')
+    t.end()
   })
 })


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
we used to do this in npm 6, and stopped in npm 7 unintentionally. this restores that behavior in a slightly more intelligent way.

by default the `--tag-version-prefix` is `'v'` which means the result of `npm version patch` would be `v1.2.3` matching the behavior in npm 6.

the enhancement here is that if someone were to `npm version patch --tag-version-prefix=release/` we would now output `release/1.2.3` matching the tag we create.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Closes #2653