### PR TITLE
fix init-package-name file version

### DIFF
--- a/node_modules/init-package-json/default-input.js
+++ b/node_modules/init-package-json/default-input.js
@@ -12,7 +12,7 @@ function isTestPkg (p) {
 }
 
 function niceName (n) {
-  return n.replace(/^node-|[.-]js$/g, '').replace(' ', '-').toLowerCase()
+  return n.replace(/^node-|[.-]js$/g, '').replace(/\s+/g, ' ').replace(/ /g, '-').toLowerCase()
 }
 
 function readDeps (test, excluded) { return function (cb) {
@@ -45,7 +45,7 @@ function readDeps (test, excluded) { return function (cb) {
   })
 }}
 
-var name = package.name || basename
+var name = niceName(package.name || basename)
 var spec
 try {
   spec = npa(name)
@@ -61,7 +61,7 @@ if (scope) {
     name = scope + '/' + name
   }
 }
-exports.name =  yes ? name : prompt('package name', niceName(name), function (data) {
+exports.name =  yes ? name : prompt('package name', name, function (data) {
   var its = validateName(data)
   if (its.validForNewPackages) return data
   var errors = (its.errors || []).concat(its.warnings || [])


### PR DESCRIPTION
Updated default-input.js for 2.0.2

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
This fixes issue #2996 . It looks like 6f46b0f7fef9891e6de4af3547c70a67cb3a7a13 updated init-package-json to 2.0.2 but didn't update default-input.js.

One thing to note: it looks like package.json wasn't updated either for this package. Not sure if this PR is the correct avenue to update that, though.

### Before:
`package name: (test-foo bar)`
### After:
`package name: (test-foo-bar)`

## References
Closes #2996 