### PR TITLE
fix(config): accept explicit production=false

### DIFF
--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -29,6 +29,8 @@ const buildOmitList = obj => {
   const only = obj.only
   if (/^prod(uction)?$/.test(only) || obj.production)
     omit.push('dev')
+  else if (obj.production === false)
+    include.push('dev')
 
   if (/^dev/.test(obj.also))
     include.push('dev')
@@ -1396,8 +1398,8 @@ define('preid', {
 })
 
 define('production', {
-  default: false,
-  type: Boolean,
+  default: null,
+  type: [null, Boolean],
   deprecated: 'Use `--omit=dev` instead.',
   description: 'Alias for `--omit=dev`',
   flatten (key, obj, flatOptions) {

--- a/tap-snapshots/test-lib-utils-config-describe-all.js-TAP.test.js
+++ b/tap-snapshots/test-lib-utils-config-describe-all.js-TAP.test.js
@@ -1338,8 +1338,8 @@ Alias for --include=optional or --omit=optional
 
 #### \`production\`
 
-* Default: false
-* Type: Boolean
+* Default: null
+* Type: null or Boolean
 * DEPRECATED: Use \`--omit=dev\` instead.
 
 Alias for \`--omit=dev\`

--- a/test/lib/utils/config/definitions.js
+++ b/test/lib/utils/config/definitions.js
@@ -310,9 +310,9 @@ t.test('flatteners that populate flat.omit array', t => {
     definitions.production.flatten('production', obj, flat)
     t.strictSame(obj, {
       production: false,
-      include: [],
+      include: ['dev'],
       omit: [],
-    }, '--no-production has no effect')
+    }, '--no-production explicitly includes dev')
     t.strictSame(flat, { omit: [] }, '--no-production has no effect')
 
     obj.production = true


### PR DESCRIPTION
This allows for overriding the implicit omit value based on if
NODE_ENV=production


## References
Fixes https://github.com/npm/cli/issues/2936

![Screen Shot 2021-03-24 at 1 39 32 PM](https://user-images.githubusercontent.com/36607/112380215-601e7280-8ca6-11eb-8be4-1805cfa8f362.png)
