### PR TITLE
fix(flatOptions): re-add `_auth`

### DIFF
--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -143,6 +143,7 @@ define('_auth', {
     is safer to use a registry-provided authentication bearer token stored in
     the ~/.npmrc file by running \`npm login\`.
   `,
+  flatten,
 })
 
 define('access', {


### PR DESCRIPTION
This was not being added to flatOptions, and things like
`npm-registry-fetch` are looking for it.

## References
Fixes https://github.com/npm/cli/issues/2935