### PR TITLE
Update ssri to fix CVE-2021-27290

### DIFF
--- a/node_modules/ssri/CHANGELOG.md
+++ b/node_modules/ssri/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="6.0.2"></a>
+## [6.0.2](https://github.com/zkat/ssri/compare/v6.0.1...v6.0.2) (2021-04-07)
+
+
+### Bug Fixes
+
+* backport regex change from 8.0.1 ([b30dfdb](https://github.com/zkat/ssri/commit/b30dfdb)), closes [#19](https://github.com/zkat/ssri/issues/19)
+
+
+
 <a name="6.0.1"></a>
 ## [6.0.1](https://github.com/zkat/ssri/compare/v6.0.0...v6.0.1) (2018-08-27)
 

--- a/node_modules/ssri/index.js
+++ b/node_modules/ssri/index.js
@@ -8,7 +8,7 @@ const SPEC_ALGORITHMS = ['sha256', 'sha384', 'sha512']
 
 const BASE64_REGEX = /^[a-z0-9+/]+(?:=?=?)$/i
 const SRI_REGEX = /^([^-]+)-([^?]+)([?\S*]*)$/
-const STRICT_SRI_REGEX = /^([^-]+)-([A-Za-z0-9+/=]{44,88})(\?[\x21-\x7E]*)*$/
+const STRICT_SRI_REGEX = /^([^-]+)-([A-Za-z0-9+/=]{44,88})(\?[\x21-\x7E]*)?$/
 const VCHAR_REGEX = /^[\x21-\x7E]+$/
 
 const SsriOpts = figgyPudding({

--- a/node_modules/ssri/package.json
+++ b/node_modules/ssri/package.json
@@ -1,31 +1,32 @@
 {
-  "_from": "ssri@latest",
-  "_id": "ssri@6.0.1",
+  "_from": "ssri@6.0.2",
+  "_id": "ssri@6.0.2",
   "_inBundle": false,
-  "_integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+  "_integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
   "_location": "/ssri",
   "_phantomChildren": {},
   "_requested": {
-    "type": "tag",
+    "type": "version",
     "registry": true,
-    "raw": "ssri@latest",
+    "raw": "ssri@6.0.2",
     "name": "ssri",
     "escapedName": "ssri",
-    "rawSpec": "latest",
+    "rawSpec": "6.0.2",
     "saveSpec": null,
-    "fetchSpec": "latest"
+    "fetchSpec": "6.0.2"
   },
   "_requiredBy": [
     "#USER",
     "/",
     "/cacache",
+    "/libnpmpublish",
     "/make-fetch-happen",
     "/pacote"
   ],
-  "_resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-  "_shasum": "2a3c41b28dd45b62b63676ecb74001265ae9edd8",
-  "_spec": "ssri@latest",
-  "_where": "/Users/zkat/Documents/code/work/npm",
+  "_resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+  "_shasum": "157939134f20464e7301ddba3e90ffa8f7728ac5",
+  "_spec": "ssri@6.0.2",
+  "_where": "/home/kasicka/temp/cli/node_modules",
   "author": {
     "name": "Kat Marchán",
     "email": "kzm@sykosomatic.org"
@@ -89,5 +90,5 @@
     "update-coc": "weallbehave -o . && git add CODE_OF_CONDUCT.md && git commit -m 'docs(coc): updated CODE_OF_CONDUCT.md'",
     "update-contrib": "weallcontribute -o . && git add CONTRIBUTING.md && git commit -m 'docs(contributing): updated CONTRIBUTING.md'"
   },
-  "version": "6.0.1"
+  "version": "6.0.2"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5091,9 +5091,9 @@
       }
     },
     "ssri": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.2.tgz",
+      "integrity": "sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==",
       "requires": {
         "figgy-pudding": "^3.5.1"
       }

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "slide": "~1.1.6",
     "sorted-object": "~2.0.1",
     "sorted-union-stream": "~2.1.3",
-    "ssri": "^6.0.1",
+    "ssri": "^6.0.2",
     "stringify-package": "^1.0.1",
     "tar": "^4.4.13",
     "text-table": "~0.2.0",


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Fixes [CVE-2021-27290](https://github.com/advisories/GHSA-vx3p-948g-6vhq)

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
