### PR TITLE
fix(install): ignore auditLevel

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -126,15 +126,15 @@ class Install extends BaseCommand {
     if (this.npm.config.get('dev'))
       log.warn('install', 'Usage of the `--dev` option is deprecated. Use `--include=dev` instead.')
 
-    const arb = new Arborist({
+    const opts = {
       ...this.npm.flatOptions,
+      auditLevel: null,
       path: where,
-    })
-
-    await arb.reify({
-      ...this.npm.flatOptions,
       add: args,
-    })
+    }
+    const arb = new Arborist(opts)
+    await arb.reify(opts)
+
     if (!args.length && !isGlobalInstall && !ignoreScripts) {
       const scriptShell = this.npm.config.get('script-shell') || undefined
       const scripts = [

--- a/test/lib/install.js
+++ b/test/lib/install.js
@@ -32,7 +32,7 @@ test('should install using Arborist', (t) => {
 
   const npm = mockNpm({
     config: { dev: true },
-    flatOptions: { global: false },
+    flatOptions: { global: false, auditLevel: 'low' },
     globalDir: 'path/to/node_modules/',
     prefix: 'foo',
   })
@@ -42,7 +42,9 @@ test('should install using Arborist', (t) => {
     install.exec(['fizzbuzz'], er => {
       if (er)
         throw er
-      t.match(ARB_ARGS, { global: false, path: 'foo' })
+      t.match(ARB_ARGS,
+        { global: false, path: 'foo', auditLevel: null },
+        'Arborist gets correct args and ignores auditLevel')
       t.equal(REIFY_CALLED, true, 'called reify')
       t.strictSame(SCRIPTS, [], 'no scripts when adding dep')
       t.end()


### PR DESCRIPTION
`npm install` should not be affected by the `auditLevel` config, as the
results of audit do not change its exit status.


## References
Closes https://github.com/npm/cli/issues/2715