### PR TITLE
docs: mention `directories.bin` in `bin`

### DIFF
--- a/docs/content/configuring-npm/package-json.md
+++ b/docs/content/configuring-npm/package-json.md
@@ -386,6 +386,8 @@ Please make sure that your file(s) referenced in `bin` starts with
 `#!/usr/bin/env node`, otherwise the scripts are started without the node
 executable!
 
+Note that you can also set the executable files using [directories.bin](#directoriesbin).
+
 ### man
 
 Specify either a single file or an array of filenames to put in place for


### PR DESCRIPTION
I had no clue about `directories.bin`, and it seems that I'm not the only one. I believe we can make this a lot clearer this way.

References https://github.com/bats-core/bats-core/pull/430
References https://github.com/volta-cli/volta/issues/978