### PR TITLE
fix(search): don't pass unused args

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -8,7 +8,7 @@ const packageFilter = require('./search/package-filter.js')
 const output = require('./utils/output.js')
 const usageUtil = require('./utils/usage.js')
 
-function prepareIncludes (args, searchopts) {
+function prepareIncludes (args) {
   return args
     .map(s => s.toLowerCase())
     .filter(s => s)
@@ -47,7 +47,7 @@ class Search {
     const opts = {
       ...this.npm.flatOptions,
       ...this.npm.flatOptions.search,
-      include: prepareIncludes(args, this.npm.flatOptions.search.opts),
+      include: prepareIncludes(args),
       exclude: prepareExcludes(this.npm.flatOptions.search.exclude),
     }
 


### PR DESCRIPTION
The searchopts get parsed and added to the query elsewhere, they're not
part of the `include` array they are an extra querystring that is added
to the search request.

These already make it to the search request, this was dead code.

## References
Closes https://github.com/npm/cli/issues/2791