### PR TITLE
Remove unused arguments on various function calls

### DIFF
--- a/lib/access.js
+++ b/lib/access.js
@@ -10,7 +10,7 @@ const usageUtil = require('./utils/usage.js')
 const getIdentity = require('./utils/get-identity.js')
 
 const usage = usageUtil(
-  'npm access',
+  'access',
   'npm access public [<package>]\n' +
   'npm access restricted [<package>]\n' +
   'npm access grant <read-only|read-write> <scope:team> [<package>]\n' +

--- a/lib/ls.js
+++ b/lib/ls.js
@@ -31,7 +31,7 @@ const usage = usageUtil(
 
 const cmd = (args, cb) => ls(args).then(() => cb()).catch(cb)
 
-const initTree = async ({ arb, args, json }) => {
+const initTree = async ({ arb, args }) => {
   const tree = await arb.loadActual()
   tree[_include] = args.length === 0
   tree[_depth] = 0
@@ -252,7 +252,6 @@ const augmentNodesWithMetadata = ({
   args,
   currentDepth,
   nodeResult,
-  parseable,
   seenNodes,
 }) => (node) => {
   // if the original edge was a deduped dep, treeverse will fail to
@@ -285,7 +284,7 @@ const augmentNodesWithMetadata = ({
   // _filteredBy is used to apply extra color info to the item that
   // was used in args in order to filter
   node[_filteredBy] = node[_include] =
-    filterByPositionalArgs(args, { node: seenNodes.get(node.path), seenNodes })
+    filterByPositionalArgs(args, { node: seenNodes.get(node.path) })
   // _depth keeps track of how many levels deep tree traversal currently is
   // so that we can `npm ls --depth=1`
   node[_depth] = currentDepth + 1
@@ -389,8 +388,6 @@ const ls = async (args) => {
   const tree = await initTree({
     arb,
     args,
-    global,
-    json,
   })
 
   const seenItems = new Set()
@@ -436,7 +433,6 @@ const ls = async (args) => {
             args,
             currentDepth: node[_depth],
             nodeResult,
-            parseable,
             seenNodes,
           }))
     },

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -193,7 +193,7 @@ const npm = module.exports = new class extends EventEmitter {
     this.title = tokrev ? 'npm token revoke' + (this.argv[2] ? ' ***' : '')
       : ['npm', ...this.argv].join(' ')
 
-    this.color = setupLog(this.config, this)
+    this.color = setupLog(this.config)
     process.env.COLOR = this.color ? '1' : '0'
 
     cleanUpLogFiles(this.cache, this.config.get('logs-max'), log.warn)

--- a/lib/profile.js
+++ b/lib/profile.js
@@ -14,9 +14,10 @@ const readUserInfo = require('./utils/read-user-info.js')
 const usageUtil = require('./utils/usage.js')
 
 const usage = usageUtil(
-  'npm profile enable-2fa [auth-only|auth-and-writes]\n',
-  'npm profile disable-2fa\n',
-  'npm profile get [<key>]\n',
+  'profile',
+  'npm profile enable-2fa [auth-only|auth-and-writes]\n' +
+  'npm profile disable-2fa\n' +
+  'npm profile get [<key>]\n' +
   'npm profile set <key> <value>'
 )
 

--- a/lib/whoami.js
+++ b/lib/whoami.js
@@ -3,13 +3,13 @@ const output = require('./utils/output.js')
 const getIdentity = require('./utils/get-identity.js')
 const usageUtil = require('./utils/usage.js')
 
-const cmd = (args, cb) => whoami(args).then(() => cb()).catch(cb)
+const cmd = (args, cb) => whoami().then(() => cb()).catch(cb)
 
 const usage = usageUtil('whoami', 'npm whoami [--registry <registry>]\n(just prints username according to given registry)')
 
-const whoami = async ([spec]) => {
+const whoami = async () => {
   const opts = npm.flatOptions
-  const username = await getIdentity(opts, spec)
+  const username = await getIdentity(opts)
   output(opts.json ? JSON.stringify(username) : username)
 }
 

--- a/tap-snapshots/test-lib-utils-npm-usage.js-TAP.test.js
+++ b/tap-snapshots/test-lib-utils-npm-usage.js-TAP.test.js
@@ -393,11 +393,10 @@ All commands:
 
     prefix          npm prefix [-g]
 
-    profile         npm profile disable-2fa
-                    
-                    
-                    common options: npm profile get [<key>]
-                    
+    profile         npm profile enable-2fa [auth-only|auth-and-writes]
+                    npm profile disable-2fa
+                    npm profile get [<key>]
+                    npm profile set <key> <value>
 
     prune           npm prune [[<@scope>/]<pkg>...] [--production]
 


### PR DESCRIPTION
I checked cli's code with Typescript using the tsconfig below. The compiler found a few arguments that are not used, so I removed them.

- In the case of `npm whoami`, it is clearer that it ignores its `args` and instead relies on `npm.flatOptions`.
- For `npm profile`, it turns out that it was missing `+` between its string arguments; the test baselines show that this fixes profile's help output.

```json
{
    "compilerOptions": {
        "moduleResolution": "node",
        "module": "commonjs",
        "resolveJsonModule": true,
        "target": "es2019",
        "noImplicitAny": false,
        "noImplicitThis": true,
        "strict": true,
        "maxNodeModuleJsDepth": 0,
        "noEmit": true,
        "allowJs": true,
        "checkJs": true,
        "types": ["node"],
        "lib": ["esnext"]
    },
    "include": ["lib"]
}
```