### PR TITLE
docs(configuring-npm): Fix broken link

### DIFF
--- a/docs/content/configuring-npm/package-json.md
+++ b/docs/content/configuring-npm/package-json.md
@@ -562,8 +562,7 @@ tarball or git URL.
 **Please do not put test harnesses or transpilers or other "development"
 time tools in your `dependencies` object.**  See `devDependencies`, below.
 
-See [semver]([/using-npm/semver](https://github.com/npm/node-semver#versions))
-for more details about specifying version ranges.
+See [semver](/using-npm/semver#versions) for more details about specifying version ranges.
 
 * `version` Must match `version` exactly
 * `>version` Must be greater than `version`


### PR DESCRIPTION
<!-- What / Why --> 
This fixes a broken link on the configuring-npm docs
<!-- Describe the request in detail. What it does and why it's being changed. -->
A broken link confuses the person referring to the docs.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
