### PR TITLE
fix(docs): proper postinstall script file name

### DIFF
--- a/docs/content/using-npm/scripts.md
+++ b/docs/content/using-npm/scripts.md
@@ -304,7 +304,7 @@ For example, if your package.json contains this:
 {
   "scripts" : {
     "install" : "scripts/install.js",
-    "postinstall" : "scripts/postinstall.js",
+    "postinstall" : "scripts/install.js",
     "uninstall" : "scripts/uninstall.js"
   }
 }


### PR DESCRIPTION
I think this change was incorrect: https://github.com/npm/cli/pull/2024

The point of this example is that the same script is being used for two different stages (`install` and `post-install`) so it would be a good idea to look at the `npm_lifecycle_event` environment variable inside this script to determine which stage is being run.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
