### PR TITLE
fix(publish): skip private workspaces

### DIFF
--- a/tap-snapshots/test/lib/publish.js.test.cjs
+++ b/tap-snapshots/test/lib/publish.js.test.cjs
@@ -5,6 +5,40 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/lib/publish.js TAP private workspaces colorless > should output all publishes 1`] = `
+Array [
+  "+ @npmcli/b@1.0.0",
+]
+`
+
+exports[`test/lib/publish.js TAP private workspaces colorless > should publish all non-private workspaces 1`] = `
+Array [
+  Object {
+    "_id": "@npmcli/b@1.0.0",
+    "name": "@npmcli/b",
+    "readme": "ERROR: No README data found!",
+    "version": "1.0.0",
+  },
+]
+`
+
+exports[`test/lib/publish.js TAP private workspaces with color > should output all publishes 1`] = `
+Array [
+  "+ @npmcli/b@1.0.0",
+]
+`
+
+exports[`test/lib/publish.js TAP private workspaces with color > should publish all non-private workspaces 1`] = `
+Array [
+  Object {
+    "_id": "@npmcli/b@1.0.0",
+    "name": "@npmcli/b",
+    "readme": "ERROR: No README data found!",
+    "version": "1.0.0",
+  },
+]
+`
+
 exports[`test/lib/publish.js TAP shows usage with wrong set of arguments > should print usage 1`] = `
 Error: 
 Usage: npm publish


### PR DESCRIPTION
Allow users to publish all workspaces with `npm publish --ws` while also
skipping any workspace that might have been intentionally marked as
private, using `"private": true` in its package.json file.

## References
Fixes: https://github.com/npm/cli/issues/3268

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
