### PR TITLE
change 'maxsockets' default value to 15

### DIFF
--- a/docs/content/using-npm/config.md
+++ b/docs/content/using-npm/config.md
@@ -795,7 +795,7 @@ Show extended information in `npm ls` and `npm search`.
 
 #### `maxsockets`
 
-* Default: Infinity
+* Default: 15
 * Type: Number
 
 The maximum number of connections to use per origin (protocol/host/port

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -1154,7 +1154,7 @@ define('long', {
 })
 
 define('maxsockets', {
-  default: Infinity,
+  default: 15,
   type: Number,
   description: `
     The maximum number of connections to use per origin (protocol/host/port

--- a/tap-snapshots/test-lib-utils-config-describe-all.js-TAP.test.js
+++ b/tap-snapshots/test-lib-utils-config-describe-all.js-TAP.test.js
@@ -674,7 +674,7 @@ Show extended information in \`npm ls\` and \`npm search\`.
 
 #### \`maxsockets\`
 
-* Default: Infinity
+* Default: 15
 * Type: Number
 
 The maximum number of connections to use per origin (protocol/host/port


### PR DESCRIPTION
The default value for 'maxsockets' was changed during the refactoring in #2878 from 50 to 'Inifinity', this PR changes it back to the previous value of 50.

Details in #2978 '[BUG] (Regression) 'maxsockets' default config changed to 'Infinity' in v7.7.0'

Related to #2878
Fixes #2978

