### PR TITLE
Update hosted-git-info to fix CVE-2021-23362

### DIFF
--- a/node_modules/hosted-git-info/CHANGELOG.md
+++ b/node_modules/hosted-git-info/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="2.8.9"></a>
+## [2.8.9](https://github.com/npm/hosted-git-info/compare/v2.8.8...v2.8.9) (2021-04-07)
+
+
+### Bug Fixes
+
+* backport regex fix from [#76](https://github.com/npm/hosted-git-info/issues/76) ([29adfe5](https://github.com/npm/hosted-git-info/commit/29adfe5)), closes [#84](https://github.com/npm/hosted-git-info/issues/84)
+
+
+
 <a name="2.8.8"></a>
 ## [2.8.8](https://github.com/npm/hosted-git-info/compare/v2.8.7...v2.8.8) (2020-02-29)
 

--- a/node_modules/hosted-git-info/index.js
+++ b/node_modules/hosted-git-info/index.js
@@ -41,7 +41,7 @@ function fromUrl (giturl, opts) {
     isGitHubShorthand(giturl) ? 'github:' + giturl : giturl
   )
   var parsed = parseGitUrl(url)
-  var shortcutMatch = url.match(new RegExp('^([^:]+):(?:(?:[^@:]+(?:[^@]+)?@)?([^/]*))[/](.+?)(?:[.]git)?($|#)'))
+  var shortcutMatch = url.match(/^([^:]+):(?:[^@]+@)?(?:([^/]*)\/)?([^#]+)/)
   var matches = Object.keys(gitHosts).map(function (gitHostName) {
     try {
       var gitHostInfo = gitHosts[gitHostName]
@@ -55,7 +55,7 @@ function fromUrl (giturl, opts) {
       var defaultRepresentation = null
       if (shortcutMatch && shortcutMatch[1] === gitHostName) {
         user = shortcutMatch[2] && decodeURIComponent(shortcutMatch[2])
-        project = decodeURIComponent(shortcutMatch[3])
+        project = decodeURIComponent(shortcutMatch[3].replace(/\.git$/, ''))
         defaultRepresentation = 'shortcut'
       } else {
         if (parsed.host && parsed.host !== gitHostInfo.domain && parsed.host.replace(/^www[.]/, '') !== gitHostInfo.domain) return

--- a/node_modules/hosted-git-info/package.json
+++ b/node_modules/hosted-git-info/package.json
@@ -1,19 +1,19 @@
 {
-  "_from": "hosted-git-info@2.8.8",
-  "_id": "hosted-git-info@2.8.8",
+  "_from": "hosted-git-info@2",
+  "_id": "hosted-git-info@2.8.9",
   "_inBundle": false,
-  "_integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+  "_integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
   "_location": "/hosted-git-info",
   "_phantomChildren": {},
   "_requested": {
-    "type": "version",
+    "type": "range",
     "registry": true,
-    "raw": "hosted-git-info@2.8.8",
+    "raw": "hosted-git-info@2",
     "name": "hosted-git-info",
     "escapedName": "hosted-git-info",
-    "rawSpec": "2.8.8",
+    "rawSpec": "2",
     "saveSpec": null,
-    "fetchSpec": "2.8.8"
+    "fetchSpec": "2"
   },
   "_requiredBy": [
     "#USER",
@@ -21,10 +21,10 @@
     "/normalize-package-data",
     "/npm-package-arg"
   ],
-  "_resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-  "_shasum": "7539bd4bc1e0e0a895815a2e0262420b12858488",
-  "_spec": "hosted-git-info@2.8.8",
-  "_where": "/Users/darcyclarke/Documents/Repos/npm/cli",
+  "_resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+  "_shasum": "dffc0bf9a21c02209090f2aa69429e1414daf3f9",
+  "_spec": "hosted-git-info@2",
+  "_where": "/home/kasicka/temp/cli/node_modules",
   "author": {
     "name": "Rebecca Turner",
     "email": "me@re-becca.org",
@@ -68,5 +68,5 @@
     "test": "tap -J --coverage=90 --no-esm test/*.js",
     "test:coverage": "tap --coverage-report=html -J --coverage=90 --no-esm test/*.js"
   },
-  "version": "2.8.8"
+  "version": "2.8.9"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2311,9 +2311,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
     },
     "html-escaper": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "glob": "^7.1.6",
     "graceful-fs": "^4.2.4",
     "has-unicode": "~2.0.1",
-    "hosted-git-info": "^2.8.8",
+    "hosted-git-info": "^2.8.9",
     "iferr": "^1.0.2",
     "infer-owner": "^1.0.4",
     "inflight": "~1.0.6",


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Fixes [CVE-2021-23362](https://snyk.io/vuln/SNYK-JS-HOSTEDGITINFO-1088355)

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
