### PR TITLE
usage: specify the key each time for multiples

### DIFF
--- a/docs/content/using-npm/config.md
+++ b/docs/content/using-npm/config.md
@@ -185,7 +185,7 @@ registry and all registries configured for scopes. See the documentation for
 #### `audit-level`
 
 * Default: null
-* Type: "info", "low", "moderate", "high", "critical", "none", or null
+* Type: null, "info", "low", "moderate", "high", "critical", or "none"
 
 The minimum level of vulnerability for `npm audit` to exit with a non-zero
 exit code.

--- a/lib/utils/config/definition.js
+++ b/lib/utils/config/definition.js
@@ -116,13 +116,14 @@ const describeUsage = (def) => {
     description = def.hint
   }
 
-  if (multiple)
-    description = `${description} [${description} ...]`
-
   if (bool)
     key = `${key}|${key}`
 
-  return `${key} ${description}`
+  const usage = `${key} ${description}`
+  if (multiple)
+    return `${usage} [${usage} ...]`
+  else
+    return usage
 }
 
 const describeType = type => {

--- a/tap-snapshots/test-lib-utils-npm-usage.js-TAP.test.js
+++ b/tap-snapshots/test-lib-utils-npm-usage.js-TAP.test.js
@@ -335,7 +335,7 @@ All commands:
                     npm docs [<pkgname> [<pkgname> ...]]
                     
                     Options:
-                    [--browser|--browser <browser>] [-w|--workspace <workspace-name> [<workspace-name> ...]] [-ws|--workspaces]
+                    [--browser|--browser <browser>] [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]] [-ws|--workspaces]
                     
                     alias: home
                     
@@ -370,7 +370,7 @@ All commands:
                     npm exec --package=foo -c '<cmd> [args...]'
                     
                     Options:
-                    [-w|--workspace <workspace-name> [<workspace-name> ...]] [-ws|--workspaces]
+                    [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]] [-ws|--workspaces]
                     
                     alias: x
                     
@@ -702,7 +702,7 @@ All commands:
                     npm repo [<pkgname> [<pkgname> ...]]
                     
                     Options:
-                    [--browser|--browser <browser>] [-w|--workspace <workspace-name> [<workspace-name> ...]] [-ws|--workspaces]
+                    [--browser|--browser <browser>] [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]] [-ws|--workspaces]
                     
                     Run "npm help repo" for more info
 
@@ -735,7 +735,7 @@ All commands:
                     npm run-script <command> [-- <args>]
                     
                     Options:
-                    [-w|--workspace <workspace-name> [<workspace-name> ...]] [-ws|--workspaces]
+                    [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]] [-ws|--workspaces]
                     
                     aliases: run, rum, urn
                     
@@ -772,7 +772,7 @@ All commands:
                     npm set-script [<script>] [<command>]
                     
                     Options:
-                    [-w|--workspace <workspace-name> [<workspace-name> ...]] [-ws|--workspaces]
+                    [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]] [-ws|--workspaces]
                     
                     Run "npm help set-script" for more info
 
@@ -921,7 +921,7 @@ All commands:
                     npm view [<@scope>/]<pkg>[@<version>] [<field>[.subfield]...]
                     
                     Options:
-                    [--json] [-w|--workspace <workspace-name> [<workspace-name> ...]] [-ws|--workspaces]
+                    [--json] [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]] [-ws|--workspaces]
                     
                     aliases: v, info, show
                     


### PR DESCRIPTION
If a user runs 'npm install -w foo bar baz', that won't set 'bar' and
'baz' as workspace names.  The correct incantation is 'npm install -w
foo -w bar -w baz'.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
