### PR TITLE
fix(tests): use config defaults

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -149,7 +149,7 @@ class Outdated extends BaseCommand {
       : edge.dev ? 'devDependencies'
       : 'dependencies'
 
-    for (const omitType of this.npm.config.get('omit') || []) {
+    for (const omitType of this.npm.config.get('omit')) {
       if (node[omitType])
         return
     }

--- a/test/fixtures/mock-npm.js
+++ b/test/fixtures/mock-npm.js
@@ -2,6 +2,8 @@
 // npm.config You still need a separate flatOptions but this is the first step
 // to eventually just using npm itself
 
+const realConfig = require('../../lib/utils/config')
+
 const mockLog = {
   clearProgress: () => {},
   disableProgress: () => {},
@@ -25,10 +27,10 @@ const mockNpm = (base = {}) => {
     config: {
       // for now just set `find` to what config.find should return
       // this works cause `find` is not an existing config entry
-      find: (k) => config[k],
-      get: (k) => config[k],
+      find: (k) => ({...realConfig.defaults, ...config})[k],
+      get: (k) => ({...realConfig.defaults, ...config})[k],
       set: (k, v) => config[k] = v,
-      list: [config]
+      list: [{ ...realConfig.defaults, ...config}]
     },
   }
 }

--- a/test/lib/dist-tag.js
+++ b/test/lib/dist-tag.js
@@ -68,10 +68,9 @@ const DistTag = t.mock('../../lib/dist-tag.js', {
   },
 })
 
+const config = {}
 const npm = mockNpm({
-  config: {
-    global: false,
-  },
+  config,
   output: msg => {
     result = result ? [result, msg].join('\n') : msg
   },
@@ -349,6 +348,10 @@ t.test('add using valid semver range as name', (t) => {
 
 t.test('add missing args', (t) => {
   npm.prefix = t.testdir({})
+  config.tag = ''
+  t.teardown(() => {
+    delete config.tag
+  })
   distTag.exec(['add', '@scoped/another@7.7.7'], (err) => {
     t.matchSnapshot(err, 'should exit usage error message')
     t.end()

--- a/test/lib/view.js
+++ b/test/lib/view.js
@@ -248,7 +248,7 @@ t.test('should log package info', t => {
     },
   })
   const npm = mockNpm({
-    config: { global: false },
+    config: { unicode: false },
   })
   const view = new View(npm)
 
@@ -268,10 +268,7 @@ t.test('should log package info', t => {
     },
   })
   const unicodeNpm = mockNpm({
-    config: {
-      global: false,
-      unicode: true,
-    },
+    config: { unicode: true },
   })
   const viewUnicode = new ViewUnicode(unicodeNpm)
 
@@ -358,7 +355,6 @@ t.test('should log info of package in current working dir', t => {
     prefix: testDir,
     config: {
       tag: '1.0.0',
-      global: false,
     },
   })
   const view = new View(npm)
@@ -389,7 +385,6 @@ t.test('should log info by field name', t => {
   const jsonNpm = mockNpm({
     config: {
       json: true,
-      global: false,
     },
   })
 
@@ -400,9 +395,7 @@ t.test('should log info by field name', t => {
       packument,
     },
   })
-  const npm = mockNpm({
-    config: { global: false },
-  })
+  const npm = mockNpm()
   const view = new View(npm)
 
   t.test('readme', t => {
@@ -489,7 +482,6 @@ t.test('throw ENOENT error if package.json misisng', (t) => {
   const View = t.mock('../../lib/view.js')
   const npm = mockNpm({
     prefix: testDir,
-    config: { global: false },
   })
   const view = new View(npm)
   view.exec([], (err) => {
@@ -506,7 +498,6 @@ t.test('throw EJSONPARSE error if package.json not json', (t) => {
   const View = t.mock('../../lib/view.js')
   const npm = mockNpm({
     prefix: testDir,
-    config: { global: false },
   })
   const view = new View(npm)
   view.exec([], (err) => {
@@ -523,7 +514,6 @@ t.test('throw error if package.json has no name', (t) => {
   const View = t.mock('../../lib/view.js')
   const npm = mockNpm({
     prefix: testDir,
-    config: { global: false },
   })
   const view = new View(npm)
   view.exec([], (err) => {
@@ -541,7 +531,6 @@ t.test('throws when unpublished', (t) => {
   const npm = mockNpm({
     config: {
       tag: '1.0.1',
-      global: false,
     },
   })
   const view = new View(npm)
@@ -581,6 +570,7 @@ t.test('workspaces', t => {
     },
   })
   const config = {
+    unicode: false,
     tag: 'latest',
   }
   let warnMsg
@@ -684,7 +674,6 @@ t.test('completion', async t => {
   const npm = mockNpm({
     config: {
       tag: '1.0.1',
-      global: false,
     },
   })
   const view = new View(npm)
@@ -700,7 +689,6 @@ t.test('no registry completion', async t => {
   const npm = mockNpm({
     config: {
       tag: '1.0.1',
-      global: false,
     },
   })
   const view = new View(npm)


### PR DESCRIPTION
The mocked npm now uses all config defaults, ensuring we don't have bugs
from the disconnect between our currently heavily mocked tests and
reality. Eventually the npm mock will be closer to reality, this moves
the needle.