### PR TITLE
chore(refactor): clean up lifecycle-cmds

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -49,6 +49,7 @@ const makeCmd = cmd => {
 }
 
 const { types, defaults, shorthands } = require('./utils/config.js')
+const { shellouts } = require('./utils/cmd-list.js')
 
 let warnedNonDashArg = false
 const _runCmd = Symbol('_runCmd')
@@ -79,6 +80,10 @@ const npm = module.exports = new class extends EventEmitter {
     })
     this[_title] = process.title
     this.updateNotification = null
+  }
+
+  get shelloutCommands () {
+    return shellouts
   }
 
   deref (c) {

--- a/lib/restart.js
+++ b/lib/restart.js
@@ -1,1 +1,2 @@
-module.exports = require('./utils/lifecycle-cmd.js')('restart')
+const npm = require('./npm.js')
+module.exports = require('./utils/lifecycle-cmd.js')(npm, 'restart')

--- a/lib/start.js
+++ b/lib/start.js
@@ -1,1 +1,2 @@
-module.exports = require('./utils/lifecycle-cmd.js')('start')
+const npm = require('./npm.js')
+module.exports = require('./utils/lifecycle-cmd.js')(npm, 'start')

--- a/lib/stop.js
+++ b/lib/stop.js
@@ -1,1 +1,2 @@
-module.exports = require('./utils/lifecycle-cmd.js')('stop')
+const npm = require('./npm.js')
+module.exports = require('./utils/lifecycle-cmd.js')(npm, 'stop')

--- a/lib/test.js
+++ b/lib/test.js
@@ -1,4 +1,5 @@
-const testCmd = require('./utils/lifecycle-cmd.js')('test')
+const npm = require('./npm.js')
+const testCmd = require('./utils/lifecycle-cmd.js')(npm, 'test')
 const { completion, usage } = testCmd
 const cmd = (args, cb) => testCmd(args, er => {
   if (er && er.code === 'ELIFECYCLE') {

--- a/lib/utils/cmd-list.js
+++ b/lib/utils/cmd-list.js
@@ -136,10 +136,24 @@ const cmdList = [
 ]
 
 const plumbing = ['birthday', 'help-search']
+
+// these commands just shell out to something else or handle the
+// error themselves, so it's confusing and weird to write out
+// our full error log banner when they exit non-zero
+const shellouts = [
+  'exec',
+  'run-script',
+  'test',
+  'start',
+  'stop',
+  'restart',
+]
+
 module.exports = {
   aliases: Object.assign({}, shorthands, affordances),
   shorthands,
   affordances,
   cmdList,
   plumbing,
+  shellouts,
 }

--- a/lib/utils/lifecycle-cmd.js
+++ b/lib/utils/lifecycle-cmd.js
@@ -1,12 +1,11 @@
 // The implementation of commands that are just "run a script"
 // test, start, stop, restart
 
-const npm = require('../npm.js')
 const usageUtil = require('./usage.js')
+const completion = require('./completion/none.js')
 
-module.exports = stage => {
-  const cmd = (args, cb) => npm.commands.run([stage, ...args], cb)
+module.exports = (npm, stage) => {
+  const cmd = (args, cb) => npm.commands['run-script']([stage, ...args], cb)
   const usage = usageUtil(stage, `npm ${stage} [-- <args>]`)
-  const completion = require('./completion/none.js')
   return Object.assign(cmd, { usage, completion })
 }

--- a/tap-snapshots/test-lib-utils-cmd-list.js-TAP.test.js
+++ b/tap-snapshots/test-lib-utils-cmd-list.js-TAP.test.js
@@ -173,6 +173,14 @@ Object {
     "birthday",
     "help-search",
   ],
+  "shellouts": Array [
+    "exec",
+    "run-script",
+    "test",
+    "start",
+    "stop",
+    "restart",
+  ],
   "shorthands": Object {
     "c": "config",
     "cit": "install-ci-test",

--- a/test/lib/npm.js
+++ b/test/lib/npm.js
@@ -79,6 +79,7 @@ t.test('not yet loaded', t => {
       set: Function,
     },
     version: String,
+    shelloutCommands: Array,
   })
   t.throws(() => npm.config.set('foo', 'bar'))
   t.throws(() => npm.config.get('foo'))

--- a/test/lib/test.js
+++ b/test/lib/test.js
@@ -3,7 +3,7 @@ const requireInject = require('require-inject')
 let RUN_ARGS = null
 const npmock = {
   commands: {
-    run: (args, cb) => {
+    'run-script': (args, cb) => {
       RUN_ARGS = args
       cb()
     },
@@ -26,12 +26,12 @@ t.test('run a test', t => {
   })
   const otherErr = new Error('should see this')
 
-  npmock.commands.run = (args, cb) => cb(lcErr)
+  npmock.commands['run-script'] = (args, cb) => cb(lcErr)
   test([], (er) => {
     t.equal(er, 'Test failed.  See above for more details.')
   })
 
-  npmock.commands.run = (args, cb) => cb(otherErr)
+  npmock.commands['run-script'] = (args, cb) => cb(otherErr)
   test([], (er) => {
     t.match(er, { message: 'should see this' })
   })

--- a/test/lib/utils/lifecycle-cmd.js
+++ b/test/lib/utils/lifecycle-cmd.js
@@ -1,15 +1,12 @@
 const t = require('tap')
-const requireInject = require('require-inject')
-const lifecycleCmd = requireInject('../../../lib/utils/lifecycle-cmd.js', {
-  '../../../lib/npm.js': {
-    commands: {
-      run: (args, cb) => cb(null, 'called npm.commands.run'),
-    },
+const lifecycleCmd = require('../../../lib/utils/lifecycle-cmd.js')
+const npm = {
+  commands: {
+    'run-script': (args, cb) => cb(null, 'called npm.commands.run'),
   },
-})
-
+}
 t.test('create a lifecycle command', t => {
-  const cmd = lifecycleCmd('asdf')
+  const cmd = lifecycleCmd(npm, 'asdf')
   t.equal(cmd.completion, require('../../../lib/utils/completion/none.js'), 'empty completion')
   cmd(['some', 'args'], (er, result) => {
     t.strictSame(result, 'called npm.commands.run')


### PR DESCRIPTION
This is a small incremental step in removing some of the complexity
surrounding the `npm` object in our code.

It moves that object one level up the chain of code, with the end goal
being that we will only require it once in the codebase, ultimately allowing
us to improve our tests.

I also changed the command that it calls to `run-script` because that is the
base command. `run` was an alias, and that is one more layer of hoops a
developer would have to jump through to find what file in `./lib` is even
being referenced here.