### PR TITLE
Fix cb() never called in search with --json option

### DIFF
--- a/lib/search/format-package-stream.js
+++ b/lib/search/format-package-stream.js
@@ -43,6 +43,7 @@ class JSONOutputStream extends Minipass {
 
   end () {
     super.write(this._didFirst ? ']\n' : '\n]\n')
+    super.end()
   }
 }
 

--- a/test/lib/search.js
+++ b/test/lib/search.js
@@ -80,6 +80,48 @@ t.test('search <name>', t => {
   src.end()
 })
 
+t.test('search <name> --json', (t) => {
+  const src = new Minipass()
+  src.objectMode = true
+
+  flatOptions.json = true
+  const libnpmsearch = {
+    stream () {
+      return src
+    },
+  }
+
+  const Search = requireInject('../../lib/search.js', {
+    ...mocks,
+    libnpmsearch,
+  })
+  const search = new Search(npm)
+
+  search.exec(['libnpm'], (err) => {
+    if (err)
+      throw err
+
+    const parsedResult = JSON.parse(result)
+    parsedResult.forEach((entry) => {
+      entry.date = new Date(entry.date)
+    })
+
+    t.same(
+      parsedResult,
+      libnpmsearchResultFixture,
+      'should have expected search results as json'
+    )
+
+    flatOptions.json = false
+    t.end()
+  })
+
+  for (const i of libnpmsearchResultFixture)
+    src.write(i)
+
+  src.end()
+})
+
 t.test('search <name> --searchexclude --searchopts', t => {
   npm.flatOptions.search = {
     ...flatOptions.search,


### PR DESCRIPTION
Running `npm search` using --json option throws a ERR! cb() never called! error. Since version 7, checked on osX and Linux.

This PR fixes it by properly calling `Minipass.prototype.end()` upon completion in the `JSONOutputStream` class.

Also add a test case to ensure that `search --json` output a json