### PR TITLE
fix(config): properly translate user-agent

### DIFF
--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -1970,6 +1970,11 @@ define('user-agent', {
         .replace(/\{arch\}/gi, process.arch)
         .replace(/\{ci\}/gi, ciName ? `ci/${ciName}` : '')
         .trim()
+    // user-agent is a unique kind of config item that gets set from a template
+    // and ends up translated.  Because of this, the normal "should we set this
+    // to process.env also doesn't work
+    obj[key] = flatOptions.userAgent
+    process.env.npm_config_user_agent = flatOptions.userAgent
   },
 })
 

--- a/test/lib/utils/config/definitions.js
+++ b/test/lib/utils/config/definitions.js
@@ -733,10 +733,16 @@ t.test('user-agent', t => {
     `${process.platform} ${process.arch}`
   definitions['user-agent'].flatten('user-agent', obj, flat)
   t.equal(flat.userAgent, expectNoCI)
+  t.equal(process.env.npm_config_user_agent, flat.userAgent, 'npm_user_config environment is set')
+  t.equal(obj['user-agent'], flat.userAgent, 'config user-agent template is translated')
+
   obj['ci-name'] = 'foo'
+  obj['user-agent'] = definitions['user-agent'].default
   const expectCI = `${expectNoCI} ci/foo`
   definitions['user-agent'].flatten('user-agent', obj, flat)
   t.equal(flat.userAgent, expectCI)
+  t.equal(process.env.npm_config_user_agent, flat.userAgent, 'npm_user_config environment is set')
+  t.equal(obj['user-agent'], flat.userAgent, 'config user-agent template is translated')
   t.end()
 })
 


### PR DESCRIPTION
This config item is a bit of a unique one, as it can be set as a
template, but then gets translated and also populated to
process.env.npm_config_user_agent.  This adds that logic back in during
the flattening.


## References
Fixes https://github.com/npm/cli/issues/2960