### PR TITLE
chore(tests): consistent error assertions

### DIFF
--- a/test/lib/access.js
+++ b/test/lib/access.js
@@ -117,7 +117,7 @@ t.test('access public on scoped package', (t) => {
   access.exec([
     'public',
   ], (err) => {
-    t.error(err, 'npm access')
+    t.error(err, { bail: true })
     t.ok('should successfully access public on scoped package')
   })
 })
@@ -202,7 +202,7 @@ t.test('access restricted on scoped package', (t) => {
   access.exec([
     'restricted',
   ], (err) => {
-    t.error(err, 'npm access')
+    t.error(err, { bail: true })
     t.ok('should successfully access restricted on scoped package')
   })
 })
@@ -261,7 +261,7 @@ t.test('access grant read-only', (t) => {
     'myorg:myteam',
     '@scoped/another',
   ], (err) => {
-    t.error(err, 'npm access')
+    t.error(err, { bail: true })
     t.ok('should successfully access grant read-only')
   })
 })
@@ -285,7 +285,7 @@ t.test('access grant read-write', (t) => {
     'myorg:myteam',
     '@scoped/another',
   ], (err) => {
-    t.error(err, 'npm access')
+    t.error(err, { bail: true })
     t.ok('should successfully access grant read-write')
   })
 })
@@ -313,7 +313,7 @@ t.test('access grant current cwd', (t) => {
     'read-write',
     'myorg:myteam',
   ], (err) => {
-    t.error(err, 'npm access')
+    t.error(err, { bail: true })
     t.ok('should successfully access grant current cwd')
   })
 })
