### PR TITLE
Avoid locale-specific string sorting issues

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -199,7 +199,7 @@ class Config extends BaseCommand {
 ; Configs like \`//<hostname>/:_authToken\` are auth that is restricted
 ; to the registry host specified.
 
-${data.split('\n').sort((a, b) => a.localeCompare(b)).join('\n').trim()}
+${data.split('\n').sort((a, b) => a.localeCompare(b, 'en')).join('\n').trim()}
 
 ;;;;
 ; all available options shown below with default values
@@ -227,7 +227,7 @@ ${defData}
       if (where === 'default' && !long)
         continue
 
-      const keys = Object.keys(data).sort((a, b) => a.localeCompare(b))
+      const keys = Object.keys(data).sort((a, b) => a.localeCompare(b, 'en'))
       if (!keys.length)
         continue
 

--- a/lib/help.js
+++ b/lib/help.js
@@ -77,7 +77,7 @@ class Help extends BaseCommand {
       if (aManNumber !== bManNumber)
         return aManNumber - bManNumber
 
-      return a.localeCompare(b)
+      return a.localeCompare(b, 'en')
     })
     const man = mans[0]
 

--- a/lib/ls.js
+++ b/lib/ls.js
@@ -443,7 +443,7 @@ const augmentNodesWithMetadata = ({
 }
 
 const sortAlphabetically = (a, b) =>
-  a.pkgid.localeCompare(b.pkgid)
+  a.pkgid.localeCompare(b.pkgid, 'en')
 
 const humanOutput = ({ color, result, seenItems, unicode }) => {
   // we need to traverse the entire tree in order to determine which items

--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -68,7 +68,7 @@ class Outdated extends BaseCommand {
     }))
 
     // sorts list alphabetically
-    const outdated = this.list.sort((a, b) => a.name.localeCompare(b.name))
+    const outdated = this.list.sort((a, b) => a.name.localeCompare(b.name, 'en'))
 
     // return if no outdated packages
     if (outdated.length === 0 && !this.npm.config.get('json'))

--- a/lib/utils/completion/installed-deep.js
+++ b/lib/utils/completion/installed-deep.js
@@ -16,7 +16,7 @@ const installedDeep = async (npm) => {
       })
       .filter(i => (i.depth - 1) <= depth)
       .sort((a, b) => a.depth - b.depth)
-      .sort((a, b) => a.depth === b.depth ? a.name.localeCompare(b.name) : 0)
+      .sort((a, b) => a.depth === b.depth ? a.name.localeCompare(b.name, 'en') : 0)
 
   const res = new Set()
   const gArb = new Arborist({ global: true, path: resolve(npm.globalDir, '..') })

--- a/lib/utils/config/describe-all.js
+++ b/lib/utils/config/describe-all.js
@@ -7,7 +7,7 @@ const describeAll = () => {
   const sort = ([keya, {deprecated: depa}], [keyb, {deprecated: depb}]) => {
     return depa && !depb ? 1
       : !depa && depb ? -1
-      : keya.localeCompare(keyb)
+      : keya.localeCompare(keyb, 'en')
   }
   return Object.entries(definitions).sort(sort)
     .map(([key, def]) => def.describe())

--- a/lib/utils/npm-usage.js
+++ b/lib/utils/npm-usage.js
@@ -62,7 +62,7 @@ const usages = (npm) => {
     maxLen = Math.max(maxLen, c.length)
     return set
   }, [])
-    .sort((a, b) => a[0].localeCompare(b[0]))
+    .sort((a, b) => a[0].localeCompare(b[0], 'en'))
     .map(([c, usage]) => `\n    ${c}${' '.repeat(maxLen - c.length + 1)}${
       (usage.split('\n').join('\n' + ' '.repeat(maxLen + 5)))}`)
     .join('\n')

--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -76,7 +76,7 @@ const getContents = async (manifest, tarball) => {
   })
 
   const comparator = (a, b) => {
-    return a.path.localeCompare(b.path, undefined, {
+    return a.path.localeCompare(b.path, 'en', {
       sensitivity: 'case',
       numeric: true,
     })
@@ -84,7 +84,7 @@ const getContents = async (manifest, tarball) => {
 
   const isUpper = (str) => {
     const ch = str.charAt(0)
-    return ch >= 'A' && ch <= 'Z'
+    return ch === ch.toUpperCase()
   }
 
   const uppers = files.filter(file => isUpper(file.path))

--- a/package.json
+++ b/package.json
@@ -216,6 +216,9 @@
     "Remove the 'files' below once we're done porting old tests over"
   ],
   "tap": {
+    "test-env": [
+      "LC_ALL=sk"
+    ],
     "color": 1,
     "files": "test/{lib,bin}",
     "coverage-map": "test/coverage-map.js",

--- a/scripts/bundle-and-gitignore-deps.js
+++ b/scripts/bundle-and-gitignore-deps.js
@@ -18,9 +18,9 @@ arb.loadVirtual().then(tree => {
       bundle.push(node.name)
     }
   }
-  pkg.bundleDependencies = bundle.sort((a, b) => a.localeCompare(b))
+  pkg.bundleDependencies = bundle.sort((a, b) => a.localeCompare(b, 'en'))
 
-  const ignores = shouldIgnore.sort((a, b) => a.localeCompare(b))
+  const ignores = shouldIgnore.sort((a, b) => a.localeCompare(b, 'en'))
     .map(i => `/${i}`)
     .join('\n')
   const ignoreData = `# Automatically generated to ignore dev deps

--- a/scripts/config-doc.js
+++ b/scripts/config-doc.js
@@ -35,8 +35,8 @@ const addShorthands = doc => {
   const body = Object.entries(shorthands)
     .sort(([shorta, expansiona], [shortb, expansionb]) => {
       // sort by what they're short FOR
-      return expansiona.join(' ').localeCompare(expansionb.join(' ')) ||
-        shorta.localeCompare(shortb)
+      return expansiona.join(' ').localeCompare(expansionb.join(' '), 'en') ||
+        shorta.localeCompare(shortb, 'en')
     })
     .map(([short, expansion]) => {
     const dash = short.length === 1 ? '-' : '--'

--- a/tap-snapshots/test/lib/config.js.test.cjs
+++ b/tap-snapshots/test/lib/config.js.test.cjs
@@ -88,6 +88,9 @@ exports[`test/lib/config.js TAP config edit > should write config file 2`] = `
 exports[`test/lib/config.js TAP config get no args > should list configs on config get no args 1`] = `
 ; "cli" config from command line options
 
+cat = true 
+chai = true 
+dog = true 
 editor = "vi" 
 global = false 
 json = false 
@@ -109,6 +112,9 @@ init.version = "1.0.0"
 
 ; "cli" config from command line options
 
+cat = true 
+chai = true 
+dog = true 
 editor = "vi" 
 global = false 
 json = false 
@@ -118,6 +124,9 @@ long = true
 exports[`test/lib/config.js TAP config list > should list configs 1`] = `
 ; "cli" config from command line options
 
+cat = true 
+chai = true 
+dog = true 
 editor = "vi" 
 global = false 
 json = false 
@@ -132,6 +141,9 @@ long = false
 exports[`test/lib/config.js TAP config list overrides > should list overridden configs 1`] = `
 ; "cli" config from command line options
 
+cat = true 
+chai = true 
+dog = true 
 editor = "vi" 
 global = false 
 init.author.name = "Bar" 

--- a/tap-snapshots/test/lib/ls.js.test.cjs
+++ b/tap-snapshots/test/lib/ls.js.test.cjs
@@ -47,8 +47,8 @@ test-npm-ls-ignore-missing-optional@1.2.3 {project}
 
 exports[`test/lib/ls.js TAP ls --depth=0 > should output tree containing only top-level dependencies 1`] = `
 test-npm-ls@1.0.0 {CWD}/tap-testdir-ls-ls---depth-0
-+-- foo@1.0.0
-\`-- lorem@1.0.0
++-- chai@1.0.0
+\`-- foo@1.0.0
 
 `
 
@@ -64,7 +64,7 @@ exports[`test/lib/ls.js TAP ls --dev > should output tree containing dev deps 1`
 test-npm-ls@1.0.0 {CWD}/tap-testdir-ls-ls---dev
 \`-- dev-dep@1.0.0
   \`-- foo@1.0.0
-    \`-- bar@1.0.0
+    \`-- dog@1.0.0
 
 `
 
@@ -78,10 +78,10 @@ exports[`test/lib/ls.js TAP ls --long --depth=0 > should output tree containing 
 test-npm-ls@1.0.0
 | {CWD}/tap-testdir-ls-ls---long---depth-0
 | 
++-- chai@1.0.0
+|   
 +-- dev-dep@1.0.0
 |   A DEV dep kind of dep
-+-- lorem@1.0.0
-|   
 +-- optional-dep@1.0.0
 |   Maybe a dep?
 +-- peer-dep@1.0.0
@@ -95,21 +95,21 @@ exports[`test/lib/ls.js TAP ls --long > should output tree info with description
 test-npm-ls@1.0.0
 | {CWD}/tap-testdir-ls-ls---long
 | 
++-- chai@1.0.0
+|   
 +-- dev-dep@1.0.0
 | | A DEV dep kind of dep
 | \`-- foo@1.0.0
 |   | 
-|   \`-- bar@1.0.0
+|   \`-- dog@1.0.0
 |       
-+-- lorem@1.0.0
-|   
 +-- optional-dep@1.0.0
 |   Maybe a dep?
 +-- peer-dep@1.0.0
 |   Peer-dep description here
 \`-- prod-dep@1.0.0
   | A PROD dep kind of dep
-  \`-- bar@2.0.0
+  \`-- dog@2.0.0
       A dep that bars
 
 `
@@ -118,37 +118,37 @@ exports[`test/lib/ls.js TAP ls --only=development > should output tree containin
 test-npm-ls@1.0.0 {CWD}/tap-testdir-ls-ls---only-development
 \`-- dev-dep@1.0.0
   \`-- foo@1.0.0
-    \`-- bar@1.0.0
+    \`-- dog@1.0.0
 
 `
 
 exports[`test/lib/ls.js TAP ls --only=prod > should output tree containing only prod deps 1`] = `
 test-npm-ls@1.0.0 {CWD}/tap-testdir-ls-ls---only-prod
-+-- lorem@1.0.0
++-- chai@1.0.0
 +-- optional-dep@1.0.0
 \`-- prod-dep@1.0.0
-  \`-- bar@2.0.0
+  \`-- dog@2.0.0
 
 `
 
 exports[`test/lib/ls.js TAP ls --parseable --depth=0 > should output tree containing only top-level dependencies 1`] = `
 {CWD}/tap-testdir-ls-ls---parseable---depth-0
+{CWD}/tap-testdir-ls-ls---parseable---depth-0/node_modules/chai
 {CWD}/tap-testdir-ls-ls---parseable---depth-0/node_modules/foo
-{CWD}/tap-testdir-ls-ls---parseable---depth-0/node_modules/lorem
 `
 
 exports[`test/lib/ls.js TAP ls --parseable --depth=1 > should output parseable containing top-level deps and their deps only 1`] = `
 {CWD}/tap-testdir-ls-ls---parseable---depth-1
+{CWD}/tap-testdir-ls-ls---parseable---depth-1/node_modules/chai
 {CWD}/tap-testdir-ls-ls---parseable---depth-1/node_modules/foo
-{CWD}/tap-testdir-ls-ls---parseable---depth-1/node_modules/lorem
-{CWD}/tap-testdir-ls-ls---parseable---depth-1/node_modules/bar
+{CWD}/tap-testdir-ls-ls---parseable---depth-1/node_modules/dog
 `
 
 exports[`test/lib/ls.js TAP ls --parseable --dev > should output tree containing dev deps 1`] = `
 {CWD}/tap-testdir-ls-ls---parseable---dev
 {CWD}/tap-testdir-ls-ls---parseable---dev/node_modules/dev-dep
 {CWD}/tap-testdir-ls-ls---parseable---dev/node_modules/foo
-{CWD}/tap-testdir-ls-ls---parseable---dev/node_modules/bar
+{CWD}/tap-testdir-ls-ls---parseable---dev/node_modules/dog
 `
 
 exports[`test/lib/ls.js TAP ls --parseable --link > should output tree containing linked deps 1`] = `
@@ -158,8 +158,8 @@ exports[`test/lib/ls.js TAP ls --parseable --link > should output tree containin
 
 exports[`test/lib/ls.js TAP ls --parseable --long --depth=0 > should output tree containing top-level deps with descriptions 1`] = `
 {CWD}/tap-testdir-ls-ls---parseable---long---depth-0:test-npm-ls@1.0.0
+{CWD}/tap-testdir-ls-ls---parseable---long---depth-0/node_modules/chai:chai@1.0.0
 {CWD}/tap-testdir-ls-ls---parseable---long---depth-0/node_modules/dev-dep:dev-dep@1.0.0
-{CWD}/tap-testdir-ls-ls---parseable---long---depth-0/node_modules/lorem:lorem@1.0.0
 {CWD}/tap-testdir-ls-ls---parseable---long---depth-0/node_modules/optional-dep:optional-dep@1.0.0
 {CWD}/tap-testdir-ls-ls---parseable---long---depth-0/node_modules/peer-dep:peer-dep@1.0.0
 {CWD}/tap-testdir-ls-ls---parseable---long---depth-0/node_modules/prod-dep:prod-dep@1.0.0
@@ -167,64 +167,64 @@ exports[`test/lib/ls.js TAP ls --parseable --long --depth=0 > should output tree
 
 exports[`test/lib/ls.js TAP ls --parseable --long > should output tree info with descriptions 1`] = `
 {CWD}/tap-testdir-ls-ls---parseable---long:test-npm-ls@1.0.0
+{CWD}/tap-testdir-ls-ls---parseable---long/node_modules/chai:chai@1.0.0
 {CWD}/tap-testdir-ls-ls---parseable---long/node_modules/dev-dep:dev-dep@1.0.0
-{CWD}/tap-testdir-ls-ls---parseable---long/node_modules/lorem:lorem@1.0.0
 {CWD}/tap-testdir-ls-ls---parseable---long/node_modules/optional-dep:optional-dep@1.0.0
 {CWD}/tap-testdir-ls-ls---parseable---long/node_modules/peer-dep:peer-dep@1.0.0
 {CWD}/tap-testdir-ls-ls---parseable---long/node_modules/prod-dep:prod-dep@1.0.0
 {CWD}/tap-testdir-ls-ls---parseable---long/node_modules/foo:foo@1.0.0
-{CWD}/tap-testdir-ls-ls---parseable---long/node_modules/prod-dep/node_modules/bar:bar@2.0.0
-{CWD}/tap-testdir-ls-ls---parseable---long/node_modules/bar:bar@1.0.0
+{CWD}/tap-testdir-ls-ls---parseable---long/node_modules/prod-dep/node_modules/dog:dog@2.0.0
+{CWD}/tap-testdir-ls-ls---parseable---long/node_modules/dog:dog@1.0.0
 `
 
 exports[`test/lib/ls.js TAP ls --parseable --long missing/invalid/extraneous > should output parseable result containing EXTRANEOUS/INVALID labels 1`] = `
 {CWD}/tap-testdir-ls-ls---parseable---long-missing-invalid-extraneous:test-npm-ls@1.0.0
+{CWD}/tap-testdir-ls-ls---parseable---long-missing-invalid-extraneous/node_modules/chai:chai@1.0.0:EXTRANEOUS
 {CWD}/tap-testdir-ls-ls---parseable---long-missing-invalid-extraneous/node_modules/foo:foo@1.0.0:INVALID
-{CWD}/tap-testdir-ls-ls---parseable---long-missing-invalid-extraneous/node_modules/lorem:lorem@1.0.0:EXTRANEOUS
-{CWD}/tap-testdir-ls-ls---parseable---long-missing-invalid-extraneous/node_modules/bar:bar@1.0.0
+{CWD}/tap-testdir-ls-ls---parseable---long-missing-invalid-extraneous/node_modules/dog:dog@1.0.0
 `
 
 exports[`test/lib/ls.js TAP ls --parseable --long print symlink target location > should output parseable results with symlink targets 1`] = `
 {CWD}/tap-testdir-ls-ls---parseable---long-print-symlink-target-location:test-npm-ls@1.0.0
+{CWD}/tap-testdir-ls-ls---parseable---long-print-symlink-target-location/node_modules/chai:chai@1.0.0
 {CWD}/tap-testdir-ls-ls---parseable---long-print-symlink-target-location/node_modules/dev-dep:dev-dep@1.0.0
 {CWD}/tap-testdir-ls-ls---parseable---long-print-symlink-target-location/node_modules/linked-dep:linked-dep@1.0.0:{CWD}/tap-testdir-ls-ls---parseable---long-print-symlink-target-location/linked-dep
-{CWD}/tap-testdir-ls-ls---parseable---long-print-symlink-target-location/node_modules/lorem:lorem@1.0.0
 {CWD}/tap-testdir-ls-ls---parseable---long-print-symlink-target-location/node_modules/optional-dep:optional-dep@1.0.0
 {CWD}/tap-testdir-ls-ls---parseable---long-print-symlink-target-location/node_modules/peer-dep:peer-dep@1.0.0
 {CWD}/tap-testdir-ls-ls---parseable---long-print-symlink-target-location/node_modules/prod-dep:prod-dep@1.0.0
 {CWD}/tap-testdir-ls-ls---parseable---long-print-symlink-target-location/node_modules/foo:foo@1.0.0
-{CWD}/tap-testdir-ls-ls---parseable---long-print-symlink-target-location/node_modules/prod-dep/node_modules/bar:bar@2.0.0
-{CWD}/tap-testdir-ls-ls---parseable---long-print-symlink-target-location/node_modules/bar:bar@1.0.0
+{CWD}/tap-testdir-ls-ls---parseable---long-print-symlink-target-location/node_modules/prod-dep/node_modules/dog:dog@2.0.0
+{CWD}/tap-testdir-ls-ls---parseable---long-print-symlink-target-location/node_modules/dog:dog@1.0.0
 `
 
 exports[`test/lib/ls.js TAP ls --parseable --long with extraneous deps > should output long parseable output with extraneous info 1`] = `
 {CWD}/tap-testdir-ls-ls---parseable---long-with-extraneous-deps:test-npm-ls@1.0.0
+{CWD}/tap-testdir-ls-ls---parseable---long-with-extraneous-deps/node_modules/chai:chai@1.0.0:EXTRANEOUS
 {CWD}/tap-testdir-ls-ls---parseable---long-with-extraneous-deps/node_modules/foo:foo@1.0.0
-{CWD}/tap-testdir-ls-ls---parseable---long-with-extraneous-deps/node_modules/lorem:lorem@1.0.0:EXTRANEOUS
-{CWD}/tap-testdir-ls-ls---parseable---long-with-extraneous-deps/node_modules/bar:bar@1.0.0
+{CWD}/tap-testdir-ls-ls---parseable---long-with-extraneous-deps/node_modules/dog:dog@1.0.0
 `
 
 exports[`test/lib/ls.js TAP ls --parseable --only=development > should output tree containing only development deps 1`] = `
 {CWD}/tap-testdir-ls-ls---parseable---only-development
 {CWD}/tap-testdir-ls-ls---parseable---only-development/node_modules/dev-dep
 {CWD}/tap-testdir-ls-ls---parseable---only-development/node_modules/foo
-{CWD}/tap-testdir-ls-ls---parseable---only-development/node_modules/bar
+{CWD}/tap-testdir-ls-ls---parseable---only-development/node_modules/dog
 `
 
 exports[`test/lib/ls.js TAP ls --parseable --only=prod > should output tree containing only prod deps 1`] = `
 {CWD}/tap-testdir-ls-ls---parseable---only-prod
-{CWD}/tap-testdir-ls-ls---parseable---only-prod/node_modules/lorem
+{CWD}/tap-testdir-ls-ls---parseable---only-prod/node_modules/chai
 {CWD}/tap-testdir-ls-ls---parseable---only-prod/node_modules/optional-dep
 {CWD}/tap-testdir-ls-ls---parseable---only-prod/node_modules/prod-dep
-{CWD}/tap-testdir-ls-ls---parseable---only-prod/node_modules/prod-dep/node_modules/bar
+{CWD}/tap-testdir-ls-ls---parseable---only-prod/node_modules/prod-dep/node_modules/dog
 `
 
 exports[`test/lib/ls.js TAP ls --parseable --production > should output tree containing production deps 1`] = `
 {CWD}/tap-testdir-ls-ls---parseable---production
-{CWD}/tap-testdir-ls-ls---parseable---production/node_modules/lorem
+{CWD}/tap-testdir-ls-ls---parseable---production/node_modules/chai
 {CWD}/tap-testdir-ls-ls---parseable---production/node_modules/optional-dep
 {CWD}/tap-testdir-ls-ls---parseable---production/node_modules/prod-dep
-{CWD}/tap-testdir-ls-ls---parseable---production/node_modules/prod-dep/node_modules/bar
+{CWD}/tap-testdir-ls-ls---parseable---production/node_modules/prod-dep/node_modules/dog
 `
 
 exports[`test/lib/ls.js TAP ls --parseable cycle deps > should print tree output omitting deduped ref 1`] = `
@@ -235,8 +235,8 @@ exports[`test/lib/ls.js TAP ls --parseable cycle deps > should print tree output
 
 exports[`test/lib/ls.js TAP ls --parseable default --depth value should be 0 > should output parseable output containing only top-level dependencies 1`] = `
 {CWD}/tap-testdir-ls-ls---parseable-default---depth-value-should-be-0
+{CWD}/tap-testdir-ls-ls---parseable-default---depth-value-should-be-0/node_modules/chai
 {CWD}/tap-testdir-ls-ls---parseable-default---depth-value-should-be-0/node_modules/foo
-{CWD}/tap-testdir-ls-ls---parseable-default---depth-value-should-be-0/node_modules/lorem
 `
 
 exports[`test/lib/ls.js TAP ls --parseable empty location > should print empty result 1`] = `
@@ -245,9 +245,9 @@ exports[`test/lib/ls.js TAP ls --parseable empty location > should print empty r
 
 exports[`test/lib/ls.js TAP ls --parseable extraneous deps > should output containing problems info 1`] = `
 {CWD}/tap-testdir-ls-ls---parseable-extraneous-deps
+{CWD}/tap-testdir-ls-ls---parseable-extraneous-deps/node_modules/chai
 {CWD}/tap-testdir-ls-ls---parseable-extraneous-deps/node_modules/foo
-{CWD}/tap-testdir-ls-ls---parseable-extraneous-deps/node_modules/lorem
-{CWD}/tap-testdir-ls-ls---parseable-extraneous-deps/node_modules/bar
+{CWD}/tap-testdir-ls-ls---parseable-extraneous-deps/node_modules/dog
 `
 
 exports[`test/lib/ls.js TAP ls --parseable from and resolved properties > should not be printed in tree output 1`] = `
@@ -268,23 +268,23 @@ exports[`test/lib/ls.js TAP ls --parseable json read problems > should print emp
 
 exports[`test/lib/ls.js TAP ls --parseable missing package.json > should output parseable missing name/version of top-level package 1`] = `
 {CWD}/tap-testdir-ls-ls---parseable-missing-package.json
-{CWD}/tap-testdir-ls-ls---parseable-missing-package.json/node_modules/bar
+{CWD}/tap-testdir-ls-ls---parseable-missing-package.json/node_modules/chai
+{CWD}/tap-testdir-ls-ls---parseable-missing-package.json/node_modules/dog
 {CWD}/tap-testdir-ls-ls---parseable-missing-package.json/node_modules/foo
-{CWD}/tap-testdir-ls-ls---parseable-missing-package.json/node_modules/lorem
 `
 
 exports[`test/lib/ls.js TAP ls --parseable missing/invalid/extraneous > should output parseable containing top-level deps and their deps only 1`] = `
 {CWD}/tap-testdir-ls-ls---parseable-missing-invalid-extraneous
+{CWD}/tap-testdir-ls-ls---parseable-missing-invalid-extraneous/node_modules/chai
 {CWD}/tap-testdir-ls-ls---parseable-missing-invalid-extraneous/node_modules/foo
-{CWD}/tap-testdir-ls-ls---parseable-missing-invalid-extraneous/node_modules/lorem
-{CWD}/tap-testdir-ls-ls---parseable-missing-invalid-extraneous/node_modules/bar
+{CWD}/tap-testdir-ls-ls---parseable-missing-invalid-extraneous/node_modules/dog
 `
 
 exports[`test/lib/ls.js TAP ls --parseable no args > should output parseable representation of dependencies structure 1`] = `
 {CWD}/tap-testdir-ls-ls---parseable-no-args
+{CWD}/tap-testdir-ls-ls---parseable-no-args/node_modules/chai
 {CWD}/tap-testdir-ls-ls---parseable-no-args/node_modules/foo
-{CWD}/tap-testdir-ls-ls---parseable-no-args/node_modules/lorem
-{CWD}/tap-testdir-ls-ls---parseable-no-args/node_modules/bar
+{CWD}/tap-testdir-ls-ls---parseable-no-args/node_modules/dog
 `
 
 exports[`test/lib/ls.js TAP ls --parseable resolved points to git ref > should output tree containing git refs 1`] = `
@@ -294,26 +294,26 @@ exports[`test/lib/ls.js TAP ls --parseable resolved points to git ref > should o
 
 exports[`test/lib/ls.js TAP ls --parseable unmet optional dep > should output parseable with empty entry for missing optional deps 1`] = `
 {CWD}/tap-testdir-ls-ls---parseable-unmet-optional-dep
+{CWD}/tap-testdir-ls-ls---parseable-unmet-optional-dep/node_modules/chai
 {CWD}/tap-testdir-ls-ls---parseable-unmet-optional-dep/node_modules/dev-dep
-{CWD}/tap-testdir-ls-ls---parseable-unmet-optional-dep/node_modules/lorem
 {CWD}/tap-testdir-ls-ls---parseable-unmet-optional-dep/node_modules/optional-dep
 {CWD}/tap-testdir-ls-ls---parseable-unmet-optional-dep/node_modules/peer-dep
 {CWD}/tap-testdir-ls-ls---parseable-unmet-optional-dep/node_modules/prod-dep
 {CWD}/tap-testdir-ls-ls---parseable-unmet-optional-dep/node_modules/foo
-{CWD}/tap-testdir-ls-ls---parseable-unmet-optional-dep/node_modules/prod-dep/node_modules/bar
-{CWD}/tap-testdir-ls-ls---parseable-unmet-optional-dep/node_modules/bar
+{CWD}/tap-testdir-ls-ls---parseable-unmet-optional-dep/node_modules/prod-dep/node_modules/dog
+{CWD}/tap-testdir-ls-ls---parseable-unmet-optional-dep/node_modules/dog
 `
 
 exports[`test/lib/ls.js TAP ls --parseable unmet peer dep > should output parseable signaling missing peer dep in problems 1`] = `
 {CWD}/tap-testdir-ls-ls---parseable-unmet-peer-dep
+{CWD}/tap-testdir-ls-ls---parseable-unmet-peer-dep/node_modules/chai
 {CWD}/tap-testdir-ls-ls---parseable-unmet-peer-dep/node_modules/dev-dep
-{CWD}/tap-testdir-ls-ls---parseable-unmet-peer-dep/node_modules/lorem
 {CWD}/tap-testdir-ls-ls---parseable-unmet-peer-dep/node_modules/optional-dep
 {CWD}/tap-testdir-ls-ls---parseable-unmet-peer-dep/node_modules/peer-dep
 {CWD}/tap-testdir-ls-ls---parseable-unmet-peer-dep/node_modules/prod-dep
 {CWD}/tap-testdir-ls-ls---parseable-unmet-peer-dep/node_modules/foo
-{CWD}/tap-testdir-ls-ls---parseable-unmet-peer-dep/node_modules/prod-dep/node_modules/bar
-{CWD}/tap-testdir-ls-ls---parseable-unmet-peer-dep/node_modules/bar
+{CWD}/tap-testdir-ls-ls---parseable-unmet-peer-dep/node_modules/prod-dep/node_modules/dog
+{CWD}/tap-testdir-ls-ls---parseable-unmet-peer-dep/node_modules/dog
 `
 
 exports[`test/lib/ls.js TAP ls --parseable using aliases > should output tree containing aliases 1`] = `
@@ -322,11 +322,11 @@ exports[`test/lib/ls.js TAP ls --parseable using aliases > should output tree co
 `
 
 exports[`test/lib/ls.js TAP ls --parseable with filter arg > should output parseable contaning only occurrences of filtered by package 1`] = `
-{CWD}/tap-testdir-ls-ls---parseable-with-filter-arg/node_modules/lorem
+{CWD}/tap-testdir-ls-ls---parseable-with-filter-arg/node_modules/chai
 `
 
 exports[`test/lib/ls.js TAP ls --parseable with filter arg nested dep > should output parseable contaning only occurrences of filtered package 1`] = `
-{CWD}/tap-testdir-ls-ls---parseable-with-filter-arg-nested-dep/node_modules/bar
+{CWD}/tap-testdir-ls-ls---parseable-with-filter-arg-nested-dep/node_modules/dog
 `
 
 exports[`test/lib/ls.js TAP ls --parseable with missing filter arg > should output parseable output containing no dependencies info 1`] = `
@@ -334,16 +334,16 @@ exports[`test/lib/ls.js TAP ls --parseable with missing filter arg > should outp
 `
 
 exports[`test/lib/ls.js TAP ls --parseable with multiple filter args > should output parseable contaning only occurrences of multiple filtered packages and their ancestors 1`] = `
-{CWD}/tap-testdir-ls-ls---parseable-with-multiple-filter-args/node_modules/lorem
-{CWD}/tap-testdir-ls-ls---parseable-with-multiple-filter-args/node_modules/bar
+{CWD}/tap-testdir-ls-ls---parseable-with-multiple-filter-args/node_modules/chai
+{CWD}/tap-testdir-ls-ls---parseable-with-multiple-filter-args/node_modules/dog
 `
 
 exports[`test/lib/ls.js TAP ls --production > should output tree containing production deps 1`] = `
 test-npm-ls@1.0.0 {CWD}/tap-testdir-ls-ls---production
-+-- lorem@1.0.0
++-- chai@1.0.0
 +-- optional-dep@1.0.0
 \`-- prod-dep@1.0.0
-  \`-- bar@2.0.0
+  \`-- dog@2.0.0
 
 `
 
@@ -355,10 +355,10 @@ npm-broken-resolved-field-test@1.0.0 {CWD}/tap-testdir-ls-ls-broken-resolved-fie
 
 exports[`test/lib/ls.js TAP ls colored output > should output tree containing color info 1`] = `
 [0mtest-npm-ls@1.0.0 {CWD}/tap-testdir-ls-ls-colored-output[0m
+[0m+-- chai@1.0.0 [32m[40mextraneous[49m[39m[0m
 [0m+-- foo@1.0.0 [31m[40minvalid[49m[39m[0m
-[0m| \`-- bar@1.0.0[0m
-[0m+-- [31m[40mUNMET DEPENDENCY[49m[39m ipsum@^1.0.0[0m
-[0m\`-- lorem@1.0.0 [32m[40mextraneous[49m[39m[0m
+[0m| \`-- dog@1.0.0[0m
+[0m\`-- [31m[40mUNMET DEPENDENCY[49m[39m ipsum@^1.0.0[0m
 [0m[0m
 `
 
@@ -388,8 +388,8 @@ test-npm-ls@1.0.0 {CWD}/tap-testdir-ls-ls-deduped-missing-dep
 
 exports[`test/lib/ls.js TAP ls default --depth value should be 0 > should output tree containing only top-level dependencies 1`] = `
 test-npm-ls@1.0.0 {CWD}/tap-testdir-ls-ls-default---depth-value-should-be-0
-+-- foo@1.0.0
-\`-- lorem@1.0.0
++-- chai@1.0.0
+\`-- foo@1.0.0
 
 `
 
@@ -401,9 +401,9 @@ exports[`test/lib/ls.js TAP ls empty location > should print empty result 1`] = 
 
 exports[`test/lib/ls.js TAP ls extraneous deps > should output containing problems info 1`] = `
 test-npm-ls@1.0.0 {CWD}/tap-testdir-ls-ls-extraneous-deps
-+-- foo@1.0.0
-| \`-- bar@1.0.0
-\`-- lorem@1.0.0 extraneous
++-- chai@1.0.0 extraneous
+\`-- foo@1.0.0
+  \`-- dog@1.0.0
 
 `
 
@@ -461,14 +461,14 @@ exports[`test/lib/ls.js TAP ls invalid deduped dep > should output tree signalin
 
 exports[`test/lib/ls.js TAP ls invalid peer dep > should output tree signaling mismatching peer dep in problems 1`] = `
 test-npm-ls@1.0.0 {CWD}/tap-testdir-ls-ls-invalid-peer-dep
++-- chai@1.0.0
 +-- dev-dep@1.0.0
 | \`-- foo@1.0.0
-|   \`-- bar@1.0.0
-+-- lorem@1.0.0
+|   \`-- dog@1.0.0
 +-- optional-dep@1.0.0
 +-- peer-dep@1.0.0 invalid
 \`-- prod-dep@1.0.0
-  \`-- bar@2.0.0
+  \`-- dog@2.0.0
 
 `
 
@@ -494,27 +494,27 @@ filter-by-child-of-missing-dep@1.0.0 {CWD}/tap-testdir-ls-ls-loading-a-tree-cont
 
 exports[`test/lib/ls.js TAP ls missing package.json > should output tree missing name/version of top-level package 1`] = `
 {CWD}/tap-testdir-ls-ls-missing-package.json
-+-- bar@1.0.0 extraneous
-+-- foo@1.0.0 extraneous
-| \`-- bar@1.0.0 deduped
-\`-- lorem@1.0.0 extraneous
++-- chai@1.0.0 extraneous
++-- dog@1.0.0 extraneous
+\`-- foo@1.0.0 extraneous
+  \`-- dog@1.0.0 deduped
 
 `
 
 exports[`test/lib/ls.js TAP ls missing/invalid/extraneous > should output tree containing missing, invalid, extraneous labels 1`] = `
 test-npm-ls@1.0.0 {CWD}/tap-testdir-ls-ls-missing-invalid-extraneous
++-- chai@1.0.0 extraneous
 +-- foo@1.0.0 invalid
-| \`-- bar@1.0.0
-+-- UNMET DEPENDENCY ipsum@^1.0.0
-\`-- lorem@1.0.0 extraneous
+| \`-- dog@1.0.0
+\`-- UNMET DEPENDENCY ipsum@^1.0.0
 
 `
 
 exports[`test/lib/ls.js TAP ls no args > should output tree representation of dependencies structure 1`] = `
 test-npm-ls@1.0.0 {CWD}/tap-testdir-ls-ls-no-args
-+-- foo@1.0.0
-| \`-- bar@1.0.0
-\`-- lorem@1.0.0
++-- chai@1.0.0
+\`-- foo@1.0.0
+  \`-- dog@1.0.0
 
 `
 
@@ -534,15 +534,15 @@ test-npm-ls@1.0.0 {CWD}/tap-testdir-ls-ls-resolved-points-to-git-ref
 
 exports[`test/lib/ls.js TAP ls unmet optional dep > should output tree with empty entry for missing optional deps 1`] = `
 [0mtest-npm-ls@1.0.0 {CWD}/tap-testdir-ls-ls-unmet-optional-dep[0m
+[0m+-- chai@1.0.0[0m
 [0m+-- dev-dep@1.0.0[0m
 [0m| \`-- foo@1.0.0[0m
-[0m|   \`-- bar@1.0.0[0m
-[0m+-- lorem@1.0.0[0m
+[0m|   \`-- dog@1.0.0[0m
 [0m+-- [33m[40mUNMET OPTIONAL DEPENDENCY[49m[39m missing-optional-dep@^1.0.0[0m
 [0m+-- optional-dep@1.0.0 [31m[40minvalid[49m[39m[0m
 [0m+-- peer-dep@1.0.0[0m
 [0m\`-- prod-dep@1.0.0[0m
-[0m  \`-- bar@2.0.0[0m
+[0m  \`-- dog@2.0.0[0m
 [0m[0m
 `
 
@@ -586,14 +586,14 @@ test-npm-ls@1.0.0 {CWD}/tap-testdir-ls-ls-with-dot-filter-arg
 
 exports[`test/lib/ls.js TAP ls with filter arg > should output tree contaning only occurrences of filtered by package and colored output 1`] = `
 [0mtest-npm-ls@1.0.0 {CWD}/tap-testdir-ls-ls-with-filter-arg[0m
-[0m\`-- [33m[40mlorem@1.0.0[49m[39m[0m
+[0m\`-- [33m[40mchai@1.0.0[49m[39m[0m
 [0m[0m
 `
 
 exports[`test/lib/ls.js TAP ls with filter arg nested dep > should output tree contaning only occurrences of filtered package and its ancestors 1`] = `
 test-npm-ls@1.0.0 {CWD}/tap-testdir-ls-ls-with-filter-arg-nested-dep
 \`-- foo@1.0.0
-  \`-- bar@1.0.0
+  \`-- dog@1.0.0
 
 `
 
@@ -605,9 +605,9 @@ test-npm-ls@1.0.0 {CWD}/tap-testdir-ls-ls-with-missing-filter-arg
 
 exports[`test/lib/ls.js TAP ls with multiple filter args > should output tree contaning only occurrences of multiple filtered packages and their ancestors 1`] = `
 test-npm-ls@1.0.0 {CWD}/tap-testdir-ls-ls-with-multiple-filter-args
-+-- foo@1.0.0
-| \`-- bar@1.0.0
-\`-- lorem@1.0.0
++-- chai@1.0.0
+\`-- foo@1.0.0
+  \`-- dog@1.0.0
 
 `
 

--- a/tap-snapshots/test/lib/outdated.js.test.cjs
+++ b/tap-snapshots/test/lib/outdated.js.test.cjs
@@ -7,38 +7,38 @@
 'use strict'
 exports[`test/lib/outdated.js TAP should display outdated deps outdated --all > must match snapshot 1`] = `
 
-Package  Current  Wanted  Latest  Location            Depended by
-alpha      1.0.0   1.0.1   1.0.1  node_modules/alpha  tap-testdir-outdated-should-display-outdated-deps
-beta       1.0.0   1.0.1   1.0.1  node_modules/beta   tap-testdir-outdated-should-display-outdated-deps
-gamma      1.0.1   1.0.1   2.0.0  node_modules/gamma  tap-testdir-outdated-should-display-outdated-deps
-theta    MISSING   1.0.1   1.0.1  -                   tap-testdir-outdated-should-display-outdated-deps
+Package  Current  Wanted  Latest  Location           Depended by
+cat        1.0.0   1.0.1   1.0.1  node_modules/cat   tap-testdir-outdated-should-display-outdated-deps
+chai       1.0.0   1.0.1   1.0.1  node_modules/chai  tap-testdir-outdated-should-display-outdated-deps
+dog        1.0.1   1.0.1   2.0.0  node_modules/dog   tap-testdir-outdated-should-display-outdated-deps
+theta    MISSING   1.0.1   1.0.1  -                  tap-testdir-outdated-should-display-outdated-deps
 `
 
 exports[`test/lib/outdated.js TAP should display outdated deps outdated --json --long > must match snapshot 1`] = `
 
 {
-  "alpha": {
+  "cat": {
     "current": "1.0.0",
     "wanted": "1.0.1",
     "latest": "1.0.1",
     "dependent": "tap-testdir-outdated-should-display-outdated-deps",
-    "location": "{CWD}/test/lib/tap-testdir-outdated-should-display-outdated-deps/node_modules/alpha",
+    "location": "{CWD}/test/lib/tap-testdir-outdated-should-display-outdated-deps/node_modules/cat",
     "type": "dependencies"
   },
-  "beta": {
+  "chai": {
     "current": "1.0.0",
     "wanted": "1.0.1",
     "latest": "1.0.1",
     "dependent": "tap-testdir-outdated-should-display-outdated-deps",
-    "location": "{CWD}/test/lib/tap-testdir-outdated-should-display-outdated-deps/node_modules/beta",
+    "location": "{CWD}/test/lib/tap-testdir-outdated-should-display-outdated-deps/node_modules/chai",
     "type": "peerDependencies"
   },
-  "gamma": {
+  "dog": {
     "current": "1.0.1",
     "wanted": "1.0.1",
     "latest": "2.0.0",
     "dependent": "tap-testdir-outdated-should-display-outdated-deps",
-    "location": "{CWD}/test/lib/tap-testdir-outdated-should-display-outdated-deps/node_modules/gamma",
+    "location": "{CWD}/test/lib/tap-testdir-outdated-should-display-outdated-deps/node_modules/dog",
     "type": "dependencies"
   },
   "theta": {
@@ -53,26 +53,26 @@ exports[`test/lib/outdated.js TAP should display outdated deps outdated --json -
 exports[`test/lib/outdated.js TAP should display outdated deps outdated --json > must match snapshot 1`] = `
 
 {
-  "alpha": {
+  "cat": {
     "current": "1.0.0",
     "wanted": "1.0.1",
     "latest": "1.0.1",
     "dependent": "tap-testdir-outdated-should-display-outdated-deps",
-    "location": "{CWD}/test/lib/tap-testdir-outdated-should-display-outdated-deps/node_modules/alpha"
+    "location": "{CWD}/test/lib/tap-testdir-outdated-should-display-outdated-deps/node_modules/cat"
   },
-  "beta": {
+  "chai": {
     "current": "1.0.0",
     "wanted": "1.0.1",
     "latest": "1.0.1",
     "dependent": "tap-testdir-outdated-should-display-outdated-deps",
-    "location": "{CWD}/test/lib/tap-testdir-outdated-should-display-outdated-deps/node_modules/beta"
+    "location": "{CWD}/test/lib/tap-testdir-outdated-should-display-outdated-deps/node_modules/chai"
   },
-  "gamma": {
+  "dog": {
     "current": "1.0.1",
     "wanted": "1.0.1",
     "latest": "2.0.0",
     "dependent": "tap-testdir-outdated-should-display-outdated-deps",
-    "location": "{CWD}/test/lib/tap-testdir-outdated-should-display-outdated-deps/node_modules/gamma"
+    "location": "{CWD}/test/lib/tap-testdir-outdated-should-display-outdated-deps/node_modules/dog"
   },
   "theta": {
     "wanted": "1.0.1",
@@ -84,71 +84,71 @@ exports[`test/lib/outdated.js TAP should display outdated deps outdated --json >
 
 exports[`test/lib/outdated.js TAP should display outdated deps outdated --long > must match snapshot 1`] = `
 
-Package  Current  Wanted  Latest  Location            Depended by                                        Package Type      Homepage
-alpha      1.0.0   1.0.1   1.0.1  node_modules/alpha  tap-testdir-outdated-should-display-outdated-deps  dependencies
-beta       1.0.0   1.0.1   1.0.1  node_modules/beta   tap-testdir-outdated-should-display-outdated-deps  peerDependencies
-gamma      1.0.1   1.0.1   2.0.0  node_modules/gamma  tap-testdir-outdated-should-display-outdated-deps  dependencies
-theta    MISSING   1.0.1   1.0.1  -                   tap-testdir-outdated-should-display-outdated-deps  dependencies
+Package  Current  Wanted  Latest  Location           Depended by                                        Package Type      Homepage
+cat        1.0.0   1.0.1   1.0.1  node_modules/cat   tap-testdir-outdated-should-display-outdated-deps  dependencies
+chai       1.0.0   1.0.1   1.0.1  node_modules/chai  tap-testdir-outdated-should-display-outdated-deps  peerDependencies
+dog        1.0.1   1.0.1   2.0.0  node_modules/dog   tap-testdir-outdated-should-display-outdated-deps  dependencies
+theta    MISSING   1.0.1   1.0.1  -                  tap-testdir-outdated-should-display-outdated-deps  dependencies
 `
 
 exports[`test/lib/outdated.js TAP should display outdated deps outdated --omit=dev --omit=peer > must match snapshot 1`] = `
 
-[4mPackage[24m  [4mCurrent[24m  [4mWanted[24m  [4mLatest[24m  [4mLocation[24m            [4mDepended by[24m
-[31malpha[39m      1.0.0   [32m1.0.1[39m   [35m1.0.1[39m  node_modules/alpha  tap-testdir-outdated-should-display-outdated-deps
-[33mgamma[39m      1.0.1   [32m1.0.1[39m   [35m2.0.0[39m  node_modules/gamma  tap-testdir-outdated-should-display-outdated-deps
-[31mtheta[39m    MISSING   [32m1.0.1[39m   [35m1.0.1[39m  -                   tap-testdir-outdated-should-display-outdated-deps
+[4mPackage[24m  [4mCurrent[24m  [4mWanted[24m  [4mLatest[24m  [4mLocation[24m          [4mDepended by[24m
+[31mcat[39m        1.0.0   [32m1.0.1[39m   [35m1.0.1[39m  node_modules/cat  tap-testdir-outdated-should-display-outdated-deps
+[33mdog[39m        1.0.1   [32m1.0.1[39m   [35m2.0.0[39m  node_modules/dog  tap-testdir-outdated-should-display-outdated-deps
+[31mtheta[39m    MISSING   [32m1.0.1[39m   [35m1.0.1[39m  -                 tap-testdir-outdated-should-display-outdated-deps
 `
 
 exports[`test/lib/outdated.js TAP should display outdated deps outdated --omit=dev > must match snapshot 1`] = `
 
-[4mPackage[24m  [4mCurrent[24m  [4mWanted[24m  [4mLatest[24m  [4mLocation[24m            [4mDepended by[24m
-[31malpha[39m      1.0.0   [32m1.0.1[39m   [35m1.0.1[39m  node_modules/alpha  tap-testdir-outdated-should-display-outdated-deps
-[31mbeta[39m       1.0.0   [32m1.0.1[39m   [35m1.0.1[39m  node_modules/beta   tap-testdir-outdated-should-display-outdated-deps
-[33mgamma[39m      1.0.1   [32m1.0.1[39m   [35m2.0.0[39m  node_modules/gamma  tap-testdir-outdated-should-display-outdated-deps
-[31mtheta[39m    MISSING   [32m1.0.1[39m   [35m1.0.1[39m  -                   tap-testdir-outdated-should-display-outdated-deps
+[4mPackage[24m  [4mCurrent[24m  [4mWanted[24m  [4mLatest[24m  [4mLocation[24m           [4mDepended by[24m
+[31mcat[39m        1.0.0   [32m1.0.1[39m   [35m1.0.1[39m  node_modules/cat   tap-testdir-outdated-should-display-outdated-deps
+[31mchai[39m       1.0.0   [32m1.0.1[39m   [35m1.0.1[39m  node_modules/chai  tap-testdir-outdated-should-display-outdated-deps
+[33mdog[39m        1.0.1   [32m1.0.1[39m   [35m2.0.0[39m  node_modules/dog   tap-testdir-outdated-should-display-outdated-deps
+[31mtheta[39m    MISSING   [32m1.0.1[39m   [35m1.0.1[39m  -                  tap-testdir-outdated-should-display-outdated-deps
 `
 
 exports[`test/lib/outdated.js TAP should display outdated deps outdated --omit=prod > must match snapshot 1`] = `
 
-[4mPackage[24m  [4mCurrent[24m  [4mWanted[24m  [4mLatest[24m  [4mLocation[24m            [4mDepended by[24m
-[31malpha[39m      1.0.0   [32m1.0.1[39m   [35m1.0.1[39m  node_modules/alpha  tap-testdir-outdated-should-display-outdated-deps
-[31mbeta[39m       1.0.0   [32m1.0.1[39m   [35m1.0.1[39m  node_modules/beta   tap-testdir-outdated-should-display-outdated-deps
-[33mgamma[39m      1.0.1   [32m1.0.1[39m   [35m2.0.0[39m  node_modules/gamma  tap-testdir-outdated-should-display-outdated-deps
+[4mPackage[24m  [4mCurrent[24m  [4mWanted[24m  [4mLatest[24m  [4mLocation[24m           [4mDepended by[24m
+[31mcat[39m        1.0.0   [32m1.0.1[39m   [35m1.0.1[39m  node_modules/cat   tap-testdir-outdated-should-display-outdated-deps
+[31mchai[39m       1.0.0   [32m1.0.1[39m   [35m1.0.1[39m  node_modules/chai  tap-testdir-outdated-should-display-outdated-deps
+[33mdog[39m        1.0.1   [32m1.0.1[39m   [35m2.0.0[39m  node_modules/dog   tap-testdir-outdated-should-display-outdated-deps
 `
 
 exports[`test/lib/outdated.js TAP should display outdated deps outdated --parseable --long > must match snapshot 1`] = `
 
-{CWD}/test/lib/tap-testdir-outdated-should-display-outdated-deps/node_modules/alpha:alpha@1.0.1:alpha@1.0.0:alpha@1.0.1:tap-testdir-outdated-should-display-outdated-deps:dependencies:
-{CWD}/test/lib/tap-testdir-outdated-should-display-outdated-deps/node_modules/beta:beta@1.0.1:beta@1.0.0:beta@1.0.1:tap-testdir-outdated-should-display-outdated-deps:peerDependencies:
-{CWD}/test/lib/tap-testdir-outdated-should-display-outdated-deps/node_modules/gamma:gamma@1.0.1:gamma@1.0.1:gamma@2.0.0:tap-testdir-outdated-should-display-outdated-deps:dependencies:
+{CWD}/test/lib/tap-testdir-outdated-should-display-outdated-deps/node_modules/cat:cat@1.0.1:cat@1.0.0:cat@1.0.1:tap-testdir-outdated-should-display-outdated-deps:dependencies:
+{CWD}/test/lib/tap-testdir-outdated-should-display-outdated-deps/node_modules/chai:chai@1.0.1:chai@1.0.0:chai@1.0.1:tap-testdir-outdated-should-display-outdated-deps:peerDependencies:
+{CWD}/test/lib/tap-testdir-outdated-should-display-outdated-deps/node_modules/dog:dog@1.0.1:dog@1.0.1:dog@2.0.0:tap-testdir-outdated-should-display-outdated-deps:dependencies:
 :theta@1.0.1:MISSING:theta@1.0.1:tap-testdir-outdated-should-display-outdated-deps:dependencies:
 `
 
 exports[`test/lib/outdated.js TAP should display outdated deps outdated --parseable > must match snapshot 1`] = `
 
-{CWD}/test/lib/tap-testdir-outdated-should-display-outdated-deps/node_modules/alpha:alpha@1.0.1:alpha@1.0.0:alpha@1.0.1:tap-testdir-outdated-should-display-outdated-deps
-{CWD}/test/lib/tap-testdir-outdated-should-display-outdated-deps/node_modules/beta:beta@1.0.1:beta@1.0.0:beta@1.0.1:tap-testdir-outdated-should-display-outdated-deps
-{CWD}/test/lib/tap-testdir-outdated-should-display-outdated-deps/node_modules/gamma:gamma@1.0.1:gamma@1.0.1:gamma@2.0.0:tap-testdir-outdated-should-display-outdated-deps
+{CWD}/test/lib/tap-testdir-outdated-should-display-outdated-deps/node_modules/cat:cat@1.0.1:cat@1.0.0:cat@1.0.1:tap-testdir-outdated-should-display-outdated-deps
+{CWD}/test/lib/tap-testdir-outdated-should-display-outdated-deps/node_modules/chai:chai@1.0.1:chai@1.0.0:chai@1.0.1:tap-testdir-outdated-should-display-outdated-deps
+{CWD}/test/lib/tap-testdir-outdated-should-display-outdated-deps/node_modules/dog:dog@1.0.1:dog@1.0.1:dog@2.0.0:tap-testdir-outdated-should-display-outdated-deps
 :theta@1.0.1:MISSING:theta@1.0.1:tap-testdir-outdated-should-display-outdated-deps
 `
 
 exports[`test/lib/outdated.js TAP should display outdated deps outdated > must match snapshot 1`] = `
 
-[4mPackage[24m  [4mCurrent[24m  [4mWanted[24m  [4mLatest[24m  [4mLocation[24m            [4mDepended by[24m
-[31malpha[39m      1.0.0   [32m1.0.1[39m   [35m1.0.1[39m  node_modules/alpha  tap-testdir-outdated-should-display-outdated-deps
-[31mbeta[39m       1.0.0   [32m1.0.1[39m   [35m1.0.1[39m  node_modules/beta   tap-testdir-outdated-should-display-outdated-deps
-[33mgamma[39m      1.0.1   [32m1.0.1[39m   [35m2.0.0[39m  node_modules/gamma  tap-testdir-outdated-should-display-outdated-deps
-[31mtheta[39m    MISSING   [32m1.0.1[39m   [35m1.0.1[39m  -                   tap-testdir-outdated-should-display-outdated-deps
+[4mPackage[24m  [4mCurrent[24m  [4mWanted[24m  [4mLatest[24m  [4mLocation[24m           [4mDepended by[24m
+[31mcat[39m        1.0.0   [32m1.0.1[39m   [35m1.0.1[39m  node_modules/cat   tap-testdir-outdated-should-display-outdated-deps
+[31mchai[39m       1.0.0   [32m1.0.1[39m   [35m1.0.1[39m  node_modules/chai  tap-testdir-outdated-should-display-outdated-deps
+[33mdog[39m        1.0.1   [32m1.0.1[39m   [35m2.0.0[39m  node_modules/dog   tap-testdir-outdated-should-display-outdated-deps
+[31mtheta[39m    MISSING   [32m1.0.1[39m   [35m1.0.1[39m  -                  tap-testdir-outdated-should-display-outdated-deps
 `
 
 exports[`test/lib/outdated.js TAP should display outdated deps outdated global > must match snapshot 1`] = `
 
-Package  Current  Wanted  Latest  Location            Depended by
-alpha      1.0.0   1.0.1   1.0.1  node_modules/alpha  global
+Package  Current  Wanted  Latest  Location          Depended by
+cat        1.0.0   1.0.1   1.0.1  node_modules/cat  global
 `
 
 exports[`test/lib/outdated.js TAP should display outdated deps outdated specific dep > must match snapshot 1`] = `
 
-Package  Current  Wanted  Latest  Location            Depended by
-alpha      1.0.0   1.0.1   1.0.1  node_modules/alpha  tap-testdir-outdated-should-display-outdated-deps
+Package  Current  Wanted  Latest  Location          Depended by
+cat        1.0.0   1.0.1   1.0.1  node_modules/cat  tap-testdir-outdated-should-display-outdated-deps
 `

--- a/tap-snapshots/test/lib/utils/tar.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/tar.js.test.cjs
@@ -11,6 +11,9 @@ exports[`test/lib/utils/tar.js TAP should log tarball contents > must match snap
 package: my-cool-pkg@1.0.0
 === Tarball Contents ===
 
+4B  cat         
+4B  chai        
+4B  dog         
 97B package.json
 === Bundled Dependencies ===
 
@@ -20,14 +23,14 @@ bundle-dep
 name:          my-cool-pkg                             
 version:       1.0.0                                   
 filename:      my-cool-pkg-1.0.0.tgz                   
-package size:  216 B                                   
-unpacked size: 101 B                                   
-shasum:        a604258e06adecec0b18f48e901c5802f19f7dab
-integrity:     sha512-fnN6NmI8DerTt[...]6rH17jx7OIFig==
+package size:  274 B                                   
+unpacked size: 113 B                                   
+shasum:        cd0dfccff77dff944eb761854bc0b0497d974f67
+integrity:     sha512-qeFip1jH05vkW[...]zHSdMdPpYogMA==
 bundled deps:  1                                       
 bundled files: 0                                       
-own files:     2                                       
-total files:   2                                       
+own files:     5                                       
+total files:   5                                       
 
 
 `

--- a/test/lib/config.js
+++ b/test/lib/config.js
@@ -49,6 +49,9 @@ const cliConfig = {
   json: false,
   long: false,
   global: false,
+  cat: true,
+  chai: true,
+  dog: true,
 }
 
 const npm = {
@@ -197,6 +200,9 @@ t.test('config list --json', t => {
         json: true,
         long: false,
         global: false,
+        cat: true,
+        chai: true,
+        dog: true,
       },
       'should list configs usin json'
     )

--- a/test/lib/exec.js
+++ b/test/lib/exec.js
@@ -601,7 +601,7 @@ t.test('run command with 2 packages, need install, verify sort', t => {
   for (const packages of cases) {
     t.test(packages.join(', '), t => {
       config.package = packages
-      const add = packages.map(p => `${p}@`).sort((a, b) => a.localeCompare(b))
+      const add = packages.map(p => `${p}@`).sort((a, b) => a.localeCompare(b, 'en'))
       const path = t.testdir()
       const installDir = resolve('cache-dir/_npx/07de77790e5f40f2')
       npm.localPrefix = path
@@ -756,7 +756,7 @@ t.test('prompt when installs are needed if not already present and shell is a TT
   config.package = packages
   config.yes = undefined
 
-  const add = packages.map(p => `${p}@`).sort((a, b) => a.localeCompare(b))
+  const add = packages.map(p => `${p}@`).sort((a, b) => a.localeCompare(b, 'en'))
   const path = t.testdir()
   const installDir = resolve('cache-dir/_npx/07de77790e5f40f2')
   npm.localPrefix = path
@@ -825,7 +825,7 @@ t.test('skip prompt when installs are needed if not already present and shell is
   config.package = packages
   config.yes = undefined
 
-  const add = packages.map(p => `${p}@`).sort((a, b) => a.localeCompare(b))
+  const add = packages.map(p => `${p}@`).sort((a, b) => a.localeCompare(b, 'en'))
   const path = t.testdir()
   const installDir = resolve('cache-dir/_npx/07de77790e5f40f2')
   npm.localPrefix = path
@@ -892,7 +892,7 @@ t.test('skip prompt when installs are needed if not already present and shell is
   config.package = packages
   config.yes = undefined
 
-  const add = packages.map(p => `${p}@`).sort((a, b) => a.localeCompare(b))
+  const add = packages.map(p => `${p}@`).sort((a, b) => a.localeCompare(b, 'en'))
   const path = t.testdir()
   const installDir = resolve('cache-dir/_npx/f7fbba6e0636f890')
   npm.localPrefix = path

--- a/test/lib/link.js
+++ b/test/lib/link.js
@@ -27,7 +27,7 @@ const printLinks = async (opts) => {
   const arb = new Arborist(opts)
   const tree = await arb.loadActual()
   const linkedItems = [...tree.inventory.values()]
-    .sort((a, b) => a.pkgid.localeCompare(b.pkgid))
+    .sort((a, b) => a.pkgid.localeCompare(b.pkgid, 'en'))
   for (const item of linkedItems) {
     if (item.target)
       res += `${item.path} -> ${item.target.path}\n`

--- a/test/lib/load-all-commands.js
+++ b/test/lib/load-all-commands.js
@@ -15,7 +15,7 @@ t.test('load each command', t => {
   npm.load((er) => {
     t.notOk(er)
     npm.config.set('usage', true)
-    for (const cmd of cmdList.sort((a, b) => a.localeCompare(b))) {
+    for (const cmd of cmdList.sort((a, b) => a.localeCompare(b, 'en'))) {
       t.test(cmd, t => {
         const impl = npm.commands[cmd]
         if (impl.completion)

--- a/test/lib/ls.js
+++ b/test/lib/ls.js
@@ -21,19 +21,19 @@ const simpleNmFixture = {
         name: 'foo',
         version: '1.0.0',
         dependencies: {
-          bar: '^1.0.0',
+          dog: '^1.0.0',
         },
       }),
     },
-    bar: {
+    dog: {
       'package.json': JSON.stringify({
-        name: 'bar',
+        name: 'dog',
         version: '1.0.0',
       }),
     },
-    lorem: {
+    chai: {
       'package.json': JSON.stringify({
-        name: 'lorem',
+        name: 'chai',
         version: '1.0.0',
       }),
     },
@@ -58,13 +58,13 @@ const diffDepTypesNmFixture = {
         description: 'A PROD dep kind of dep',
         version: '1.0.0',
         dependencies: {
-          bar: '^2.0.0',
+          dog: '^2.0.0',
         },
       }),
       node_modules: {
-        bar: {
+        dog: {
           'package.json': JSON.stringify({
-            name: 'bar',
+            name: 'dog',
             description: 'A dep that bars',
             version: '2.0.0',
           }),
@@ -132,7 +132,7 @@ t.test('ls', (t) => {
         version: '1.0.0',
         dependencies: {
           foo: '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
       }),
       ...simpleNmFixture,
@@ -181,12 +181,12 @@ t.test('ls', (t) => {
         version: '1.0.0',
         dependencies: {
           foo: '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
       }),
       ...simpleNmFixture,
     })
-    ls.exec(['lorem'], (err) => {
+    ls.exec(['chai'], (err) => {
       t.error(err, 'npm ls')
       t.matchSnapshot(redactCwd(result), 'should output tree contaning only occurrences of filtered by package and colored output')
       npm.color = false
@@ -224,12 +224,12 @@ t.test('ls', (t) => {
         version: '1.0.0',
         dependencies: {
           foo: '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
       }),
       ...simpleNmFixture,
     })
-    ls.exec(['bar'], (err) => {
+    ls.exec(['dog'], (err) => {
       t.error(err, 'npm ls')
       t.matchSnapshot(redactCwd(result), 'should output tree contaning only occurrences of filtered package and its ancestors')
       t.end()
@@ -243,7 +243,7 @@ t.test('ls', (t) => {
         version: '1.0.0',
         dependencies: {
           foo: '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
           ipsum: '^1.0.0',
         },
       }),
@@ -257,7 +257,7 @@ t.test('ls', (t) => {
         },
       },
     })
-    ls.exec(['bar@*', 'lorem@1.0.0'], (err) => {
+    ls.exec(['dog@*', 'chai@1.0.0'], (err) => {
       t.error(err, 'npm ls')
       t.matchSnapshot(redactCwd(result), 'should output tree contaning only occurrences of multiple filtered packages and their ancestors')
       t.end()
@@ -271,7 +271,7 @@ t.test('ls', (t) => {
         version: '1.0.0',
         dependencies: {
           foo: '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
       }),
       ...simpleNmFixture,
@@ -298,7 +298,7 @@ t.test('ls', (t) => {
         version: '1.0.0',
         dependencies: {
           foo: '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
       }),
       ...simpleNmFixture,
@@ -321,7 +321,7 @@ t.test('ls', (t) => {
         version: '1.0.0',
         dependencies: {
           foo: '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
       }),
       ...simpleNmFixture,
@@ -412,9 +412,9 @@ t.test('ls', (t) => {
       t.equal(err.code, 'ELSPROBLEMS', 'should have error code')
       t.equal(
         redactCwd(err.message).replace(/\r\n/g, '\n'),
+        'extraneous: chai@1.0.0 {CWD}/tap-testdir-ls-ls-missing-invalid-extraneous/node_modules/chai\n' +
         'invalid: foo@1.0.0 {CWD}/tap-testdir-ls-ls-missing-invalid-extraneous/node_modules/foo\n' +
-        'missing: ipsum@^1.0.0, required by test-npm-ls@1.0.0\n' +
-        'extraneous: lorem@1.0.0 {CWD}/tap-testdir-ls-ls-missing-invalid-extraneous/node_modules/lorem',
+        'missing: ipsum@^1.0.0, required by test-npm-ls@1.0.0',
         'should log missing/invalid/extraneous errors'
       )
       t.matchSnapshot(redactCwd(result), 'should output tree containing missing, invalid, extraneous labels')
@@ -451,7 +451,7 @@ t.test('ls', (t) => {
         version: '1.0.0',
         dependencies: {
           'prod-dep': '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
         devDependencies: {
           'dev-dep': '^1.0.0',
@@ -480,7 +480,7 @@ t.test('ls', (t) => {
         version: '1.0.0',
         dependencies: {
           'prod-dep': '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
         devDependencies: {
           'dev-dep': '^1.0.0',
@@ -509,7 +509,7 @@ t.test('ls', (t) => {
         version: '1.0.0',
         dependencies: {
           'prod-dep': '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
           'linked-dep': '^1.0.0',
         },
         devDependencies: {
@@ -584,7 +584,7 @@ t.test('ls', (t) => {
         version: '1.0.0',
         dependencies: {
           'prod-dep': '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
         devDependencies: {
           'dev-dep': '^1.0.0',
@@ -613,7 +613,7 @@ t.test('ls', (t) => {
         version: '1.0.0',
         dependencies: {
           'prod-dep': '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
         devDependencies: {
           'dev-dep': '^1.0.0',
@@ -642,7 +642,7 @@ t.test('ls', (t) => {
         version: '1.0.0',
         dependencies: {
           'prod-dep': '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
         devDependencies: {
           'dev-dep': '^1.0.0',
@@ -673,7 +673,7 @@ t.test('ls', (t) => {
         version: '1.0.0',
         dependencies: {
           'prod-dep': '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
         devDependencies: {
           'dev-dep': '^1.0.0',
@@ -723,7 +723,7 @@ t.test('ls', (t) => {
         version: '1.0.0',
         dependencies: {
           'prod-dep': '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
         devDependencies: {
           'dev-dep': '^1.0.0',
@@ -835,7 +835,7 @@ t.test('ls', (t) => {
         version: '1.0.0',
         dependencies: {
           'prod-dep': '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
         devDependencies: {
           'dev-dep': '^1.0.0',
@@ -1243,7 +1243,7 @@ t.test('ls', (t) => {
         dependencies: {
           a: {
             version: '1.0.1',
-            resolved: 'foo@bar://b8f3a2fc0c3bb8ffd8b0d0072cc6b5a3667e963c',
+            resolved: 'foo@dog://b8f3a2fc0c3bb8ffd8b0d0072cc6b5a3667e963c',
             integrity: 'sha512-8AN9lNCcBt5Xeje7fMEEpp5K3rgcAzIpTtAjYb/YMUYu8SbIVF6wz0WqACDVKvpQOUcSfNHZQNLNmue0QSwXOQ==',
           },
         },
@@ -1544,7 +1544,7 @@ t.test('ls --parseable', (t) => {
         version: '1.0.0',
         dependencies: {
           foo: '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
       }),
       ...simpleNmFixture,
@@ -1592,12 +1592,12 @@ t.test('ls --parseable', (t) => {
         version: '1.0.0',
         dependencies: {
           foo: '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
       }),
       ...simpleNmFixture,
     })
-    ls.exec(['lorem'], (err) => {
+    ls.exec(['chai'], (err) => {
       t.error(err, 'npm ls')
       t.matchSnapshot(redactCwd(result), 'should output parseable contaning only occurrences of filtered by package')
       t.end()
@@ -1611,12 +1611,12 @@ t.test('ls --parseable', (t) => {
         version: '1.0.0',
         dependencies: {
           foo: '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
       }),
       ...simpleNmFixture,
     })
-    ls.exec(['bar'], (err) => {
+    ls.exec(['dog'], (err) => {
       t.error(err, 'npm ls')
       t.matchSnapshot(redactCwd(result), 'should output parseable contaning only occurrences of filtered package')
       t.end()
@@ -1630,7 +1630,7 @@ t.test('ls --parseable', (t) => {
         version: '1.0.0',
         dependencies: {
           foo: '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
           ipsum: '^1.0.0',
         },
       }),
@@ -1644,7 +1644,7 @@ t.test('ls --parseable', (t) => {
         },
       },
     })
-    ls.exec(['bar@*', 'lorem@1.0.0'], (err) => {
+    ls.exec(['dog@*', 'chai@1.0.0'], (err) => {
       t.error(err, 'npm ls')
       t.matchSnapshot(redactCwd(result), 'should output parseable contaning only occurrences of multiple filtered packages and their ancestors')
       t.end()
@@ -1658,7 +1658,7 @@ t.test('ls --parseable', (t) => {
         version: '1.0.0',
         dependencies: {
           foo: '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
       }),
       ...simpleNmFixture,
@@ -1685,7 +1685,7 @@ t.test('ls --parseable', (t) => {
         version: '1.0.0',
         dependencies: {
           foo: '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
       }),
       ...simpleNmFixture,
@@ -1708,7 +1708,7 @@ t.test('ls --parseable', (t) => {
         version: '1.0.0',
         dependencies: {
           foo: '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
       }),
       ...simpleNmFixture,
@@ -1731,7 +1731,7 @@ t.test('ls --parseable', (t) => {
         version: '1.0.0',
         dependencies: {
           foo: '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
       }),
       ...simpleNmFixture,
@@ -1772,7 +1772,7 @@ t.test('ls --parseable', (t) => {
         version: '1.0.0',
         dependencies: {
           'prod-dep': '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
         devDependencies: {
           'dev-dep': '^1.0.0',
@@ -1801,7 +1801,7 @@ t.test('ls --parseable', (t) => {
         version: '1.0.0',
         dependencies: {
           'prod-dep': '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
         devDependencies: {
           'dev-dep': '^1.0.0',
@@ -1830,7 +1830,7 @@ t.test('ls --parseable', (t) => {
         version: '1.0.0',
         dependencies: {
           'prod-dep': '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
           'linked-dep': '^1.0.0',
         },
         devDependencies: {
@@ -1869,7 +1869,7 @@ t.test('ls --parseable', (t) => {
         version: '1.0.0',
         dependencies: {
           'prod-dep': '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
         devDependencies: {
           'dev-dep': '^1.0.0',
@@ -1898,7 +1898,7 @@ t.test('ls --parseable', (t) => {
         version: '1.0.0',
         dependencies: {
           'prod-dep': '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
         devDependencies: {
           'dev-dep': '^1.0.0',
@@ -1927,7 +1927,7 @@ t.test('ls --parseable', (t) => {
         version: '1.0.0',
         dependencies: {
           'prod-dep': '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
         devDependencies: {
           'dev-dep': '^1.0.0',
@@ -1995,7 +1995,7 @@ t.test('ls --parseable', (t) => {
         version: '1.0.0',
         dependencies: {
           'prod-dep': '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
           'linked-dep': '^1.0.0',
         },
         devDependencies: {
@@ -2037,7 +2037,7 @@ t.test('ls --parseable', (t) => {
         version: '1.0.0',
         dependencies: {
           'prod-dep': '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
         devDependencies: {
           'dev-dep': '^1.0.0',
@@ -2087,7 +2087,7 @@ t.test('ls --parseable', (t) => {
         version: '1.0.0',
         dependencies: {
           'prod-dep': '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
         devDependencies: {
           'dev-dep': '^1.0.0',
@@ -2114,7 +2114,7 @@ t.test('ls --parseable', (t) => {
         version: '1.0.0',
         dependencies: {
           'prod-dep': '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
         devDependencies: {
           'dev-dep': '^1.0.0',
@@ -2463,7 +2463,7 @@ t.test('ls --json', (t) => {
         version: '1.0.0',
         dependencies: {
           foo: '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
       }),
       ...simpleNmFixture,
@@ -2479,12 +2479,12 @@ t.test('ls --json', (t) => {
             foo: {
               version: '1.0.0',
               dependencies: {
-                bar: {
+                dog: {
                   version: '1.0.0',
                 },
               },
             },
-            lorem: {
+            chai: {
               version: '1.0.0',
             },
           },
@@ -2505,16 +2505,16 @@ t.test('ls --json', (t) => {
         jsonParse(result),
         {
           problems: [
-            'extraneous: bar@1.0.0 {CWD}/tap-testdir-ls-ls---json-missing-package.json/node_modules/bar',
+            'extraneous: chai@1.0.0 {CWD}/tap-testdir-ls-ls---json-missing-package.json/node_modules/chai',
+            'extraneous: dog@1.0.0 {CWD}/tap-testdir-ls-ls---json-missing-package.json/node_modules/dog',
             'extraneous: foo@1.0.0 {CWD}/tap-testdir-ls-ls---json-missing-package.json/node_modules/foo',
-            'extraneous: lorem@1.0.0 {CWD}/tap-testdir-ls-ls---json-missing-package.json/node_modules/lorem',
           ],
           dependencies: {
-            bar: {
+            dog: {
               version: '1.0.0',
               extraneous: true,
               problems: [
-                'extraneous: bar@1.0.0 {CWD}/tap-testdir-ls-ls---json-missing-package.json/node_modules/bar',
+                'extraneous: dog@1.0.0 {CWD}/tap-testdir-ls-ls---json-missing-package.json/node_modules/dog',
               ],
             },
             foo: {
@@ -2524,16 +2524,16 @@ t.test('ls --json', (t) => {
                 'extraneous: foo@1.0.0 {CWD}/tap-testdir-ls-ls---json-missing-package.json/node_modules/foo',
               ],
               dependencies: {
-                bar: {
+                dog: {
                   version: '1.0.0',
                 },
               },
             },
-            lorem: {
+            chai: {
               version: '1.0.0',
               extraneous: true,
               problems: [
-                'extraneous: lorem@1.0.0 {CWD}/tap-testdir-ls-ls---json-missing-package.json/node_modules/lorem',
+                'extraneous: chai@1.0.0 {CWD}/tap-testdir-ls-ls---json-missing-package.json/node_modules/chai',
               ],
             },
           },
@@ -2563,22 +2563,22 @@ t.test('ls --json', (t) => {
           name: 'test-npm-ls',
           version: '1.0.0',
           problems: [
-            'extraneous: lorem@1.0.0 {CWD}/tap-testdir-ls-ls---json-extraneous-deps/node_modules/lorem',
+            'extraneous: chai@1.0.0 {CWD}/tap-testdir-ls-ls---json-extraneous-deps/node_modules/chai',
           ],
           dependencies: {
             foo: {
               version: '1.0.0',
               dependencies: {
-                bar: {
+                dog: {
                   version: '1.0.0',
                 },
               },
             },
-            lorem: {
+            chai: {
               version: '1.0.0',
               extraneous: true,
               problems: [
-                'extraneous: lorem@1.0.0 {CWD}/tap-testdir-ls-ls---json-extraneous-deps/node_modules/lorem',
+                'extraneous: chai@1.0.0 {CWD}/tap-testdir-ls-ls---json-extraneous-deps/node_modules/chai',
               ],
             },
           },
@@ -2597,8 +2597,8 @@ t.test('ls --json', (t) => {
         version: '1.0.0',
         dependencies: {
           foo: '^1.0.0',
-          bar: '^1.0.0',
-          lorem: '^1.0.0',
+          dog: '^1.0.0',
+          chai: '^1.0.0',
           ipsum: '^1.0.0',
         },
       }),
@@ -2638,12 +2638,12 @@ t.test('ls --json', (t) => {
         version: '1.0.0',
         dependencies: {
           foo: '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
       }),
       ...simpleNmFixture,
     })
-    ls.exec(['lorem'], (err) => {
+    ls.exec(['chai'], (err) => {
       t.error(err, 'npm ls')
       t.same(
         jsonParse(result),
@@ -2651,7 +2651,7 @@ t.test('ls --json', (t) => {
           name: 'test-npm-ls',
           version: '1.0.0',
           dependencies: {
-            lorem: {
+            chai: {
               version: '1.0.0',
             },
           },
@@ -2674,12 +2674,12 @@ t.test('ls --json', (t) => {
         version: '1.0.0',
         dependencies: {
           foo: '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
       }),
       ...simpleNmFixture,
     })
-    ls.exec(['bar'], (err) => {
+    ls.exec(['dog'], (err) => {
       t.error(err, 'npm ls')
       t.same(
         jsonParse(result),
@@ -2690,7 +2690,7 @@ t.test('ls --json', (t) => {
             foo: {
               version: '1.0.0',
               dependencies: {
-                bar: {
+                dog: {
                   version: '1.0.0',
                 },
               },
@@ -2710,7 +2710,7 @@ t.test('ls --json', (t) => {
         version: '1.0.0',
         dependencies: {
           foo: '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
           ipsum: '^1.0.0',
         },
       }),
@@ -2724,7 +2724,7 @@ t.test('ls --json', (t) => {
         },
       },
     })
-    ls.exec(['bar@*', 'lorem@1.0.0'], (err) => {
+    ls.exec(['dog@*', 'chai@1.0.0'], (err) => {
       t.error(err, 'npm ls')
       t.same(
         jsonParse(result),
@@ -2735,12 +2735,12 @@ t.test('ls --json', (t) => {
             foo: {
               version: '1.0.0',
               dependencies: {
-                bar: {
+                dog: {
                   version: '1.0.0',
                 },
               },
             },
-            lorem: {
+            chai: {
               version: '1.0.0',
             },
           },
@@ -2758,7 +2758,7 @@ t.test('ls --json', (t) => {
         version: '1.0.0',
         dependencies: {
           foo: '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
       }),
       ...simpleNmFixture,
@@ -2792,7 +2792,7 @@ t.test('ls --json', (t) => {
         version: '1.0.0',
         dependencies: {
           foo: '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
       }),
       ...simpleNmFixture,
@@ -2808,7 +2808,7 @@ t.test('ls --json', (t) => {
             foo: {
               version: '1.0.0',
             },
-            lorem: {
+            chai: {
               version: '1.0.0',
             },
           },
@@ -2830,7 +2830,7 @@ t.test('ls --json', (t) => {
         version: '1.0.0',
         dependencies: {
           foo: '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
       }),
       ...simpleNmFixture,
@@ -2846,7 +2846,7 @@ t.test('ls --json', (t) => {
             foo: {
               version: '1.0.0',
             },
-            lorem: {
+            chai: {
               version: '1.0.0',
             },
           },
@@ -2868,7 +2868,7 @@ t.test('ls --json', (t) => {
         version: '1.0.0',
         dependencies: {
           foo: '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
       }),
       ...simpleNmFixture,
@@ -2884,12 +2884,12 @@ t.test('ls --json', (t) => {
             foo: {
               version: '1.0.0',
               dependencies: {
-                bar: {
+                dog: {
                   version: '1.0.0',
                 },
               },
             },
-            lorem: {
+            chai: {
               version: '1.0.0',
             },
           },
@@ -2922,9 +2922,9 @@ t.test('ls --json', (t) => {
           name: 'test-npm-ls',
           version: '1.0.0',
           problems: [
+            'extraneous: chai@1.0.0 {CWD}/tap-testdir-ls-ls---json-missing-invalid-extraneous/node_modules/chai',
             'invalid: foo@1.0.0 {CWD}/tap-testdir-ls-ls---json-missing-invalid-extraneous/node_modules/foo',
             'missing: ipsum@^1.0.0, required by test-npm-ls@1.0.0',
-            'extraneous: lorem@1.0.0 {CWD}/tap-testdir-ls-ls---json-missing-invalid-extraneous/node_modules/lorem',
           ],
           dependencies: {
             foo: {
@@ -2934,16 +2934,16 @@ t.test('ls --json', (t) => {
                 'invalid: foo@1.0.0 {CWD}/tap-testdir-ls-ls---json-missing-invalid-extraneous/node_modules/foo',
               ],
               dependencies: {
-                bar: {
+                dog: {
                   version: '1.0.0',
                 },
               },
             },
-            lorem: {
+            chai: {
               version: '1.0.0',
               extraneous: true,
               problems: [
-                'extraneous: lorem@1.0.0 {CWD}/tap-testdir-ls-ls---json-missing-invalid-extraneous/node_modules/lorem',
+                'extraneous: chai@1.0.0 {CWD}/tap-testdir-ls-ls---json-missing-invalid-extraneous/node_modules/chai',
               ],
             },
             ipsum: {
@@ -2969,7 +2969,7 @@ t.test('ls --json', (t) => {
         version: '1.0.0',
         dependencies: {
           'prod-dep': '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
         devDependencies: {
           'dev-dep': '^1.0.0',
@@ -2995,7 +2995,7 @@ t.test('ls --json', (t) => {
               dependencies: {
                 foo: {
                   version: '1.0.0',
-                  dependencies: { bar: { version: '1.0.0' } },
+                  dependencies: { dog: { version: '1.0.0' } },
                 },
               },
             },
@@ -3016,7 +3016,7 @@ t.test('ls --json', (t) => {
         version: '1.0.0',
         dependencies: {
           'prod-dep': '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
         devDependencies: {
           'dev-dep': '^1.0.0',
@@ -3042,7 +3042,7 @@ t.test('ls --json', (t) => {
               dependencies: {
                 foo: {
                   version: '1.0.0',
-                  dependencies: { bar: { version: '1.0.0' } },
+                  dependencies: { dog: { version: '1.0.0' } },
                 },
               },
             },
@@ -3063,7 +3063,7 @@ t.test('ls --json', (t) => {
         version: '1.0.0',
         dependencies: {
           'prod-dep': '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
           'linked-dep': '^1.0.0',
         },
         devDependencies: {
@@ -3115,7 +3115,7 @@ t.test('ls --json', (t) => {
         version: '1.0.0',
         dependencies: {
           'prod-dep': '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
         devDependencies: {
           'dev-dep': '^1.0.0',
@@ -3136,9 +3136,9 @@ t.test('ls --json', (t) => {
           name: 'test-npm-ls',
           version: '1.0.0',
           dependencies: {
-            lorem: { version: '1.0.0' },
+            chai: { version: '1.0.0' },
             'optional-dep': { version: '1.0.0' },
-            'prod-dep': { version: '1.0.0', dependencies: { bar: { version: '2.0.0' } } },
+            'prod-dep': { version: '1.0.0', dependencies: { dog: { version: '2.0.0' } } },
           },
         },
         'should output json containing production deps'
@@ -3156,7 +3156,7 @@ t.test('ls --json', (t) => {
         version: '1.0.0',
         dependencies: {
           'prod-dep': '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
         devDependencies: {
           'dev-dep': '^1.0.0',
@@ -3177,9 +3177,9 @@ t.test('ls --json', (t) => {
           name: 'test-npm-ls',
           version: '1.0.0',
           dependencies: {
-            lorem: { version: '1.0.0' },
+            chai: { version: '1.0.0' },
             'optional-dep': { version: '1.0.0' },
-            'prod-dep': { version: '1.0.0', dependencies: { bar: { version: '2.0.0' } } },
+            'prod-dep': { version: '1.0.0', dependencies: { dog: { version: '2.0.0' } } },
           },
         },
         'should output json containing only prod deps'
@@ -3326,7 +3326,7 @@ t.test('ls --json', (t) => {
         version: '1.0.0',
         dependencies: {
           'prod-dep': '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
         devDependencies: {
           'dev-dep': '^1.0.0',
@@ -3367,21 +3367,21 @@ t.test('ls --json', (t) => {
                   name: 'foo',
                   version: '1.0.0',
                   dependencies: {
-                    bar: {
-                      name: 'bar',
+                    dog: {
+                      name: 'dog',
                       version: '1.0.0',
-                      _id: 'bar@1.0.0',
+                      _id: 'dog@1.0.0',
                       devDependencies: {},
                       peerDependencies: {},
                       _dependencies: {},
-                      path: '{CWD}/tap-testdir-ls-ls---json---long/node_modules/bar',
+                      path: '{CWD}/tap-testdir-ls-ls---json---long/node_modules/dog',
                       extraneous: false,
                     },
                   },
                   _id: 'foo@1.0.0',
                   devDependencies: {},
                   peerDependencies: {},
-                  _dependencies: { bar: '^1.0.0' },
+                  _dependencies: { dog: '^1.0.0' },
                   path: '{CWD}/tap-testdir-ls-ls---json---long/node_modules/foo',
                   extraneous: false,
                 },
@@ -3393,14 +3393,14 @@ t.test('ls --json', (t) => {
               path: '{CWD}/tap-testdir-ls-ls---json---long/node_modules/dev-dep',
               extraneous: false,
             },
-            lorem: {
-              name: 'lorem',
+            chai: {
+              name: 'chai',
               version: '1.0.0',
-              _id: 'lorem@1.0.0',
+              _id: 'chai@1.0.0',
               devDependencies: {},
               peerDependencies: {},
               _dependencies: {},
-              path: '{CWD}/tap-testdir-ls-ls---json---long/node_modules/lorem',
+              path: '{CWD}/tap-testdir-ls-ls---json---long/node_modules/chai',
               extraneous: false,
             },
             'optional-dep': {
@@ -3419,22 +3419,22 @@ t.test('ls --json', (t) => {
               description: 'A PROD dep kind of dep',
               version: '1.0.0',
               dependencies: {
-                bar: {
-                  name: 'bar',
+                dog: {
+                  name: 'dog',
                   description: 'A dep that bars',
                   version: '2.0.0',
-                  _id: 'bar@2.0.0',
+                  _id: 'dog@2.0.0',
                   devDependencies: {},
                   peerDependencies: {},
                   _dependencies: {},
-                  path: '{CWD}/tap-testdir-ls-ls---json---long/node_modules/prod-dep/node_modules/bar',
+                  path: '{CWD}/tap-testdir-ls-ls---json---long/node_modules/prod-dep/node_modules/dog',
                   extraneous: false,
                 },
               },
               _id: 'prod-dep@1.0.0',
               devDependencies: {},
               peerDependencies: {},
-              _dependencies: { bar: '^2.0.0' },
+              _dependencies: { dog: '^2.0.0' },
               path: '{CWD}/tap-testdir-ls-ls---json---long/node_modules/prod-dep',
               extraneous: false,
             },
@@ -3443,7 +3443,7 @@ t.test('ls --json', (t) => {
           optionalDependencies: { 'optional-dep': '^1.0.0' },
           peerDependencies: { 'peer-dep': '^1.0.0' },
           _id: 'test-npm-ls@1.0.0',
-          _dependencies: { 'prod-dep': '^1.0.0', lorem: '^1.0.0', 'optional-dep': '^1.0.0' },
+          _dependencies: { 'prod-dep': '^1.0.0', chai: '^1.0.0', 'optional-dep': '^1.0.0' },
           path: '{CWD}/tap-testdir-ls-ls---json---long',
           extraneous: false,
         },
@@ -3464,7 +3464,7 @@ t.test('ls --json', (t) => {
         version: '1.0.0',
         dependencies: {
           'prod-dep': '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
         devDependencies: {
           'dev-dep': '^1.0.0',
@@ -3507,14 +3507,14 @@ t.test('ls --json', (t) => {
               path: '{CWD}/tap-testdir-ls-ls---json---long---depth-0/node_modules/dev-dep',
               extraneous: false,
             },
-            lorem: {
-              name: 'lorem',
+            chai: {
+              name: 'chai',
               version: '1.0.0',
-              _id: 'lorem@1.0.0',
+              _id: 'chai@1.0.0',
               devDependencies: {},
               peerDependencies: {},
               _dependencies: {},
-              path: '{CWD}/tap-testdir-ls-ls---json---long---depth-0/node_modules/lorem',
+              path: '{CWD}/tap-testdir-ls-ls---json---long---depth-0/node_modules/chai',
               extraneous: false,
             },
             'optional-dep': {
@@ -3535,7 +3535,7 @@ t.test('ls --json', (t) => {
               _id: 'prod-dep@1.0.0',
               devDependencies: {},
               peerDependencies: {},
-              _dependencies: { bar: '^2.0.0' },
+              _dependencies: { dog: '^2.0.0' },
               path: '{CWD}/tap-testdir-ls-ls---json---long---depth-0/node_modules/prod-dep',
               extraneous: false,
             },
@@ -3544,7 +3544,7 @@ t.test('ls --json', (t) => {
           optionalDependencies: { 'optional-dep': '^1.0.0' },
           peerDependencies: { 'peer-dep': '^1.0.0' },
           _id: 'test-npm-ls@1.0.0',
-          _dependencies: { 'prod-dep': '^1.0.0', lorem: '^1.0.0', 'optional-dep': '^1.0.0' },
+          _dependencies: { 'prod-dep': '^1.0.0', chai: '^1.0.0', 'optional-dep': '^1.0.0' },
           path: '{CWD}/tap-testdir-ls-ls---json---long---depth-0',
           extraneous: false,
         },
@@ -3598,7 +3598,7 @@ t.test('ls --json', (t) => {
         version: '1.0.0',
         dependencies: {
           'prod-dep': '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
         devDependencies: {
           'dev-dep': '^1.0.0',
@@ -3635,13 +3635,13 @@ t.test('ls --json', (t) => {
               dependencies: {
                 foo: {
                   version: '1.0.0',
-                  dependencies: { bar: { version: '1.0.0' } },
+                  dependencies: { dog: { version: '1.0.0' } },
                 },
               },
             },
-            lorem: { version: '1.0.0' },
+            chai: { version: '1.0.0' },
             'optional-dep': { version: '1.0.0' },
-            'prod-dep': { version: '1.0.0', dependencies: { bar: { version: '2.0.0' } } },
+            'prod-dep': { version: '1.0.0', dependencies: { dog: { version: '2.0.0' } } },
           },
         },
         'should output json signaling missing peer dep in problems'
@@ -3657,7 +3657,7 @@ t.test('ls --json', (t) => {
         version: '1.0.0',
         dependencies: {
           'prod-dep': '^1.0.0',
-          lorem: '^1.0.0',
+          chai: '^1.0.0',
         },
         devDependencies: {
           'dev-dep': '^1.0.0',
@@ -3699,12 +3699,12 @@ t.test('ls --json', (t) => {
               dependencies: {
                 foo: {
                   version: '1.0.0',
-                  dependencies: { bar: { version: '1.0.0' } },
+                  dependencies: { dog: { version: '1.0.0' } },
                 },
               },
             },
-            lorem: { version: '1.0.0' },
-            'prod-dep': { version: '1.0.0', dependencies: { bar: { version: '2.0.0' } } },
+            chai: { version: '1.0.0' },
+            'prod-dep': { version: '1.0.0', dependencies: { dog: { version: '2.0.0' } } },
             'missing-optional-dep': {}, // missing optional dep has an empty entry in json output
           },
         },

--- a/test/lib/outdated.js
+++ b/test/lib/outdated.js
@@ -3,8 +3,8 @@ const mockNpm = require('../fixtures/mock-npm')
 
 const packument = spec => {
   const mocks = {
-    alpha: {
-      name: 'alpha',
+    cat: {
+      name: 'cat',
       'dist-tags': {
         latest: '1.0.1',
       },
@@ -12,13 +12,13 @@ const packument = spec => {
         '1.0.1': {
           version: '1.0.1',
           dependencies: {
-            gamma: '2.0.0',
+            dog: '2.0.0',
           },
         },
       },
     },
-    beta: {
-      name: 'beta',
+    chai: {
+      name: 'chai',
       'dist-tags': {
         latest: '1.0.1',
       },
@@ -28,8 +28,8 @@ const packument = spec => {
         },
       },
     },
-    gamma: {
-      name: 'gamma',
+    dog: {
+      name: 'dog',
       'dist-tags': {
         latest: '2.0.0',
       },
@@ -74,9 +74,9 @@ const output = (msg) => {
 
 const globalDir = t.testdir({
   node_modules: {
-    alpha: {
+    cat: {
       'package.json': JSON.stringify({
-        name: 'alpha',
+        name: 'cat',
         version: '1.0.0',
       }, null, 2),
     },
@@ -116,8 +116,8 @@ t.test('should display outdated deps', t => {
       name: 'delta',
       version: '1.0.0',
       dependencies: {
-        alpha: '^1.0.0',
-        gamma: '^1.0.0',
+        cat: '^1.0.0',
+        dog: '^1.0.0',
         theta: '^1.0.0',
       },
       devDependencies: {
@@ -127,36 +127,36 @@ t.test('should display outdated deps', t => {
         lorem: '^1.0.0',
       },
       peerDependencies: {
-        beta: '^1.0.0',
+        chai: '^1.0.0',
       },
     }, null, 2),
     node_modules: {
-      alpha: {
+      cat: {
         'package.json': JSON.stringify({
-          name: 'alpha',
+          name: 'cat',
           version: '1.0.0',
           dependencies: {
-            gamma: '2.0.0',
+            dog: '2.0.0',
           },
         }, null, 2),
         node_modules: {
-          gamma: {
+          dog: {
             'package.json': JSON.stringify({
-              name: 'gamma',
+              name: 'dog',
               version: '2.0.0',
             }, null, 2),
           },
         },
       },
-      beta: {
+      chai: {
         'package.json': JSON.stringify({
-          name: 'beta',
+          name: 'chai',
           version: '1.0.0',
         }, null, 2),
       },
-      gamma: {
+      dog: {
         'package.json': JSON.stringify({
-          name: 'gamma',
+          name: 'dog',
           version: '1.0.1',
         }, null, 2),
       },
@@ -307,7 +307,7 @@ t.test('should display outdated deps', t => {
       config: {
         global: false,
       },
-    }).exec(['alpha'], () => {
+    }).exec(['cat'], () => {
       t.matchSnapshot(logs)
       t.end()
     })
@@ -322,13 +322,13 @@ t.test('should return if no outdated deps', t => {
       name: 'delta',
       version: '1.0.0',
       dependencies: {
-        alpha: '^1.0.0',
+        cat: '^1.0.0',
       },
     }, null, 2),
     node_modules: {
-      alpha: {
+      cat: {
         'package.json': JSON.stringify({
-          name: 'alpha',
+          name: 'cat',
           version: '1.0.1',
         }, null, 2),
       },
@@ -376,7 +376,7 @@ t.test('should skip missing non-prod deps', t => {
       name: 'delta',
       version: '1.0.0',
       devDependencies: {
-        beta: '^1.0.0',
+        chai: '^1.0.0',
       },
     }, null, 2),
     node_modules: {},
@@ -396,13 +396,13 @@ t.test('should skip invalid pkg ranges', t => {
       name: 'delta',
       version: '1.0.0',
       dependencies: {
-        alpha: '>=^2',
+        cat: '>=^2',
       },
     }, null, 2),
     node_modules: {
-      alpha: {
+      cat: {
         'package.json': JSON.stringify({
-          name: 'alpha',
+          name: 'cat',
           version: '1.0.0',
         }, null, 2),
       },
@@ -421,13 +421,13 @@ t.test('should skip git specs', t => {
       name: 'delta',
       version: '1.0.0',
       dependencies: {
-        alpha: 'github:username/foo',
+        cat: 'github:username/foo',
       },
     }, null, 2),
     node_modules: {
-      alpha: {
+      cat: {
         'package.json': JSON.stringify({
-          name: 'alpha',
+          name: 'cat',
           version: '1.0.0',
         }, null, 2),
       },

--- a/test/lib/utils/cleanup-log-files.js
+++ b/test/lib/utils/cleanup-log-files.js
@@ -71,7 +71,7 @@ t.test('rimraf fail', t => {
   const warnings = []
   const warn = (...warning) => warnings.push(basename(warning[2]))
   return cleanup(cache, 3, warn).then(() => {
-    t.strictSame(warnings.sort((a, b) => a.localeCompare(b)), [
+    t.strictSame(warnings.sort((a, b) => a.localeCompare(b, 'en')), [
       '1-debug.log',
       '2-debug.log',
     ])

--- a/test/lib/utils/completion/installed-deep.js
+++ b/test/lib/utils/completion/installed-deep.js
@@ -63,6 +63,15 @@ const fixture = {
       'package.json': JSON.stringify({
         name: 'c',
         version: '1.0.0',
+        dependencies: {
+          ch: '1.0.0',
+        },
+      }),
+    },
+    ch: {
+      'package.json': JSON.stringify({
+        name: 'ch',
+        version: '1.0.0',
       }),
     },
     d: {
@@ -160,8 +169,8 @@ t.test('get list of package names', async t => {
       ['foo', '-g'],
       ['a-bar', '-g'],
       'a', 'b', 'c',
-      'd', 'e', 'f',
-      'g', 'bb',
+      'ch', 'd', 'e',
+      'f', 'g', 'bb',
     ],
     'should return list of package names and global flag'
   )
@@ -211,9 +220,9 @@ t.test('limit depth', async t => {
       ['bar', '-g'],
       ['foo', '-g'],
       'a', 'b',
-      'c', 'd',
-      'e', 'f',
-      'g',
+      'c', 'ch',
+      'd', 'e',
+      'f', 'g',
     ],
     'should print only packages up to the specified depth'
   )

--- a/test/lib/utils/tar.js
+++ b/test/lib/utils/tar.js
@@ -26,6 +26,9 @@ t.test('should log tarball contents', async (t) => {
         'bundle-dep',
       ],
     }, null, 2),
+    cat: 'meow',
+    chai: 'blub',
+    dog: 'woof',
     node_modules: {
       'bundle-dep': 'toto',
     },


### PR DESCRIPTION
This adds the 'en' locale to all instances of String.localeCompare
within the CLI codebase.

Tests added for the cases where we're sorting arbitrary user-generated
data.  The tests rely on the fact that 'ch' sorts after 'd' in the
`'sk'` locale, but ahead of `'d'` in the `'en'` locale.  To ensure that
this is the default behavior if no locale is specified, `LC_ALL=sk` is
set in the test environment.

Other instances of `localeCompare` sort data that the cli controls, so
no tests were added.

Re: https://github.com/npm/cli/issues/2829

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
