### PR TITLE
fix(clone.js): escapes Windows filename spaces

### DIFF
--- a/node_modules/@npmcli/git/lib/clone.js
+++ b/node_modules/@npmcli/git/lib/clone.js
@@ -96,7 +96,7 @@ const branch = (repo, revDoc, target, opts) => {
     '-b',
     revDoc.ref,
     repo,
-    escapeTarget(target),
+    escapeTarget(target, opts),
     '--recurse-submodules',
   ]
   if (maybeShallow(repo, opts))
@@ -111,7 +111,7 @@ const plain = (repo, revDoc, target, opts) => {
   const args = [
     'clone',
     repo,
-    escapeTarget(target),
+    escapeTarget(target, opts),
     '--recurse-submodules'
   ]
   if (maybeShallow(repo, opts))
@@ -135,7 +135,7 @@ const unresolved = (repo, ref, target, opts) => {
   // can't do this one shallowly, because the ref isn't advertised
   // but we can avoid checking out the working dir twice, at least
   const lp = isWindows(opts) ? ['--config', 'core.longpaths=true'] : []
-  const cloneArgs = ['clone', '--mirror', '-q', repo, escapeTarget(target + '/.git')]
+  const cloneArgs = ['clone', '--mirror', '-q', repo, escapeTarget(target + '/.git', opts)]
   const git = (args) => spawn(args, { ...opts, cwd: target })
   return mkdirp(target)
     .then(() => git(cloneArgs.concat(lp)))

--- a/node_modules/@npmcli/git/lib/clone.js
+++ b/node_modules/@npmcli/git/lib/clone.js
@@ -44,6 +44,10 @@ const maybeShallow = (repo, opts) =>
 
 const isWindows = opts => (opts.fakePlatform || process.platform) === 'win32'
 
+const escapeTarget = (target, opts) =>
+  isWindows(opts) && target && !target.match(/^"/) ? '"' + target + '"'
+    : target
+
 const defaultTarget = (repo, /* istanbul ignore next */ cwd = process.cwd()) =>
   resolve(cwd, basename(repo.replace(/[\/\\]?\.git$/, '')))
 
@@ -92,7 +96,7 @@ const branch = (repo, revDoc, target, opts) => {
     '-b',
     revDoc.ref,
     repo,
-    target,
+    escapeTarget(target),
     '--recurse-submodules',
   ]
   if (maybeShallow(repo, opts))
@@ -107,7 +111,7 @@ const plain = (repo, revDoc, target, opts) => {
   const args = [
     'clone',
     repo,
-    target,
+    escapeTarget(target),
     '--recurse-submodules'
   ]
   if (maybeShallow(repo, opts))
@@ -131,7 +135,7 @@ const unresolved = (repo, ref, target, opts) => {
   // can't do this one shallowly, because the ref isn't advertised
   // but we can avoid checking out the working dir twice, at least
   const lp = isWindows(opts) ? ['--config', 'core.longpaths=true'] : []
-  const cloneArgs = ['clone', '--mirror', '-q', repo, target + '/.git']
+  const cloneArgs = ['clone', '--mirror', '-q', repo, escapeTarget(target + '/.git')]
   const git = (args) => spawn(args, { ...opts, cwd: target })
   return mkdirp(target)
     .then(() => git(cloneArgs.concat(lp)))


### PR DESCRIPTION
<!-- What / Why -->
This Pull Request contains the code to fix #2414, a bug related to windows temp path containing spaces

<!-- Describe the request in detail. What it does and why it's being changed. -->
The solution is straightforward: using the already existing isWindows function, determine whether the target for the `git clone` is already escaped on Windows and, if not, escapes it.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Fixes #2414 