### PR TITLE
feat: add workspaces boolean to user-agent

### DIFF
--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -1943,6 +1943,7 @@ define('user-agent', {
            'node/{node-version} ' +
            '{platform} ' +
            '{arch} ' +
+           'workspaces/{workspaces} ' +
            '{ci}',
   type: String,
   description: `
@@ -1953,17 +1954,23 @@ define('user-agent', {
     * \`{node-version}\` - The Node.js version in use
     * \`{platform}\` - The value of \`process.platform\`
     * \`{arch}\` - The value of \`process.arch\`
+    * \`{workspaces}\` - Set to \`true\` if the \`workspaces\` or \`workspace\`
+      options are set.
     * \`{ci}\` - The value of the \`ci-name\` config, if set, prefixed with
       \`ci/\`, or an empty string if \`ci-name\` is empty.
   `,
   flatten (key, obj, flatOptions) {
     const value = obj[key]
     const ciName = obj['ci-name']
+    let inWorkspaces = false
+    if (obj.workspaces || obj.workspace && obj.workspace.length)
+      inWorkspaces = true
     flatOptions.userAgent =
       value.replace(/\{node-version\}/gi, obj['node-version'])
         .replace(/\{npm-version\}/gi, obj['npm-version'])
         .replace(/\{platform\}/gi, process.platform)
         .replace(/\{arch\}/gi, process.arch)
+        .replace(/\{workspaces\}/gi, inWorkspaces)
         .replace(/\{ci\}/gi, ciName ? `ci/${ciName}` : '')
         .trim()
     // user-agent is a unique kind of config item that gets set from a template

--- a/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
@@ -1132,7 +1132,8 @@ Show short usage output about the command specified.
 
 #### \`user-agent\`
 
-* Default: "npm/{npm-version} node/{node-version} {platform} {arch} {ci}"
+* Default: "npm/{npm-version} node/{node-version} {platform} {arch}
+  workspaces/{workspaces} {ci}"
 * Type: String
 
 Sets the User-Agent request header. The following fields are replaced with
@@ -1142,6 +1143,8 @@ their actual counterparts:
 * \`{node-version}\` - The Node.js version in use
 * \`{platform}\` - The value of \`process.platform\`
 * \`{arch}\` - The value of \`process.arch\`
+* \`{workspaces}\` - Set to \`true\` if the \`workspaces\` or \`workspace\` options
+  are set.
 * \`{ci}\` - The value of the \`ci-name\` config, if set, prefixed with \`ci/\`, or
   an empty string if \`ci-name\` is empty.
 

--- a/test/lib/utils/config/definitions.js
+++ b/test/lib/utils/config/definitions.js
@@ -729,7 +729,7 @@ t.test('user-agent', t => {
   }
   const flat = {}
   const expectNoCI = `npm/1.2.3 node/9.8.7 ` +
-    `${process.platform} ${process.arch}`
+    `${process.platform} ${process.arch} workspaces/false`
   definitions['user-agent'].flatten('user-agent', obj, flat)
   t.equal(flat.userAgent, expectNoCI)
   t.equal(process.env.npm_config_user_agent, flat.userAgent, 'npm_user_config environment is set')
@@ -740,6 +740,23 @@ t.test('user-agent', t => {
   const expectCI = `${expectNoCI} ci/foo`
   definitions['user-agent'].flatten('user-agent', obj, flat)
   t.equal(flat.userAgent, expectCI)
+  t.equal(process.env.npm_config_user_agent, flat.userAgent, 'npm_user_config environment is set')
+  t.equal(obj['user-agent'], flat.userAgent, 'config user-agent template is translated')
+
+  delete obj['ci-name']
+  obj.workspaces = true
+  obj['user-agent'] = definitions['user-agent'].default
+  const expectWorkspaces = expectNoCI.replace('workspaces/false', 'workspaces/true')
+  definitions['user-agent'].flatten('user-agent', obj, flat)
+  t.equal(flat.userAgent, expectWorkspaces)
+  t.equal(process.env.npm_config_user_agent, flat.userAgent, 'npm_user_config environment is set')
+  t.equal(obj['user-agent'], flat.userAgent, 'config user-agent template is translated')
+
+  delete obj.workspaces
+  obj.workspace = ['foo']
+  obj['user-agent'] = definitions['user-agent'].default
+  definitions['user-agent'].flatten('user-agent', obj, flat)
+  t.equal(flat.userAgent, expectWorkspaces)
   t.equal(process.env.npm_config_user_agent, flat.userAgent, 'npm_user_config environment is set')
   t.equal(obj['user-agent'], flat.userAgent, 'config user-agent template is translated')
   t.end()


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
this gives us a signal to help track adoption of workspaces without sharing any information about the user's actual code.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Closes npm/statusboard#354