### PR TITLE
fix(docs): add workspaces configuration

### DIFF
--- a/docs/content/commands/npm-docs.md
+++ b/docs/content/commands/npm-docs.md
@@ -41,6 +41,19 @@ Set to `true` to use default system URL opener.
 
 The base URL of the npm package registry.
 
+#### workspaces
+
+Enables workspaces context while searching the `package.json` in the
+current folder.  Documentation urls for the packages named in each
+workspace will be opened.
+
+#### workspace
+
+Enables workspaces context and limits results to only those specified by
+this config item.  Only the documentation urls for the packages named in
+the workspaces given here will be opened.
+
+
 ### See Also
 
 * [npm view](/commands/npm-view)

--- a/docs/content/commands/npm-repo.md
+++ b/docs/content/commands/npm-repo.md
@@ -31,6 +31,19 @@ terminal.
 
 Set to `true` to use default system URL opener.
 
+#### workspaces
+
+Enables workspaces context while searching the `package.json` in the
+current folder.  Repo urls for the packages named in each workspace will
+be opened.
+
+#### workspace
+
+Enables workspaces context and limits results to only those specified by
+this config item.  Only the repo urls for the packages named in the
+workspaces given here will be opened.
+
+
 ### See Also
 
 * [npm docs](/commands/npm-docs)

--- a/docs/content/commands/npm-set-script.md
+++ b/docs/content/commands/npm-set-script.md
@@ -5,7 +5,7 @@ description: Set tasks in the scripts section of package.json
 ---
 
 ### Synopsis
-An npm command that lets you create a task in the scripts section of the package.json.
+An npm command that lets you create a task in the `scripts` section of the `package.json`.
 
 ```bash
 npm set-script [<script>] [<command>]
@@ -25,6 +25,19 @@ npm set-script [<script>] [<command>]
   }
 }
 ```
+
+### Configuration
+
+#### workspaces
+
+Enables workspaces context. Tasks will be created in the `scripts` section
+of the `package.json` of each workspace.
+
+#### workspace
+
+Enables workspaces context and limits creating a task to the
+`package.json` files of the workspaces given.
+
 
 ### See Also
 

--- a/lib/docs.js
+++ b/lib/docs.js
@@ -18,7 +18,7 @@ class Docs extends BaseCommand {
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
   static get params () {
-    return ['browser', 'workspace', 'workspaces']
+    return ['browser', 'registry', 'workspace', 'workspaces']
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */

--- a/tap-snapshots/test-lib-utils-npm-usage.js-TAP.test.js
+++ b/tap-snapshots/test-lib-utils-npm-usage.js-TAP.test.js
@@ -335,7 +335,7 @@ All commands:
                     npm docs [<pkgname> [<pkgname> ...]]
                     
                     Options:
-                    [--browser|--browser <browser>] [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]] [-ws|--workspaces]
+                    [--browser|--browser <browser>] [--registry <registry>] [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]] [-ws|--workspaces]
                     
                     alias: home
                     


### PR DESCRIPTION
Adds workspaces configuration to `docs`, `repo`, and `set-script`.