### PR TITLE
fix(audit-level): add `info` audit level

### DIFF
--- a/lib/audit.js
+++ b/lib/audit.js
@@ -18,6 +18,7 @@ class Audit extends BaseCommand {
   /* istanbul ignore next - see test/lib/load-all-commands.js */
   static get params () {
     return [
+      'audit-level',
       'dry-run',
       'force',
       'json',

--- a/lib/install.js
+++ b/lib/install.js
@@ -126,15 +126,15 @@ class Install extends BaseCommand {
     if (this.npm.config.get('dev'))
       log.warn('install', 'Usage of the `--dev` option is deprecated. Use `--include=dev` instead.')
 
-    const arb = new Arborist({
+    const opts = {
       ...this.npm.flatOptions,
+      auditLevel: null,
       path: where,
-    })
-
-    await arb.reify({
-      ...this.npm.flatOptions,
       add: args,
-    })
+    }
+    const arb = new Arborist(opts)
+    await arb.reify(opts)
+
     if (!args.length && !isGlobalInstall && !ignoreScripts) {
       const scriptShell = this.npm.config.get('script-shell') || undefined
       const scripts = [

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -220,7 +220,7 @@ define('audit', {
 
 define('audit-level', {
   default: null,
-  type: ['low', 'moderate', 'high', 'critical', 'none', null],
+  type: ['info', 'low', 'moderate', 'high', 'critical', 'none', null],
   description: `
     The minimum level of vulnerability for \`npm audit\` to exit with
     a non-zero exit code.

--- a/tap-snapshots/test-lib-utils-config-describe-all.js-TAP.test.js
+++ b/tap-snapshots/test-lib-utils-config-describe-all.js-TAP.test.js
@@ -64,7 +64,7 @@ registry and all registries configured for scopes. See the documentation for
 #### \`audit-level\`
 
 * Default: null
-* Type: "low", "moderate", "high", "critical", "none", or null
+* Type: "info", "low", "moderate", "high", "critical", "none", or null
 
 The minimum level of vulnerability for \`npm audit\` to exit with a non-zero
 exit code.

--- a/tap-snapshots/test-lib-utils-npm-usage.js-TAP.test.js
+++ b/tap-snapshots/test-lib-utils-npm-usage.js-TAP.test.js
@@ -204,7 +204,7 @@ All commands:
                     npm audit [fix]
                     
                     Options:
-                    [--dry-run] [-f|--force] [--json] [--package-lock-only] [--production]
+                    [--audit-level <info|low|moderate|high|critical|none>] [--dry-run] [-f|--force] [--json] [--package-lock-only] [--production]
                     
                     Run "npm help audit" for more info
 

--- a/test/lib/install.js
+++ b/test/lib/install.js
@@ -32,7 +32,7 @@ test('should install using Arborist', (t) => {
 
   const npm = mockNpm({
     config: { dev: true },
-    flatOptions: { global: false },
+    flatOptions: { global: false, auditLevel: 'low' },
     globalDir: 'path/to/node_modules/',
     prefix: 'foo',
   })
@@ -42,7 +42,9 @@ test('should install using Arborist', (t) => {
     install.exec(['fizzbuzz'], er => {
       if (er)
         throw er
-      t.match(ARB_ARGS, { global: false, path: 'foo' })
+      t.match(ARB_ARGS,
+        { global: false, path: 'foo', auditLevel: null },
+        'Arborist gets correct args and ignores auditLevel')
       t.equal(REIFY_CALLED, true, 'called reify')
       t.strictSame(SCRIPTS, [], 'no scripts when adding dep')
       t.end()


### PR DESCRIPTION
This is a valid level but wasn't configured to be allowed.

Also added this param to the usage output for `npm audit`

![Screen Shot 2021-03-23 at 10 30 35 AM](https://user-images.githubusercontent.com/36607/112191046-d5b11280-8bc2-11eb-8b4c-655338f93993.png)

## References
Related to https://github.com/npm/cli/issues/2715