### PR TITLE
Remove --always-auth config definition

### DIFF
--- a/docs/content/commands/npm-adduser.md
+++ b/docs/content/commands/npm-adduser.md
@@ -7,7 +7,7 @@ description: Add a registry user account
 ### Synopsis
 
 ```bash
-npm adduser [--registry=url] [--scope=@orgname] [--always-auth] [--auth-type=legacy]
+npm adduser [--registry=url] [--scope=@orgname] [--auth-type=legacy]
 
 aliases: login, add-user
 ```
@@ -57,23 +57,6 @@ npm adduser --registry=http://myregistry.example.com --scope=@myco
 
 This will set a registry for the given scope and login or create a user for
 that registry at the same time.
-
-#### always-auth
-
-Default: false
-
-If specified, save configuration indicating that all requests to the given
-registry should include authorization information. Useful for private
-registries. Can be used with `--registry` and / or `--scope`, e.g.
-
-```bash
-npm adduser --registry=http://private-registry.example.com --always-auth
-```
-
-This will ensure that all requests to that registry (including for tarballs)
-include an authorization header. This setting may be necessary for use with
-private registries where metadata and package tarballs are stored on hosts with
-different hostnames. See `always-auth` in [`config`](/using-npm/config) for more details on always-auth. Registry-specific configuration of `always-auth` takes precedence over any global configuration.
 
 #### auth-type
 

--- a/docs/content/using-npm/config.md
+++ b/docs/content/using-npm/config.md
@@ -165,14 +165,6 @@ upon by the current project.
 Prevents throwing an error when `npm version` is used to set the new version
 to the same value as the current version.
 
-#### `always-auth`
-
-* Default: false
-* Type: Boolean
-
-Force npm to always require authentication when accessing the registry, even
-for `GET` requests.
-
 #### `audit`
 
 * Default: true
@@ -1087,8 +1079,8 @@ installation of packages specified according to the pattern
 * Default: '/bin/sh' on POSIX systems, 'cmd.exe' on Windows
 * Type: null or String
 
-The shell to use for scripts run with the `npm exec`, `npm run` and
-`npm init <pkg>` commands.
+The shell to use for scripts run with the `npm exec`, `npm run` and `npm
+init <pkg>` commands.
 
 #### `searchexclude`
 

--- a/lib/adduser.js
+++ b/lib/adduser.js
@@ -21,7 +21,6 @@ class AddUser extends BaseCommand {
     return [
       'registry',
       'scope',
-      'always-auth',
     ]
   }
 

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -199,16 +199,6 @@ define('also', {
   },
 })
 
-define('always-auth', {
-  default: false,
-  type: Boolean,
-  description: `
-    Force npm to always require authentication when accessing the registry,
-    even for \`GET\` requests.
-  `,
-  flatten,
-})
-
 define('audit', {
   default: true,
   type: Boolean,

--- a/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
@@ -12,7 +12,6 @@ Array [
   "all",
   "allow-same-version",
   "also",
-  "always-auth",
   "audit",
   "audit-level",
   "auth-type",

--- a/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
@@ -44,14 +44,6 @@ upon by the current project.
 Prevents throwing an error when \`npm version\` is used to set the new version
 to the same value as the current version.
 
-#### \`always-auth\`
-
-* Default: false
-* Type: Boolean
-
-Force npm to always require authentication when accessing the registry, even
-for \`GET\` requests.
-
 #### \`audit\`
 
 * Default: true

--- a/tap-snapshots/test/lib/utils/npm-usage.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/npm-usage.js.test.cjs
@@ -190,7 +190,7 @@ All commands:
                     npm adduser
                     
                     Options:
-                    [--registry <registry>] [--scope <@scope>] [--always-auth]
+                    [--registry <registry>] [--scope <@scope>]
                     
                     aliases: login, add-user
                     
@@ -565,7 +565,7 @@ All commands:
                     npm adduser
                     
                     Options:
-                    [--registry <registry>] [--scope <@scope>] [--always-auth]
+                    [--registry <registry>] [--scope <@scope>]
                     
                     aliases: login, add-user
                     


### PR DESCRIPTION
As of the recent updates to npm-registry-fetch and @npmcli/config,
this config field is no longer used anywhere.

Prior to those changes, it was used, but not in the manner documented.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
