### PR TITLE
fix(config): flatten savePrefix properly

### DIFF
--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -1581,7 +1581,9 @@ define('save-prefix', {
     \`npm config set save-prefix='~'\` it would be set to \`~1.2.3\` which
     only allows patch upgrades.
   `,
-  flatten,
+  flatten (key, obj, flatOptions) {
+    flatOptions.savePrefix = obj['save-exact'] ? '' : obj['save-prefix']
+  },
 })
 
 define('save-prod', {

--- a/test/lib/utils/config/definitions.js
+++ b/test/lib/utils/config/definitions.js
@@ -695,3 +695,18 @@ t.test('user-agent', t => {
   t.equal(flat.userAgent, expectCI)
   t.end()
 })
+
+t.test('save-prefix', t => {
+  const obj = {
+    'save-exact': true,
+    'save-prefix': '~1.2.3',
+  }
+  const flat = {}
+  definitions['save-prefix']
+    .flatten('save-prefix', { ...obj, 'save-exact': true }, flat)
+  t.strictSame(flat, { savePrefix: '' })
+  definitions['save-prefix']
+    .flatten('save-prefix', { ...obj, 'save-exact': false }, flat)
+  t.strictSame(flat, { savePrefix: '~1.2.3' })
+  t.end()
+})

--- a/test/lib/utils/config/flatten.js
+++ b/test/lib/utils/config/flatten.js
@@ -6,6 +6,8 @@ delete process.env.NODE
 process.execPath = '/path/to/node'
 
 const obj = {
+  'save-exact': true,
+  'save-prefix': 'ignored',
   'save-dev': true,
   '@foobar:registry': 'https://foo.bar.com/',
   '//foo.bar.com:_authToken': 'foobarbazquuxasdf',
@@ -15,6 +17,8 @@ const obj = {
 const flat = flatten(obj)
 t.strictSame(flat, {
   saveType: 'dev',
+  saveExact: true,
+  savePrefix: '',
   '@foobar:registry': 'https://foo.bar.com/',
   '//foo.bar.com:_authToken': 'foobarbazquuxasdf',
   npmBin: '/path/to/npm',
@@ -26,6 +30,8 @@ t.strictSame(flat, {
 process.env.NODE = '/usr/local/bin/node.exe'
 flatten({ 'save-dev': false }, flat)
 t.strictSame(flat, {
+  saveExact: true,
+  savePrefix: '',
   '@foobar:registry': 'https://foo.bar.com/',
   '//foo.bar.com:_authToken': 'foobarbazquuxasdf',
   npmBin: '/path/to/npm',


### PR DESCRIPTION
It needs to take save-exact into consideration

## References
Closes https://github.com/npm/cli/issues/2932
