### PR TITLE
Feature: explain command shows "bundled" flag for edge

### DIFF
--- a/lib/utils/explain-dep.js
+++ b/lib/utils/explain-dep.js
@@ -86,9 +86,10 @@ const explainDependents = ({ name, dependents }, depth, color) => {
   return str.split('\n').join('\n  ')
 }
 
-const explainEdge = ({ name, type, from, spec }, depth, color) => {
+const explainEdge = ({ name, type, bundled, from, spec }, depth, color) => {
   const { bold } = color ? chalk : nocolor
   return (type === 'prod' ? '' : `${colorType(type, color)} `) +
+    (bundled ? `${colorType('bundled', color)} ` : '') +
     `${bold(name)}@"${bold(spec)}" from ` +
     explainFrom(from, depth, color)
 }

--- a/tap-snapshots/test-lib-utils-explain-dep.js-TAP.test.js
+++ b/tap-snapshots/test-lib-utils-explain-dep.js-TAP.test.js
@@ -24,13 +24,13 @@ manydep@1.0.0
 exports[`test/lib/utils/explain-dep.js TAP bundled > explain color deep 1`] = `
 [1mbundle-of-joy[22m@[1m1.0.0[22m [1m[34mbundled[39m[22m[2m[22m
 [2mnode_modules/bundle-of-joy[22m
-  [1mprod-dep[22m@"[1m1.x[22m" from the root project
+  [34mbundled[39m [1mprod-dep[22m@"[1m1.x[22m" from the root project
 `
 
 exports[`test/lib/utils/explain-dep.js TAP bundled > explain nocolor shallow 1`] = `
 bundle-of-joy@1.0.0 bundled
 node_modules/bundle-of-joy
-  prod-dep@"1.x" from the root project
+  bundled prod-dep@"1.x" from the root project
 `
 
 exports[`test/lib/utils/explain-dep.js TAP bundled > print color 1`] = `

--- a/test/lib/utils/explain-dep.js
+++ b/test/lib/utils/explain-dep.js
@@ -107,6 +107,7 @@ const cases = {
         type: 'prod',
         name: 'prod-dep',
         spec: '1.x',
+        bundled: true,
         from: {
           location: '/path/to/project',
         },


### PR DESCRIPTION
Now that npm/arborist#241 is merged, we can include a bundled decoration for edges as well. very helpful for seeing where in the branch of a dep tree the bundle happened

![image](https://user-images.githubusercontent.com/1474978/109589745-c56ac200-7b45-11eb-91fc-fc8150715e06.png)

## References
Continuation of https://github.com/npm/cli/pull/2750
