### PR TITLE
fix The "path" argument must be of type string

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -137,7 +137,10 @@ class Publish extends BaseCommand {
   publishConfigToOpts (publishConfig) {
     // create a new object that inherits from the config stack
     // then squash the css-case into camelCase opts, like we do
-    return flatten({...this.npm.config.list[0], ...publishConfig})
+
+    return flatten(
+      Object.assign(Object.create(this.npm.config.list[0]), publishConfig)
+    )
   }
 }
 module.exports = Publish


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Fix crash when `publishConfig` field present in package.json
see #2834 for detail

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Fixes #2893 Fixes #2834 