### PR TITLE
Update republish timeout after unpublish

### DIFF
--- a/docs/content/commands/npm-unpublish.md
+++ b/docs/content/commands/npm-unpublish.md
@@ -42,7 +42,7 @@ versions then the registry will remove the root package entry entirely.
 Even if you unpublish a package version, that specific name and version
 combination can never be reused. In order to publish the package again,
 you must use a new version number. If you unpublish the entire package,
-you may not publish any new versions of that package until 28 days have
+you may not publish any new versions of that package until 24 hours have
 passed.
 
 ### See Also


### PR DESCRIPTION
The timeout for republishing a package that has been unpublished is 24 hours. Updating the documentation to reflect that.


## References
Part of closing https://github.com/github/npm/issues/2234
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
