### PR TITLE
Do not print error banner for shell proxy commands

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -49,6 +49,7 @@ const makeCmd = cmd => {
 }
 
 const { types, defaults, shorthands } = require('./utils/config.js')
+const { shellouts } = require('./utils/cmd-list.js')
 
 let warnedNonDashArg = false
 const _runCmd = Symbol('_runCmd')
@@ -79,6 +80,10 @@ const npm = module.exports = new class extends EventEmitter {
     })
     this[_title] = process.title
     this.updateNotification = null
+  }
+
+  get shelloutCommands () {
+    return shellouts
   }
 
   deref (c) {

--- a/lib/utils/cmd-list.js
+++ b/lib/utils/cmd-list.js
@@ -136,10 +136,24 @@ const cmdList = [
 ]
 
 const plumbing = ['birthday', 'help-search']
+
+// these commands just shell out to something else or handle the
+// error themselves, so it's confusing and weird to write out
+// our full error log banner when they exit non-zero
+const shellouts = [
+  'exec',
+  'run-script',
+  'test',
+  'start',
+  'stop',
+  'restart',
+]
+
 module.exports = {
   aliases: Object.assign({}, shorthands, affordances),
   shorthands,
   affordances,
   cmdList,
   plumbing,
+  shellouts,
 }

--- a/tap-snapshots/test-lib-utils-cmd-list.js-TAP.test.js
+++ b/tap-snapshots/test-lib-utils-cmd-list.js-TAP.test.js
@@ -173,6 +173,14 @@ Object {
     "birthday",
     "help-search",
   ],
+  "shellouts": Array [
+    "exec",
+    "run-script",
+    "test",
+    "start",
+    "stop",
+    "restart",
+  ],
   "shorthands": Object {
     "c": "config",
     "cit": "install-ci-test",

--- a/test/lib/npm.js
+++ b/test/lib/npm.js
@@ -79,6 +79,7 @@ t.test('not yet loaded', t => {
       set: Function,
     },
     version: String,
+    shelloutCommands: Array,
   })
   t.throws(() => npm.config.set('foo', 'bar'))
   t.throws(() => npm.config.get('foo'))


### PR DESCRIPTION
There are a few commands (exec, run-script, and the run-script proxies)
where essentially npm is acting like a very fancy shell.  It is peculiar
and noisy for npm to print a verbose error banner at the end of these
commands, since presumably the command itself already did whatever it
had to do to report the error appropriately.

For example, `npm test` runs a test script, usually outputting test
results.  Having npm then tell me that my tests failed with exit status
1 and print a debug log, is unnecessary and unwanted.

When the error encountered for these commands does not have a non-zero
numeric 'code', then we still print the standard npm error reporting
messages, because presumably something went wrong OTHER than a process
exiting with a non-zero status code.

Not sure if this should be considered a breaking change or a bugfix or a feature.  It is a change to our output, so anyone relying on that for test failures will be broken.  However, it also removes a lot of clutter that is providing no value in the vast majority of uses of `npm test`, and allows you to use `npm exec` with commands that may communicate something interesting both in stderr and the exit status code.  For example, a shell script that outputs JSON to stderr would not be usable with `npm exec` right now because of this extra debugging output.



<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
