### PR TITLE
fix(runScript): obey silent loglevel

### DIFF
--- a/lib/ci.js
+++ b/lib/ci.js
@@ -68,6 +68,7 @@ const ci = async () => {
         scriptShell,
         stdio: 'inherit',
         stdioString: true,
+        banner: log.level !== 'silent',
         event,
       })
     }

--- a/lib/install.js
+++ b/lib/install.js
@@ -57,6 +57,7 @@ const install = async args => {
         scriptShell,
         stdio: 'inherit',
         stdioString: true,
+        banner: log.level !== 'silent',
         event,
       })
     }

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -85,6 +85,7 @@ const publish_ = async (arg, opts) => {
       path: spec.fetchSpec,
       stdio: 'inherit',
       pkg: manifest,
+      banner: log.level !== 'silent',
     })
   }
 
@@ -121,6 +122,7 @@ const publish_ = async (arg, opts) => {
       path: spec.fetchSpec,
       stdio: 'inherit',
       pkg: manifest,
+      banner: log.level !== 'silent',
     })
 
     await runScript({
@@ -128,6 +130,7 @@ const publish_ = async (arg, opts) => {
       path: spec.fetchSpec,
       stdio: 'inherit',
       pkg: manifest,
+      banner: log.level !== 'silent',
     })
   }
 

--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -1,5 +1,5 @@
-const run = require('@npmcli/run-script')
-const { isServerPackage } = run
+const runScript = require('@npmcli/run-script')
+const { isServerPackage } = runScript
 const npm = require('./npm.js')
 const readJson = require('read-package-json-fast')
 const { resolve } = require('path')
@@ -27,11 +27,11 @@ const completion = async (opts, cb) => {
 }
 
 const cmd = (args, cb) => {
-  const fn = args.length ? runScript : list
+  const fn = args.length ? doRun : list
   return fn(args).then(() => cb()).catch(cb)
 }
 
-const runScript = async (args) => {
+const doRun = async (args) => {
   const path = npm.localPrefix
   const event = args.shift()
   const { scriptShell } = npm.flatOptions
@@ -76,7 +76,7 @@ const runScript = async (args) => {
   }
 
   for (const [event, args] of events) {
-    await run({
+    await runScript({
       ...opts,
       event,
       args,


### PR DESCRIPTION
If the user has specified a silent loglevel, we should pass that intention on
when we call runScript

Also a small cleanup in lib/run-script.js so that the reference to
@npmcli/run-script is named the same as other files.
