### PR TITLE
fix: config should not error when workspaces are configured

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -88,6 +88,10 @@ class Config extends BaseCommand {
     this.config(args).then(() => cb()).catch(cb)
   }
 
+  execWorkspaces (args, filters, cb) {
+    this.exec(args, cb)
+  }
+
   async config ([action, ...args]) {
     this.npm.log.disableProgress()
     try {

--- a/test/lib/config.js
+++ b/test/lib/config.js
@@ -93,6 +93,13 @@ t.test('config no args', t => {
   })
 })
 
+t.test('config ignores workspaces', t => {
+  config.execWorkspaces([], [], (err) => {
+    t.match(err, /usage instructions/, 'should not error out when workspaces are defined')
+    t.end()
+  })
+})
+
 t.test('config list', t => {
   t.plan(2)
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
`npm config` should retain its old behavior of ignoring workspace configuration entirely, this change does exactly that.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Closes https://github.com/npm/cli/issues/2941