### PR TITLE
fix(diff): set option "where" for pacote

### DIFF
--- a/lib/diff.js
+++ b/lib/diff.js
@@ -50,10 +50,11 @@ class Diff {
     const [a, b] = await this.retrieveSpecs(specs)
     npmlog.info('diff', { src: a, dst: b })
 
-    const res = await libdiff(
-      [a, b],
-      { ...this.npm.flatOptions, diffFiles: args }
-    )
+    const res = await libdiff([a, b], {
+      ...this.npm.flatOptions,
+      diffFiles: args,
+      where: this.where,
+    })
     return output(res)
   }
 

--- a/test/lib/diff.js
+++ b/test/lib/diff.js
@@ -951,12 +951,13 @@ t.test('first arg is a valid semver range', t => {
 
 t.test('first arg is an unknown dependency name', t => {
   t.test('second arg is a qualified spec', t => {
-    t.plan(3)
+    t.plan(4)
 
     libnpmdiff = async ([a, b], opts) => {
       t.equal(a, 'bar@latest', 'should set expected first spec')
       t.equal(b, 'bar@2.0.0', 'should set expected second spec')
       t.match(opts, npm.flatOptions, 'should forward flat options')
+      t.match(opts, { where: '.' }, 'should forward pacote options')
     }
 
     npm.flatOptions.diff = ['bar', 'bar@2.0.0']


### PR DESCRIPTION
pacote expects a **where** option that sets the cwd for all its
operations, ref: https://github.com/npm/pacote#options

This change properly sets that option in libnpmdiff options that will
then properly forward it to pacote, this is specially important for when
reading local file system specs.