@@ -370,7 +370,7 @@ t.test('access grant malformed team arg', (t) => {
 })
 
 t.test('access 2fa-required/2fa-not-required', t => {
-  t.plan(2)
+  t.plan(4)
   const Access = t.mock('../../lib/access.js', {
     libnpmaccess: {
       tfaRequired: (spec) => {
@@ -385,14 +385,12 @@ t.test('access 2fa-required/2fa-not-required', t => {
   })
   const access = new Access({})
 
-  access.exec(['2fa-required', '@scope/pkg'], er => {
-    if (er)
-      throw er
+  access.exec(['2fa-required', '@scope/pkg'], err => {
+    t.error(err, { bail: true })
   })
 
-  access.exec(['2fa-not-required', 'unscoped-pkg'], er => {
-    if (er)
-      throw er
+  access.exec(['2fa-not-required', 'unscoped-pkg'], err => {
+    t.error(err, { bail: true })
   })
 })
 
@@ -413,7 +411,7 @@ t.test('access revoke', (t) => {
     'myorg:myteam',
     '@scoped/another',
   ], (err) => {
-    t.error(err, 'npm access')
+    t.error(err, { bail: true })
     t.ok('should successfully access revoke')
   })
 })
@@ -465,7 +463,7 @@ t.test('npm access ls-packages with no team', (t) => {
   access.exec([
     'ls-packages',
   ], (err) => {
-    t.error(err, 'npm access')
+    t.error(err, { bail: true })
     t.ok('should successfully access ls-packages with no team')
   })
 })
@@ -485,7 +483,7 @@ t.test('access ls-packages on team', (t) => {
     'ls-packages',
     'myorg:myteam',
   ], (err) => {
-    t.error(err, 'npm access')
+    t.error(err, { bail: true })
     t.ok('should successfully access ls-packages on team')
   })
 })
@@ -509,7 +507,7 @@ t.test('access ls-collaborators on current', (t) => {
   access.exec([
     'ls-collaborators',
   ], (err) => {
-    t.error(err, 'npm access')
+    t.error(err, { bail: true })
     t.ok('should successfully access ls-collaborators on current')
   })
 })
@@ -529,7 +527,7 @@ t.test('access ls-collaborators on spec', (t) => {
     'ls-collaborators',
     'yargs',
   ], (err) => {
-    t.error(err, 'npm access')
+    t.error(err, { bail: true })
     t.ok('should successfully access ls-packages with no team')
   })
 })

--- a/test/lib/adduser.js
+++ b/test/lib/adduser.js
@@ -83,7 +83,7 @@ t.test('usage', (t) => {
 })
 t.test('simple login', (t) => {
   adduser.exec([], (err) => {
-    t.error(err, 'npm adduser')
+    t.error(err, { bail: true })
 
     t.equal(
       registryOutput,
@@ -154,7 +154,7 @@ t.test('scoped login', (t) => {
   _flatOptions.scope = '@myscope'
 
   adduser.exec([], (err) => {
-    t.error(err, 'npm adduser')
+    t.error(err, { bail: true })
 
     t.same(
       setConfig['@myscope:registry'],
@@ -175,7 +175,7 @@ t.test('scoped login with valid scoped registry config', (t) => {
   _flatOptions.scope = '@myscope'
 
   adduser.exec([], (err) => {
-    t.error(err, 'npm adduser')
+    t.error(err, { bail: true })
 
     t.same(
       setConfig['@myscope:registry'],

--- a/test/lib/bin.js
+++ b/test/lib/bin.js
@@ -18,7 +18,7 @@ t.test('bin', (t) => {
   t.match(bin.usage, 'bin', 'usage has command name in it')
 
   bin.exec([], (err) => {
-    t.error(err, 'npm bin')
+    t.error(err, { bail: true })
     t.ok('should have printed directory')
   })
 })
@@ -49,7 +49,7 @@ t.test('bin -g', (t) => {
   const bin = new Bin(npm)
 
   bin.exec([], (err) => {
-    t.error(err, 'npm bin')
+    t.error(err, { bail: true })
     t.ok('should have printed directory')
   })
 })
@@ -79,7 +79,7 @@ t.test('bin -g (not in path)', (t) => {
   const bin = new Bin(npm)
 
   bin.exec([], (err) => {
-    t.error(err, 'npm bin')
+    t.error(err, { bail: true })
     t.ok('should have printed directory')
   })
 })

--- a/test/lib/bugs.js
+++ b/test/lib/bugs.js
@@ -86,8 +86,7 @@ t.test('open bugs urls & emails', t => {
   keys.forEach(pkg => {
     t.test(pkg, t => {
       bugs.exec([pkg], (er) => {
-        if (er)
-          throw er
+        t.error(er, { bail: true })
         t.equal(opened[expect[pkg]], 1, 'opened expected url', {opened})
         t.end()
       })
@@ -97,8 +96,7 @@ t.test('open bugs urls & emails', t => {
 
 t.test('open default package if none specified', t => {
   bugs.exec([], (er) => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.equal(opened['https://example.com'], 2, 'opened expected url', {opened})
     t.end()
   })

--- a/test/lib/cache.js
+++ b/test/lib/cache.js
@@ -88,7 +88,7 @@ t.test('cache clean (force)', t => {
   })
 
   cache.exec(['clear'], err => {
-    t.error(err)
+    t.error(err, { bail: true })
     t.equal(rimrafPath, path.join(npm.cache, '_cacache'))
     t.end()
   })
@@ -123,7 +123,7 @@ t.test('cache add pkg only', t => {
   })
 
   cache.exec(['add', 'mypkg'], err => {
-    t.error(err)
+    t.error(err, { bail: true })
     t.strictSame(logOutput, [
       ['silly', 'cache add', 'args', ['mypkg']],
       ['silly', 'cache add', 'spec', 'mypkg'],
@@ -142,7 +142,7 @@ t.test('cache add pkg w/ spec modifier', t => {
   })
 
   cache.exec(['add', 'mypkg', 'latest'], err => {
-    t.error(err)
+    t.error(err, { bail: true })
     t.strictSame(logOutput, [
       ['silly', 'cache add', 'args', ['mypkg', 'latest']],
       ['silly', 'cache add', 'spec', 'mypkg@latest'],
@@ -159,7 +159,7 @@ t.test('cache verify', t => {
   })
 
   cache.exec(['verify'], err => {
-    t.error(err)
+    t.error(err, { bail: true })
     t.match(outputOutput, [
       `Cache verified and compressed (${path.join(npm.cache, '_cacache')})`,
       'Content verified: 1 (100 bytes)',
@@ -186,7 +186,7 @@ t.test('cache verify w/ extra output', t => {
   })
 
   cache.exec(['check'], err => {
-    t.error(err)
+    t.error(err, { bail: true })
     t.match(outputOutput, [
       `Cache verified and compressed (~${path.join('/fake/path', '_cacache')})`,
       'Content verified: 1 (100 bytes)',

--- a/test/lib/ci.js
+++ b/test/lib/ci.js
@@ -33,8 +33,7 @@ t.test('should ignore scripts with --ignore-scripts', (t) => {
   const ci = new CI(npm)
 
   ci.exec([], er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.equal(REIFY_CALLED, true, 'called reify')
     t.strictSame(SCRIPTS, [], 'no scripts when running ci')
     t.end()
@@ -122,8 +121,7 @@ t.test('should use Arborist and run-script', (t) => {
   const ci = new CI(npm)
 
   ci.exec(null, er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     for (const [msg, result] of Object.entries(timers))
       t.notOk(result, `properly resolved ${msg} timer`)
     t.match(timers, { 'npm-ci:rm': false }, 'saw the rimraf timer')
@@ -141,7 +139,6 @@ t.test('should pass flatOptions to Arborist.reify', (t) => {
       this.loadVirtual = () => Promise.resolve(true)
       this.reify = async (options) => {
         t.equal(options.production, true, 'should pass flatOptions to Arborist.reify')
-        t.end()
       }
     },
   })
@@ -153,8 +150,8 @@ t.test('should pass flatOptions to Arborist.reify', (t) => {
   })
   const ci = new CI(npm)
   ci.exec(null, er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
+    t.end()
   })
 })
 
@@ -224,7 +221,6 @@ t.test('should remove existing node_modules before installing', (t) => {
         const contents = await readdir(testDir)
         const nodeModules = contents.filter((path) => path.startsWith('node_modules'))
         t.same(nodeModules, ['node_modules'], 'should only have the node_modules directory')
-        t.end()
       }
     },
   })
@@ -238,7 +234,7 @@ t.test('should remove existing node_modules before installing', (t) => {
   const ci = new CI(npm)
 
   ci.exec(null, er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
+    t.end()
   })
 })

--- a/test/lib/config.js
+++ b/test/lib/config.js
@@ -120,7 +120,7 @@ t.test('config list', t => {
   })
 
   config.exec(['list'], (err) => {
-    t.error(err, 'npm config list')
+    t.error(err, { bail: true })
     t.matchSnapshot(result, 'should list configs')
   })
 })
@@ -146,7 +146,7 @@ t.test('config list overrides', t => {
   })
 
   config.exec(['list'], (err) => {
-    t.error(err, 'npm config list')
+    t.error(err, { bail: true })
     t.matchSnapshot(result, 'should list overridden configs')
   })
 })
@@ -164,7 +164,7 @@ t.test('config list --long', t => {
   })
 
   config.exec(['list'], (err) => {
-    t.error(err, 'npm config list --long')
+    t.error(err, { bail: true })
     t.matchSnapshot(result, 'should list all configs')
   })
 })
@@ -189,7 +189,7 @@ t.test('config list --json', t => {
   })
 
   config.exec(['list'], (err) => {
-    t.error(err, 'npm config list --json')
+    t.error(err, { bail: true })
     t.same(
       JSON.parse(result),
       {
@@ -223,7 +223,7 @@ t.test('config delete key', t => {
   }
 
   config.exec(['delete', 'foo'], (err) => {
-    t.error(err, 'npm config delete key')
+    t.error(err, { bail: true })
   })
 
   t.teardown(() => {
@@ -250,7 +250,7 @@ t.test('config delete multiple key', t => {
   }
 
   config.exec(['delete', 'foo', 'bar'], (err) => {
-    t.error(err, 'npm config delete keys')
+    t.error(err, { bail: true })
   })
 
   t.teardown(() => {
@@ -273,7 +273,7 @@ t.test('config delete key --global', t => {
 
   cliConfig.global = true
   config.exec(['delete', 'foo'], (err) => {
-    t.error(err, 'npm config delete key --global')
+    t.error(err, { bail: true })
   })
 
   t.teardown(() => {
@@ -304,7 +304,7 @@ t.test('config set key', t => {
   }
 
   config.exec(['set', 'foo', 'bar'], (err) => {
-    t.error(err, 'npm config set key')
+    t.error(err, { bail: true })
   })
 
   t.teardown(() => {
@@ -327,7 +327,7 @@ t.test('config set key=val', t => {
   }
 
   config.exec(['set', 'foo=bar'], (err) => {
-    t.error(err, 'npm config set key')
+    t.error(err, { bail: true })
   })
 
   t.teardown(() => {
@@ -358,7 +358,7 @@ t.test('config set multiple keys', t => {
   }
 
   config.exec(['set', ...args], (err) => {
-    t.error(err, 'npm config set key')
+    t.error(err, { bail: true })
   })
 
   t.teardown(() => {
@@ -381,7 +381,7 @@ t.test('config set key to empty value', t => {
   }
 
   config.exec(['set', 'foo'], (err) => {
-    t.error(err, 'npm config set key to empty value')
+    t.error(err, { bail: true })
   })
 
   t.teardown(() => {
@@ -409,7 +409,7 @@ t.test('config set invalid key', t => {
   })
 
   config.exec(['set', 'foo', 'bar'], (err) => {
-    t.error(err, 'npm config set invalid key')
+    t.error(err, { bail: true })
   })
 })
 
@@ -428,7 +428,7 @@ t.test('config set key --global', t => {
 
   cliConfig.global = true
   config.exec(['set', 'foo', 'bar'], (err) => {
-    t.error(err, 'npm config set key --global')
+    t.error(err, { bail: true })
   })
 
   t.teardown(() => {
@@ -449,7 +449,7 @@ t.test('config get no args', t => {
   })
 
   config.exec(['get'], (err) => {
-    t.error(err, 'npm config get no args')
+    t.error(err, { bail: true })
     t.matchSnapshot(result, 'should list configs on config get no args')
   })
 })
@@ -468,7 +468,7 @@ t.test('config get key', t => {
   }
 
   config.exec(['get', 'foo'], (err) => {
-    t.error(err, 'npm config get key')
+    t.error(err, { bail: true })
   })
 
   t.teardown(() => {
@@ -496,7 +496,7 @@ t.test('config get multiple keys', t => {
   }
 
   config.exec(['get', 'foo', 'bar'], (err) => {
-    t.error(err, 'npm config get multiple keys')
+    t.error(err, { bail: true })
     t.equal(result, 'foo=asdf\nbar=asdf')
   })
 
@@ -558,7 +558,7 @@ sign-git-commit=true`
   const config = new Config(npm)
 
   config.exec(['edit'], (err) => {
-    t.error(err, 'npm config edit')
+    t.error(err, { bail: true })
 
     // test no config file result
     editMocks.fs.readFile = (p, e, cb) => {
@@ -567,7 +567,7 @@ sign-git-commit=true`
     const Config = t.mock('../../lib/config.js', editMocks)
     const config = new Config(npm)
     config.exec(['edit'], (err) => {
-      t.error(err, 'npm config edit')
+      t.error(err, { bail: true })
     })
   })
 

--- a/test/lib/dedupe.js
+++ b/test/lib/dedupe.js
@@ -36,8 +36,7 @@ t.test('should remove dupes using Arborist', (t) => {
   })
   const dedupe = new Dedupe(npm)
   dedupe.exec([], er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.ok(true, 'callback is called')
     t.end()
   })

--- a/test/lib/dist-tag.js
+++ b/test/lib/dist-tag.js
@@ -85,7 +85,7 @@ t.test('ls in current package', (t) => {
     }),
   })
   distTag.exec(['ls'], (err) => {
-    t.error(err, 'npm dist-tags ls')
+    t.error(err, { bail: true })
     t.matchSnapshot(
       result,
       'should list available tags for current package'
@@ -101,7 +101,7 @@ t.test('no args in current package', (t) => {
     }),
   })
   distTag.exec([], (err) => {
-    t.error(err, 'npm dist-tags ls')
+    t.error(err, { bail: true })
     t.matchSnapshot(
       result,
       'should default to listing available tags for current package'
@@ -121,7 +121,7 @@ t.test('borked cmd usage', (t) => {
 t.test('ls on named package', (t) => {
   npm.prefix = t.testdir({})
   distTag.exec(['ls', '@scoped/another'], (err) => {
-    t.error(err, 'npm dist-tags ls')
+    t.error(err, { bail: true })
     t.matchSnapshot(
       result,
       'should list tags for the specified package'
@@ -163,7 +163,7 @@ t.test('ls on missing name in current package', (t) => {
 t.test('only named package arg', (t) => {
   npm.prefix = t.testdir({})
   distTag.exec(['@scoped/another'], (err) => {
-    t.error(err, 'npm dist-tags ls')
+    t.error(err, { bail: true })
     t.matchSnapshot(
       result,
       'should default to listing tags for the specified package'
@@ -201,7 +201,7 @@ t.test('workspaces', (t) => {
 
   t.test('no args', t => {
     distTag.execWorkspaces([], [], (err) => {
-      t.error(err)
+      t.error(err, { bail: true })
       t.matchSnapshot(result, 'printed the expected output')
       t.end()
     })
@@ -209,7 +209,7 @@ t.test('workspaces', (t) => {
 
   t.test('no args, one workspace', t => {
     distTag.execWorkspaces([], ['workspace-a'], (err) => {
-      t.error(err)
+      t.error(err, { bail: true })
       t.matchSnapshot(result, 'printed the expected output')
       t.end()
     })
@@ -217,7 +217,7 @@ t.test('workspaces', (t) => {
 
   t.test('one arg -- .', t => {
     distTag.execWorkspaces(['.'], [], (err) => {
-      t.error(err)
+      t.error(err, { bail: true })
       t.matchSnapshot(result, 'printed the expected output')
       t.end()
     })
@@ -225,7 +225,7 @@ t.test('workspaces', (t) => {
 
   t.test('one arg -- .@1, ignores version spec', t => {
     distTag.execWorkspaces(['.@'], [], (err) => {
-      t.error(err)
+      t.error(err, { bail: true })
       t.matchSnapshot(result, 'printed the expected output')
       t.end()
     })
@@ -233,7 +233,7 @@ t.test('workspaces', (t) => {
 
   t.test('one arg -- list', t => {
     distTag.execWorkspaces(['list'], [], (err) => {
-      t.error(err)
+      t.error(err, { bail: true })
       t.matchSnapshot(result, 'printed the expected output')
       t.end()
     })
@@ -241,7 +241,7 @@ t.test('workspaces', (t) => {
 
   t.test('two args -- list, .', t => {
     distTag.execWorkspaces(['list', '.'], [], (err) => {
-      t.error(err)
+      t.error(err, { bail: true })
       t.matchSnapshot(result, 'printed the expected output')
       t.end()
     })
@@ -249,7 +249,7 @@ t.test('workspaces', (t) => {
 
   t.test('two args -- list, .@1, ignores version spec', t => {
     distTag.execWorkspaces(['list', '.@'], [], (err) => {
-      t.error(err)
+      t.error(err, { bail: true })
       t.matchSnapshot(result, 'printed the expected output')
       t.end()
     })
@@ -257,7 +257,7 @@ t.test('workspaces', (t) => {
 
   t.test('two args -- list, @scoped/pkg, logs a warning and ignores workspaces', t => {
     distTag.execWorkspaces(['list', '@scoped/pkg'], [], (err) => {
-      t.error(err)
+      t.error(err, { bail: true })
       t.match(log, 'Ignoring workspaces for specified package', 'logs a warning')
       t.matchSnapshot(result, 'printed the expected output')
       t.end()
@@ -298,7 +298,7 @@ t.test('workspaces', (t) => {
     })
 
     distTag.execWorkspaces([], [], (err) => {
-      t.error(err)
+      t.error(err, { bail: true })
       t.equal(process.exitCode, 1, 'set the error status')
       process.exitCode = 0
       t.match(log, 'dist-tag ls Couldn\'t get dist-tag data for workspace-d@latest', 'logs the error')
@@ -322,7 +322,7 @@ t.test('add new tag', (t) => {
   }
   npm.prefix = t.testdir({})
   distTag.exec(['add', '@scoped/another@7.7.7', 'c'], (err) => {
-    t.error(err, 'npm dist-tags add')
+    t.error(err, { bail: true })
     t.matchSnapshot(
       result,
       'should return success msg'
@@ -366,7 +366,7 @@ t.test('add missing pkg name', (t) => {
 t.test('set existing version', (t) => {
   npm.prefix = t.testdir({})
   distTag.exec(['set', '@scoped/another@0.6.0', 'b'], (err) => {
-    t.error(err, 'npm dist-tags set')
+    t.error(err, { bail: true })
     t.matchSnapshot(
       log,
       'should log warn msg'
@@ -386,7 +386,7 @@ t.test('remove existing tag', (t) => {
   }
   npm.prefix = t.testdir({})
   distTag.exec(['rm', '@scoped/another', 'c'], (err) => {
-    t.error(err, 'npm dist-tags rm')
+    t.error(err, { bail: true })
     t.matchSnapshot(log, 'should log remove info')
     t.matchSnapshot(result, 'should return success msg')
     t.end()

--- a/test/lib/docs.js
+++ b/test/lib/docs.js
@@ -96,8 +96,7 @@ t.test('open docs urls', t => {
   keys.forEach(pkg => {
     t.test(pkg, t => {
       docs.exec([['.', pkg].join(sep)], (err) => {
-        if (err)
-          throw err
+        t.error(err, { bail: true })
         const url = expect[pkg]
         t.match({
           [url]: 1,
@@ -109,9 +108,8 @@ t.test('open docs urls', t => {
 })
 
 t.test('open default package if none specified', t => {
-  docs.exec([], (er) => {
-    if (er)
-      throw er
+  docs.exec([], (err) => {
+    t.error(err, { bail: true })
     t.equal(opened['https://example.com'], 1, 'opened expected url', {opened})
     t.end()
   })

--- a/test/lib/exec.js
+++ b/test/lib/exec.js
@@ -125,7 +125,7 @@ t.test('npx foo, bin already exists locally', t => {
   npm.localBin = path
 
   exec.exec(['foo', 'one arg', 'two arg'], er => {
-    t.error(er, 'npm exec')
+    t.error(er, { bail: true })
     t.match(RUN_SCRIPTS, [{
       pkg: { scripts: { npx: 'foo' }},
       args: ['one arg', 'two arg'],
@@ -151,7 +151,7 @@ t.test('npx foo, bin already exists globally', t => {
   npm.globalBin = path
 
   exec.exec(['foo', 'one arg', 'two arg'], er => {
-    t.error(er, 'npm exec')
+    t.error(er, { bail: true })
     t.match(RUN_SCRIPTS, [{
       pkg: { scripts: { npx: 'foo' }},
       args: ['one arg', 'two arg'],
@@ -183,8 +183,7 @@ t.test('npm exec foo, already present locally', t => {
     _from: 'foo@',
   }
   exec.exec(['foo', 'one arg', 'two arg'], er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.strictSame(MKDIRPS, [], 'no need to make any dirs')
     t.match(ARB_CTOR, [{ path }])
     t.strictSame(ARB_REIFY, [], 'no need to reify anything')
@@ -216,8 +215,7 @@ t.test('npm exec <noargs>, run interactive shell', t => {
     ARB_REIFY.length = 0
     OUTPUT.length = 0
     exec.exec([], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
       t.strictSame(MKDIRPS, [], 'no need to make any dirs')
       t.strictSame(ARB_CTOR, [], 'no need to instantiate arborist')
       t.strictSame(ARB_REIFY, [], 'no need to reify anything')
@@ -310,8 +308,7 @@ t.test('npm exec foo, not present locally or in central loc', t => {
     _from: 'foo@',
   }
   exec.exec(['foo', 'one arg', 'two arg'], er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.strictSame(MKDIRPS, [installDir], 'need to make install dir')
     t.match(ARB_CTOR, [{ path }])
     t.match(ARB_REIFY, [{add: ['foo@'], legacyPeerDeps: false}], 'need to install foo@')
@@ -350,8 +347,7 @@ t.test('npm exec foo, not present locally but in central loc', t => {
     _from: 'foo@',
   }
   exec.exec(['foo', 'one arg', 'two arg'], er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.strictSame(MKDIRPS, [installDir], 'need to make install dir')
     t.match(ARB_CTOR, [{ path }])
     t.match(ARB_REIFY, [], 'no need to install again, already there')
@@ -390,8 +386,7 @@ t.test('npm exec foo, present locally but wrong version', t => {
     _from: 'foo@2.x',
   }
   exec.exec(['foo@2.x', 'one arg', 'two arg'], er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.strictSame(MKDIRPS, [installDir], 'need to make install dir')
     t.match(ARB_CTOR, [{ path }])
     t.match(ARB_REIFY, [{ add: ['foo@2.x'], legacyPeerDeps: false }], 'need to add foo@2.x')
@@ -428,8 +423,7 @@ t.test('npm exec --package=foo bar', t => {
   config.package = ['foo']
   flatOptions.package = ['foo']
   exec.exec(['bar', 'one arg', 'two arg'], er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.strictSame(MKDIRPS, [], 'no need to make any dirs')
     t.match(ARB_CTOR, [{ path }])
     t.strictSame(ARB_REIFY, [], 'no need to reify anything')
@@ -470,8 +464,7 @@ t.test('npm exec @foo/bar -- --some=arg, locally installed', t => {
   }
   MANIFESTS['@foo/bar'] = foobarManifest
   exec.exec(['@foo/bar', '--some=arg'], er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.strictSame(MKDIRPS, [], 'no need to make any dirs')
     t.match(ARB_CTOR, [{ path }])
     t.strictSame(ARB_REIFY, [], 'no need to reify anything')
@@ -513,8 +506,7 @@ t.test('npm exec @foo/bar, with same bin alias and no unscoped named bin, locall
   }
   MANIFESTS['@foo/bar'] = foobarManifest
   exec.exec(['@foo/bar', 'one arg', 'two arg'], er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.strictSame(MKDIRPS, [], 'no need to make any dirs')
     t.match(ARB_CTOR, [{ path }])
     t.strictSame(ARB_REIFY, [], 'no need to reify anything')
@@ -594,8 +586,7 @@ t.test('run command with 2 packages, need install, verify sort', t => {
         _from: 'bar@',
       }
       exec.exec(['foobar', 'one arg', 'two arg'], er => {
-        if (er)
-          throw er
+        t.error(er, { bail: true })
         t.strictSame(MKDIRPS, [installDir], 'need to make install dir')
         t.match(ARB_CTOR, [{ path }])
         t.match(ARB_REIFY, [{add, legacyPeerDeps: false}], 'need to install both packages')
@@ -677,8 +668,7 @@ t.test('npm exec -p foo -c "ls -laF"', t => {
     _from: 'foo@',
   }
   exec.exec([], er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.strictSame(MKDIRPS, [], 'no need to make any dirs')
     t.match(ARB_CTOR, [{ path }])
     t.strictSame(ARB_REIFY, [], 'no need to reify anything')
@@ -749,8 +739,7 @@ t.test('prompt when installs are needed if not already present and shell is a TT
     _from: 'bar@',
   }
   exec.exec(['foobar'], er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.strictSame(MKDIRPS, [installDir], 'need to make install dir')
     t.match(ARB_CTOR, [{ path }])
     t.match(ARB_REIFY, [{add, legacyPeerDeps: false}], 'need to install both packages')
@@ -818,8 +807,7 @@ t.test('skip prompt when installs are needed if not already present and shell is
     _from: 'bar@',
   }
   exec.exec(['foobar'], er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.strictSame(MKDIRPS, [installDir], 'need to make install dir')
     t.match(ARB_CTOR, [{ path }])
     t.match(ARB_REIFY, [{add, legacyPeerDeps: false}], 'need to install both packages')
@@ -877,8 +865,7 @@ t.test('skip prompt when installs are needed if not already present and shell is
     _from: 'foo@',
   }
   exec.exec(['foobar'], er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.strictSame(MKDIRPS, [installDir], 'need to make install dir')
     t.match(ARB_CTOR, [{ path }])
     t.match(ARB_REIFY, [{add, legacyPeerDeps: false}], 'need to install the package')
@@ -1090,8 +1077,7 @@ t.test('forward legacyPeerDeps opt', t => {
   config.yes = true
   flatOptions.legacyPeerDeps = true
   exec.exec(['foo'], er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.match(ARB_REIFY, [{add: ['foo@'], legacyPeerDeps: true}], 'need to install foo@ using legacyPeerDeps opt')
     t.end()
   })
@@ -1132,8 +1118,7 @@ t.test('workspaces', t => {
 
   t.test('with args, run scripts in the context of a workspace', t => {
     exec.execWorkspaces(['foo', 'one arg', 'two arg'], ['a', 'b'], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
 
       t.match(RUN_SCRIPTS, [{
         pkg: { scripts: { npx: 'foo' }},
@@ -1157,8 +1142,7 @@ t.test('workspaces', t => {
 
     await new Promise((res, rej) => {
       exec.execWorkspaces([], ['a'], er => {
-        if (er)
-          return rej(er)
+        t.error(er, { bail: true })
 
         t.strictSame(LOG_WARN, [])
         t.strictSame(OUTPUT, [
@@ -1172,8 +1156,7 @@ t.test('workspaces', t => {
     OUTPUT.length = 0
     await new Promise((res, rej) => {
       exec.execWorkspaces([], ['a'], er => {
-        if (er)
-          return rej(er)
+        t.error(er, { bail: true })
 
         t.strictSame(LOG_WARN, [])
         t.strictSame(OUTPUT, [

--- a/test/lib/explain.js
+++ b/test/lib/explain.js
@@ -106,8 +106,7 @@ t.test('explain some nodes', t => {
   t.test('works with the location', t => {
     const path = 'node_modules/foo'
     explain.exec([path], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
       t.strictSame(OUTPUT, [['foo@1.2.3 depth=Infinity color=true']])
       t.end()
     })
@@ -115,8 +114,7 @@ t.test('explain some nodes', t => {
   t.test('works with a full actual path', t => {
     const path = resolve(npm.prefix, 'node_modules/foo')
     explain.exec([path], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
       t.strictSame(OUTPUT, [['foo@1.2.3 depth=Infinity color=true']])
       t.end()
     })
@@ -124,8 +122,7 @@ t.test('explain some nodes', t => {
 
   t.test('finds all nodes by name', t => {
     explain.exec(['bar'], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
       t.strictSame(OUTPUT, [[
         'bar@1.2.3 depth=Infinity color=true\n\n' +
         'bar@2.3.4 depth=Infinity color=true',
@@ -136,8 +133,7 @@ t.test('explain some nodes', t => {
 
   t.test('finds only nodes that match the spec', t => {
     explain.exec(['bar@1'], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
       t.strictSame(OUTPUT, [['bar@1.2.3 depth=Infinity color=true']])
       t.end()
     })
@@ -145,8 +141,7 @@ t.test('explain some nodes', t => {
 
   t.test('finds extraneous nodes', t => {
     explain.exec(['extra'], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
       t.strictSame(OUTPUT, [['extra@99.9999.999999 depth=Infinity color=true']])
       t.end()
     })
@@ -155,8 +150,7 @@ t.test('explain some nodes', t => {
   t.test('json output', t => {
     npm.flatOptions.json = true
     explain.exec(['node_modules/foo'], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
       t.match(JSON.parse(OUTPUT[0][0]), [{
         name: 'foo',
         version: '1.2.3',

--- a/test/lib/explore.js
+++ b/test/lib/explore.js
@@ -79,8 +79,7 @@ t.test('basic interactive', t => {
   t.afterEach(() => output.length = 0)
 
   t.test('windows', t => windowsExplore.exec(['pkg'], er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
 
     t.strictSame({
       ERROR_HANDLER_CALLED,
@@ -98,8 +97,7 @@ t.test('basic interactive', t => {
   }))
 
   t.test('posix', t => posixExplore.exec(['pkg'], er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
 
     t.strictSame({
       ERROR_HANDLER_CALLED,
@@ -132,8 +130,7 @@ t.test('interactive tracks exit code', t => {
   })
 
   t.test('windows', t => windowsExplore.exec(['pkg'], er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
 
     t.strictSame({
       ERROR_HANDLER_CALLED,
@@ -152,8 +149,7 @@ t.test('interactive tracks exit code', t => {
   }))
 
   t.test('posix', t => posixExplore.exec(['pkg'], er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
 
     t.strictSame({
       ERROR_HANDLER_CALLED,
@@ -220,8 +216,7 @@ t.test('basic non-interactive', t => {
   t.afterEach(() => output.length = 0)
 
   t.test('windows', t => windowsExplore.exec(['pkg', 'ls'], er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
 
     t.strictSame({
       ERROR_HANDLER_CALLED,
@@ -237,8 +232,7 @@ t.test('basic non-interactive', t => {
   }))
 
   t.test('posix', t => posixExplore.exec(['pkg', 'ls'], er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
 
     t.strictSame({
       ERROR_HANDLER_CALLED,

--- a/test/lib/fund.js
+++ b/test/lib/fund.js
@@ -226,7 +226,7 @@ t.test('fund with no package containing funding', t => {
   })
 
   fund.exec([], (err) => {
-    t.error(err, 'should not error out')
+    t.error(err, { bail: true })
     t.matchSnapshot(result, 'should print empty funding info')
     result = ''
     t.end()
@@ -237,7 +237,7 @@ t.test('fund in which same maintainer owns all its deps', t => {
   npm.prefix = t.testdir(maintainerOwnsAllDeps)
 
   fund.exec([], (err) => {
-    t.error(err, 'should not error out')
+    t.error(err, { bail: true })
     t.matchSnapshot(result, 'should print stack packages together')
     result = ''
     t.end()
@@ -249,7 +249,7 @@ t.test('fund in which same maintainer owns all its deps, using --json option', t
   npm.prefix = t.testdir(maintainerOwnsAllDeps)
 
   fund.exec([], (err) => {
-    t.error(err, 'should not error out')
+    t.error(err, { bail: true })
     t.same(
       JSON.parse(result),
       {
@@ -287,7 +287,7 @@ t.test('fund containing multi-level nested deps with no funding', t => {
   npm.prefix = t.testdir(nestedNoFundingPackages)
 
   fund.exec([], (err) => {
-    t.error(err, 'should not error out')
+    t.error(err, { bail: true })
     t.matchSnapshot(
       result,
       'should omit dependencies with no funding declared'
@@ -303,7 +303,7 @@ t.test('fund containing multi-level nested deps with no funding, using --json op
   config.json = true
 
   fund.exec([], (err) => {
-    t.error(err, 'should not error out')
+    t.error(err, { bail: true })
     t.same(
       JSON.parse(result),
       {
@@ -335,7 +335,7 @@ t.test('fund containing multi-level nested deps with no funding, using --json op
   config.json = true
 
   fund.exec([], (err) => {
-    t.error(err, 'should not error out')
+    t.error(err, { bail: true })
     t.same(
       JSON.parse(result),
       {
@@ -404,7 +404,7 @@ t.test('fund using package argument', t => {
   npm.prefix = t.testdir(maintainerOwnsAllDeps)
 
   fund.exec(['.'], (err) => {
-    t.error(err, 'should not error out')
+    t.error(err, { bail: true })
     t.matchSnapshot(printUrl, 'should open funding url')
 
     printUrl = ''
@@ -441,7 +441,7 @@ t.test('fund using string shorthand', t => {
   })
 
   fund.exec(['.'], (err) => {
-    t.error(err, 'should not error out')
+    t.error(err, { bail: true })
     t.matchSnapshot(printUrl, 'should open string-only url')
 
     printUrl = ''
@@ -453,7 +453,7 @@ t.test('fund using nested packages with multiple sources', t => {
   npm.prefix = t.testdir(nestedMultipleFundingPackages)
 
   fund.exec(['.'], (err) => {
-    t.error(err, 'should not error out')
+    t.error(err, { bail: true })
     t.matchSnapshot(result, 'should prompt with all available URLs')
 
     result = ''
@@ -481,7 +481,7 @@ t.test('fund using symlink ref', t => {
 
   // using symlinked ref
   fund.exec(['./node_modules/a'], (err) => {
-    t.error(err, 'should not error out')
+    t.error(err, { bail: true })
     t.match(
       printUrl,
       'http://example.com/a',
@@ -492,7 +492,7 @@ t.test('fund using symlink ref', t => {
 
     // using target ref
     fund.exec(['./a'], (err) => {
-      t.error(err, 'should not error out')
+      t.error(err, { bail: true })
 
       t.match(
         printUrl,
@@ -542,7 +542,7 @@ t.test('fund using data from actual tree', t => {
 
   // using symlinked ref
   fund.exec(['a'], (err) => {
-    t.error(err, 'should not error out')
+    t.error(err, { bail: true })
     t.match(
       printUrl,
       'http://example.com/_AAA',
@@ -559,7 +559,7 @@ t.test('fund using nested packages with multiple sources, with a source number',
   config.which = '1'
 
   fund.exec(['.'], (err) => {
-    t.error(err, 'should not error out')
+    t.error(err, { bail: true })
     t.matchSnapshot(printUrl, 'should open the numbered URL')
 
     config.which = null
@@ -573,7 +573,7 @@ t.test('fund using pkg name while having conflicting versions', t => {
   config.which = '1'
 
   fund.exec(['foo'], (err) => {
-    t.error(err, 'should not error out')
+    t.error(err, { bail: true })
     t.matchSnapshot(printUrl, 'should open greatest version')
 
     printUrl = ''
@@ -586,7 +586,7 @@ t.test('fund using package argument with no browser, using --json option', t => 
   config.json = true
 
   fund.exec(['.'], (err) => {
-    t.error(err, 'should not error out')
+    t.error(err, { bail: true })
     t.same(
       JSON.parse(printUrl),
       {
@@ -606,7 +606,7 @@ t.test('fund using package info fetch from registry', t => {
   npm.prefix = t.testdir({})
 
   fund.exec(['ntl'], (err) => {
-    t.error(err, 'should not error out')
+    t.error(err, { bail: true })
     t.match(
       printUrl,
       /http:\/\/example.com\/pacote/,
@@ -677,7 +677,7 @@ t.test('fund pkg missing version number', t => {
   })
 
   fund.exec([], (err) => {
-    t.error(err, 'should not error out')
+    t.error(err, { bail: true })
     t.matchSnapshot(result, 'should print name only')
     result = ''
     t.end()
@@ -718,7 +718,7 @@ t.test('fund a package with type and multiple sources', t => {
   })
 
   fund.exec(['.'], (err) => {
-    t.error(err, 'should not error out')
+    t.error(err, { bail: true })
     t.matchSnapshot(result, 'should print prompt select message')
 
     result = ''
@@ -782,7 +782,7 @@ t.test('fund colors', t => {
   npm.color = true
 
   fund.exec([], (err) => {
-    t.error(err, 'should not error out')
+    t.error(err, { bail: true })
     t.matchSnapshot(result, 'should print output with color info')
 
     result = ''
@@ -832,7 +832,7 @@ t.test('sub dep with fund info and a parent with no funding info', t => {
   })
 
   fund.exec([], (err) => {
-    t.error(err, 'should not error out')
+    t.error(err, { bail: true })
     t.matchSnapshot(result, 'should nest sub dep as child of root')
 
     result = ''

--- a/test/lib/init.js
+++ b/test/lib/init.js
@@ -37,7 +37,7 @@ t.afterEach(() => {
 
 t.test('classic npm init no args', t => {
   init.exec([], err => {
-    t.error(err, 'npm init no args')
+    t.error(err, { bail: true })
     t.matchSnapshot(result, 'should print helper info')
     t.end()
   })
@@ -60,7 +60,7 @@ t.test('classic npm init -y', t => {
     t.equal(msg, 'written successfully', 'should print done info')
   }
   init.exec([], err => {
-    t.error(err, 'npm init -y')
+    t.error(err, { bail: true })
     t.equal(result, '')
   })
 })
@@ -77,7 +77,7 @@ t.test('npm init <arg>', t => {
     cb()
   }
   init.exec(['react-app'], err => {
-    t.error(err, 'npm init react-app')
+    t.error(err, { bail: true })
   })
 })
 
@@ -92,7 +92,7 @@ t.test('npm init @scope/name', t => {
     cb()
   }
   init.exec(['@npmcli/something'], err => {
-    t.error(err, 'npm init init @scope/name')
+    t.error(err, { bail: true })
   })
 })
 
@@ -107,7 +107,7 @@ t.test('npm init git spec', t => {
     cb()
   }
   init.exec(['npm/something'], err => {
-    t.error(err, 'npm init init @scope/name')
+    t.error(err, { bail: true })
   })
 })
 
@@ -122,7 +122,7 @@ t.test('npm init @scope', t => {
     cb()
   }
   init.exec(['@npmcli'], err => {
-    t.error(err, 'npm init init @scope/create')
+    t.error(err, { bail: true })
   })
 })
 
@@ -148,7 +148,7 @@ t.test('npm init <arg>@next', t => {
     cb()
   }
   init.exec(['something@next'], err => {
-    t.error(err, 'npm init init something@next')
+    t.error(err, { bail: true })
   })
 })
 
@@ -178,7 +178,7 @@ t.test('should not rewrite flatOptions', t => {
     cb()
   }
   init.exec(['react-app', 'my-app'], err => {
-    t.error(err, 'npm init react-app')
+    t.error(err, { bail: true })
   })
 })
 
@@ -197,7 +197,7 @@ t.test('npm init cancel', t => {
     t.equal(msg, 'canceled', 'should log canceled')
   }
   init.exec([], err => {
-    t.error(err, 'npm init cancel')
+    t.error(err, { bail: true })
   })
 })
 

--- a/test/lib/install.js
+++ b/test/lib/install.js
@@ -39,8 +39,7 @@ t.test('should install using Arborist', (t) => {
 
   t.test('with args', t => {
     install.exec(['fizzbuzz'], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
       t.match(ARB_ARGS,
         { global: false, path: 'foo', auditLevel: null },
         'Arborist gets correct args and ignores auditLevel')
@@ -52,8 +51,7 @@ t.test('should install using Arborist', (t) => {
 
   t.test('just a local npm install', t => {
     install.exec([], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
       t.match(ARB_ARGS, { global: false, path: 'foo' })
       t.equal(REIFY_CALLED, true, 'called reify')
       t.strictSame(SCRIPTS, [
@@ -97,8 +95,7 @@ t.test('should ignore scripts with --ignore-scripts', (t) => {
   })
   const install = new Install(npm)
   install.exec([], er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.equal(REIFY_CALLED, true, 'called reify')
     t.strictSame(SCRIPTS, [], 'no scripts when adding dep')
     t.end()
@@ -120,8 +117,7 @@ t.test('should install globally using Arborist', (t) => {
   })
   const install = new Install(npm)
   install.exec([], er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.end()
   })
 })

--- a/test/lib/link.js
+++ b/test/lib/link.js
@@ -80,7 +80,7 @@ t.test('link to globalDir when in current working dir of pkg and no args', (t) =
   }
 
   link.exec([], (err) => {
-    t.error(err, 'should not error out')
+    t.error(err, { bail: true })
   })
 })
 
@@ -188,7 +188,7 @@ t.test('link global linked pkg to local nm when using args', (t) => {
     'a',
     'file:../link-me-too',
   ], (err) => {
-    t.error(err, 'should not error out')
+    t.error(err, { bail: true })
   })
 })
 
@@ -251,7 +251,7 @@ t.test('link pkg already in global space', (t) => {
   // - a: prev installed package available in globalDir
   // - file:./link-me-too: pkg that needs to be reified in globalDir first
   link.exec(['@myscope/linked'], (err) => {
-    t.error(err, 'should not error out')
+    t.error(err, { bail: true })
   })
 })
 
@@ -309,7 +309,7 @@ t.test('link pkg already in global space when prefix is a symlink', (t) => {
   }
 
   link.exec(['@myscope/linked'], (err) => {
-    t.error(err, 'should not error out')
+    t.error(err, { bail: true })
   })
 })
 

--- a/test/lib/logout.js
+++ b/test/lib/logout.js
@@ -54,7 +54,7 @@ t.test('token logout', async (t) => {
 
   await new Promise((res, rej) => {
     logout.exec([], (err) => {
-      t.error(err, 'should not error out')
+      t.error(err, { bail: true })
 
       t.same(
         result,
@@ -125,7 +125,7 @@ t.test('token scoped logout', async (t) => {
 
   await new Promise((res, rej) => {
     logout.exec([], (err) => {
-      t.error(err, 'should not error out')
+      t.error(err, { bail: true })
 
       t.same(
         result,
@@ -178,7 +178,7 @@ t.test('user/pass logout', async (t) => {
 
   await new Promise((res, rej) => {
     logout.exec([], (err) => {
-      t.error(err, 'should not error out')
+      t.error(err, { bail: true })
 
       delete flatOptions.username
       delete flatOptions.password
@@ -232,7 +232,7 @@ t.test('ignore invalid scoped registry config', async (t) => {
 
   await new Promise((res, rej) => {
     logout.exec([], (err) => {
-      t.error(err, 'should not error out')
+      t.error(err, { bail: true })
 
       t.same(
         result,

--- a/test/lib/ls.js
+++ b/test/lib/ls.js
@@ -138,7 +138,7 @@ t.test('ls', (t) => {
       ...simpleNmFixture,
     })
     ls.exec([], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.matchSnapshot(redactCwd(result), 'should output tree representation of dependencies structure')
       t.end()
     })
@@ -196,7 +196,7 @@ t.test('ls', (t) => {
       ...simpleNmFixture,
     })
     ls.exec(['lorem'], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.matchSnapshot(redactCwd(result), 'should output tree contaning only occurrences of filtered by package and colored output')
       npm.color = false
       t.end()
@@ -218,7 +218,7 @@ t.test('ls', (t) => {
       ...simpleNmFixture,
     })
     ls.exec(['.'], (err) => {
-      t.error(err, 'should not throw on missing dep above current level')
+      t.error(err, 'should not throw on missing dep above current level', { bail: true })
       t.matchSnapshot(redactCwd(result), 'should output tree contaning only occurrences of filtered by package and colored output')
       config.all = true
       config.depth = Infinity
@@ -239,7 +239,7 @@ t.test('ls', (t) => {
       ...simpleNmFixture,
     })
     ls.exec(['bar'], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.matchSnapshot(redactCwd(result), 'should output tree contaning only occurrences of filtered package and its ancestors')
       t.end()
     })
@@ -267,7 +267,7 @@ t.test('ls', (t) => {
       },
     })
     ls.exec(['bar@*', 'lorem@1.0.0'], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.matchSnapshot(redactCwd(result), 'should output tree contaning only occurrences of multiple filtered packages and their ancestors')
       t.end()
     })
@@ -286,7 +286,7 @@ t.test('ls', (t) => {
       ...simpleNmFixture,
     })
     ls.exec(['notadep'], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.matchSnapshot(redactCwd(result), 'should output tree containing no dependencies info')
       t.equal(
         process.exitCode,
@@ -313,7 +313,7 @@ t.test('ls', (t) => {
       ...simpleNmFixture,
     })
     ls.exec([], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.matchSnapshot(redactCwd(result), 'should output tree containing only top-level dependencies')
       config.all = true
       config.depth = Infinity
@@ -336,7 +336,7 @@ t.test('ls', (t) => {
       ...simpleNmFixture,
     })
     ls.exec([], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.matchSnapshot(redactCwd(result), 'should output tree containing only top-level dependencies')
       config.all = true
       config.depth = Infinity
@@ -397,7 +397,7 @@ t.test('ls', (t) => {
       },
     })
     ls.exec([], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.matchSnapshot(redactCwd(result), 'should output tree containing top-level deps and their deps only')
       config.all = true
       config.depth = Infinity
@@ -719,7 +719,7 @@ t.test('ls', (t) => {
   t.test('empty location', (t) => {
     npm.prefix = t.testdir({})
     ls.exec([], (err) => {
-      t.error(err, 'should not error out on empty locations')
+      t.error(err, 'should not error out on empty locations', { bail: true })
       t.matchSnapshot(redactCwd(result), 'should print empty result')
       t.end()
     })
@@ -899,7 +899,7 @@ t.test('ls', (t) => {
       },
     })
     ls.exec([], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.matchSnapshot(redactCwd(result), 'should print tree output containing deduped ref')
       t.end()
     })
@@ -937,7 +937,7 @@ t.test('ls', (t) => {
       },
     })
     ls.exec(['a'], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.matchSnapshot(redactCwd(result), 'should print tree output containing deduped ref')
       npm.color = false
       t.end()
@@ -985,7 +985,7 @@ t.test('ls', (t) => {
       },
     })
     ls.exec([], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.matchSnapshot(redactCwd(result), 'should print tree output containing deduped ref')
       t.end()
     })
@@ -1034,7 +1034,7 @@ t.test('ls', (t) => {
       },
     })
     ls.exec([], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.matchSnapshot(redactCwd(result), 'should print tree output containing deduped ref')
       config.all = true
       config.depth = Infinity
@@ -1084,7 +1084,7 @@ t.test('ls', (t) => {
       },
     })
     ls.exec(['@npmcli/b'], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.matchSnapshot(redactCwd(result), 'should print tree output containing deduped ref')
       npm.color = false
       t.end()
@@ -1132,7 +1132,7 @@ t.test('ls', (t) => {
       },
     })
     ls.exec(['@npmcli/c'], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.matchSnapshot(redactCwd(result), 'should print tree output containing deduped ref')
       t.end()
     })
@@ -1222,7 +1222,7 @@ t.test('ls', (t) => {
     })
     touchHiddenPackageLock(npm.prefix)
     ls.exec([], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.matchSnapshot(redactCwd(result), 'should output tree containing git refs')
       t.end()
     })
@@ -1266,7 +1266,7 @@ t.test('ls', (t) => {
       }),
     })
     ls.exec([], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.matchSnapshot(redactCwd(result), 'should NOT print git refs in output tree')
       t.end()
     })
@@ -1454,12 +1454,12 @@ t.test('ls', (t) => {
     })
 
     ls.exec([], (err) => {
-      t.error(err, 'should NOT have ELSPROBLEMS error code')
+      t.error(err, 'should NOT have ELSPROBLEMS error code', { bail: true })
       t.matchSnapshot(redactCwd(result), 'should list workspaces properly')
 
       // should also be able to filter out one of the workspaces
       ls.exec(['a'], (err) => {
-        t.error(err, 'should NOT have ELSPROBLEMS error code when filter')
+        t.error(err, 'should NOT have ELSPROBLEMS error code when filter', { bail: true })
         t.matchSnapshot(redactCwd(result), 'should filter single workspace')
 
         t.end()
@@ -1517,17 +1517,17 @@ t.test('ls', (t) => {
 
     t.plan(6)
     ls.exec(['a'], (err) => {
-      t.error(err, 'should NOT have ELSPROBLEMS error code')
+      t.error(err, 'should NOT have ELSPROBLEMS error code', { bail: true })
       t.matchSnapshot(redactCwd(result), 'should list a in top-level only')
 
       ls.exec(['d'], (err) => {
-        t.error(err, 'should NOT have ELSPROBLEMS error code when filter')
+        t.error(err, 'should NOT have ELSPROBLEMS error code when filter', { bail: true })
         t.matchSnapshot(redactCwd(result), 'should print empty results msg')
 
         // if no --depth config is defined, should print path to dep
         config.depth = null // default config value
         ls.exec(['d'], (err) => {
-          t.error(err, 'should NOT have ELSPROBLEMS error code when filter')
+          t.error(err, 'should NOT have ELSPROBLEMS error code when filter', { bail: true })
           t.matchSnapshot(redactCwd(result), 'should print expected result')
         })
       })
@@ -1559,7 +1559,7 @@ t.test('ls --parseable', (t) => {
       ...simpleNmFixture,
     })
     ls.exec([], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.matchSnapshot(redactCwd(result), 'should output parseable representation of dependencies structure')
       t.end()
     })
@@ -1611,7 +1611,7 @@ t.test('ls --parseable', (t) => {
       ...simpleNmFixture,
     })
     ls.exec(['lorem'], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.matchSnapshot(redactCwd(result), 'should output parseable contaning only occurrences of filtered by package')
       t.end()
     })
@@ -1630,7 +1630,7 @@ t.test('ls --parseable', (t) => {
       ...simpleNmFixture,
     })
     ls.exec(['bar'], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.matchSnapshot(redactCwd(result), 'should output parseable contaning only occurrences of filtered package')
       t.end()
     })
@@ -1658,7 +1658,7 @@ t.test('ls --parseable', (t) => {
       },
     })
     ls.exec(['bar@*', 'lorem@1.0.0'], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.matchSnapshot(redactCwd(result), 'should output parseable contaning only occurrences of multiple filtered packages and their ancestors')
       t.end()
     })
@@ -1677,7 +1677,7 @@ t.test('ls --parseable', (t) => {
       ...simpleNmFixture,
     })
     ls.exec(['notadep'], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.matchSnapshot(redactCwd(result), 'should output parseable output containing no dependencies info')
       t.equal(
         process.exitCode,
@@ -1704,7 +1704,7 @@ t.test('ls --parseable', (t) => {
       ...simpleNmFixture,
     })
     ls.exec([], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.matchSnapshot(redactCwd(result), 'should output parseable output containing only top-level dependencies')
       config.all = true
       config.depth = Infinity
@@ -1727,7 +1727,7 @@ t.test('ls --parseable', (t) => {
       ...simpleNmFixture,
     })
     ls.exec([], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.matchSnapshot(redactCwd(result), 'should output tree containing only top-level dependencies')
       config.all = true
       config.depth = Infinity
@@ -1750,7 +1750,7 @@ t.test('ls --parseable', (t) => {
       ...simpleNmFixture,
     })
     ls.exec([], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.matchSnapshot(redactCwd(result), 'should output parseable containing top-level deps and their deps only')
       config.all = true
       config.depth = Infinity
@@ -2034,7 +2034,7 @@ t.test('ls --parseable', (t) => {
       },
     })
     ls.exec([], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.matchSnapshot(redactCwd(result), 'should output parseable results with symlink targets')
       config.long = false
       t.end()
@@ -2088,7 +2088,7 @@ t.test('ls --parseable', (t) => {
   t.test('empty location', (t) => {
     npm.prefix = t.testdir({})
     ls.exec([], (err) => {
-      t.error(err, 'should not error out on empty locations')
+      t.error(err, 'should not error out on empty locations', { bail: true })
       t.matchSnapshot(redactCwd(result), 'should print empty result')
       t.end()
     })
@@ -2383,7 +2383,7 @@ t.test('ls --json', (t) => {
       ...simpleNmFixture,
     })
     ls.exec([], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.same(
         jsonParse(result),
         {
@@ -2525,7 +2525,7 @@ t.test('ls --json', (t) => {
       ...simpleNmFixture,
     })
     ls.exec(['lorem'], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.same(
         jsonParse(result),
         {
@@ -2561,7 +2561,7 @@ t.test('ls --json', (t) => {
       ...simpleNmFixture,
     })
     ls.exec(['bar'], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.same(
         jsonParse(result),
         {
@@ -2606,7 +2606,7 @@ t.test('ls --json', (t) => {
       },
     })
     ls.exec(['bar@*', 'lorem@1.0.0'], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.same(
         jsonParse(result),
         {
@@ -2645,7 +2645,7 @@ t.test('ls --json', (t) => {
       ...simpleNmFixture,
     })
     ls.exec(['notadep'], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.same(
         jsonParse(result),
         {
@@ -2679,7 +2679,7 @@ t.test('ls --json', (t) => {
       ...simpleNmFixture,
     })
     ls.exec([], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.same(
         jsonParse(result),
         {
@@ -2717,7 +2717,7 @@ t.test('ls --json', (t) => {
       ...simpleNmFixture,
     })
     ls.exec([], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.same(
         jsonParse(result),
         {
@@ -2755,7 +2755,7 @@ t.test('ls --json', (t) => {
       ...simpleNmFixture,
     })
     ls.exec([], (err) => {
-      t.error(err, 'npm ls')
+      t.error(err, { bail: true })
       t.same(
         jsonParse(result),
         {
@@ -3462,7 +3462,7 @@ t.test('ls --json', (t) => {
   t.test('empty location', (t) => {
     npm.prefix = t.testdir({})
     ls.exec([], (err) => {
-      t.error(err, 'should not error out on empty locations')
+      t.error(err, 'should not error out on empty locations', { bail: true })
       t.same(
         jsonParse(result),
         {},

--- a/test/lib/npm.js
+++ b/test/lib/npm.js
@@ -129,8 +129,7 @@ t.test('npm.load', t => {
     })
     let firstCalled = false
     const first = (er) => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
 
       firstCalled = true
       t.equal(npm.loaded, true)
@@ -231,8 +230,7 @@ t.test('npm.load', t => {
     freshConfig({ argv: [...process.argv, '--force', '--color', 'always'] })
     process.argv[0] = 'this exe does not exist or else this test will fail'
     return npm.load(er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
 
       t.match(logs.filter(l => l[0] !== 'timing'), [
         [
@@ -284,8 +282,7 @@ t.test('npm.load', t => {
     logs.length = 0
 
     await npm.load(er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
 
       t.equal(npm.config.get('scope'), '@foo', 'added the @ sign to scope')
       t.match(logs.filter(l => l[0] !== 'timing' || !/^config:/.test(l[1])), [
@@ -310,8 +307,7 @@ t.test('npm.load', t => {
     })
 
     await npm.commands.ll([], (er) => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
 
       t.equal(npm.command, 'll', 'command set to first npm command')
       t.equal(npm.flatOptions.npmCommand, 'll', 'npmCommand flatOption set')
@@ -324,8 +320,7 @@ t.test('npm.load', t => {
     })
 
     await npm.commands.get(['scope', '\u2010not-a-dash'], (er) => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
 
       t.strictSame([npm.command, npm.flatOptions.npmCommand], ['ll', 'll'],
         'does not change npm.command when another command is called')
@@ -404,8 +399,7 @@ t.test('npm.load', t => {
     })
 
     await npm.load(er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
     })
 
     npm.localPrefix = dir
@@ -415,8 +409,7 @@ t.test('npm.load', t => {
       // the npm.command property to the full canonical name of the cmd.
       npm.command = null
       npm.commands.run([], er => {
-        if (er)
-          rej(er)
+        t.error(er, { bail: true })
 
         t.equal(npm.command, 'run-script', 'npm.command set to canonical name')
 
@@ -490,8 +483,7 @@ t.test('set process.title', t => {
       ],
     })
     await npm.load(er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
       t.equal(npm.title, 'npm ls')
       t.equal(process.title, 'npm ls')
     })
@@ -510,8 +502,7 @@ t.test('set process.title', t => {
       ],
     })
     await npm.load(er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
       t.equal(npm.title, 'npm token revoke ***')
       t.equal(process.title, 'npm token revoke ***')
     })
@@ -529,8 +520,7 @@ t.test('set process.title', t => {
       ],
     })
     await npm.load(er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
       t.equal(npm.title, 'npm token revoke')
       t.equal(process.title, 'npm token revoke')
     })

--- a/test/lib/owner.js
+++ b/test/lib/owner.js
@@ -71,7 +71,7 @@ t.test('owner ls no args', t => {
   })
 
   owner.exec(['ls'], err => {
-    t.error(err, 'npm owner ls no args')
+    t.error(err, { bail: true })
     t.matchSnapshot(result, 'should output owners of cwd package')
   })
 })
@@ -139,7 +139,7 @@ t.test('owner ls <pkg>', t => {
   })
 
   owner.exec(['ls', '@npmcli/map-workspaces'], err => {
-    t.error(err, 'npm owner ls <pkg>')
+    t.error(err, { bail: true })
     t.matchSnapshot(result, 'should output owners of <pkg>')
   })
 })
@@ -155,7 +155,7 @@ t.test('owner ls <pkg> no maintainers', t => {
   })
 
   owner.exec(['ls', '@npmcli/map-workspaces'], err => {
-    t.error(err, 'npm owner ls <pkg> no maintainers')
+    t.error(err, { bail: true })
     t.equal(result, 'no admin found', 'should output no admint found msg')
     t.end()
   })
@@ -226,7 +226,7 @@ t.test('owner add <user> <pkg>', t => {
   })
 
   owner.exec(['add', 'foo', '@npmcli/map-workspaces'], err => {
-    t.error(err, 'npm owner add <user> <pkg>')
+    t.error(err, { bail: true })
     t.equal(result, '+ foo (@npmcli/map-workspaces)', 'should output add result')
   })
 })
@@ -259,7 +259,7 @@ t.test('owner add <user> cwd package', t => {
   })
 
   owner.exec(['add', 'foo'], err => {
-    t.error(err, 'npm owner add <user> cwd package')
+    t.error(err, { bail: true })
     t.equal(result, '+ foo (@npmcli/map-workspaces)', 'should output add result')
     t.end()
   })
@@ -302,7 +302,7 @@ t.test('owner add <user> <pkg> already an owner', t => {
   })
 
   owner.exec(['add', 'ruyadorno', '@npmcli/map-workspaces'], err => {
-    t.error(err, 'npm owner add <user> <pkg> already an owner')
+    t.error(err, { bail: true })
   })
 })
 
@@ -447,7 +447,7 @@ t.test('owner add <user> <pkg> no previous maintainers property from server', t 
   })
 
   owner.exec(['add', 'foo', '@npmcli/no-owners-pkg'], err => {
-    t.error(err, 'npm owner add <user> <pkg>')
+    t.error(err, { bail: true })
     t.equal(result, '+ foo (@npmcli/no-owners-pkg)', 'should output add result')
     t.end()
   })
@@ -535,7 +535,7 @@ t.test('owner rm <user> <pkg>', t => {
   })
 
   owner.exec(['rm', 'ruyadorno', '@npmcli/map-workspaces'], err => {
-    t.error(err, 'npm owner rm <user> <pkg>')
+    t.error(err, { bail: true })
     t.equal(result, '- ruyadorno (@npmcli/map-workspaces)', 'should output rm result')
   })
 })
@@ -575,7 +575,7 @@ t.test('owner rm <user> <pkg> not a current owner', t => {
   })
 
   owner.exec(['rm', 'foo', '@npmcli/map-workspaces'], err => {
-    t.error(err, 'npm owner rm <user> <pkg> not a current owner')
+    t.error(err, { bail: true })
   })
 })
 
@@ -607,7 +607,7 @@ t.test('owner rm <user> cwd package', t => {
   })
 
   owner.exec(['rm', 'ruyadorno'], err => {
-    t.error(err, 'npm owner rm <user> cwd package')
+    t.error(err, { bail: true })
     t.equal(result, '- ruyadorno (@npmcli/map-workspaces)', 'should output rm result')
     t.end()
   })

--- a/test/lib/ping.js
+++ b/test/lib/ping.js
@@ -32,7 +32,7 @@ t.test('pings', (t) => {
 
   ping.exec([], (err) => {
     t.equal(noticeCalls, 2, 'should have logged 2 lines')
-    t.error(err, 'npm ping')
+    t.error(err, { bail: true })
     t.ok('should be able to ping')
   })
 })
@@ -73,7 +73,7 @@ t.test('pings and logs details', (t) => {
 
   ping.exec([], (err) => {
     t.equal(noticeCalls, 3, 'should have logged 3 lines')
-    t.error(err, 'npm ping')
+    t.error(err, { bail: true })
     t.ok('should be able to ping')
   })
 })
@@ -116,7 +116,7 @@ t.test('pings and returns json', (t) => {
 
   ping.exec([], (err) => {
     t.equal(noticeCalls, 2, 'should have logged 2 lines')
-    t.error(err, 'npm ping')
+    t.error(err, { bail: true })
     t.ok('should be able to ping')
   })
 })

--- a/test/lib/prefix.js
+++ b/test/lib/prefix.js
@@ -13,7 +13,7 @@ t.test('prefix', (t) => {
   })
 
   prefix.exec([], (err) => {
-    t.error(err, 'npm prefix')
+    t.error(err, { bail: true })
     t.ok('should have printed directory')
   })
 })

--- a/test/lib/prune.js
+++ b/test/lib/prune.js
@@ -20,8 +20,7 @@ t.test('should prune using Arborist', (t) => {
     },
   })
   prune.exec(null, er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.ok(true, 'callback is called')
     t.end()
   })

--- a/test/lib/publish.js
+++ b/test/lib/publish.js
@@ -21,7 +21,7 @@ const config = defaults
 t.afterEach(() => log.level = 'silent')
 
 t.test('should publish with libnpmpublish, passing through flatOptions and respecting publishConfig.registry', (t) => {
-  t.plan(7)
+  t.plan(8)
 
   const registry = 'https://some.registry'
   const publishConfig = { registry }
@@ -66,15 +66,14 @@ t.test('should publish with libnpmpublish, passing through flatOptions and respe
   const publish = new Publish(npm)
 
   publish.exec([testDir], (er) => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.pass('got to callback')
     t.end()
   })
 })
 
 t.test('re-loads publishConfig.registry if added during script process', (t) => {
-  t.plan(6)
+  t.plan(7)
   const registry = 'https://some.registry'
   const publishConfig = { registry }
   const testDir = t.testdir({
@@ -110,15 +109,14 @@ t.test('re-loads publishConfig.registry if added during script process', (t) => 
   const publish = new Publish(npm)
 
   publish.exec([testDir], (er) => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.pass('got to callback')
     t.end()
   })
 })
 
 t.test('if loglevel=info and json, should not output package contents', (t) => {
-  t.plan(4)
+  t.plan(5)
 
   const testDir = t.testdir({
     'package.json': JSON.stringify({
@@ -156,15 +154,14 @@ t.test('if loglevel=info and json, should not output package contents', (t) => {
   const publish = new Publish(npm)
 
   publish.exec([testDir], (er) => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.pass('got to callback')
     t.end()
   })
 })
 
 t.test('if loglevel=silent and dry-run, should not output package contents or publish or validate credentials, should log tarball contents', (t) => {
-  t.plan(2)
+  t.plan(3)
 
   const testDir = t.testdir({
     'package.json': JSON.stringify({
@@ -202,15 +199,14 @@ t.test('if loglevel=silent and dry-run, should not output package contents or pu
   const publish = new Publish(npm)
 
   publish.exec([testDir], (er) => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.pass('got to callback')
     t.end()
   })
 })
 
 t.test('if loglevel=info and dry-run, should not publish, should log package contents and log tarball contents', (t) => {
-  t.plan(3)
+  t.plan(4)
 
   const testDir = t.testdir({
     'package.json': JSON.stringify({
@@ -247,8 +243,7 @@ t.test('if loglevel=info and dry-run, should not publish, should log package con
   const publish = new Publish(npm)
 
   publish.exec([testDir], (er) => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.pass('got to callback')
     t.end()
   })
@@ -283,7 +278,7 @@ t.test('throws when invalid tag', (t) => {
 })
 
 t.test('can publish a tarball', t => {
-  t.plan(4)
+  t.plan(5)
 
   const testDir = t.testdir({
     tarball: {},
@@ -321,8 +316,7 @@ t.test('can publish a tarball', t => {
   const publish = new Publish(npm)
 
   publish.exec([`${testDir}/tarball/package.tgz`], (er) => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.pass('got to callback')
     t.end()
   })
@@ -401,7 +395,7 @@ t.test('should check auth for scope specific registry', t => {
 })
 
 t.test('should use auth for scope specific registry', t => {
-  t.plan(4)
+  t.plan(5)
   const registry = 'https://some.registry'
   const testDir = t.testdir({
     'package.json': JSON.stringify({
@@ -429,15 +423,14 @@ t.test('should use auth for scope specific registry', t => {
   const publish = new Publish(npm)
 
   publish.exec([testDir], (er) => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.pass('got to callback')
     t.end()
   })
 })
 
 t.test('read registry only from publishConfig', t => {
-  t.plan(4)
+  t.plan(5)
 
   const registry = 'https://some.registry'
   const publishConfig = { registry }
@@ -467,15 +460,14 @@ t.test('read registry only from publishConfig', t => {
   const publish = new Publish(npm)
 
   publish.exec([testDir], (er) => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.pass('got to callback')
     t.end()
   })
 })
 
 t.test('able to publish after if encountered multiple configs', t => {
-  t.plan(3)
+  t.plan(4)
 
   const registry = 'https://some.registry'
   const tag = 'better-tag'
@@ -519,8 +511,7 @@ t.test('able to publish after if encountered multiple configs', t => {
   })
 
   publish.exec([testDir], (er) => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.pass('got to callback')
     t.end()
   })

--- a/test/lib/repo.js
+++ b/test/lib/repo.js
@@ -229,8 +229,7 @@ t.test('open repo urls', t => {
   keys.forEach(pkg => {
     t.test(pkg, t => {
       repo.exec([['.', pkg].join(sep)], (err) => {
-        if (err)
-          throw err
+        t.error(err, { bail: true })
         const url = expect[pkg]
         t.match({
           [url]: 1,
@@ -264,9 +263,8 @@ t.test('fail if cannot figure out repo url', t => {
 
 t.test('open default package if none specified', t => {
   flatOptions.where = pkgDirs
-  repo.exec([], (er) => {
-    if (er)
-      throw er
+  repo.exec([], (err) => {
+    t.error(err, { bail: true })
     t.equal(opened['https://example.com/thispkg'], 1, 'opened expected url', {opened})
     t.end()
   })

--- a/test/lib/root.js
+++ b/test/lib/root.js
@@ -13,7 +13,7 @@ t.test('root', (t) => {
   })
 
   root.exec([], (err) => {
-    t.error(err, 'npm root')
+    t.error(err, { bail: true })
     t.ok('should have printed directory')
   })
 })

--- a/test/lib/run-script.js
+++ b/test/lib/run-script.js
@@ -115,8 +115,7 @@ t.test('default env, start, and restart scripts', t => {
 
   t.test('start', t => {
     runScript.exec(['start'], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
 
       t.match(RUN_SCRIPTS, [
         {
@@ -135,8 +134,7 @@ t.test('default env, start, and restart scripts', t => {
 
   t.test('env', t => {
     runScript.exec(['env'], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
 
       t.match(RUN_SCRIPTS, [
         {
@@ -162,8 +160,7 @@ t.test('default env, start, and restart scripts', t => {
 
   t.test('windows env', t => {
     runScriptWin.exec(['env'], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
 
       t.match(RUN_SCRIPTS, [
         {
@@ -187,8 +184,7 @@ t.test('default env, start, and restart scripts', t => {
 
   t.test('restart', t => {
     runScript.exec(['restart'], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
 
       t.match(RUN_SCRIPTS, [
         {
@@ -225,8 +221,7 @@ t.test('non-default env script', t => {
 
   t.test('env', t => {
     runScript.exec(['env'], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
 
       t.match(RUN_SCRIPTS, [
         {
@@ -252,8 +247,7 @@ t.test('non-default env script', t => {
 
   t.test('env windows', t => {
     runScriptWin.exec(['env'], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
 
       t.match(RUN_SCRIPTS, [
         {
@@ -318,8 +312,7 @@ t.test('try to run missing script', t => {
   t.test('with --if-present', t => {
     config['if-present'] = true
     runScript.exec(['goodbye'], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
 
       t.strictSame(RUN_SCRIPTS, [], 'did not try to run anything')
       t.end()
@@ -341,8 +334,7 @@ t.test('run pre/post hooks', t => {
   })
 
   runScript.exec(['env'], er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
 
     t.match(RUN_SCRIPTS, [
       { event: 'preenv' },
@@ -381,8 +373,7 @@ t.test('skip pre/post hooks when using ignoreScripts', t => {
   })
 
   runScript.exec(['env'], er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
 
     t.same(RUN_SCRIPTS, [
       {
@@ -426,8 +417,7 @@ t.test('run silent', t => {
   })
 
   runScript.exec(['env'], er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
 
     t.match(RUN_SCRIPTS, [
       {
@@ -476,8 +466,7 @@ t.test('list scripts', t => {
 
   t.test('no args', t => {
     runScript.exec([], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
       t.strictSame(output, [
         ['Lifecycle scripts included in x@1.2.3:'],
         ['  test\n    exit 2'],
@@ -495,8 +484,7 @@ t.test('list scripts', t => {
   t.test('silent', t => {
     npmlog.level = 'silent'
     runScript.exec([], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
       t.strictSame(output, [])
       t.end()
     })
@@ -505,8 +493,7 @@ t.test('list scripts', t => {
     npmlog.level = 'warn'
     config.json = true
     runScript.exec([], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
       t.strictSame(output, [[JSON.stringify(scripts, 0, 2)]], 'json report')
       t.end()
     })
@@ -515,8 +502,7 @@ t.test('list scripts', t => {
   t.test('parseable', t => {
     config.parseable = true
     runScript.exec([], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
       t.strictSame(output, [
         ['test:exit 2'],
         ['start:node server.js'],
@@ -539,8 +525,7 @@ t.test('list scripts when no scripts', t => {
   })
 
   runScript.exec([], er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.strictSame(output, [], 'nothing to report')
     t.end()
   })
@@ -556,8 +541,7 @@ t.test('list scripts, only commands', t => {
   })
 
   runScript.exec([], er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.strictSame(output, [
       ['Lifecycle scripts included in x@1.2.3:'],
       ['  preversion\n    echo doing the version dance'],
@@ -577,8 +561,7 @@ t.test('list scripts, only non-commands', t => {
   })
 
   runScript.exec([], er => {
-    if (er)
-      throw er
+    t.error(er, { bail: true })
     t.strictSame(output, [
       ['Scripts available in x@1.2.3 via `npm run-script`:'],
       ['  glorp\n    echo doing the glerp glop'],
@@ -648,8 +631,7 @@ t.test('workspaces', t => {
 
   t.test('list all scripts', t => {
     runScript.execWorkspaces([], [], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
       t.strictSame(output, [
         ['Scripts available in a@1.0.0 via `npm run-script`:'],
         ['  glorp\n    echo a doing the glerp glop'],
@@ -678,8 +660,7 @@ t.test('workspaces', t => {
 
   t.test('list regular scripts, filtered by name', t => {
     runScript.execWorkspaces([], ['a', 'b'], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
       t.strictSame(output, [
         ['Scripts available in a@1.0.0 via `npm run-script`:'],
         ['  glorp\n    echo a doing the glerp glop'],
@@ -694,8 +675,7 @@ t.test('workspaces', t => {
 
   t.test('list regular scripts, filtered by path', t => {
     runScript.execWorkspaces([], ['./packages/a'], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
       t.strictSame(output, [
         ['Scripts available in a@1.0.0 via `npm run-script`:'],
         ['  glorp\n    echo a doing the glerp glop'],
@@ -707,8 +687,7 @@ t.test('workspaces', t => {
 
   t.test('list regular scripts, filtered by parent folder', t => {
     runScript.execWorkspaces([], ['./packages'], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
       t.strictSame(output, [
         ['Scripts available in a@1.0.0 via `npm run-script`:'],
         ['  glorp\n    echo a doing the glerp glop'],
@@ -738,8 +717,7 @@ t.test('workspaces', t => {
   t.test('list all scripts with colors', t => {
     npm.color = true
     runScript.execWorkspaces([], [], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
       t.strictSame(output, [
         [
           '\u001b[1mScripts\u001b[22m available in \x1B[32ma@1.0.0\x1B[39m via `\x1B[34mnpm run-script\x1B[39m`:',
@@ -779,8 +757,7 @@ t.test('workspaces', t => {
   t.test('list all scripts --json', t => {
     config.json = true
     runScript.execWorkspaces([], [], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
       t.strictSame(output, [
         [
           '{\n' +
@@ -814,8 +791,7 @@ t.test('workspaces', t => {
   t.test('list all scripts --parseable', t => {
     config.parseable = true
     runScript.execWorkspaces([], [], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
       t.strictSame(output, [
         ['a:glorp:echo a doing the glerp glop'],
         ['b:glorp:echo b doing the glerp glop'],
@@ -834,8 +810,7 @@ t.test('workspaces', t => {
   t.test('list no scripts --loglevel=silent', t => {
     npmlog.level = 'silent'
     runScript.execWorkspaces([], [], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
       t.strictSame(output, [])
       t.end()
     })
@@ -843,8 +818,7 @@ t.test('workspaces', t => {
 
   t.test('run scripts across all workspaces', t => {
     runScript.execWorkspaces(['test'], [], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
 
       t.match(RUN_SCRIPTS, [
         {
@@ -929,8 +903,7 @@ t.test('workspaces', t => {
       LOG.push(String(err))
     }
     runScript.execWorkspaces(['test'], ['a', 'b', 'c', 'd'], er => {
-      if (er)
-        throw er
+      t.error(er, { bail: true })
 
       t.match(RUN_SCRIPTS, [])
       t.strictSame(LOG.map(cleanOutput), [

--- a/test/lib/token.js
+++ b/test/lib/token.js
@@ -154,7 +154,7 @@ t.test('token list', (t) => {
   t.teardown(reset)
 
   token.exec([], (err) => {
-    t.error(err, 'npm token list')
+    t.error(err, { bail: true })
   })
 })
 
@@ -208,7 +208,7 @@ t.test('token list json output', (t) => {
   t.teardown(reset)
 
   token.exec(['list'], (err) => {
-    t.error(err, 'npm token list')
+    t.error(err, { bail: true })
   })
 })
 
@@ -276,7 +276,7 @@ t.test('token list parseable output', (t) => {
   t.teardown(reset)
 
   token.exec(['list'], (err) => {
-    t.error(err, 'npm token list')
+    t.error(err, { bail: true })
   })
 })
 
@@ -329,7 +329,7 @@ t.test('token revoke', (t) => {
   t.teardown(reset)
 
   token.exec(['rm', 'abcd'], (err) => {
-    t.error(err, 'npm token rm')
+    t.error(err, { bail: true })
   })
 })
 
@@ -381,7 +381,7 @@ t.test('token revoke multiple tokens', (t) => {
   t.teardown(reset)
 
   token.exec(['revoke', 'abcd', 'efgh'], (err) => {
-    t.error(err, 'npm token rm')
+    t.error(err, { bail: true })
   })
 })
 
@@ -433,7 +433,7 @@ t.test('token revoke json output', (t) => {
   t.teardown(reset)
 
   token.exec(['delete', 'abcd'], (err) => {
-    t.error(err, 'npm token rm')
+    t.error(err, { bail: true })
   })
 })
 
@@ -483,7 +483,7 @@ t.test('token revoke parseable output', (t) => {
   t.teardown(reset)
 
   token.exec(['remove', 'abcd'], (err) => {
-    t.error(err, 'npm token rm')
+    t.error(err, { bail: true })
   })
 })
 
@@ -533,7 +533,7 @@ t.test('token revoke by token', (t) => {
   t.teardown(reset)
 
   token.exec(['rm', 'efgh5678'], (err) => {
-    t.error(err, 'npm token rm')
+    t.error(err, { bail: true })
   })
 })
 
@@ -706,7 +706,7 @@ t.test('token create', (t) => {
   t.teardown(reset)
 
   token.exec(['create'], (err) => {
-    t.error(err, 'npm token create')
+    t.error(err, { bail: true })
   })
 })
 
@@ -765,7 +765,7 @@ t.test('token create json output', (t) => {
   t.teardown(reset)
 
   token.exec(['create'], (err) => {
-    t.error(err, 'npm token create')
+    t.error(err, { bail: true })
   })
 })
 
@@ -831,7 +831,7 @@ t.test('token create parseable output', (t) => {
   t.teardown(reset)
 
   token.exec(['create'], (err) => {
-    t.error(err, 'npm token create')
+    t.error(err, { bail: true })
   })
 })
 

--- a/test/lib/view.js
+++ b/test/lib/view.js
@@ -597,7 +597,7 @@ t.test('workspaces', t => {
 
   t.test('all workspaces', t => {
     view.execWorkspaces([], [], (err) => {
-      t.error(err)
+      t.error(err, { bail: true })
       t.matchSnapshot(logs)
       t.end()
     })
@@ -605,7 +605,7 @@ t.test('workspaces', t => {
 
   t.test('one specific workspace', t => {
     view.execWorkspaces([], ['green'], (err) => {
-      t.error(err)
+      t.error(err, { bail: true })
       t.matchSnapshot(logs)
       t.end()
     })
@@ -614,7 +614,7 @@ t.test('workspaces', t => {
   t.test('all workspaces --json', t => {
     config.json = true
     view.execWorkspaces([], [], (err) => {
-      t.error(err)
+      t.error(err, { bail: true })
       t.matchSnapshot(logs)
       t.end()
     })
@@ -622,7 +622,7 @@ t.test('workspaces', t => {
 
   t.test('all workspaces single field', t => {
     view.execWorkspaces(['.', 'name'], [], (err) => {
-      t.error(err)
+      t.error(err, { bail: true })
       t.matchSnapshot(logs)
       t.end()
     })
@@ -630,7 +630,7 @@ t.test('workspaces', t => {
 
   t.test('all workspaces nonexistent field', t => {
     view.execWorkspaces(['.', 'foo'], [], (err) => {
-      t.error(err)
+      t.error(err, { bail: true })
       t.matchSnapshot(logs)
       t.end()
     })
@@ -639,7 +639,7 @@ t.test('workspaces', t => {
   t.test('all workspaces nonexistent field --json', t => {
     config.json = true
     view.execWorkspaces(['.', 'foo'], [], (err) => {
-      t.error(err)
+      t.error(err, { bail: true })
       t.matchSnapshot(logs)
       t.end()
     })
@@ -648,7 +648,7 @@ t.test('workspaces', t => {
   t.test('all workspaces single field --json', t => {
     config.json = true
     view.execWorkspaces(['.', 'name'], [], (err) => {
-      t.error(err)
+      t.error(err, { bail: true })
       t.matchSnapshot(logs)
       t.end()
     })
@@ -657,7 +657,7 @@ t.test('workspaces', t => {
   t.test('single workspace --json', t => {
     config.json = true
     view.execWorkspaces([], ['green'], (err) => {
-      t.error(err)
+      t.error(err, { bail: true })
       t.matchSnapshot(logs)
       t.end()
     })
@@ -665,7 +665,7 @@ t.test('workspaces', t => {
 
   t.test('remote package name', t => {
     view.execWorkspaces(['pink'], [], (err) => {
-      t.error(err)
+      t.error(err, { bail: true })
       t.matchSnapshot(warnMsg)
       t.matchSnapshot(logs)
       t.end()

--- a/test/lib/whoami.js
+++ b/test/lib/whoami.js
@@ -16,7 +16,7 @@ t.test('whoami', (t) => {
   const whoami = new Whoami(npm)
 
   whoami.exec([], (err) => {
-    t.error(err, 'npm whoami')
+    t.error(err, { bail: true })
     t.ok('should successfully print username')
   })
 })
@@ -35,7 +35,7 @@ t.test('whoami json', (t) => {
   const whoami = new Whoami(npm)
 
   whoami.exec([], (err) => {
-    t.error(err, 'npm whoami')
+    t.error(err, { bail: true })
     t.ok('should successfully print username as json')
   })
 })


### PR DESCRIPTION
Our handling of "there should be no error" was not consistent.  It is
preferable to stay within the assertion library of your testing
framework, but tap also does not by default bail out on a test suite on
a failed assertion.  The `bail` flag turns this on for these assertions,
so now we are dealing with them in a consistent way and in a way that
aligns with what people are likely expecting when they see this kind of
assertion (i.e. there should be no error).

Coincidentally this found a subtle bug in at least one test where we
were checking that no error was generated after we had called t.end().
The `if (err) throw err` not using the testing framework meant this was
impossible to catch.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
