### PR TITLE
fix(docs): search description typo

### DIFF
--- a/lib/search.js
+++ b/lib/search.js
@@ -28,7 +28,7 @@ const BaseCommand = require('./base-command.js')
 class Search extends BaseCommand {
   /* istanbul ignore next - see test/lib/load-all-commands.js */
   static get description () {
-    return 'Search for pacakges'
+    return 'Search for packages'
   }
 
   /* istanbul ignore next - see test/lib/load-all-commands.js */

--- a/tap-snapshots/test/lib/load-all-commands.js.test.cjs
+++ b/tap-snapshots/test/lib/load-all-commands.js.test.cjs
@@ -819,7 +819,7 @@ Run "npm help run-script" for more info
 exports[`test/lib/load-all-commands.js TAP load each command search > must match snapshot 1`] = `
 npm search
 
-Search for pacakges
+Search for packages
 
 Usage:
 npm search [search terms ...]

--- a/tap-snapshots/test/lib/utils/npm-usage.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/npm-usage.js.test.cjs
@@ -884,7 +884,7 @@ All commands:
 
     search          npm search
                     
-                    Search for pacakges
+                    Search for packages
                     
                     Usage:
                     npm search [search terms ...]


### PR DESCRIPTION
<!-- What / Why -->

Just a typo in a command description

<!-- Describe the request in detail. What it does and why it's being changed. -->

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
