### PR TITLE
feat(pack): add --json support

### DIFF
--- a/docs/content/commands/npm-pack.md
+++ b/docs/content/commands/npm-pack.md
@@ -7,7 +7,7 @@ description: Create a tarball from a package
 ### Synopsis
 
 ```bash
-npm pack [[<@scope>/]<pkg>...] [--dry-run]
+npm pack [[<@scope>/]<pkg>...] [--dry-run] [--json]
 ```
 
 ### Configuration

--- a/lib/pack.js
+++ b/lib/pack.js
@@ -24,7 +24,7 @@ class Pack extends BaseCommand {
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
   static get params () {
-    return ['dry-run', 'workspace', 'workspaces']
+    return ['dry-run', 'json', 'workspace', 'workspaces']
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */
@@ -46,6 +46,7 @@ class Pack extends BaseCommand {
 
     const unicode = this.npm.config.get('unicode')
     const dryRun = this.npm.config.get('dry-run')
+    const json = this.npm.config.get('json')
 
     // Get the manifests and filenames first so we can bail early on manifest
     // errors before making any tarballs
@@ -72,6 +73,11 @@ class Pack extends BaseCommand {
         await writeFile(filename, tarballData)
 
       tarballs.push(pkgContents)
+    }
+
+    if (json) {
+      this.npm.output(JSON.stringify(tarballs, null, 2))
+      return
     }
 
     for (const tar of tarballs) {

--- a/tap-snapshots/test/lib/load-all-commands.js.test.cjs
+++ b/tap-snapshots/test/lib/load-all-commands.js.test.cjs
@@ -653,7 +653,7 @@ Usage:
 npm pack [[<@scope>/]<pkg>...]
 
 Options:
-[--dry-run]
+[--dry-run] [--json]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [-ws|--workspaces]
 

--- a/tap-snapshots/test/lib/utils/npm-usage.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/npm-usage.js.test.cjs
@@ -740,7 +740,7 @@ All commands:
                     npm pack [[<@scope>/]<pkg>...]
                     
                     Options:
-                    [--dry-run]
+                    [--dry-run] [--json]
                     [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
                     [-ws|--workspaces]
                     


### PR DESCRIPTION
<!-- What / Why -->

This PR returns the `--json` argument to the `npm pack` command. This argument was lost in the current major version (`npm@7`), but present in `npm@6.14.13`.

<!-- Describe the request in detail. What it does and why it's being changed. -->

The implementation is based on the code from the previous version (`npm@6`).

* [command](https://github.com/npm/cli/blob/addb68478255fec2d8a3fc6020e65cb97e4affd3/lib/pack.js#L56)
* [test](https://github.com/npm/cli/blob/addb68478255fec2d8a3fc6020e65cb97e4affd3/test/tap/pack.js#L136-L167)

I'm not familiar with your quality standards, so I'm open to suggestions.

## References

Fixes #2038.