### PR TITLE
fix(view): fix git specs

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -202,7 +202,10 @@ class View extends BaseCommand {
     const spec = npa(pkg)
 
     // get the data about this package
-    let version = spec.rawSpec || this.npm.config.get('tag')
+    let version = this.npm.config.get('tag')
+    // rawSpec is the git url if this is from git
+    if (spec.type !== 'git' && spec.rawSpec)
+      version = spec.rawSpec
 
     const pckmnt = await packument(spec, opts)
 

--- a/tap-snapshots/test/lib/view.js.test.cjs
+++ b/tap-snapshots/test/lib/view.js.test.cjs
@@ -80,7 +80,7 @@ dist
 .unpackedSize:[33m1[39m B
 
 dist-tags:
-
+[1m[32mlatest[39m[22m: 1.0.0
 
 published [33ma year ago[39m
 `
@@ -97,9 +97,39 @@ dist
 .unpackedSize:[33m1[39m B
 
 dist-tags:
-
+[1m[32mlatest[39m[22m: 1.0.0
 
 published [33ma year ago[39m
+`
+
+exports[`test/lib/view.js TAP should log package info package from git > must match snapshot 1`] = `
+
+
+[4m[1m[32mgreen[39m@[32m1.0.0[39m[22m[24m | [32mACME[39m | deps: [36m2[39m | versions: [33m2[39m
+green is a very important color
+
+[1m[31mDEPRECATED[39m[22m!! - true
+
+keywords:[33mcolors[39m, [33mgreen[39m, [33mcrayola[39m
+
+bin:[33mgreen[39m
+
+dist
+.tarball:[36mhttp://hm.green.com/1.0.0.tgz[39m
+.shasum:[33m123[39m
+.integrity:[33m---[39m
+.unpackedSize:[33m1[39m B
+
+dependencies:
+[33mred[39m: 1.0.0
+[33myellow[39m: 1.0.0
+
+maintainers:
+-[33mclaudia[39m <[36mc@yellow.com[39m>
+-[33misaacs[39m <[36mi@yellow.com[39m>
+
+dist-tags:
+[1m[32mlatest[39m[22m: 1.0.0
 `
 
 exports[`test/lib/view.js TAP should log package info package with --json and semver range > must match snapshot 1`] = `
@@ -108,7 +138,9 @@ exports[`test/lib/view.js TAP should log package info package with --json and se
   {
     "_npmUser": "claudia <claudia@cyan.com>",
     "name": "cyan",
-    "dist-tags": {},
+    "dist-tags": {
+      "latest": "1.0.0"
+    },
     "versions": [
       "1.0.0",
       "1.0.1"
@@ -125,7 +157,9 @@ exports[`test/lib/view.js TAP should log package info package with --json and se
   {
     "_npmUser": "claudia <claudia@cyan.com>",
     "name": "cyan",
-    "dist-tags": {},
+    "dist-tags": {
+      "latest": "1.0.0"
+    },
     "versions": [
       "1.0.0",
       "1.0.1"
@@ -249,7 +283,7 @@ dist
 .unpackedSize:[33m1[39m B
 
 dist-tags:
-
+[1m[32mlatest[39m[22m: 1.0.0
 
 published by [33mclaudia[39m <[36mclaudia@cyan.com[39m>
 `
@@ -266,7 +300,7 @@ dist
 .unpackedSize:[33m1[39m B
 
 dist-tags:
-
+[1m[32mlatest[39m[22m: 1.0.0
 
 published [33ma year ago[39m
 `

--- a/test/lib/view.js
+++ b/test/lib/view.js
@@ -34,7 +34,9 @@ const packument = (nv, opts) => {
     },
     blue: {
       name: 'blue',
-      'dist-tags': {},
+      'dist-tags': {
+        latest: '1.0.0',
+      },
       time: {
         '1.0.0': '2019-08-06T16:21:09.842Z',
       },
@@ -59,7 +61,9 @@ const packument = (nv, opts) => {
         email: 'claudia@cyan.com',
       },
       name: 'cyan',
-      'dist-tags': {},
+      'dist-tags': {
+        latest: '1.0.0',
+      },
       versions: {
         '1.0.0': {
           version: '1.0.0',
@@ -236,6 +240,8 @@ const packument = (nv, opts) => {
       },
     },
   }
+  if (nv.type === 'git')
+    return mocks[nv.hosted.project]
   return mocks[nv.name]
 }
 
@@ -258,7 +264,10 @@ t.test('should log package info', t => {
     },
   })
   const jsonNpm = mockNpm({
-    config: { json: true },
+    config: {
+      json: true,
+      tag: 'latest',
+    },
   })
   const viewJson = new ViewJson(jsonNpm)
 
@@ -271,6 +280,13 @@ t.test('should log package info', t => {
     config: { unicode: true },
   })
   const viewUnicode = new ViewUnicode(unicodeNpm)
+
+  t.test('package from git', t => {
+    view.exec(['https://github.com/npm/green'], () => {
+      t.matchSnapshot(logs)
+      t.end()
+    })
+  })
 
   t.test('package with license, bugs, repository and other fields', t => {
     view.exec(['green@1.0.0'], () => {
@@ -384,6 +400,7 @@ t.test('should log info by field name', t => {
   })
   const jsonNpm = mockNpm({
     config: {
+      tag: 'latest',
       json: true,
     },
   })
@@ -467,7 +484,10 @@ t.test('should log info by field name', t => {
 t.test('throw error if global mode', (t) => {
   const View = t.mock('../../lib/view.js')
   const npm = mockNpm({
-    config: { global: true },
+    config: {
+      global: true,
+      tag: 'latest',
+    },
   })
   const view = new View(npm)
   view.exec([], (err) => {


### PR DESCRIPTION
This was working by coincidence in 7.7.6 and before, and broken in the 7.8.0
refactor.  Before, it would see there was no "name" in the spec, and then read
your local package.json, and from that get a `latest` tag.  So, if you didn't
have a package.json in your CWD it would fail with an ENOENT trying to read it.

This fixes it for real, so that if you are asking for info from a git spec, it
goes ahead and looks for the `latest` tag (or whatever tag you have configured
as your default).

## References
Related to https://github.com/nodejs/citgm/pull/862