### PR TITLE
docs: fix refs to ws shorthand

### DIFF
--- a/docs/content/commands/npm-exec.md
+++ b/docs/content/commands/npm-exec.md
@@ -11,7 +11,7 @@ npm exec -- <pkg>[@<version>] [args...]
 npm exec --package=<pkg>[@<version>] -- <cmd> [args...]
 npm exec -c '<cmd> [args...]'
 npm exec --package=foo -c '<cmd> [args...]'
-npm exec [-ws] [-w <workspace-name] [args...]
+npm exec [--ws] [-w <workspace-name] [args...]
 
 npx <pkg>[@<specifier>] [args...]
 npx -p <pkg>[@<specifier>] <cmd> [args...]
@@ -184,7 +184,7 @@ in this example we're using **eslint** to lint any js file found within each
 workspace folder:
 
 ```
-npm exec -ws -- eslint ./*.js
+npm exec --ws -- eslint ./*.js
 ```
 
 #### Filtering workspaces
@@ -275,7 +275,7 @@ children workspaces)
 
 #### workspaces
 
-* Alias: `-ws`
+* Alias: `--ws`
 * Type: Boolean
 * Default: `false`
 

--- a/docs/content/commands/npm-run-script.md
+++ b/docs/content/commands/npm-run-script.md
@@ -189,7 +189,7 @@ children workspaces)
 
 #### workspaces
 
-* Alias: `-ws`
+* Alias: `--ws`
 * Type: Boolean
 * Default: `false`
 


### PR DESCRIPTION
Normalizes usage of `--ws` in docs.

## References
Fixes: https://github.com/npm/statusboard/issues/313

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
