### PR TITLE
feat(find-dupes): pretty-print diff on `--dry-run`

### DIFF
--- a/lib/utils/reify-output.js
+++ b/lib/utils/reify-output.js
@@ -19,10 +19,23 @@ const auditError = require('./audit-error.js')
 // TODO: output JSON if flatOptions.json is true
 const reifyOutput = (npm, arb) => {
   // don't print any info in --silent mode
+
+  // XXX: maybe it _should_ print something in dry-run anyway?
+  // I'm not sure.  Even if it's "silent", isn't the pretty printed diff
+  // kind of "the point" when it's a dry-run?  Maybe play with this?
   if (log.levels[log.level] > log.levels.error)
     return
 
   const { diff, actualTree } = arb
+
+  // XXX: added bit here, not sure if it goes here?  Should it be
+  // later?  Earlier?  Some room for creativity/iteration here.
+  if (npm.config.get('dry-run')) {
+    // a method that will show what WOULD have been done
+    prettyPrintDiff(npm, diff) // might need to pass the npm object, if anything in here is config-specific?
+    // maybe return?  Maybe it makes sense to still print the rest?
+    // this is where we should try some stuff and see what UX feels right
+  }
 
   // note: fails and crashes if we're running audit fix and there was an error
   // which is a good thing, because there's no point printing all this other
@@ -147,6 +160,24 @@ const packagesFundingMessage = (npm, { funding }) => {
   const is = funding === 1 ? 'is' : 'are'
   npm.output(`${funding} ${pkg} ${is} looking for funding`)
   npm.output('  run `npm fund` for details')
+}
+
+const prettyPrintDiff = (npm, diff) => {
+  const msg = ['\n']
+  diff.children.forEach(d => {
+    msg.push(d.action.toLowerCase() + '\t')
+    if (d.action === 'ADD')
+      msg.push(d.ideal.name + '\t' + d.ideal.package.version)
+
+    else if (d.action === 'CHANGE')
+      msg.push(d.actual.name + '\t' + d.actual.package.version + ' -> ' + d.ideal.package.version)
+
+    else if (d.action === 'REMOVE')
+      msg.push(d.actual.name + '\t' + d.actual.package.version)
+
+    msg.push('\n')
+  })
+  npm.output(msg.join(''))
 }
 
 module.exports = reifyOutput

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm",
-  "version": "7.10.0",
+  "version": "7.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "npm",
-      "version": "7.10.0",
+      "version": "7.11.0",
       "bundleDependencies": [
         "@npmcli/arborist",
         "@npmcli/ci-detect",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.10.0",
+  "version": "7.11.0",
   "name": "npm",
   "description": "a package manager for JavaScript",
   "keywords": [


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
`npm find-dupes` for v7 currently does not have a descriptive message of what packages are being added/changed/removed.
This PR will output how each package would change.

![image](https://user-images.githubusercontent.com/6621087/111874358-e82d1100-8962-11eb-9519-2af4b3421128.png)


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Related to #2687

## TODO

- Add test cases
- When package version remains the same, printing `change mkdirp 1.0.4 -> 1.0.4` is not useful. Need to find the actual change.

![image](https://user-images.githubusercontent.com/6621087/111874955-44913000-8965-11eb-97fe-1db0e14576e9.png)

- Determine how to find node module path changes like below. I'm unable to find where this info lies in the `diff` object.
```
$ npx npm@6 find-dupes
move	source-map	0.5.7	node_modules/@babel/core/node_modules/source-map		node_modules/tap/node_modules/@babel/core/node_modules/source-map
move	@babel/helper-annotate-as-pure	7.10.4	node_modules/@babel/helper-annotate-as-pure		node_modules/tap/node_modules/@babel/helper-annotate-as-pure
move	@babel/helper-builder-react-jsx	7.10.4	node_modules/@babel/helper-builder-react-jsx		node_modules/tap/node_modules/@babel/helper-builder-react-jsx
move	@babel/helper-member-expression-to-functions	7.10.5	node_modules/@babel/helper-member-expression-to-functions		node_modules/tap/node_modules/@babel/helper-member-expression-to-functions
... etc
```