### PR TITLE
fix: npm ls --long missing deps

### DIFF
--- a/lib/ls.js
+++ b/lib/ls.js
@@ -302,7 +302,7 @@ const getJsonOutputItem = (node, { global, long }) => {
   if (node.isRoot && hasPackageJson)
     item.name = node.package.name || node.name
 
-  if (long) {
+  if (long && !node[_missing]) {
     item.name = item[_name]
     const { dependencies, ...packageInfo } = node.package
     Object.assign(item, packageInfo)

--- a/test/lib/ls.js
+++ b/test/lib/ls.js
@@ -2512,6 +2512,48 @@ t.test('ls --json', (t) => {
     })
   })
 
+  t.test('missing deps --long', (t) => {
+    config.long = true
+    npm.prefix = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'test-npm-ls',
+        version: '1.0.0',
+        dependencies: {
+          foo: '^1.0.0',
+          bar: '^1.0.0',
+          lorem: '^1.0.0',
+          ipsum: '^1.0.0',
+        },
+      }),
+      ...simpleNmFixture,
+    })
+    ls.exec([], (err) => {
+      t.equal(
+        redactCwd(err.message),
+        'missing: ipsum@^1.0.0, required by test-npm-ls@1.0.0',
+        'should log missing dep as error'
+      )
+      t.equal(
+        err.code,
+        'ELSPROBLEMS',
+        'should have ELSPROBLEMS error code'
+      )
+      t.match(
+        jsonParse(result),
+        {
+          name: 'test-npm-ls',
+          version: '1.0.0',
+          problems: [
+            'missing: ipsum@^1.0.0, required by test-npm-ls@1.0.0',
+          ],
+        },
+        'should output json containing problems info'
+      )
+      config.long = false
+      t.end()
+    })
+  })
+
   t.test('with filter arg', (t) => {
     npm.prefix = t.testdir({
       'package.json': JSON.stringify({


### PR DESCRIPTION
Running `npm ls --json --long --all` was broken for any project
containing a missing dependency from the `node_modules` folder. This
fixes it by avoiding trying to read the extra data required by the
`--long` option in case a dependency is missing.

## References
Fixes: https://github.com/npm/cli/issues/2724
