### PR TITLE
Always set npm.command to canonical command name

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -25,7 +25,7 @@ const proxyCmds = new Proxy({}, {
       // old way of doing things, until we can make breaking changes to the
       // npm.commands[x] api
       target[actual] = new Proxy(
-        (args, cb) => npm[_runCmd](cmd, impl, args, cb),
+        (args, cb) => npm[_runCmd](actual, impl, args, cb),
         {
           get: (target, attr, receiver) => {
             return Reflect.get(impl, attr, receiver)

--- a/test/lib/npm.js
+++ b/test/lib/npm.js
@@ -15,7 +15,7 @@ for (const env of Object.keys(process.env).filter(e => /^npm_/.test(e))) {
         'should match "npm test" or "npm run test"'
       )
     } else
-      t.match(process.env[env], /^(run)|(run-script)|(exec)$/)
+      t.match(process.env[env], /^(run-script|exec)$/)
   }
   delete process.env[env]
 }
@@ -411,9 +411,14 @@ t.test('npm.load', t => {
     npm.localPrefix = dir
 
     await new Promise((res, rej) => {
-      npm.commands['run-script']([], er => {
+      // verify that calling the command with a short name still sets
+      // the npm.command property to the full canonical name of the cmd.
+      npm.command = null
+      npm.commands.run([], er => {
         if (er)
           rej(er)
+
+        t.equal(npm.command, 'run-script', 'npm.command set to canonical name')
 
         t.match(
           consoleLogs,


### PR DESCRIPTION
This ensures that we get a npm_command env set to, eg 'run-script'
instead of the shorthand 'run'.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
