### PR TITLE
Docs: add asdf-nodejs as a viable version manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ If you're looking to manage multiple versions of **`node`** &/or **`npm`**, cons
 * [**`n`**](https://github.com/tj/n)
 * [**`volta`**](https://github.com/volta-cli/volta)
 * [**`nodenv`**](https://github.com/nodenv/nodenv)
+* [**`asdf-nodejs`**](https://github.com/asdf-vm/asdf-nodejs)
 
 ### Usage
 


### PR DESCRIPTION
Document the asdf-nodejs plugin as a viable option for node version managing

More on asdf-vm and asdf-nodejs:
- [asdf, the universal version manager](https://asdf-vm.com/)
- [asdf Github repository](https://github.com/asdf-vm/asdf)
- [asdf-nodejs Github repository](https://github.com/asdf-vm/asdf-nodejs)
- [HackerNews discussion about asdf](https://news.ycombinator.com/item?id=26018684)