### PR TITLE
Fix manNumberRegex in help.js

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -9,7 +9,7 @@ const BaseCommand = require('./base-command.js')
 // Strips out the number from foo.7 or foo.7. or foo.7.tgz
 // We don't currently compress our man pages but if we ever did this would
 // seemlessly continue supporting it
-const manNumberRegex = /\.(\d+)(\..*)?$/
+const manNumberRegex = /\.(\d+)(\.[^/\\]*)?$/
 
 class Help extends BaseCommand {
   /* istanbul ignore next - see test/lib/load-all-commands.js */

--- a/test/lib/help.js
+++ b/test/lib/help.js
@@ -340,3 +340,26 @@ test('npm help - man viewer propagates errors', t => {
     t.end()
   })
 })
+
+test('npm help with complex installation path finds proper help file', t => {
+  npmConfig.viewer = 'browser'
+  globResult = [
+    'C:/Program Files/node-v14.15.5-win-x64/node_modules/npm/man/man1/npm-install.1',
+    // glob always returns forward slashes, even on Windows
+  ]
+
+  t.teardown(() => {
+    npmConfig.viewer = undefined
+    globResult = globDefaults
+    spawnBin = null
+    spawnArgs = null
+  })
+
+  return help.exec(['1', 'install'], (err) => {
+    if (err)
+      throw err
+
+    t.match(openUrlArg, /commands(\/|\\)npm-install.html$/, 'attempts to open the correct url')
+    t.end()
+  })
+})


### PR DESCRIPTION
The current regex will match any .[0-9]. pattern anywhere in the path, which will give incorrect results if npm is installed to a path like .../node-v14.5.5/...

This change restricts it to only the last path element.