### PR TITLE
fix(config): tie save-exact/save-prefix together

### DIFF
--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -1526,7 +1526,10 @@ define('save-exact', {
     Dependencies saved to package.json will be configured with an exact
     version rather than using npm's default semver range operator.
   `,
-  flatten,
+  flatten (key, obj, flatOptions) {
+    // just call the save-prefix flattener, it reads from obj['save-exact']
+    definitions['save-prefix'].flatten('save-prefix', obj, flatOptions)
+  },
 })
 
 define('save-optional', {
@@ -1595,6 +1598,7 @@ define('save-prefix', {
   `,
   flatten (key, obj, flatOptions) {
     flatOptions.savePrefix = obj['save-exact'] ? '' : obj['save-prefix']
+    obj['save-prefix'] = flatOptions.savePrefix
   },
 })
 

--- a/test/lib/utils/config/definitions.js
+++ b/test/lib/utils/config/definitions.js
@@ -760,3 +760,18 @@ t.test('save-prefix', t => {
   t.strictSame(flat, { savePrefix: '~1.2.3' })
   t.end()
 })
+
+t.test('save-exact', t => {
+  const obj = {
+    'save-exact': true,
+    'save-prefix': '~1.2.3',
+  }
+  const flat = {}
+  definitions['save-exact']
+    .flatten('save-exact', { ...obj, 'save-exact': true }, flat)
+  t.strictSame(flat, { savePrefix: '' })
+  definitions['save-exact']
+    .flatten('save-exact', { ...obj, 'save-exact': false }, flat)
+  t.strictSame(flat, { savePrefix: '~1.2.3' })
+  t.end()
+})

--- a/test/lib/utils/config/flatten.js
+++ b/test/lib/utils/config/flatten.js
@@ -17,7 +17,6 @@ const obj = {
 const flat = flatten(obj)
 t.strictSame(flat, {
   saveType: 'dev',
-  saveExact: true,
   savePrefix: '',
   '@foobar:registry': 'https://foo.bar.com/',
   '//foo.bar.com:_authToken': 'foobarbazquuxasdf',
@@ -30,7 +29,6 @@ t.strictSame(flat, {
 process.env.NODE = '/usr/local/bin/node.exe'
 flatten({ 'save-dev': false }, flat)
 t.strictSame(flat, {
-  saveExact: true,
   savePrefix: '',
   '@foobar:registry': 'https://foo.bar.com/',
   '//foo.bar.com:_authToken': 'foobarbazquuxasdf',


### PR DESCRIPTION
Each affects the other, so we tie their flatteners together like we did with omit et al.

![Screen Shot 2021-03-25 at 9 58 38 AM](https://user-images.githubusercontent.com/36607/112512527-b0eaa580-8d50-11eb-9bc8-54161fe53f29.png)

## References
Fixes https://github.com/npm/cli/issues/2963
