### PR TITLE
Explicitly add stream to cache on `cache add`

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -5,6 +5,8 @@ const pacote = require('pacote')
 const path = require('path')
 const rimraf = promisify(require('rimraf'))
 const BaseCommand = require('./base-command.js')
+const MinipassPipeline = require('minipass-pipeline')
+const npa = require('npm-package-arg')
 
 class Cache extends BaseCommand {
   static get description () {
@@ -105,12 +107,19 @@ with --force.`)
 
     log.silly('cache add', 'spec', spec)
 
-    // we ask pacote for the thing, and then just throw the data
-    // away so that it tee-pipes it into the cache like it does
-    // for a normal request.
     await pacote.tarball.stream(spec, stream => {
-      stream.resume()
-      return stream.promise()
+      const nspec = npa(spec)
+      if (nspec.type === 'remote' || nspec.registry) {
+        stream.resume()
+        return stream.promise()
+      }
+      return new MinipassPipeline(
+        stream,
+        cacache.put.stream(
+          path.join(this.npm.config.get('cache'), '_cacache'),
+          `npm-cache-add:${spec}`
+        )
+      ).promise()
     }, this.npm.flatOptions)
   }
 

--- a/test/lib/cache.js
+++ b/test/lib/cache.js
@@ -20,6 +20,12 @@ const npmlog = {
   },
 }
 
+const pipeline = {
+  pipe: () => pipeline,
+  promise: () => Promise.resolve(),
+  resume: () => {},
+}
+
 let tarballStreamSpec = ''
 let tarballStreamOpts = {}
 const pacote = {
@@ -27,10 +33,7 @@ const pacote = {
     stream: (spec, handler, opts) => {
       tarballStreamSpec = spec
       tarballStreamOpts = opts
-      return handler({
-        resume: () => {},
-        promise: () => Promise.resolve(),
-      })
+      return handler(pipeline)
     },
   },
 }
@@ -41,9 +44,15 @@ const cacacheVerifyStats = {
   totalEntries: 1,
   runTime: { total: 2000 },
 }
+
 const cacache = {
   verify: (path) => {
     return cacacheVerifyStats
+  },
+  put: {
+    stream: (cache, stream) => {
+      return pipeline
+    },
   },
 }
 


### PR DESCRIPTION
Pacote doesn't do this automatically anymore

Fixes npm/pacote#73 & Fixes npm/cli#2160