### PR TITLE
chore(config): remove flatOptions references

### DIFF
--- a/lib/access.js
+++ b/lib/access.js
@@ -75,7 +75,7 @@ class Access extends BaseCommand {
     if (!subcommands.includes(cmd) || !this[cmd])
       throw this.usageError(`${cmd} is not a recognized subcommand.`)
 
-    return this[cmd](args, { ...this.npm.flatOptions })
+    return this[cmd](args, this.npm.flatOptions)
   }
 
   public ([pkg], opts) {

--- a/lib/audit.js
+++ b/lib/audit.js
@@ -37,11 +37,14 @@ class Audit extends BaseCommand {
   }
 
   async audit (args) {
-    const arb = new Arborist({
+    const reporter = this.npm.config.get('json') ? 'json' : 'detail'
+    const opts = {
       ...this.npm.flatOptions,
       audit: true,
       path: this.npm.prefix,
-    })
+      reporter,
+    }
+    const arb = new Arborist(opts)
     const fix = args[0] === 'fix'
     await arb.audit({ fix })
     if (fix)
@@ -49,11 +52,7 @@ class Audit extends BaseCommand {
     else {
       // will throw if there's an error, because this is an audit command
       auditError(this.npm, arb.auditReport)
-      const reporter = this.npm.flatOptions.json ? 'json' : 'detail'
-      const result = auditReport(arb.auditReport, {
-        ...this.npm.flatOptions,
-        reporter,
-      })
+      const result = auditReport(arb.auditReport, opts)
       process.exitCode = process.exitCode || result.exitCode
       this.npm.output(result.report)
     }

--- a/lib/bin.js
+++ b/lib/bin.js
@@ -17,7 +17,7 @@ class Bin extends BaseCommand {
   async bin (args) {
     const b = this.npm.bin
     this.npm.output(b)
-    if (this.npm.flatOptions.global && !envPath.includes(b))
+    if (this.npm.config.get('global') && !envPath.includes(b))
       console.error('(not in PATH env variable)')
   }
 }

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -63,7 +63,7 @@ class Cache extends BaseCommand {
       throw new Error('npm cache clear does not accept arguments')
 
     const cachePath = path.join(this.npm.cache, '_cacache')
-    if (!this.npm.flatOptions.force) {
+    if (!this.npm.config.get('force')) {
       throw new Error(`As of npm@5, the npm cache self-heals from corruption issues
 by treating integrity mismatches as cache misses.  As a result,
 data extracted from the cache is guaranteed to be valid.  If you
@@ -100,7 +100,6 @@ with --force.`)
       throw Object.assign(new Error(usage), { code: 'EUSAGE' })
 
     log.silly('cache add', 'spec', spec)
-    const opts = { ...this.npm.flatOptions }
 
     // we ask pacote for the thing, and then just throw the data
     // away so that it tee-pipes it into the cache like it does
@@ -108,7 +107,7 @@ with --force.`)
     await pacote.tarball.stream(spec, stream => {
       stream.resume()
       return stream.promise()
-    }, opts)
+    }, this.npm.flatOptions)
   }
 
   async verify () {

--- a/lib/ci.js
+++ b/lib/ci.js
@@ -30,14 +30,13 @@ class CI extends BaseCommand {
   }
 
   async ci () {
-    if (this.npm.flatOptions.global) {
+    if (this.npm.config.get('global')) {
       const err = new Error('`npm ci` does not work for global packages')
       err.code = 'ECIGLOBAL'
       throw err
     }
 
     const where = this.npm.prefix
-    const { scriptShell, ignoreScripts } = this.npm.flatOptions
     const arb = new Arborist({ ...this.npm.flatOptions, path: where })
 
     await Promise.all([
@@ -54,6 +53,7 @@ class CI extends BaseCommand {
     // npm ci should never modify the lockfile or package.json
     await arb.reify({ ...this.npm.flatOptions, save: false })
 
+    const ignoreScripts = this.npm.config.get('ignore-scripts')
     // run the same set of scripts that `npm install` runs.
     if (!ignoreScripts) {
       const scripts = [
@@ -65,6 +65,7 @@ class CI extends BaseCommand {
         'prepare',
         'postprepare',
       ]
+      const scriptShell = this.npm.config.get('script-shell') || undefined
       for (const event of scripts) {
         await runScript({
           path: where,

--- a/lib/dedupe.js
+++ b/lib/dedupe.js
@@ -23,12 +23,13 @@ class Dedupe extends BaseCommand {
 
     const dryRun = this.npm.config.get('dry-run')
     const where = this.npm.prefix
-    const arb = new Arborist({
+    const opts = {
       ...this.npm.flatOptions,
       path: where,
       dryRun,
-    })
-    await arb.dedupe(this.npm.flatOptions)
+    }
+    const arb = new Arborist(opts)
+    await arb.dedupe(opts)
     await reifyFinish(this.npm, arb)
   }
 }

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -30,7 +30,7 @@ class Diff extends BaseCommand {
 
   get where () {
     const globalTop = resolve(this.npm.globalDir, '..')
-    const { global } = this.npm.flatOptions
+    const global = this.npm.config.get('global')
     return global ? globalTop : this.npm.prefix
   }
 
@@ -39,7 +39,7 @@ class Diff extends BaseCommand {
   }
 
   async diff (args) {
-    const specs = this.npm.flatOptions.diff.filter(d => d)
+    const specs = this.npm.config.get('diff').filter(d => d)
     if (specs.length > 2) {
       throw new TypeError(
         'Can\'t use more than two --diff arguments.\n\n' +
@@ -91,7 +91,7 @@ class Diff extends BaseCommand {
     }
 
     return [
-      `${pkgName}@${this.npm.flatOptions.defaultTag}`,
+      `${pkgName}@${this.npm.config.get('tag')}`,
       `file:${this.npm.prefix}`,
     ]
   }

--- a/lib/dist-tag.js
+++ b/lib/dist-tag.js
@@ -61,7 +61,7 @@ class DistTag extends BaseCommand {
   async add (spec, tag, opts) {
     spec = npa(spec || '')
     const version = spec.rawSpec
-    const defaultTag = tag || opts.defaultTag
+    const defaultTag = tag || this.npm.config.get('tag')
 
     log.verbose('dist-tag add', defaultTag, 'to', spec.name + '@' + version)
 

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -24,7 +24,7 @@ const BaseCommand = require('./base-command.js')
 //
 // npm x -p pkg@version -- foo --registry=/dev/null
 //
-// const pkg = npm.flatOptions.package || getPackageFrom(args[0])
+// const pkg = npm.config.get('package') || getPackageFrom(args[0])
 // const cmd = getCommand(pkg, args[0])
 // --> npm x -c 'cmd ...args.slice(1)'
 //
@@ -66,7 +66,10 @@ class Exec extends BaseCommand {
   // When commands go async and we can dump the boilerplate exec methods this
   // can be named correctly
   async _exec (args) {
-    const { package: packages, call, shell } = this.npm.flatOptions
+    const call = this.npm.config.get('call')
+    const shell = this.npm.config.get('shell')
+    // dereferenced because we manipulate it later
+    const packages = [...this.npm.config.get('package')]
 
     if (call && args.length)
       throw this.usage
@@ -165,9 +168,9 @@ class Exec extends BaseCommand {
 
       // no need to install if already present
       if (add.length) {
-        if (!this.npm.flatOptions.yes) {
+        if (!this.npm.config.get('yes')) {
           // set -n to always say no
-          if (this.npm.flatOptions.yes === false)
+          if (this.npm.config.get('yes') === false)
             throw 'canceled'
 
           if (!process.stdin.isTTY || ciDetect()) {

--- a/lib/fund.js
+++ b/lib/fund.js
@@ -42,9 +42,8 @@ class Fund extends BaseCommand {
   }
 
   async fund (args) {
-    const opts = this.npm.flatOptions
     const spec = args[0]
-    const numberArg = opts.which
+    const numberArg = this.npm.config.get('which')
 
     const fundingSourceNumber = numberArg && parseInt(numberArg, 10)
 
@@ -58,14 +57,14 @@ class Fund extends BaseCommand {
       throw err
     }
 
-    if (opts.global) {
+    if (this.npm.config.get('global')) {
       const err = new Error('`npm fund` does not support global packages')
       err.code = 'EFUNDGLOBAL'
       throw err
     }
 
     const where = this.npm.prefix
-    const arb = new Arborist({ ...opts, path: where })
+    const arb = new Arborist({ ...this.npm.flatOptions, path: where })
     const tree = await arb.loadActual()
 
     if (spec) {
@@ -78,23 +77,19 @@ class Fund extends BaseCommand {
       return
     }
 
-    const print = opts.json
-      ? this.printJSON
-      : this.printHuman
-
-    this.npm.output(
-      print(
-        getFundingInfo(tree),
-        opts
-      )
-    )
+    if (this.npm.config.get('json'))
+      this.npm.output(this.printJSON(getFundingInfo(tree)))
+    else
+      this.npm.output(this.printHuman(getFundingInfo(tree)))
   }
 
   printJSON (fundingInfo) {
     return JSON.stringify(fundingInfo, null, 2)
   }
 
-  printHuman (fundingInfo, { color, unicode }) {
+  printHuman (fundingInfo) {
+    const color = !!this.npm.color
+    const unicode = this.npm.config.get('unicode')
     const seenUrls = new Map()
 
     const tree = obj =>

--- a/lib/help-search.js
+++ b/lib/help-search.js
@@ -166,7 +166,7 @@ class HelpSearch extends BaseCommand {
       out.push(' '.repeat((Math.max(1, cols - out.join(' ').length - r.length - 1))))
       out.push(r)
 
-      if (!this.npm.flatOptions.long)
+      if (!this.npm.config.get('long'))
         return out.join('')
 
       out.unshift('\n\n')
@@ -198,7 +198,7 @@ class HelpSearch extends BaseCommand {
       return out.join('')
     }).join('\n')
 
-    const finalOut = results.length && !this.npm.flatOptions.long
+    const finalOut = results.length && !this.npm.config.get('long')
       ? 'Top hits for ' + (args.map(JSON.stringify).join(' ')) + '\n' +
       '—'.repeat(cols - 1) + '\n' +
       out + '\n' +

--- a/lib/init.js
+++ b/lib/init.js
@@ -59,7 +59,7 @@ class Init extends BaseCommand {
     this.npm.log.pause()
     this.npm.log.disableProgress()
     const initFile = this.npm.config.get('init-module')
-    if (!this.npm.flatOptions.yes && !this.npm.flatOptions.force) {
+    if (!this.npm.config.get('yes') && !this.npm.config.get('force')) {
       this.npm.output([
         'This utility will walk you through creating a package.json file.',
         'It only covers the most common items, and tries to guess sensible defaults.',

--- a/lib/install.js
+++ b/lib/install.js
@@ -98,7 +98,8 @@ class Install extends BaseCommand {
   async install (args) {
     // the /path/to/node_modules/..
     const globalTop = resolve(this.npm.globalDir, '..')
-    const { ignoreScripts, global: isGlobalInstall } = this.npm.flatOptions
+    const ignoreScripts = this.npm.config.get('ignore-scripts')
+    const isGlobalInstall = this.npm.config.get('global')
     const where = isGlobalInstall ? globalTop : this.npm.prefix
 
     // don't try to install the prefix into itself
@@ -122,7 +123,7 @@ class Install extends BaseCommand {
       add: args,
     })
     if (!args.length && !isGlobalInstall && !ignoreScripts) {
-      const { scriptShell } = this.npm.flatOptions
+      const scriptShell = this.npm.config.get('script-shell') || undefined
       const scripts = [
         'preinstall',
         'install',

--- a/lib/link.js
+++ b/lib/link.js
@@ -96,7 +96,13 @@ class Link extends BaseCommand {
     // npm link should not save=true by default unless you're
     // using any of --save-dev or other types
     const save =
-      Boolean(this.npm.config.find('save') !== 'default' || this.npm.flatOptions.saveType)
+      Boolean(
+        this.npm.config.find('save') !== 'default' ||
+        this.npm.config.get('save-optional') ||
+        this.npm.config.get('save-peer') ||
+        this.npm.config.get('save-dev') ||
+        this.npm.config.get('save-prod')
+      )
 
     // create a new arborist instance for the local prefix and
     // reify all the pending names as symlinks there

--- a/lib/logout.js
+++ b/lib/logout.js
@@ -19,9 +19,10 @@ class Logout extends BaseCommand {
   }
 
   async logout (args) {
-    const { registry, scope } = this.npm.flatOptions
+    const registry = this.npm.config.get('registry')
+    const scope = this.npm.config.get('scope')
     const regRef = scope ? `${scope}:registry` : 'registry'
-    const reg = this.npm.flatOptions[regRef] || registry
+    const reg = this.npm.config.get(regRef) || registry
 
     const auth = getAuth(reg, this.npm.flatOptions)
 

--- a/lib/ls.js
+++ b/lib/ls.js
@@ -43,24 +43,22 @@ class LS extends BaseCommand {
   }
 
   async ls (args) {
-    const {
-      all,
-      color,
-      depth,
-      json,
-      long,
-      global,
-      parseable,
-      prefix,
-      unicode,
-    } = this.npm.flatOptions
-    const path = global ? resolve(this.npm.globalDir, '..') : prefix
+    const all = this.npm.config.get('all')
+    const color = !!this.npm.color
+    const depth = this.npm.config.get('depth')
     const dev = this.npm.config.get('dev')
     const development = this.npm.config.get('development')
+    const global = this.npm.config.get('global')
+    const json = this.npm.config.get('json')
     const link = this.npm.config.get('link')
+    const long = this.npm.config.get('long')
     const only = this.npm.config.get('only')
+    const parseable = this.npm.config.get('parseable')
     const prod = this.npm.config.get('prod')
     const production = this.npm.config.get('production')
+    const unicode = this.npm.config.get('unicode')
+
+    const path = global ? resolve(this.npm.globalDir, '..') : this.npm.prefix
 
     const arb = new Arborist({
       global,

--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -28,15 +28,13 @@ class Outdated extends BaseCommand {
   }
 
   async outdated (args) {
-    this.opts = this.npm.flatOptions
-
     const global = path.resolve(this.npm.globalDir, '..')
-    const where = this.opts.global
+    const where = this.npm.config.get('global')
       ? global
       : this.npm.prefix
 
     const arb = new Arborist({
-      ...this.opts,
+      ...this.npm.flatOptions,
       path: where,
     })
 
@@ -51,7 +49,7 @@ class Outdated extends BaseCommand {
         this.getEdges(nodes, 'edgesIn')
       }
     } else {
-      if (this.opts.all) {
+      if (this.npm.config.get('all')) {
         // all deps in tree
         const nodes = this.tree.inventory.values()
         this.getEdges(nodes, 'edgesOut')
@@ -68,13 +66,13 @@ class Outdated extends BaseCommand {
     const outdated = this.list.sort((a, b) => a.name.localeCompare(b.name))
 
     // return if no outdated packages
-    if (outdated.length === 0 && !this.opts.json)
+    if (outdated.length === 0 && !this.npm.config.get('json'))
       return
 
     // display results
-    if (this.opts.json)
+    if (this.npm.config.get('json'))
       this.npm.output(this.makeJSON(outdated))
-    else if (this.opts.parseable)
+    else if (this.npm.config.get('parseable'))
       this.npm.output(this.makeParseable(outdated))
     else {
       const outList = outdated.map(x => this.makePretty(x))
@@ -86,11 +84,11 @@ class Outdated extends BaseCommand {
         'Depended by',
       ]
 
-      if (this.opts.long)
+      if (this.npm.config.get('long'))
         outHead.push('Package Type', 'Homepage')
       const outTable = [outHead].concat(outList)
 
-      if (this.opts.color)
+      if (this.npm.color)
         outTable[0] = outTable[0].map(heading => styles.underline(heading))
 
       const tableOpts = {
@@ -117,7 +115,7 @@ class Outdated extends BaseCommand {
   }
 
   getEdgesOut (node) {
-    if (this.opts.global) {
+    if (this.npm.config.get('global')) {
       for (const child of node.children.values())
         this.edges.add(child)
     } else {
@@ -129,7 +127,7 @@ class Outdated extends BaseCommand {
   async getPackument (spec) {
     const packument = await pacote.packument(spec, {
       ...this.npm.flatOptions,
-      fullMetadata: this.npm.flatOptions.long,
+      fullMetadata: this.npm.config.get('long'),
       preferOnline: true,
     })
     return packument
@@ -146,7 +144,7 @@ class Outdated extends BaseCommand {
       : edge.dev ? 'devDependencies'
       : 'dependencies'
 
-    for (const omitType of this.opts.omit || []) {
+    for (const omitType of this.npm.config.get('omit') || []) {
       if (node[omitType])
         return
     }
@@ -213,12 +211,12 @@ class Outdated extends BaseCommand {
 
     const columns = [name, current, wanted, latest, location, dependent]
 
-    if (this.opts.long) {
+    if (this.npm.config.get('long')) {
       columns[6] = type
       columns[7] = homepage
     }
 
-    if (this.opts.color) {
+    if (this.npm.color) {
       columns[0] = color[current === wanted ? 'yellow' : 'red'](columns[0]) // current
       columns[2] = color.green(columns[2]) // wanted
       columns[3] = color.magenta(columns[3]) // latest
@@ -248,7 +246,7 @@ class Outdated extends BaseCommand {
         name + '@' + latest,
         dependent,
       ]
-      if (this.opts.long)
+      if (this.npm.config.get('long'))
         out.push(type, homepage)
 
       return out.join(':')
@@ -275,7 +273,7 @@ class Outdated extends BaseCommand {
         dependent,
         location: path,
       }
-      if (this.opts.long) {
+      if (this.npm.config.get('long')) {
         out[name].type = type
         out[name].homepage = homepage
       }

--- a/lib/pack.js
+++ b/lib/pack.js
@@ -29,12 +29,12 @@ class Pack extends BaseCommand {
     if (args.length === 0)
       args = ['.']
 
-    const { unicode } = this.npm.flatOptions
+    const unicode = this.npm.config.get('unicode')
 
     // clone the opts because pacote mutates it with resolved/integrity
     const tarballs = await Promise.all(args.map(async (arg) => {
       const spec = npa(arg)
-      const { dryRun } = this.npm.flatOptions
+      const dryRun = this.npm.config.get('dry-run')
       const manifest = await pacote.manifest(spec, this.npm.flatOptions)
       const filename = `${manifest.name}-${manifest.version}.tgz`
         .replace(/^@/, '').replace(/\//, '-')

--- a/lib/ping.js
+++ b/lib/ping.js
@@ -18,14 +18,14 @@ class Ping extends BaseCommand {
   }
 
   async ping (args) {
-    log.notice('PING', this.npm.flatOptions.registry)
+    log.notice('PING', this.npm.config.get('registry'))
     const start = Date.now()
     const details = await pingUtil(this.npm.flatOptions)
     const time = Date.now() - start
     log.notice('PONG', `${time / 1000}ms`)
-    if (this.npm.flatOptions.json) {
+    if (this.npm.config.get('json')) {
       this.npm.output(JSON.stringify({
-        registry: this.npm.flatOptions.registry,
+        registry: this.npm.config.get('registry'),
         time,
         details,
       }, null, 2))

--- a/lib/profile.js
+++ b/lib/profile.js
@@ -108,14 +108,14 @@ class Profile extends BaseCommand {
 
   async get (args) {
     const tfa = 'two-factor auth'
-    const conf = { ...this.npm.flatOptions }
-
-    const info = await pulseTillDone.withPromise(npmProfile.get(conf))
+    const info = await pulseTillDone.withPromise(
+      npmProfile.get(this.npm.flatOptions)
+    )
 
     if (!info.cidr_whitelist)
       delete info.cidr_whitelist
 
-    if (conf.json) {
+    if (this.npm.config.get('json')) {
       this.npm.output(JSON.stringify(info, null, 2))
       return
     }
@@ -147,7 +147,7 @@ class Profile extends BaseCommand {
         .join('\t')
       this.npm.output(values)
     } else {
-      if (conf.parseable) {
+      if (this.npm.config.get('parseable')) {
         for (const key of Object.keys(info)) {
           if (key === 'tfa')
             this.npm.output(`${key}\t${cleaned[tfa]}`)
@@ -165,7 +165,7 @@ class Profile extends BaseCommand {
   }
 
   async set (args) {
-    const conf = { ...this.npm.flatOptions }
+    const conf = this.npm.flatOptions
     const prop = (args[0] || '').toLowerCase().trim()
 
     let value = args.length > 1 ? args.slice(1).join(' ') : null
@@ -214,9 +214,9 @@ class Profile extends BaseCommand {
 
     const result = await otplease(conf, conf => npmProfile.set(newUser, conf))
 
-    if (conf.json)
+    if (this.npm.config.get('json'))
       this.npm.output(JSON.stringify({ [prop]: result[prop] }, null, 2))
-    else if (conf.parseable)
+    else if (this.npm.config.get('parseable'))
       this.npm.output(prop + '\t' + result[prop])
     else if (result[prop] != null)
       this.npm.output('Set', prop, 'to', result[prop])
@@ -239,11 +239,10 @@ class Profile extends BaseCommand {
       )
     }
 
-    const conf = { ...this.npm.flatOptions }
-    if (conf.json || conf.parseable) {
+    if (this.npm.config.get('json') || this.npm.config.get('parseable')) {
       throw new Error(
         'Enabling two-factor authentication is an interactive operation and ' +
-        (conf.json ? 'JSON' : 'parseable') + ' output mode is not available'
+        (this.npm.config.get('json') ? 'JSON' : 'parseable') + ' output mode is not available'
       )
     }
 
@@ -255,7 +254,7 @@ class Profile extends BaseCommand {
 
     // if they're using legacy auth currently then we have to
     // update them to a bearer token before continuing.
-    const creds = this.npm.config.getCredentialsByURI(conf.registry)
+    const creds = this.npm.config.getCredentialsByURI(this.npm.config.get('registry'))
     const auth = {}
 
     if (creds.token)
@@ -267,32 +266,29 @@ class Profile extends BaseCommand {
       auth.basic = { username: basic[0], password: basic[1] }
     }
 
-    if (conf.otp)
-      auth.otp = conf.otp
-
     if (!auth.basic && !auth.token) {
       throw new Error(
         'You need to be logged in to registry ' +
-        `${conf.registry} in order to enable 2fa`
+        `${this.npm.config.get('registry')} in order to enable 2fa`
       )
     }
 
     if (auth.basic) {
       log.info('profile', 'Updating authentication to bearer token')
       const result = await npmProfile.createToken(
-        auth.basic.password, false, [], conf
+        auth.basic.password, false, [], this.npm.flatOptions
       )
 
       if (!result.token) {
         throw new Error(
-          `Your registry ${conf.registry} does not seem to ` +
+          `Your registry ${this.npm.config.get('registry')} does not seem to ` +
           'support bearer tokens. Bearer tokens are required for ' +
           'two-factor authentication'
         )
       }
 
       this.npm.config.setCredentialsByURI(
-        conf.registry,
+        this.npm.config.get('registry'),
         { token: result.token }
       )
       await this.npm.config.save('user')
@@ -303,21 +299,21 @@ class Profile extends BaseCommand {
     info.tfa.password = password
 
     log.info('profile', 'Determine if tfa is pending')
-    const userInfo = await pulseTillDone.withPromise(npmProfile.get(conf))
+    const userInfo = await pulseTillDone.withPromise(
+      npmProfile.get(this.npm.flatOptions)
+    )
 
+    const conf = { ...this.npm.flatOptions }
     if (userInfo && userInfo.tfa && userInfo.tfa.pending) {
       log.info('profile', 'Resetting two-factor authentication')
       await pulseTillDone.withPromise(
         npmProfile.set({ tfa: { password, mode: 'disable' } }, conf)
       )
     } else if (userInfo && userInfo.tfa) {
-      if (conf.otp)
-        conf.otp = conf.otp
-      else {
-        const otp = await readUserInfo.otp(
+      if (!conf.otp) {
+        conf.otp = await readUserInfo.otp(
           'Enter one-time password from your authenticator app: '
         )
-        conf.otp = otp
       }
     }
 
@@ -390,9 +386,9 @@ class Profile extends BaseCommand {
       tfa: { password: password, mode: 'disable' },
     }, conf))
 
-    if (conf.json)
+    if (this.npm.config.get('json'))
       this.npm.output(JSON.stringify({ tfa: false }, null, 2))
-    else if (conf.parseable)
+    else if (this.npm.config.get('parseable'))
       this.npm.output('tfa\tfalse')
     else
       this.npm.output('Two factor authentication disabled.')

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -43,11 +43,15 @@ class Publish extends BaseCommand {
 
     log.verbose('publish', args)
 
-    const opts = { ...this.npm.flatOptions }
-    const { unicode, dryRun, json, defaultTag } = opts
+    const unicode = this.npm.config.get('unicode')
+    const dryRun = this.npm.config.get('dry-run')
+    const json = this.npm.config.get('json')
+    const defaultTag = this.npm.config.get('tag')
 
     if (semver.validRange(defaultTag))
       throw new Error('Tag name must not be a valid SemVer range: ' + defaultTag.trim())
+
+    const opts = { ...this.npm.flatOptions }
 
     // you can publish name@version, ./foo.tgz, etc.
     // even though the default is the 'file:.' cwd.

--- a/lib/rebuild.js
+++ b/lib/rebuild.js
@@ -27,7 +27,7 @@ class Rebuild extends BaseCommand {
 
   async rebuild (args) {
     const globalTop = resolve(this.npm.globalDir, '..')
-    const where = this.npm.flatOptions.global ? globalTop : this.npm.prefix
+    const where = this.npm.config.get('global') ? globalTop : this.npm.prefix
     const arb = new Arborist({
       ...this.npm.flatOptions,
       path: where,

--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -49,7 +49,9 @@ class RunScript extends BaseCommand {
   async run (args) {
     const path = this.npm.localPrefix
     const event = args.shift()
-    const { scriptShell } = this.npm.flatOptions
+    // this || undefined is because runScript will be unhappy with the default
+    // null value
+    const scriptShell = this.npm.config.get('script-shell') || undefined
 
     const pkg = await readJson(`${path}/package.json`)
     const { scripts = {} } = pkg
@@ -75,7 +77,7 @@ class RunScript extends BaseCommand {
 
     // positional args only added to the main event, not pre/post
     const events = [[event, args]]
-    if (!this.npm.flatOptions.ignoreScripts) {
+    if (!this.npm.config.get('ignore-scripts')) {
       if (scripts[`pre${event}`])
         events.unshift([`pre${event}`, []])
 
@@ -113,12 +115,12 @@ class RunScript extends BaseCommand {
     if (log.level === 'silent')
       return allScripts
 
-    if (this.npm.flatOptions.json) {
+    if (this.npm.config.get('json')) {
       this.npm.output(JSON.stringify(scripts, null, 2))
       return allScripts
     }
 
-    if (this.npm.flatOptions.parseable) {
+    if (this.npm.config.get('parseable')) {
       for (const [script, cmd] of Object.entries(scripts))
         this.npm.output(`${script}:${cmd}`)
 

--- a/lib/search.js
+++ b/lib/search.js
@@ -84,7 +84,7 @@ class Search extends BaseCommand {
     })
 
     await p.promise()
-    if (!anyOutput && !opts.json && !opts.parseable)
+    if (!anyOutput && !this.npm.config.get('json') && !this.npm.config.get('parseable'))
       this.npm.output('No matches found for ' + (args.map(JSON.stringify).join(' ')))
 
     log.silly('search', 'search completed')

--- a/lib/shrinkwrap.js
+++ b/lib/shrinkwrap.js
@@ -24,7 +24,7 @@ class Shrinkwrap extends BaseCommand {
     //
     // loadVirtual, fall back to loadActual
     // rename shrinkwrap file type, and tree.meta.save()
-    if (this.npm.flatOptions.global) {
+    if (this.npm.config.get('global')) {
       const er = new Error('`npm shrinkwrap` does not work for global packages')
       er.code = 'ESHRINKWRAPGLOBAL'
       throw er

--- a/lib/star.js
+++ b/lib/star.js
@@ -26,7 +26,7 @@ class Star extends BaseCommand {
 
     // if we're unstarring, then show an empty star image
     // otherwise, show the full star image
-    const { unicode } = this.npm.flatOptions
+    const unicode = this.npm.config.get('unicode')
     const unstar = this.npm.config.get('star.unstar')
     const full = unicode ? '\u2605 ' : '(*)'
     const empty = unicode ? '\u2606 ' : '( )'

--- a/lib/uninstall.js
+++ b/lib/uninstall.js
@@ -28,7 +28,8 @@ class Uninstall extends BaseCommand {
 
   async uninstall (args) {
     // the /path/to/node_modules/..
-    const { global, prefix } = this.npm.flatOptions
+    const global = this.npm.config.get('global')
+    const prefix = this.npm.config.get('prefix')
     const path = global ? resolve(this.npm.globalDir, '..') : prefix
 
     if (!args.length) {

--- a/lib/unpublish.js
+++ b/lib/unpublish.js
@@ -63,8 +63,9 @@ class Unpublish extends BaseCommand {
       throw new Error(this.usage)
 
     const spec = args.length && npa(args[0])
-    const opts = this.npm.flatOptions
-    const { force, silent, loglevel } = opts
+    const force = this.npm.config.get('force')
+    const silent = this.npm.config.get('silent')
+    const loglevel = this.npm.config.get('loglevel')
     let pkgName
     let pkgVersion
 
@@ -79,6 +80,7 @@ class Unpublish extends BaseCommand {
       )
     }
 
+    const opts = this.npm.flatOptions
     if (!spec || path.resolve(spec.name) === this.npm.localPrefix) {
       // if there's a package.json in the current folder, then
       // read the package name and version out of that.

--- a/lib/update.js
+++ b/lib/update.js
@@ -30,11 +30,11 @@ class Update extends BaseCommand {
   async update (args) {
     const update = args.length === 0 ? true : args
     const global = path.resolve(this.npm.globalDir, '..')
-    const where = this.npm.flatOptions.global
+    const where = this.npm.config.get('global')
       ? global
       : this.npm.prefix
 
-    if (this.npm.flatOptions.depth) {
+    if (this.npm.config.get('depth')) {
       log.warn('update', 'The --depth option no longer has any effect. See RFC0019.\n' +
         'https://github.com/npm/rfcs/blob/latest/implemented/0019-remove-update-depth-option.md')
     }

--- a/lib/utils/ping.js
+++ b/lib/utils/ping.js
@@ -1,7 +1,7 @@
 // ping the npm registry
 // used by the ping and doctor commands
 const fetch = require('npm-registry-fetch')
-module.exports = async (opts) => {
-  const res = await fetch('/-/ping?write=true', opts)
+module.exports = async (flatOptions) => {
+  const res = await fetch('/-/ping?write=true', flatOptions)
   return res.json().catch(() => ({}))
 }

--- a/lib/utils/read-local-package.js
+++ b/lib/utils/read-local-package.js
@@ -1,11 +1,12 @@
 const { resolve } = require('path')
 const readJson = require('read-package-json-fast')
 async function readLocalPackageName (npm) {
-  if (npm.flatOptions.global)
+  if (npm.config.get('global'))
     return
 
-  const filepath = resolve(npm.flatOptions.prefix, 'package.json')
-  return (await readJson(filepath)).name
+  const filepath = resolve(npm.prefix, 'package.json')
+  const json = await readJson(filepath)
+  return json.name
 }
 
 module.exports = readLocalPackageName

--- a/lib/version.js
+++ b/lib/version.js
@@ -45,7 +45,7 @@ class Version extends BaseCommand {
   }
 
   async change (args) {
-    const prefix = this.npm.flatOptions.tagVersionPrefix
+    const prefix = this.npm.config.get('tag-version-prefix')
     const version = await libversion(args[0], {
       ...this.npm.flatOptions,
       path: this.npm.prefix,
@@ -71,7 +71,7 @@ class Version extends BaseCommand {
     for (const [key, version] of Object.entries(process.versions))
       results[key] = version
 
-    if (this.npm.flatOptions.json)
+    if (this.npm.config.get('json'))
       this.npm.output(JSON.stringify(results, null, 2))
     else
       this.npm.output(results)

--- a/lib/view.js
+++ b/lib/view.js
@@ -41,9 +41,9 @@ class View extends BaseCommand {
       fullMetadata: true,
       preferOnline: true,
     }
-    const { defaultTag } = config
     const spec = npa(opts.conf.argv.remain[2])
     const pckmnt = await packument(spec, config)
+    const defaultTag = this.npm.config.get('tag')
     const dv = pckmnt.versions[pckmnt['dist-tags'][defaultTag]]
     pckmnt.versions = Object.keys(pckmnt.versions).sort(semver.compareLoose)
 
@@ -99,7 +99,7 @@ class View extends BaseCommand {
     const name = nv.name
     const local = (name === '.' || !name)
 
-    if (opts.global && local)
+    if (this.npm.config.get('global') && local)
       throw new Error('Cannot use view command in global mode.')
 
     if (local) {
@@ -114,7 +114,7 @@ class View extends BaseCommand {
     }
 
     // get the data about this package
-    let version = nv.rawSpec || this.npm.flatOptions.defaultTag
+    let version = nv.rawSpec || this.npm.config.get('tag')
 
     const pckmnt = await packument(nv, opts)
 
@@ -159,42 +159,43 @@ class View extends BaseCommand {
     }
 
     if (
-      !opts.json &&
+      !this.npm.config.get('json') &&
       args.length === 1 &&
       args[0] === ''
     ) {
       // general view
       pckmnt.version = version
       await Promise.all(
-        results.map((v) => this.prettyView(pckmnt, v[Object.keys(v)[0]][''], opts))
+        results.map((v) => this.prettyView(pckmnt, v[Object.keys(v)[0]]['']))
       )
       return retval
     } else {
       // view by field name
-      await this.printData(retval, pckmnt._id, opts)
+      await this.printData(retval, pckmnt._id)
       return retval
     }
   }
 
-  async printData (data, name, opts) {
+  async printData (data, name) {
     const versions = Object.keys(data)
     let msg = ''
     let msgJson = []
     const includeVersions = versions.length > 1
     let includeFields
+    const json = this.npm.config.get('json')
 
     versions.forEach((v) => {
       const fields = Object.keys(data[v])
       includeFields = includeFields || (fields.length > 1)
-      if (opts.json)
+      if (json)
         msgJson.push({})
       fields.forEach((f) => {
         let d = cleanup(data[v][f])
-        if (fields.length === 1 && opts.json)
+        if (fields.length === 1 && json)
           msgJson[msgJson.length - 1][f] = d
 
         if (includeVersions || includeFields || typeof d !== 'string') {
-          if (opts.json)
+          if (json)
             msgJson[msgJson.length - 1][f] = d
           else {
             d = inspect(d, {
@@ -204,10 +205,10 @@ class View extends BaseCommand {
               maxArrayLength: null,
             })
           }
-        } else if (typeof d === 'string' && opts.json)
+        } else if (typeof d === 'string' && json)
           d = JSON.stringify(d)
 
-        if (!opts.json) {
+        if (!json) {
           if (f && includeFields)
             f += ' = '
           msg += (includeVersions ? name + '@' + v + ' ' : '') +
@@ -216,7 +217,7 @@ class View extends BaseCommand {
       })
     })
 
-    if (opts.json) {
+    if (json) {
       if (msgJson.length && Object.keys(msgJson[0]).length === 1) {
         const k = Object.keys(msgJson[0])[0]
         msgJson = msgJson.map(m => m[k])
@@ -236,9 +237,9 @@ class View extends BaseCommand {
       console.log(msg.trim())
   }
 
-  async prettyView (packument, manifest, opts) {
+  async prettyView (packument, manifest) {
     // More modern, pretty printing of default view
-    const unicode = opts.unicode
+    const unicode = this.npm.config.get('unicode')
     const tags = []
 
     Object.keys(packument['dist-tags']).forEach((t) => {

--- a/lib/whoami.js
+++ b/lib/whoami.js
@@ -22,9 +22,10 @@ class Whoami extends BaseCommand {
   }
 
   async whoami (args) {
-    const opts = this.npm.flatOptions
-    const username = await getIdentity(this.npm, opts)
-    this.npm.output(opts.json ? JSON.stringify(username) : username)
+    const username = await getIdentity(this.npm, this.npm.flatOptions)
+    this.npm.output(
+      this.npm.config.get('json') ? JSON.stringify(username) : username
+    )
   }
 }
 module.exports = Whoami

--- a/test/fixtures/mock-npm.js
+++ b/test/fixtures/mock-npm.js
@@ -1,0 +1,22 @@
+// Basic npm fixture that you can give a config object that acts like
+// npm.config You still need a separate flatOptions but this is the first step
+// to eventually just using npm itself
+
+const mockNpm = (base = {}) => {
+  const config = base.config || {}
+  const flatOptions = base.flatOptions || {}
+  return {
+    ...base,
+    flatOptions,
+    config: {
+      // for now just set `find` to what config.find should return
+      // this works cause `find` is not an existing config entry
+      find: (k) => config[k],
+      get: (k) => config[k],
+      set: (k, v) => config[k] = v,
+      list: [config]
+    },
+  }
+}
+
+module.exports = mockNpm

--- a/test/lib/audit.js
+++ b/test/lib/audit.js
@@ -1,5 +1,6 @@
 const t = require('tap')
 const requireInject = require('require-inject')
+const mockNpm = require('../fixtures/mock-npm')
 
 t.test('should audit using Arborist', t => {
   let ARB_ARGS = null
@@ -9,15 +10,15 @@ t.test('should audit using Arborist', t => {
   let OUTPUT_CALLED = false
   let ARB_OBJ = null
 
-  const npm = {
+  const npm = mockNpm({
     prefix: 'foo',
-    flatOptions: {
+    config: {
       json: false,
     },
     output: () => {
       OUTPUT_CALLED = true
     },
-  }
+  })
   const Audit = requireInject('../../lib/audit.js', {
     'npm-audit-report': () => {
       AUDIT_REPORT_CALLED = true
@@ -65,13 +66,13 @@ t.test('should audit using Arborist', t => {
 })
 
 t.test('should audit - json', t => {
-  const npm = {
+  const npm = mockNpm({
     prefix: 'foo',
-    flatOptions: {
+    config: {
       json: true,
     },
     output: () => {},
-  }
+  })
 
   const Audit = requireInject('../../lib/audit.js', {
     'npm-audit-report': () => ({
@@ -98,9 +99,12 @@ t.test('report endpoint error', t => {
     t.test(`json=${json}`, t => {
       const OUTPUT = []
       const LOGS = []
-      const npm = {
+      const npm = mockNpm({
         prefix: 'foo',
         command: 'audit',
+        config: {
+          json,
+        },
         flatOptions: {
           json,
         },
@@ -110,7 +114,7 @@ t.test('report endpoint error', t => {
         output: (...msg) => {
           OUTPUT.push(msg)
         },
-      }
+      })
       const Audit = requireInject('../../lib/audit.js', {
         'npm-audit-report': () => {
           throw new Error('should not call audit report when there are errors')

--- a/test/lib/bin.js
+++ b/test/lib/bin.js
@@ -1,5 +1,6 @@
 const { test } = require('tap')
 const requireInject = require('require-inject')
+const mockNpm = require('../fixtures/mock-npm')
 
 test('bin', (t) => {
   t.plan(4)
@@ -7,13 +8,13 @@ test('bin', (t) => {
 
   const Bin = require('../../lib/bin.js')
 
-  const npm = {
+  const npm = mockNpm({
     bin: dir,
-    flatOptions: { global: false },
+    config: { global: false },
     output: (output) => {
       t.equal(output, dir, 'prints the correct directory')
     },
-  }
+  })
   const bin = new Bin(npm)
   t.match(bin.usage, 'bin', 'usage has command name in it')
 
@@ -39,13 +40,13 @@ test('bin -g', (t) => {
     '../../lib/utils/path.js': [dir],
   })
 
-  const npm = {
+  const npm = mockNpm({
     bin: dir,
-    flatOptions: { global: true },
+    config: { global: true },
     output: (output) => {
       t.equal(output, dir, 'prints the correct directory')
     },
-  }
+  })
   const bin = new Bin(npm)
 
   bin.exec([], (err) => {
@@ -69,13 +70,13 @@ test('bin -g (not in path)', (t) => {
   const Bin = requireInject('../../lib/bin.js', {
     '../../lib/utils/path.js': ['/not/my/dir'],
   })
-  const npm = {
+  const npm = mockNpm({
     bin: dir,
-    flatOptions: { global: true },
+    config: { global: true },
     output: (output) => {
       t.equal(output, dir, 'prints the correct directory')
     },
-  }
+  })
   const bin = new Bin(npm)
 
   bin.exec([], (err) => {

--- a/test/lib/ci.js
+++ b/test/lib/ci.js
@@ -5,6 +5,7 @@ const readdir = util.promisify(fs.readdir)
 const { test } = require('tap')
 
 const requireInject = require('require-inject')
+const mockNpm = require('../fixtures/mock-npm')
 
 test('should ignore scripts with --ignore-scripts', (t) => {
   const SCRIPTS = []
@@ -22,17 +23,15 @@ test('should ignore scripts with --ignore-scripts', (t) => {
     },
   })
 
-  const ci = new CI({
+  const npm = mockNpm({
     globalDir: 'path/to/node_modules/',
     prefix: 'foo',
-    flatOptions: {
-      global: false,
-      ignoreScripts: true,
-    },
     config: {
-      get: () => false,
+      global: false,
+      'ignore-scripts': true,
     },
   })
+  const ci = new CI(npm)
 
   ci.exec([], er => {
     if (er)
@@ -115,12 +114,13 @@ test('should use Arborist and run-script', (t) => {
     },
   })
 
-  const ci = new CI({
+  const npm = mockNpm({
     prefix: path,
-    flatOptions: {
+    config: {
       global: false,
     },
   })
+  const ci = new CI(npm)
 
   ci.exec(null, er => {
     if (er)
@@ -146,12 +146,13 @@ test('should pass flatOptions to Arborist.reify', (t) => {
       }
     },
   })
-  const ci = new CI({
+  const npm = mockNpm({
     prefix: 'foo',
     flatOptions: {
       production: true,
     },
   })
+  const ci = new CI(npm)
   ci.exec(null, er => {
     if (er)
       throw er
@@ -173,14 +174,15 @@ test('should throw if package-lock.json or npm-shrinkwrap missing', (t) => {
       },
     },
   })
-  const ci = new CI({
+  const npm = mockNpm({
     prefix: testDir,
-    flatOptions: {
+    config: {
       global: false,
     },
   })
+  const ci = new CI(npm)
   ci.exec(null, (err, res) => {
-    t.ok(err, 'throws error when there is no package-lock')
+    t.match(err, /package-lock.json/, 'throws error when there is no package-lock')
     t.notOk(res)
     t.end()
   })
@@ -191,12 +193,13 @@ test('should throw ECIGLOBAL', (t) => {
     '@npmcli/run-script': opts => {},
     '../../lib/utils/reify-finish.js': async () => {},
   })
-  const ci = new CI({
+  const npm = mockNpm({
     prefix: 'foo',
-    flatOptions: {
+    config: {
       global: true,
     },
   })
+  const ci = new CI(npm)
   ci.exec(null, (err, res) => {
     t.equals(err.code, 'ECIGLOBAL', 'throws error with global packages')
     t.notOk(res)
@@ -227,12 +230,13 @@ test('should remove existing node_modules before installing', (t) => {
     },
   })
 
-  const ci = new CI({
+  const npm = mockNpm({
     prefix: testDir,
-    flatOptions: {
+    config: {
       global: false,
     },
   })
+  const ci = new CI(npm)
 
   ci.exec(null, er => {
     if (er)

--- a/test/lib/fund.js
+++ b/test/lib/fund.js
@@ -1,5 +1,6 @@
 const { test } = require('tap')
 const requireInject = require('require-inject')
+const mockNpm = require('../fixtures/mock-npm')
 
 const version = '1.0.0'
 const funding = {
@@ -180,11 +181,10 @@ const conflictingFundingPackages = {
 
 let result = ''
 let printUrl = ''
-const _flatOptions = {
+const config = {
   color: false,
   json: false,
   global: false,
-  prefix: undefined,
   unicode: false,
   which: undefined,
 }
@@ -192,7 +192,7 @@ const openUrl = async (npm, url, msg) => {
   if (url === 'http://npmjs.org')
     throw new Error('ERROR')
 
-  if (_flatOptions.json) {
+  if (config.json) {
     printUrl = JSON.stringify({
       title: msg,
       url: url,
@@ -210,18 +210,16 @@ const Fund = requireInject('../../lib/fund.js', {
       : Promise.reject(new Error('ERROR')),
   },
 })
-const fund = new Fund({
-  flatOptions: _flatOptions,
-  get prefix () {
-    return _flatOptions.prefix
-  },
+const npm = mockNpm({
+  config,
   output: msg => {
     result += msg + '\n'
   },
 })
+const fund = new Fund(npm)
 
 test('fund with no package containing funding', t => {
-  _flatOptions.prefix = t.testdir({
+  npm.prefix = t.testdir({
     'package.json': JSON.stringify({
       name: 'no-funding-package',
       version: '0.0.0',
@@ -237,7 +235,7 @@ test('fund with no package containing funding', t => {
 })
 
 test('fund in which same maintainer owns all its deps', t => {
-  _flatOptions.prefix = t.testdir(maintainerOwnsAllDeps)
+  npm.prefix = t.testdir(maintainerOwnsAllDeps)
 
   fund.exec([], (err) => {
     t.ifError(err, 'should not error out')
@@ -248,8 +246,8 @@ test('fund in which same maintainer owns all its deps', t => {
 })
 
 test('fund in which same maintainer owns all its deps, using --json option', t => {
-  _flatOptions.json = true
-  _flatOptions.prefix = t.testdir(maintainerOwnsAllDeps)
+  config.json = true
+  npm.prefix = t.testdir(maintainerOwnsAllDeps)
 
   fund.exec([], (err) => {
     t.ifError(err, 'should not error out')
@@ -281,13 +279,13 @@ test('fund in which same maintainer owns all its deps, using --json option', t =
     )
 
     result = ''
-    _flatOptions.json = false
+    config.json = false
     t.end()
   })
 })
 
 test('fund containing multi-level nested deps with no funding', t => {
-  _flatOptions.prefix = t.testdir(nestedNoFundingPackages)
+  npm.prefix = t.testdir(nestedNoFundingPackages)
 
   fund.exec([], (err) => {
     t.ifError(err, 'should not error out')
@@ -302,8 +300,8 @@ test('fund containing multi-level nested deps with no funding', t => {
 })
 
 test('fund containing multi-level nested deps with no funding, using --json option', t => {
-  _flatOptions.prefix = t.testdir(nestedNoFundingPackages)
-  _flatOptions.json = true
+  npm.prefix = t.testdir(nestedNoFundingPackages)
+  config.json = true
 
   fund.exec([], (err) => {
     t.ifError(err, 'should not error out')
@@ -328,14 +326,14 @@ test('fund containing multi-level nested deps with no funding, using --json opti
     )
 
     result = ''
-    _flatOptions.json = false
+    config.json = false
     t.end()
   })
 })
 
 test('fund containing multi-level nested deps with no funding, using --json option', t => {
-  _flatOptions.prefix = t.testdir(nestedMultipleFundingPackages)
-  _flatOptions.json = true
+  npm.prefix = t.testdir(nestedMultipleFundingPackages)
+  config.json = true
 
   fund.exec([], (err) => {
     t.ifError(err, 'should not error out')
@@ -385,26 +383,26 @@ test('fund containing multi-level nested deps with no funding, using --json opti
     )
 
     result = ''
-    _flatOptions.json = false
+    config.json = false
     t.end()
   })
 })
 
 test('fund does not support global', t => {
-  _flatOptions.prefix = t.testdir({})
-  _flatOptions.global = true
+  npm.prefix = t.testdir({})
+  config.global = true
 
   fund.exec([], (err) => {
     t.match(err.code, 'EFUNDGLOBAL', 'should throw EFUNDGLOBAL error')
 
     result = ''
-    _flatOptions.global = false
+    config.global = false
     t.end()
   })
 })
 
 test('fund using package argument', t => {
-  _flatOptions.prefix = t.testdir(maintainerOwnsAllDeps)
+  npm.prefix = t.testdir(maintainerOwnsAllDeps)
 
   fund.exec(['.'], (err) => {
     t.ifError(err, 'should not error out')
@@ -416,9 +414,9 @@ test('fund using package argument', t => {
 })
 
 test('fund does not support global, using --json option', t => {
-  _flatOptions.prefix = t.testdir({})
-  _flatOptions.global = true
-  _flatOptions.json = true
+  npm.prefix = t.testdir({})
+  config.global = true
+  config.json = true
 
   fund.exec([], (err) => {
     t.equal(err.code, 'EFUNDGLOBAL', 'should use EFUNDGLOBAL error code')
@@ -428,14 +426,14 @@ test('fund does not support global, using --json option', t => {
       'should use expected error msg'
     )
 
-    _flatOptions.global = false
-    _flatOptions.json = false
+    config.global = false
+    config.json = false
     t.end()
   })
 })
 
 test('fund using string shorthand', t => {
-  _flatOptions.prefix = t.testdir({
+  npm.prefix = t.testdir({
     'package.json': JSON.stringify({
       name: 'funding-string-shorthand',
       version: '0.0.0',
@@ -453,7 +451,7 @@ test('fund using string shorthand', t => {
 })
 
 test('fund using nested packages with multiple sources', t => {
-  _flatOptions.prefix = t.testdir(nestedMultipleFundingPackages)
+  npm.prefix = t.testdir(nestedMultipleFundingPackages)
 
   fund.exec(['.'], (err) => {
     t.ifError(err, 'should not error out')
@@ -465,7 +463,7 @@ test('fund using nested packages with multiple sources', t => {
 })
 
 test('fund using symlink ref', t => {
-  _flatOptions.prefix = t.testdir({
+  npm.prefix = t.testdir({
     'package.json': JSON.stringify({
       name: 'using-symlink-ref',
       version: '1.0.0',
@@ -511,7 +509,7 @@ test('fund using symlink ref', t => {
 })
 
 test('fund using data from actual tree', t => {
-  _flatOptions.prefix = t.testdir({
+  npm.prefix = t.testdir({
     'package.json': JSON.stringify({
       name: 'using-actual-tree',
       version: '1.0.0',
@@ -558,22 +556,22 @@ test('fund using data from actual tree', t => {
 })
 
 test('fund using nested packages with multiple sources, with a source number', t => {
-  _flatOptions.prefix = t.testdir(nestedMultipleFundingPackages)
-  _flatOptions.which = '1'
+  npm.prefix = t.testdir(nestedMultipleFundingPackages)
+  config.which = '1'
 
   fund.exec(['.'], (err) => {
     t.ifError(err, 'should not error out')
     t.matchSnapshot(printUrl, 'should open the numbered URL')
 
-    _flatOptions.which = undefined
+    config.which = undefined
     printUrl = ''
     t.end()
   })
 })
 
 test('fund using pkg name while having conflicting versions', t => {
-  _flatOptions.prefix = t.testdir(conflictingFundingPackages)
-  _flatOptions.which = '1'
+  npm.prefix = t.testdir(conflictingFundingPackages)
+  config.which = '1'
 
   fund.exec(['foo'], (err) => {
     t.ifError(err, 'should not error out')
@@ -585,8 +583,8 @@ test('fund using pkg name while having conflicting versions', t => {
 })
 
 test('fund using package argument with no browser, using --json option', t => {
-  _flatOptions.prefix = t.testdir(maintainerOwnsAllDeps)
-  _flatOptions.json = true
+  npm.prefix = t.testdir(maintainerOwnsAllDeps)
+  config.json = true
 
   fund.exec(['.'], (err) => {
     t.ifError(err, 'should not error out')
@@ -599,14 +597,14 @@ test('fund using package argument with no browser, using --json option', t => {
       'should open funding url using json output'
     )
 
-    _flatOptions.json = false
+    config.json = false
     printUrl = ''
     t.end()
   })
 })
 
 test('fund using package info fetch from registry', t => {
-  _flatOptions.prefix = t.testdir({})
+  npm.prefix = t.testdir({})
 
   fund.exec(['ntl'], (err) => {
     t.ifError(err, 'should not error out')
@@ -622,7 +620,7 @@ test('fund using package info fetch from registry', t => {
 })
 
 test('fund tries to use package info fetch from registry but registry has nothing', t => {
-  _flatOptions.prefix = t.testdir({})
+  npm.prefix = t.testdir({})
 
   fund.exec(['foo'], (err) => {
     t.equal(err.code, 'ENOFUND', 'should have ENOFUND error code')
@@ -638,7 +636,7 @@ test('fund tries to use package info fetch from registry but registry has nothin
 })
 
 test('fund but target module has no funding info', t => {
-  _flatOptions.prefix = t.testdir(nestedNoFundingPackages)
+  npm.prefix = t.testdir(nestedNoFundingPackages)
 
   fund.exec(['foo'], (err) => {
     t.equal(err.code, 'ENOFUND', 'should have ENOFUND error code')
@@ -654,8 +652,8 @@ test('fund but target module has no funding info', t => {
 })
 
 test('fund using bad which value', t => {
-  _flatOptions.prefix = t.testdir(nestedMultipleFundingPackages)
-  _flatOptions.which = 3
+  npm.prefix = t.testdir(nestedMultipleFundingPackages)
+  config.which = 3
 
   fund.exec(['bar'], (err) => {
     t.equal(err.code, 'EFUNDNUMBER', 'should have EFUNDNUMBER error code')
@@ -665,14 +663,14 @@ test('fund using bad which value', t => {
       'should have bad which option error message'
     )
 
-    _flatOptions.which = undefined
+    config.which = undefined
     result = ''
     t.end()
   })
 })
 
 test('fund pkg missing version number', t => {
-  _flatOptions.prefix = t.testdir({
+  npm.prefix = t.testdir({
     'package.json': JSON.stringify({
       name: 'foo',
       funding: 'http://example.com/foo',
@@ -688,7 +686,7 @@ test('fund pkg missing version number', t => {
 })
 
 test('fund a package throws on openUrl', t => {
-  _flatOptions.prefix = t.testdir({
+  npm.prefix = t.testdir({
     'package.json': JSON.stringify({
       name: 'foo',
       version: '1.0.0',
@@ -704,7 +702,7 @@ test('fund a package throws on openUrl', t => {
 })
 
 test('fund a package with type and multiple sources', t => {
-  _flatOptions.prefix = t.testdir({
+  npm.prefix = t.testdir({
     'package.json': JSON.stringify({
       name: 'foo',
       funding: [
@@ -730,7 +728,7 @@ test('fund a package with type and multiple sources', t => {
 })
 
 test('fund colors', t => {
-  _flatOptions.prefix = t.testdir({
+  npm.prefix = t.testdir({
     'package.json': JSON.stringify({
       name: 'test-fund-colors',
       version: '1.0.0',
@@ -782,20 +780,20 @@ test('fund colors', t => {
       },
     },
   })
-  _flatOptions.color = true
+  npm.color = true
 
   fund.exec([], (err) => {
     t.ifError(err, 'should not error out')
     t.matchSnapshot(result, 'should print output with color info')
 
     result = ''
-    _flatOptions.color = false
+    npm.color = false
     t.end()
   })
 })
 
 test('sub dep with fund info and a parent with no funding info', t => {
-  _flatOptions.prefix = t.testdir({
+  npm.prefix = t.testdir({
     'package.json': JSON.stringify({
       name: 'test-multiple-funding-sources',
       version: '1.0.0',

--- a/test/lib/help-search.js
+++ b/test/lib/help-search.js
@@ -2,6 +2,7 @@ const { test } = require('tap')
 const { join } = require('path')
 const requireInject = require('require-inject')
 const ansicolors = require('ansicolors')
+const mockNpm = require('../fixtures/mock-npm')
 
 const OUTPUT = []
 const output = (msg) => {
@@ -10,11 +11,12 @@ const output = (msg) => {
 
 let npmHelpArgs = null
 let npmHelpErr = null
-const npm = {
+const config = {
+  long: false,
+}
+const npm = mockNpm({
   color: false,
-  flatOptions: {
-    long: false,
-  },
+  config,
   commands: {
     help: (args, cb) => {
       npmHelpArgs = args
@@ -22,7 +24,7 @@ const npm = {
     },
   },
   output,
-}
+})
 
 let npmUsageArg = null
 const npmUsage = (npm, arg) => {
@@ -120,10 +122,10 @@ test('npm help-search single result propagates error', t => {
 
 test('npm help-search long output', t => {
   globRoot = t.testdir(globDir)
-  npm.flatOptions.long = true
+  config.long = true
   t.teardown(() => {
     OUTPUT.length = 0
-    npm.flatOptions.long = false
+    config.long = false
     globRoot = null
   })
 
@@ -138,11 +140,11 @@ test('npm help-search long output', t => {
 
 test('npm help-search long output with color', t => {
   globRoot = t.testdir(globDir)
-  npm.flatOptions.long = true
+  config.long = true
   npm.color = true
   t.teardown(() => {
     OUTPUT.length = 0
-    npm.flatOptions.long = false
+    config.long = false
     npm.color = false
     globRoot = null
   })

--- a/test/lib/install.js
+++ b/test/lib/install.js
@@ -2,6 +2,7 @@ const { test } = require('tap')
 
 const Install = require('../../lib/install.js')
 const requireInject = require('require-inject')
+const mockNpm = require('../fixtures/mock-npm')
 
 test('should install using Arborist', (t) => {
   const SCRIPTS = []
@@ -28,16 +29,14 @@ test('should install using Arborist', (t) => {
         throw new Error('got wrong object passed to reify-finish')
     },
   })
-  const install = new Install({
+
+  const npm = mockNpm({
+    config: { dev: true },
+    flatOptions: { global: false },
     globalDir: 'path/to/node_modules/',
     prefix: 'foo',
-    flatOptions: {
-      global: false,
-    },
-    config: {
-      get: () => true,
-    },
   })
+  const install = new Install(npm)
 
   t.test('with args', t => {
     install.exec(['fizzbuzz'], er => {
@@ -86,17 +85,16 @@ test('should ignore scripts with --ignore-scripts', (t) => {
       }
     },
   })
-  const install = new Install({
+  const npm = mockNpm({
     globalDir: 'path/to/node_modules/',
     prefix: 'foo',
-    flatOptions: {
-      global: false,
-      ignoreScripts: true,
-    },
+    flatOptions: { global: false },
     config: {
-      get: () => false,
+      global: false,
+      'ignore-scripts': true,
     },
   })
+  const install = new Install(npm)
   install.exec([], er => {
     if (er)
       throw er
@@ -113,16 +111,13 @@ test('should install globally using Arborist', (t) => {
       this.reify = () => {}
     },
   })
-  const install = new Install({
+  const npm = mockNpm({
     globalDir: 'path/to/node_modules/',
     prefix: 'foo',
-    flatOptions: {
-      global: true,
-    },
-    config: {
-      get: () => false,
-    },
+    config: { global: true },
+    flatOptions: { global: true },
   })
+  const install = new Install(npm)
   install.exec([], er => {
     if (er)
       throw er

--- a/test/lib/link.js
+++ b/test/lib/link.js
@@ -3,6 +3,7 @@ const { resolve } = require('path')
 const Arborist = require('@npmcli/arborist')
 const t = require('tap')
 const requireInject = require('require-inject')
+const mockNpm = require('../fixtures/mock-npm')
 
 const redactCwd = (path) => {
   const normalizePath = p => p
@@ -15,17 +16,13 @@ const redactCwd = (path) => {
 t.cleanSnapshot = (str) => redactCwd(str)
 
 let reifyOutput
-const npm = {
+const config = {}
+const npm = mockNpm({
   globalDir: null,
   prefix: null,
-  flatOptions: {},
-  config: {
-    get () {
-      return false
-    },
-    find () {},
-  },
-}
+  config,
+})
+
 const printLinks = async (opts) => {
   let res = ''
   const arb = new Arborist(opts)

--- a/test/lib/outdated.js
+++ b/test/lib/outdated.js
@@ -1,5 +1,6 @@
 const t = require('tap')
 const requireInject = require('require-inject')
+const mockNpm = require('../fixtures/mock-npm')
 
 const packument = spec => {
   const mocks = {
@@ -89,12 +90,13 @@ const outdated = (dir, opts) => {
       packument,
     },
   })
-  return new Outdated({
+  const npm = mockNpm({
+    ...opts,
     prefix: dir,
     globalDir: `${globalDir}/node_modules`,
-    flatOptions: opts,
     output,
   })
+  return new Outdated(npm)
 }
 
 t.beforeEach((done) => {
@@ -173,8 +175,9 @@ t.test('should display outdated deps', t => {
 
   t.test('outdated global', t => {
     outdated(null, {
-      global: true,
+      config: { global: true },
     }).exec([], () => {
+      console.log(logs)
       t.matchSnapshot(logs)
       t.end()
     })
@@ -182,7 +185,9 @@ t.test('should display outdated deps', t => {
 
   t.test('outdated', t => {
     outdated(testDir, {
-      global: false,
+      config: {
+        global: false,
+      },
       color: true,
     }).exec([], () => {
       t.matchSnapshot(logs)
@@ -192,9 +197,11 @@ t.test('should display outdated deps', t => {
 
   t.test('outdated --omit=dev', t => {
     outdated(testDir, {
-      global: false,
+      config: {
+        global: false,
+        omit: ['dev'],
+      },
       color: true,
-      omit: ['dev'],
     }).exec([], () => {
       t.matchSnapshot(logs)
       t.end()
@@ -203,9 +210,11 @@ t.test('should display outdated deps', t => {
 
   t.test('outdated --omit=dev --omit=peer', t => {
     outdated(testDir, {
-      global: false,
+      config: {
+        global: false,
+        omit: ['dev', 'peer'],
+      },
       color: true,
-      omit: ['dev', 'peer'],
     }).exec([], () => {
       t.matchSnapshot(logs)
       t.end()
@@ -214,9 +223,11 @@ t.test('should display outdated deps', t => {
 
   t.test('outdated --omit=prod', t => {
     outdated(testDir, {
-      global: false,
+      config: {
+        global: false,
+        omit: ['prod'],
+      },
       color: true,
-      omit: ['prod'],
     }).exec([], () => {
       t.matchSnapshot(logs)
       t.end()
@@ -225,8 +236,10 @@ t.test('should display outdated deps', t => {
 
   t.test('outdated --long', t => {
     outdated(testDir, {
-      global: false,
-      long: true,
+      config: {
+        global: false,
+        long: true,
+      },
     }).exec([], () => {
       t.matchSnapshot(logs)
       t.end()
@@ -235,8 +248,10 @@ t.test('should display outdated deps', t => {
 
   t.test('outdated --json', t => {
     outdated(testDir, {
-      global: false,
-      json: true,
+      config: {
+        global: false,
+        json: true,
+      },
     }).exec([], () => {
       t.matchSnapshot(logs)
       t.end()
@@ -245,9 +260,11 @@ t.test('should display outdated deps', t => {
 
   t.test('outdated --json --long', t => {
     outdated(testDir, {
-      global: false,
-      json: true,
-      long: true,
+      config: {
+        global: false,
+        json: true,
+        long: true,
+      },
     }).exec([], () => {
       t.matchSnapshot(logs)
       t.end()
@@ -256,8 +273,10 @@ t.test('should display outdated deps', t => {
 
   t.test('outdated --parseable', t => {
     outdated(testDir, {
-      global: false,
-      parseable: true,
+      config: {
+        global: false,
+        parseable: true,
+      },
     }).exec([], () => {
       t.matchSnapshot(logs)
       t.end()
@@ -266,9 +285,11 @@ t.test('should display outdated deps', t => {
 
   t.test('outdated --parseable --long', t => {
     outdated(testDir, {
-      global: false,
-      parseable: true,
-      long: true,
+      config: {
+        global: false,
+        parseable: true,
+        long: true,
+      },
     }).exec([], () => {
       t.matchSnapshot(logs)
       t.end()
@@ -277,7 +298,9 @@ t.test('should display outdated deps', t => {
 
   t.test('outdated --all', t => {
     outdated(testDir, {
-      all: true,
+      config: {
+        all: true,
+      },
     }).exec([], () => {
       t.matchSnapshot(logs)
       t.end()
@@ -286,7 +309,9 @@ t.test('should display outdated deps', t => {
 
   t.test('outdated specific dep', t => {
     outdated(testDir, {
-      global: false,
+      config: {
+        global: false,
+      },
     }).exec(['alpha'], () => {
       t.matchSnapshot(logs)
       t.end()

--- a/test/lib/pack.js
+++ b/test/lib/pack.js
@@ -1,5 +1,6 @@
 const t = require('tap')
 const requireInject = require('require-inject')
+const mockNpm = require('../fixtures/mock-npm')
 
 const OUTPUT = []
 const output = (...msg) => OUTPUT.push(msg)
@@ -25,14 +26,15 @@ t.test('should pack current directory with no arguments', (t) => {
       clearProgress: () => {},
     },
   })
-  const pack = new Pack({
-    flatOptions: {
+  const npm = mockNpm({
+    config: {
       unicode: false,
       json: false,
-      dryRun: false,
+      'dry-run': false,
     },
     output,
   })
+  const pack = new Pack(npm)
 
   pack.exec([], er => {
     if (er)
@@ -60,14 +62,15 @@ t.test('should pack given directory', (t) => {
       clearProgress: () => {},
     },
   })
-  const pack = new Pack({
-    flatOptions: {
+  const npm = mockNpm({
+    config: {
       unicode: true,
       json: true,
-      dryRun: true,
+      'dry-run': true,
     },
     output,
   })
+  const pack = new Pack(npm)
 
   pack.exec([testDir], er => {
     if (er)
@@ -95,14 +98,15 @@ t.test('should pack given directory for scoped package', (t) => {
       clearProgress: () => {},
     },
   })
-  const pack = new Pack({
-    flatOptions: {
+  const npm = mockNpm({
+    config: {
       unicode: true,
       json: true,
-      dryRun: true,
+      'dry-run': true,
     },
     output,
   })
+  const pack = new Pack(npm)
 
   return pack.exec([testDir], er => {
     if (er)
@@ -129,14 +133,15 @@ t.test('should log pack contents', (t) => {
       clearProgress: () => {},
     },
   })
-  const pack = new Pack({
-    flatOptions: {
+  const npm = mockNpm({
+    config: {
       unicode: false,
       json: false,
-      dryRun: false,
+      'dry-run': false,
     },
     output,
   })
+  const pack = new Pack(npm)
 
   pack.exec([], er => {
     if (er)

--- a/test/lib/ping.js
+++ b/test/lib/ping.js
@@ -1,14 +1,15 @@
 const { test } = require('tap')
 const requireInject = require('require-inject')
+const mockNpm = require('../fixtures/mock-npm')
 
 test('pings', (t) => {
   t.plan(8)
 
-  const flatOptions = { registry: 'https://registry.npmjs.org' }
+  const registry = 'https://registry.npmjs.org'
   let noticeCalls = 0
   const Ping = requireInject('../../lib/ping.js', {
     '../../lib/utils/ping.js': function (spec) {
-      t.equal(spec, flatOptions, 'passes flatOptions')
+      t.equal(spec.registry, registry, 'passes flatOptions')
       return {}
     },
     npmlog: {
@@ -16,7 +17,7 @@ test('pings', (t) => {
         ++noticeCalls
         if (noticeCalls === 1) {
           t.equal(type, 'PING', 'should log a PING')
-          t.equal(spec, flatOptions.registry, 'should log the registry url')
+          t.equal(spec, registry, 'should log the registry url')
         } else {
           t.equal(type, 'PONG', 'should log a PONG')
           t.match(spec, /\d+ms/, 'should log the elapsed milliseconds')
@@ -24,7 +25,11 @@ test('pings', (t) => {
       },
     },
   })
-  const ping = new Ping({ flatOptions })
+  const npm = mockNpm({
+    config: { registry },
+    flatOptions: { registry },
+  })
+  const ping = new Ping(npm)
 
   ping.exec([], (err) => {
     t.equal(noticeCalls, 2, 'should have logged 2 lines')
@@ -36,12 +41,12 @@ test('pings', (t) => {
 test('pings and logs details', (t) => {
   t.plan(10)
 
-  const flatOptions = { registry: 'https://registry.npmjs.org' }
+  const registry = 'https://registry.npmjs.org'
   const details = { extra: 'data' }
   let noticeCalls = 0
   const Ping = requireInject('../../lib/ping.js', {
     '../../lib/utils/ping.js': function (spec) {
-      t.equal(spec, flatOptions, 'passes flatOptions')
+      t.equal(spec.registry, registry, 'passes flatOptions')
       return details
     },
     npmlog: {
@@ -49,7 +54,7 @@ test('pings and logs details', (t) => {
         ++noticeCalls
         if (noticeCalls === 1) {
           t.equal(type, 'PING', 'should log a PING')
-          t.equal(spec, flatOptions.registry, 'should log the registry url')
+          t.equal(spec, registry, 'should log the registry url')
         } else if (noticeCalls === 2) {
           t.equal(type, 'PONG', 'should log a PONG')
           t.match(spec, /\d+ms/, 'should log the elapsed milliseconds')
@@ -61,7 +66,11 @@ test('pings and logs details', (t) => {
       },
     },
   })
-  const ping = new Ping({ flatOptions })
+  const npm = mockNpm({
+    config: { registry },
+    flatOptions: { registry },
+  })
+  const ping = new Ping(npm)
 
   ping.exec([], (err) => {
     t.equal(noticeCalls, 3, 'should have logged 3 lines')
@@ -73,12 +82,12 @@ test('pings and logs details', (t) => {
 test('pings and returns json', (t) => {
   t.plan(11)
 
-  const flatOptions = { registry: 'https://registry.npmjs.org', json: true }
+  const registry = 'https://registry.npmjs.org'
   const details = { extra: 'data' }
   let noticeCalls = 0
   const Ping = requireInject('../../lib/ping.js', {
     '../../lib/utils/ping.js': function (spec) {
-      t.equal(spec, flatOptions, 'passes flatOptions')
+      t.equal(spec.registry, registry, 'passes flatOptions')
       return details
     },
     npmlog: {
@@ -86,7 +95,7 @@ test('pings and returns json', (t) => {
         ++noticeCalls
         if (noticeCalls === 1) {
           t.equal(type, 'PING', 'should log a PING')
-          t.equal(spec, flatOptions.registry, 'should log the registry url')
+          t.equal(spec, registry, 'should log the registry url')
         } else {
           t.equal(type, 'PONG', 'should log a PONG')
           t.match(spec, /\d+ms/, 'should log the elapsed milliseconds')
@@ -94,15 +103,17 @@ test('pings and returns json', (t) => {
       },
     },
   })
-  const ping = new Ping({
-    flatOptions,
+  const npm = mockNpm({
+    config: { registry, json: true },
+    flatOptions: { registry },
     output: function (spec) {
       const parsed = JSON.parse(spec)
-      t.equal(parsed.registry, flatOptions.registry, 'returns the correct registry url')
+      t.equal(parsed.registry, registry, 'returns the correct registry url')
       t.match(parsed.details, details, 'prints returned details')
       t.type(parsed.time, 'number', 'returns time as a number')
     },
   })
+  const ping = new Ping(npm)
 
   ping.exec([], (err) => {
     t.equal(noticeCalls, 2, 'should have logged 2 lines')

--- a/test/lib/rebuild.js
+++ b/test/lib/rebuild.js
@@ -1,25 +1,27 @@
 const fs = require('fs')
 const { resolve } = require('path')
+const mockNpm = require('../fixtures/mock-npm')
 const t = require('tap')
 
 let result = ''
 
-const npm = {
+const config = {
+  global: false,
+}
+const npm = mockNpm({
   globalDir: '',
-  flatOptions: {
-    global: false,
-  },
+  config,
   prefix: '',
   output: (...msg) => {
     result += msg.join('\n')
   },
-}
+})
 const Rebuild = require('../../lib/rebuild.js')
 const rebuild = new Rebuild(npm)
 
 t.afterEach(cb => {
   npm.prefix = ''
-  npm.flatOptions.global = false
+  config.global = false
   npm.globalDir = ''
   result = ''
   cb()
@@ -237,7 +239,7 @@ t.test('global prefix', t => {
     },
   })
 
-  npm.flatOptions.global = true
+  config.global = true
   npm.globalDir = resolve(globalPath, 'lib', 'node_modules')
 
   rebuild.exec([], err => {

--- a/test/lib/run-script.js
+++ b/test/lib/run-script.js
@@ -1,33 +1,31 @@
 const t = require('tap')
 const requireInject = require('require-inject')
+const mockNpm = require('../fixtures/mock-npm')
 
 const RUN_SCRIPTS = []
-const npm = {
-  localPrefix: __dirname,
-  flatOptions: {
-    scriptShell: undefined,
-    json: false,
-    parseable: false,
-  },
-  config: {
-    settings: {
-      'if-present': false,
-    },
-    get: k => npm.config.settings[k],
-    set: (k, v) => {
-      npm.config.settings[k] = v
-    },
-  },
-  output: (...msg) => output.push(msg),
+const flatOptions = {
+  scriptShell: undefined,
 }
+const config = {
+  json: false,
+  parseable: false,
+  'if-present': false,
+}
+
+const npm = mockNpm({
+  localPrefix: __dirname,
+  flatOptions,
+  config,
+  output: (...msg) => output.push(msg),
+})
 
 const output = []
 
 t.afterEach(cb => {
   output.length = 0
   RUN_SCRIPTS.length = 0
-  npm.flatOptions.json = false
-  npm.flatOptions.parseable = false
+  config.json = false
+  config.parseable = false
   cb()
 })
 
@@ -331,7 +329,7 @@ t.test('run pre/post hooks', t => {
 })
 
 t.test('skip pre/post hooks when using ignoreScripts', t => {
-  npm.flatOptions.ignoreScripts = true
+  config['ignore-scripts'] = true
 
   npm.localPrefix = t.testdir({
     'package.json': JSON.stringify({
@@ -368,7 +366,7 @@ t.test('skip pre/post hooks when using ignoreScripts', t => {
       },
     ])
     t.end()
-    delete npm.flatOptions.ignoreScripts
+    delete config['ignore-scripts']
   })
 })
 
@@ -466,7 +464,7 @@ t.test('list scripts', t => {
   })
   t.test('warn json', t => {
     npmlog.level = 'warn'
-    npm.flatOptions.json = true
+    config.json = true
     runScript.exec([], er => {
       if (er)
         throw er
@@ -476,7 +474,7 @@ t.test('list scripts', t => {
   })
 
   t.test('parseable', t => {
-    npm.flatOptions.parseable = true
+    config.parseable = true
     runScript.exec([], er => {
       if (er)
         throw er

--- a/test/lib/search.js
+++ b/test/lib/search.js
@@ -1,6 +1,7 @@
 const Minipass = require('minipass')
 const t = require('tap')
 const requireInject = require('require-inject')
+const mockNpm = require('../fixtures/mock-npm')
 const libnpmsearchResultFixture =
   require('../fixtures/libnpmsearch-stream-result.js')
 
@@ -12,12 +13,17 @@ const flatOptions = {
     opts: '',
   },
 }
-const npm = {
+const config = {
+  json: false,
+  parseable: false,
+}
+const npm = mockNpm({
+  config,
   flatOptions: { ...flatOptions },
   output: (...msg) => {
     result += msg.join('\n')
   },
-}
+})
 const npmlog = {
   silly () {},
   clearProgress () {},
@@ -29,12 +35,13 @@ const mocks = {
   npmlog,
   libnpmsearch,
   '../../lib/utils/usage.js': () => 'usage instructions',
-  // '../../lib/search/format-package-stream.js': a => a,
 }
 
 t.afterEach(cb => {
   result = ''
-  npm.flatOptions = flatOptions
+  config.json = false
+  config.parseable = false
+  npm.flatOptions = { ...flatOptions }
   cb()
 })
 
@@ -86,7 +93,8 @@ t.test('search <name> --json', (t) => {
   const src = new Minipass()
   src.objectMode = true
 
-  flatOptions.json = true
+  npm.flatOptions.json = true
+  config.json = true
   const libnpmsearch = {
     stream () {
       return src
@@ -114,7 +122,7 @@ t.test('search <name> --json', (t) => {
       'should have expected search results as json'
     )
 
-    flatOptions.json = false
+    config.json = false
     t.end()
   })
 

--- a/test/lib/shrinkwrap.js
+++ b/test/lib/shrinkwrap.js
@@ -1,16 +1,21 @@
 const t = require('tap')
 const fs = require('fs')
 const requireInject = require('require-inject')
+const mockNpm = require('../fixtures/mock-npm')
 
-const npm = {
+const config = {
+  global: false,
+}
+const flatOptions = {
+  depth: 0,
+}
+const npm = mockNpm({
+  config,
+  flatOptions,
   lockfileVersion: 2,
   globalDir: '',
-  flatOptions: {
-    depth: 0,
-    global: false,
-  },
   prefix: '',
-}
+})
 const tree = {
   meta: {
     hiddenLockfile: null,
@@ -36,7 +41,7 @@ const mocks = {
 
 t.afterEach(cb => {
   npm.prefix = ''
-  npm.flatOptions.global = false
+  config.global = false
   npm.globalDir = ''
   cb()
 })
@@ -50,7 +55,7 @@ t.test('no args', t => {
     constructor (args) {
       t.deepEqual(
         args,
-        { ...npm.flatOptions, path: npm.prefix },
+        { ...flatOptions, path: npm.prefix },
         'should call arborist constructor with expected args'
       )
     }
@@ -101,7 +106,7 @@ t.test('no virtual tree', t => {
     constructor (args) {
       t.deepEqual(
         args,
-        { ...npm.flatOptions, path: npm.prefix },
+        { ...flatOptions, path: npm.prefix },
         'should call arborist constructor with expected args'
       )
     }
@@ -156,7 +161,7 @@ t.test('existing package-json file', t => {
     constructor (args) {
       t.deepEqual(
         args,
-        { ...npm.flatOptions, path: npm.prefix },
+        { ...flatOptions, path: npm.prefix },
         'should call arborist constructor with expected args'
       )
     }
@@ -218,7 +223,7 @@ t.test('update shrinkwrap file version', t => {
     constructor (args) {
       t.deepEqual(
         args,
-        { ...npm.flatOptions, path: npm.prefix },
+        { ...flatOptions, path: npm.prefix },
         'should call arborist constructor with expected args'
       )
     }
@@ -272,7 +277,7 @@ t.test('update to date shrinkwrap file', t => {
     constructor (args) {
       t.deepEqual(
         args,
-        { ...npm.flatOptions, path: npm.prefix },
+        { ...flatOptions, path: npm.prefix },
         'should call arborist constructor with expected args'
       )
     }
@@ -320,7 +325,7 @@ t.test('update to date shrinkwrap file', t => {
 t.test('shrinkwrap --global', t => {
   const Shrinkwrap = requireInject('../../lib/shrinkwrap.js', mocks)
 
-  npm.flatOptions.global = true
+  config.global = true
   const shrinkwrap = new Shrinkwrap(npm)
 
   shrinkwrap.exec([], err => {

--- a/test/lib/star.js
+++ b/test/lib/star.js
@@ -1,16 +1,20 @@
 const requireInject = require('require-inject')
+const mockNpm = require('../fixtures/mock-npm')
 const t = require('tap')
 
 let result = ''
 
 const noop = () => null
-const npm = {
-  config: { get () {} },
-  flatOptions: { unicode: false },
+const config = {
+  unicode: false,
+  'star.unstar': false,
+}
+const npm = mockNpm({
+  config,
   output: (...msg) => {
     result += msg.join('\n')
   },
-}
+})
 const npmFetch = { json: noop }
 const npmlog = { error: noop, info: noop, verbose: noop }
 const mocks = {
@@ -24,8 +28,8 @@ const Star = requireInject('../../lib/star.js', mocks)
 const star = new Star(npm)
 
 t.afterEach(cb => {
-  npm.config = { get () {} }
-  npm.flatOptions.unicode = false
+  config.unicode = false
+  config['star.unstar'] = false
   npmlog.info = noop
   result = ''
   cb()
@@ -73,7 +77,7 @@ t.test('star a package', t => {
 t.test('unstar a package', t => {
   t.plan(4)
   const pkgName = '@npmcli/arborist'
-  npm.config.get = key => key === 'star.unstar'
+  config['star.unstar'] = true
   npmFetch.json = async (uri, opts) => ({
     _id: pkgName,
     _rev: 'hash',
@@ -100,7 +104,7 @@ t.test('unstar a package', t => {
 
 t.test('unicode', async t => {
   t.test('star a package', t => {
-    npm.flatOptions.unicode = true
+    config.unicode = true
     npmFetch.json = async (uri, opts) => ({})
     star.exec(['pkg'], err => {
       if (err)
@@ -115,8 +119,8 @@ t.test('unicode', async t => {
   })
 
   t.test('unstar a package', t => {
-    npm.flatOptions.unicode = true
-    npm.config.get = key => key === 'star.unstar'
+    config.unicode = true
+    config['star.unstar'] = true
     npmFetch.json = async (uri, opts) => ({})
     star.exec(['pkg'], err => {
       if (err)

--- a/test/lib/uninstall.js
+++ b/test/lib/uninstall.js
@@ -2,18 +2,18 @@ const fs = require('fs')
 const { resolve } = require('path')
 const t = require('tap')
 const requireInject = require('require-inject')
+const mockNpm = require('../fixtures/mock-npm')
 
-const npm = {
+const npm = mockNpm({
   globalDir: '',
-  flatOptions: {
+  config: {
     global: false,
     prefix: '',
   },
   localPrefix: '',
-}
+})
 const mocks = {
   '../../lib/utils/reify-finish.js': () => Promise.resolve(),
-  '../../lib/utils/usage.js': () => 'usage instructions',
 }
 
 const Uninstall = requireInject('../../lib/uninstall.js', mocks)
@@ -85,13 +85,13 @@ t.test('remove single installed lib', t => {
   const b = resolve(path, 'node_modules/b')
   t.ok(() => fs.statSync(b))
 
-  npm.flatOptions.prefix = path
+  npm.config.set('prefix', path)
 
   uninstall.exec(['b'], err => {
     if (err)
       throw err
 
-    t.throws(() => fs.statSync(b), 'should have removed package from nm')
+    t.throws(() => fs.statSync(b), 'should have removed package from npm')
     t.end()
   })
 })
@@ -148,7 +148,7 @@ t.test('remove multiple installed libs', t => {
   t.ok(() => fs.statSync(a))
   t.ok(() => fs.statSync(b))
 
-  npm.flatOptions.prefix = path
+  npm.config.set('prefix', path)
 
   uninstall.exec(['b'], err => {
     if (err)
@@ -195,8 +195,8 @@ t.test('no args global', t => {
 
   npm.localPrefix = resolve(path, 'projects', 'a')
   npm.globalDir = resolve(path, 'lib', 'node_modules')
-  npm.flatOptions.global = true
-  npm.flatOptions.prefix = path
+  npm.config.set('global', true)
+  npm.config.set('prefix', path)
 
   const a = resolve(path, 'lib/node_modules/a')
   t.ok(() => fs.statSync(a))
@@ -221,8 +221,7 @@ t.test('no args global but no package.json', t => {
   uninstall.exec([], err => {
     t.match(
       err,
-      'usage instructions',
-      'should throw usage instructions'
+      'npm uninstall'
     )
 
     t.end()

--- a/test/lib/unpublish.js
+++ b/test/lib/unpublish.js
@@ -1,19 +1,21 @@
 const t = require('tap')
 const requireInject = require('require-inject')
+const mockNpm = require('../fixtures/mock-npm')
 
 let result = ''
 const noop = () => null
-const npm = {
+const config = {
+  force: false,
+  silent: false,
+  loglevel: 'silly',
+}
+const npm = mockNpm({
   localPrefix: '',
-  flatOptions: {
-    force: false,
-    silent: false,
-    loglevel: 'silly',
-  },
+  config,
   output: (...msg) => {
     result += msg.join('\n')
   },
-}
+})
 const mocks = {
   npmlog: { silly () {}, verbose () {} },
   libnpmaccess: { lsPackages: noop },
@@ -28,16 +30,16 @@ const mocks = {
 
 t.afterEach(cb => {
   result = ''
-  npm.flatOptions.force = false
-  npm.flatOptions.loglevel = 'silly'
-  npm.flatOptions.silent = false
+  config.force = false
+  config.loglevel = 'silly'
+  config.silent = false
   cb()
 })
 
 t.test('no args --force', t => {
   t.plan(9)
 
-  npm.flatOptions.force = true
+  config.force = true
 
   const npmlog = {
     silly (title) {
@@ -67,9 +69,6 @@ t.test('no args --force', t => {
       t.deepEqual(
         opts,
         {
-          force: true,
-          silent: false,
-          loglevel: 'silly',
           publishConfig: undefined,
         },
         'should unpublish with expected opts'
@@ -102,7 +101,7 @@ t.test('no args --force', t => {
 })
 
 t.test('no args --force missing package.json', t => {
-  npm.flatOptions.force = true
+  config.force = true
 
   const Unpublish = requireInject('../../lib/unpublish.js', {
     ...mocks,
@@ -124,7 +123,7 @@ t.test('no args --force missing package.json', t => {
 })
 
 t.test('no args --force unknown error reading package.json', t => {
-  npm.flatOptions.force = true
+  config.force = true
 
   const Unpublish = requireInject('../../lib/unpublish.js', {
     ...mocks,
@@ -200,11 +199,7 @@ t.test('unpublish <pkg>@version', t => {
       t.equal(spec, pa, 'should unpublish expected parsed spec')
       t.deepEqual(
         opts,
-        {
-          force: false,
-          silent: false,
-          loglevel: 'silly',
-        },
+        {},
         'should unpublish with expected opts'
       )
     },
@@ -231,7 +226,7 @@ t.test('unpublish <pkg>@version', t => {
 })
 
 t.test('no version found in package.json', t => {
-  npm.flatOptions.force = true
+  config.force = true
 
   const npa = () => ({
     name: 'pkg',
@@ -263,7 +258,7 @@ t.test('no version found in package.json', t => {
 })
 
 t.test('unpublish <pkg> --force no version set', t => {
-  npm.flatOptions.force = true
+  config.force = true
 
   const Unpublish = requireInject('../../lib/unpublish.js', {
     ...mocks,
@@ -289,7 +284,7 @@ t.test('unpublish <pkg> --force no version set', t => {
 })
 
 t.test('silent', t => {
-  npm.flatOptions.loglevel = 'silent'
+  config.loglevel = 'silent'
 
   const npa = () => ({
     name: 'pkg',

--- a/test/lib/update.js
+++ b/test/lib/update.js
@@ -1,16 +1,18 @@
 const { resolve } = require('path')
 const t = require('tap')
 const requireInject = require('require-inject')
+const mockNpm = require('../fixtures/mock-npm')
 
-const noop = () => null
-const npm = {
-  globalDir: '',
-  flatOptions: {
-    depth: 0,
-    global: false,
-  },
-  prefix: '',
+const config = {
+  depth: 0,
+  global: false,
 }
+const noop = () => null
+const npm = mockNpm({
+  globalDir: '',
+  config,
+  prefix: '',
+})
 const mocks = {
   npmlog: { warn () {} },
   '@npmcli/arborist': class {
@@ -22,7 +24,7 @@ const mocks = {
 
 t.afterEach(cb => {
   npm.prefix = ''
-  npm.flatOptions.global = false
+  config.global = false
   npm.globalDir = ''
   cb()
 })
@@ -99,7 +101,7 @@ t.test('update --depth=<number>', t => {
   t.plan(2)
 
   npm.prefix = '/project/a'
-  npm.flatOptions.depth = 1
+  config.depth = 1
 
   const Update = requireInject('../../lib/update.js', {
     ...mocks,
@@ -131,7 +133,7 @@ t.test('update --global', t => {
 
   npm.prefix = '/project/a'
   npm.globalDir = resolve(process.cwd(), 'global/lib/node_modules')
-  npm.flatOptions.global = true
+  config.global = true
 
   class Arborist {
     constructor (args) {

--- a/test/lib/utils/read-local-package.js
+++ b/test/lib/utils/read-local-package.js
@@ -1,22 +1,17 @@
 const requireInject = require('require-inject')
 const { test } = require('tap')
+const mockNpm = require('../../fixtures/mock-npm')
 
-let prefix
-const _flatOptions = {
+const config = {
   json: false,
   global: false,
-  get prefix () {
-    return prefix
-  },
 }
+const npm = mockNpm({ config })
 
 const readLocalPackageName = requireInject('../../../lib/utils/read-local-package.js')
-const npm = {
-  flatOptions: _flatOptions,
-}
 
 test('read local package.json', async (t) => {
-  prefix = t.testdir({
+  npm.prefix = t.testdir({
     'package.json': JSON.stringify({
       name: 'my-local-package',
       version: '1.0.0',
@@ -31,7 +26,7 @@ test('read local package.json', async (t) => {
 })
 
 test('read local scoped-package.json', async (t) => {
-  prefix = t.testdir({
+  npm.prefix = t.testdir({
     'package.json': JSON.stringify({
       name: '@my-scope/my-local-package',
       version: '1.0.0',
@@ -46,13 +41,13 @@ test('read local scoped-package.json', async (t) => {
 })
 
 test('read using --global', async (t) => {
-  prefix = t.testdir({})
-  _flatOptions.global = true
+  npm.prefix = t.testdir({})
+  config.global = true
   const packageName = await readLocalPackageName(npm)
   t.equal(
     packageName,
     undefined,
     'should not retrieve a package name'
   )
-  _flatOptions.global = false
+  config.global = false
 })

--- a/test/lib/version.js
+++ b/test/lib/version.js
@@ -1,21 +1,23 @@
 const t = require('tap')
 const requireInject = require('require-inject')
+const mockNpm = require('../fixtures/mock-npm')
 
 let result = []
 
 const noop = () => null
-const npm = {
-  flatOptions: {
-    tagVersionPrefix: 'v',
-    json: false,
-  },
+const config = {
+  'tag-version-prefix': 'v',
+  json: false,
+}
+const npm = mockNpm({
+  config,
   prefix: '',
   version: '1.0.0',
   output: (...msg) => {
     for (const m of msg)
       result.push(m)
   },
-}
+})
 const mocks = {
   libnpmversion: noop,
 }
@@ -25,7 +27,7 @@ const version = new Version(npm)
 
 const _processVersions = process.versions
 t.afterEach(cb => {
-  npm.flatOptions.json = false
+  config.json = false
   npm.prefix = ''
   process.versions = _processVersions
   result = []
@@ -116,7 +118,7 @@ t.test('failure reading package.json', t => {
 
 t.test('--json option', t => {
   const prefix = t.testdir({})
-  npm.flatOptions.json = true
+  config.json = true
   npm.prefix = prefix
   Object.defineProperty(process, 'versions', { value: {} })
 
@@ -140,8 +142,6 @@ t.test('with one arg', t => {
       t.deepEqual(
         opts,
         {
-          tagVersionPrefix: 'v',
-          json: false,
           path: '',
         },
         'should forward expected options'

--- a/test/lib/view.js
+++ b/test/lib/view.js
@@ -1,5 +1,6 @@
 const t = require('tap')
 const requireInject = require('require-inject')
+const mockNpm = require('../fixtures/mock-npm')
 
 let logs
 const cleanLogs = (done) => {
@@ -243,34 +244,33 @@ t.test('should log package info', t => {
       packument,
     },
   })
-  const view = new View({
-    flatOptions: {
-      global: false,
-    },
+  const npm = mockNpm({
+    config: { global: false },
   })
+  const view = new View(npm)
 
   const ViewJson = requireInject('../../lib/view.js', {
     pacote: {
       packument,
     },
   })
-  const viewJson = new ViewJson({
-    flatOptions: {
-      json: true,
-    },
+  const jsonNpm = mockNpm({
+    config: { json: true },
   })
+  const viewJson = new ViewJson(jsonNpm)
 
   const ViewUnicode = requireInject('../../lib/view.js', {
     pacote: {
       packument,
     },
   })
-  const viewUnicode = new ViewUnicode({
-    flatOptions: {
+  const unicodeNpm = mockNpm({
+    config: {
       global: false,
       unicode: true,
     },
   })
+  const viewUnicode = new ViewUnicode(unicodeNpm)
 
   t.test('package with license, bugs, repository and other fields', t => {
     view.exec(['green@1.0.0'], () => {
@@ -351,13 +351,14 @@ t.test('should log info of package in current working dir', t => {
       packument,
     },
   })
-  const view = new View({
+  const npm = mockNpm({
     prefix: testDir,
-    flatOptions: {
-      defaultTag: '1.0.0',
+    config: {
+      tag: '1.0.0',
       global: false,
     },
   })
+  const view = new View(npm)
 
   t.test('specific version', t => {
     view.exec(['.@1.0.0'], () => {
@@ -382,23 +383,24 @@ t.test('should log info by field name', t => {
       packument,
     },
   })
-  const viewJson = new ViewJson({
-    flatOptions: {
+  const jsonNpm = mockNpm({
+    config: {
       json: true,
       global: false,
     },
   })
+
+  const viewJson = new ViewJson(jsonNpm)
 
   const View = requireInject('../../lib/view.js', {
     pacote: {
       packument,
     },
   })
-  const view = new View({
-    flatOptions: {
-      global: false,
-    },
+  const npm = mockNpm({
+    config: { global: false },
   })
+  const view = new View(npm)
 
   t.test('readme', t => {
     view.exec(['yellow@1.0.0', 'readme'], () => {
@@ -468,11 +470,10 @@ t.test('should log info by field name', t => {
 
 t.test('throw error if global mode', (t) => {
   const View = requireInject('../../lib/view.js')
-  const view = new View({
-    flatOptions: {
-      global: true,
-    },
+  const npm = mockNpm({
+    config: { global: true },
   })
+  const view = new View(npm)
   view.exec([], (err) => {
     t.equals(err.message, 'Cannot use view command in global mode.')
     t.end()
@@ -483,12 +484,11 @@ t.test('throw ENOENT error if package.json misisng', (t) => {
   const testDir = t.testdir({})
 
   const View = requireInject('../../lib/view.js')
-  const view = new View({
+  const npm = mockNpm({
     prefix: testDir,
-    flatOptions: {
-      global: false,
-    },
+    config: { global: false },
   })
+  const view = new View(npm)
   view.exec([], (err) => {
     t.match(err, { code: 'ENOENT' })
     t.end()
@@ -501,12 +501,11 @@ t.test('throw EJSONPARSE error if package.json not json', (t) => {
   })
 
   const View = requireInject('../../lib/view.js')
-  const view = new View({
+  const npm = mockNpm({
     prefix: testDir,
-    flatOptions: {
-      global: false,
-    },
+    config: { global: false },
   })
+  const view = new View(npm)
   view.exec([], (err) => {
     t.match(err, { code: 'EJSONPARSE' })
     t.end()
@@ -519,12 +518,11 @@ t.test('throw error if package.json has no name', (t) => {
   })
 
   const View = requireInject('../../lib/view.js')
-  const view = new View({
+  const npm = mockNpm({
     prefix: testDir,
-    flatOptions: {
-      global: false,
-    },
+    config: { global: false },
   })
+  const view = new View(npm)
   view.exec([], (err) => {
     t.equals(err.message, 'Invalid package.json, no "name" field')
     t.end()
@@ -537,12 +535,13 @@ t.test('throws when unpublished', (t) => {
       packument,
     },
   })
-  const view = new View({
-    flatOptions: {
-      defaultTag: '1.0.1',
+  const npm = mockNpm({
+    config: {
+      tag: '1.0.1',
       global: false,
     },
   })
+  const view = new View(npm)
   view.exec(['red'], (err) => {
     t.equals(err.code, 'E404')
     t.end()
@@ -555,12 +554,13 @@ t.test('completion', async t => {
       packument,
     },
   })
-  const view = new View({
-    flatOptions: {
-      defaultTag: '1.0.1',
+  const npm = mockNpm({
+    config: {
+      tag: '1.0.1',
       global: false,
     },
   })
+  const view = new View(npm)
   const res = await view.completion({
     conf: { argv: { remain: ['npm', 'view', 'green@1.0.0'] } },
   })
@@ -570,11 +570,13 @@ t.test('completion', async t => {
 
 t.test('no registry completion', async t => {
   const View = requireInject('../../lib/view.js')
-  const view = new View({
-    flatOptions: {
-      defaultTag: '1.0.1',
+  const npm = mockNpm({
+    config: {
+      tag: '1.0.1',
+      global: false,
     },
   })
+  const view = new View(npm)
   const res = await view.completion({conf: { argv: { remain: ['npm', 'view'] } } })
   t.notOk(res, 'there is no package completion')
   t.end()

--- a/test/lib/whoami.js
+++ b/test/lib/whoami.js
@@ -1,17 +1,20 @@
 const { test } = require('tap')
 const requireInject = require('require-inject')
+const mockNpm = require('../fixtures/mock-npm')
 
 test('whoami', (t) => {
   t.plan(3)
   const Whoami = requireInject('../../lib/whoami.js', {
     '../../lib/utils/get-identity.js': () => Promise.resolve('foo'),
   })
-  const whoami = new Whoami({
-    flatOptions: {},
+  const npm = mockNpm({
+    config: { json: false },
     output: (output) => {
       t.equal(output, 'foo', 'should output the username')
     },
   })
+
+  const whoami = new Whoami(npm)
 
   whoami.exec([], (err) => {
     t.ifError(err, 'npm whoami')
@@ -24,12 +27,13 @@ test('whoami json', (t) => {
   const Whoami = requireInject('../../lib/whoami.js', {
     '../../lib/utils/get-identity.js': () => Promise.resolve('foo'),
   })
-  const whoami = new Whoami({
-    flatOptions: { json: true },
+  const npm = mockNpm({
+    config: { json: true },
     output: (output) => {
-      t.equal(output, '"foo"', 'should output the username as json')
+      t.equal(output, '"foo"', 'should output the username')
     },
   })
+  const whoami = new Whoami(npm)
 
   whoami.exec([], (err) => {
     t.ifError(err, 'npm whoami')


### PR DESCRIPTION
Iterative change moving us towards a more unified config.
No longer pulling config from flatOptions where we don't have to.

This also moves our tests closer to using a real npm instance by having an interim `mockNpm` that acts like npm where we need it to.

Closes https://github.com/npm/statusboard/issues/280