### PR TITLE
fix: npm config warn on workspaces

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -89,6 +89,7 @@ class Config extends BaseCommand {
   }
 
   execWorkspaces (args, filters, cb) {
+    this.npm.log.warn('config', 'This command does not support workspaces.')
     this.exec(args, cb)
   }
 

--- a/test/lib/config.js
+++ b/test/lib/config.js
@@ -54,6 +54,7 @@ const cliConfig = {
 
 const npm = {
   log: {
+    warn: () => null,
     info: () => null,
     enableProgress: () => null,
     disableProgress: () => null,
@@ -94,8 +95,17 @@ t.test('config no args', t => {
 })
 
 t.test('config ignores workspaces', t => {
+  npm.log.warn = (title, msg) => {
+    t.equal(title, 'config', 'should warn with expected title')
+    t.equal(
+      msg,
+      'This command does not support workspaces.',
+      'should warn with unsupported option msg'
+    )
+  }
   config.execWorkspaces([], [], (err) => {
     t.match(err, /usage instructions/, 'should not error out when workspaces are defined')
+    npm.log.warn = () => null
     t.end()
   })
 })
@@ -396,7 +406,7 @@ t.test('config set invalid key', t => {
     npm.config.validate = npmConfigValidate
     delete npm.config.save
     delete npm.config.set
-    delete npm.log.warn
+    npm.log.warn = () => null
   })
 
   config.exec(['set', 'foo', 'bar'], (err) => {


### PR DESCRIPTION
When a workspace/workspaces config option is defined, we should log a
warning message to be explicit about not supporting workspaces in the
context of the `npm config` command.

