### PR TITLE
fix: refactor get package name

### DIFF
--- a/lib/diff.js
+++ b/lib/diff.js
@@ -8,7 +8,7 @@ const npmlog = require('npmlog')
 const pacote = require('pacote')
 const pickManifest = require('npm-pick-manifest')
 
-const readLocalPkg = require('./utils/read-local-package.js')
+const readPackageName = require('./utils/read-package-name.js')
 const BaseCommand = require('./base-command.js')
 
 class Diff extends BaseCommand {
@@ -97,7 +97,7 @@ class Diff extends BaseCommand {
     let noPackageJson
     let pkgName
     try {
-      pkgName = await readLocalPkg(this.npm)
+      pkgName = await readPackageName(this.npm.prefix)
     } catch (e) {
       npmlog.verbose('diff', 'could not read project dir package.json')
       noPackageJson = true
@@ -120,7 +120,7 @@ class Diff extends BaseCommand {
     let noPackageJson
     let pkgName
     try {
-      pkgName = await readLocalPkg(this.npm)
+      pkgName = await readPackageName(this.npm.prefix)
     } catch (e) {
       npmlog.verbose('diff', 'could not read project dir package.json')
       noPackageJson = true
@@ -238,7 +238,7 @@ class Diff extends BaseCommand {
     if (semverA && semverB) {
       let pkgName
       try {
-        pkgName = await readLocalPkg(this.npm)
+        pkgName = await readPackageName(this.npm.prefix)
       } catch (e) {
         npmlog.verbose('diff', 'could not read project dir package.json')
       }

--- a/lib/dist-tag.js
+++ b/lib/dist-tag.js
@@ -4,7 +4,7 @@ const regFetch = require('npm-registry-fetch')
 const semver = require('semver')
 
 const otplease = require('./utils/otplease.js')
-const readLocalPkgName = require('./utils/read-local-package.js')
+const readPackageName = require('./utils/read-package-name.js')
 const getWorkspaces = require('./workspaces/get-workspaces.js')
 const BaseCommand = require('./base-command.js')
 
@@ -64,7 +64,7 @@ class DistTag extends BaseCommand {
       // should be listing the existing tags
       return this.list(cmdName, opts)
     } else
-      throw this.usage
+      throw this.usageError()
   }
 
   execWorkspaces (args, filters, cb) {
@@ -102,7 +102,7 @@ class DistTag extends BaseCommand {
     log.verbose('dist-tag add', defaultTag, 'to', spec.name + '@' + version)
 
     if (!spec.name || !version || !defaultTag)
-      throw this.usage
+      throw this.usageError()
 
     const t = defaultTag.trim()
 
@@ -135,7 +135,7 @@ class DistTag extends BaseCommand {
     log.verbose('dist-tag del', tag, 'from', spec.name)
 
     if (!spec.name)
-      throw this.usage
+      throw this.usageError()
 
     const tags = await this.fetchTags(spec, opts)
     if (!tags[tag]) {
@@ -157,9 +157,11 @@ class DistTag extends BaseCommand {
 
   async list (spec, opts) {
     if (!spec) {
-      const pkg = await readLocalPkgName(this.npm)
+      if (this.npm.config.get('global'))
+        throw this.usageError()
+      const pkg = await readPackageName(this.npm.prefix)
       if (!pkg)
-        throw this.usage
+        throw this.usageError()
 
       return this.list(pkg, opts)
     }

--- a/lib/owner.js
+++ b/lib/owner.js
@@ -4,7 +4,7 @@ const npmFetch = require('npm-registry-fetch')
 const pacote = require('pacote')
 
 const otplease = require('./utils/otplease.js')
-const readLocalPkg = require('./utils/read-local-package.js')
+const readLocalPkgName = require('./utils/read-package-name.js')
 const BaseCommand = require('./base-command.js')
 
 class Owner extends BaseCommand {
@@ -47,7 +47,9 @@ class Owner extends BaseCommand {
 
     // reaches registry in order to autocomplete rm
     if (argv[2] === 'rm') {
-      const pkgName = await readLocalPkg(this.npm)
+      if (this.npm.config.get('global'))
+        return []
+      const pkgName = await readLocalPkgName(this.npm.prefix)
       if (!pkgName)
         return []
 
@@ -84,7 +86,10 @@ class Owner extends BaseCommand {
 
   async ls (pkg, opts) {
     if (!pkg) {
-      const pkgName = await readLocalPkg(this.npm)
+      if (this.npm.config.get('global'))
+        throw this.usageError()
+
+      const pkgName = await readLocalPkgName(this.npm.prefix)
       if (!pkgName)
         throw this.usageError()
 
@@ -113,7 +118,9 @@ class Owner extends BaseCommand {
       throw this.usageError()
 
     if (!pkg) {
-      const pkgName = await readLocalPkg(this.npm)
+      if (this.npm.config.get('global'))
+        throw this.usageError()
+      const pkgName = await readLocalPkgName(this.npm.prefix)
       if (!pkgName)
         throw this.usageError()
 
@@ -131,7 +138,9 @@ class Owner extends BaseCommand {
       throw this.usageError()
 
     if (!pkg) {
-      const pkgName = await readLocalPkg(this.npm)
+      if (this.npm.config.get('global'))
+        throw this.usageError()
+      const pkgName = await readLocalPkgName(this.npm.prefix)
       if (!pkgName)
         throw this.usageError()
 

--- a/lib/utils/read-package-name.js
+++ b/lib/utils/read-package-name.js
@@ -1,10 +1,7 @@
 const { resolve } = require('path')
 const readJson = require('read-package-json-fast')
-async function readLocalPackageName (npm) {
-  if (npm.config.get('global'))
-    return
-
-  const filepath = resolve(npm.prefix, 'package.json')
+async function readLocalPackageName (prefix) {
+  const filepath = resolve(prefix, 'package.json')
   const json = await readJson(filepath)
   return json.name
 }

--- a/tap-snapshots/test/lib/dist-tag.js.test.cjs
+++ b/tap-snapshots/test/lib/dist-tag.js.test.cjs
@@ -6,7 +6,8 @@
  */
 'use strict'
 exports[`test/lib/dist-tag.js TAP add missing args > should exit usage error message 1`] = `
-npm dist-tag
+Error: 
+Usage: npm dist-tag
 
 Modify package distribution tags
 
@@ -21,11 +22,14 @@ Options:
 
 alias: dist-tags
 
-Run "npm help dist-tag" for more info
+Run "npm help dist-tag" for more info {
+  "code": "EUSAGE",
+}
 `
 
 exports[`test/lib/dist-tag.js TAP add missing pkg name > should exit usage error message 1`] = `
-npm dist-tag
+Error: 
+Usage: npm dist-tag
 
 Modify package distribution tags
 
@@ -40,7 +44,9 @@ Options:
 
 alias: dist-tags
 
-Run "npm help dist-tag" for more info
+Run "npm help dist-tag" for more info {
+  "code": "EUSAGE",
+}
 `
 
 exports[`test/lib/dist-tag.js TAP add new tag > should return success msg 1`] = `
@@ -53,7 +59,8 @@ dist-tag add 1.0.0 to @scoped/another@7.7.7
 `
 
 exports[`test/lib/dist-tag.js TAP borked cmd usage > should show usage error 1`] = `
-npm dist-tag
+Error: 
+Usage: npm dist-tag
 
 Modify package distribution tags
 
@@ -68,7 +75,31 @@ Options:
 
 alias: dist-tags
 
-Run "npm help dist-tag" for more info
+Run "npm help dist-tag" for more info {
+  "code": "EUSAGE",
+}
+`
+
+exports[`test/lib/dist-tag.js TAP ls global > should throw basic usage 1`] = `
+Error: 
+Usage: npm dist-tag
+
+Modify package distribution tags
+
+Usage:
+npm dist-tag add <pkg>@<version> [<tag>]
+npm dist-tag rm <pkg> <tag>
+npm dist-tag ls [<pkg>]
+
+Options:
+[-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
+[-ws|--workspaces]
+
+alias: dist-tags
+
+Run "npm help dist-tag" for more info {
+  "code": "EUSAGE",
+}
 `
 
 exports[`test/lib/dist-tag.js TAP ls in current package > should list available tags for current package 1`] = `
@@ -78,7 +109,8 @@ latest: 1.0.0
 `
 
 exports[`test/lib/dist-tag.js TAP ls on missing name in current package > should throw usage error message 1`] = `
-npm dist-tag
+Error: 
+Usage: npm dist-tag
 
 Modify package distribution tags
 
@@ -93,7 +125,9 @@ Options:
 
 alias: dist-tags
 
-Run "npm help dist-tag" for more info
+Run "npm help dist-tag" for more info {
+  "code": "EUSAGE",
+}
 `
 
 exports[`test/lib/dist-tag.js TAP ls on missing package > should log no dist-tag found msg 1`] = `
@@ -133,7 +167,8 @@ exports[`test/lib/dist-tag.js TAP remove existing tag > should return success ms
 `
 
 exports[`test/lib/dist-tag.js TAP remove missing pkg name > should exit usage error message 1`] = `
-npm dist-tag
+Error: 
+Usage: npm dist-tag
 
 Modify package distribution tags
 
@@ -148,7 +183,9 @@ Options:
 
 alias: dist-tags
 
-Run "npm help dist-tag" for more info
+Run "npm help dist-tag" for more info {
+  "code": "EUSAGE",
+}
 `
 
 exports[`test/lib/dist-tag.js TAP remove non-existing tag > should log error msg 1`] = `

--- a/test/lib/dist-tag.js
+++ b/test/lib/dist-tag.js
@@ -93,6 +93,20 @@ t.test('ls in current package', (t) => {
   })
 })
 
+t.test('ls global', (t) => {
+  t.teardown(() => {
+    config.global = false
+  })
+  config.global = true
+  distTag.exec(['ls'], (err) => {
+    t.matchSnapshot(
+      err,
+      'should throw basic usage'
+    )
+    t.end()
+  })
+})
+
 t.test('no args in current package', (t) => {
   npm.prefix = t.testdir({
     'package.json': JSON.stringify({

--- a/test/lib/utils/read-package-name.js
+++ b/test/lib/utils/read-package-name.js
@@ -1,13 +1,8 @@
 const t = require('tap')
 const mockNpm = require('../../fixtures/mock-npm')
+const npm = mockNpm()
 
-const config = {
-  json: false,
-  global: false,
-}
-const npm = mockNpm({ config })
-
-const readLocalPackageName = require('../../../lib/utils/read-local-package.js')
+const readPackageName = require('../../../lib/utils/read-package-name.js')
 
 t.test('read local package.json', async (t) => {
   npm.prefix = t.testdir({
@@ -16,7 +11,7 @@ t.test('read local package.json', async (t) => {
       version: '1.0.0',
     }),
   })
-  const packageName = await readLocalPackageName(npm)
+  const packageName = await readPackageName(npm.prefix)
   t.equal(
     packageName,
     'my-local-package',
@@ -31,22 +26,10 @@ t.test('read local scoped-package.json', async (t) => {
       version: '1.0.0',
     }),
   })
-  const packageName = await readLocalPackageName(npm)
+  const packageName = await readPackageName(npm.prefix)
   t.equal(
     packageName,
     '@my-scope/my-local-package',
     'should retrieve scoped package name'
   )
-})
-
-t.test('read using --global', async (t) => {
-  npm.prefix = t.testdir({})
-  config.global = true
-  const packageName = await readLocalPackageName(npm)
-  t.equal(
-    packageName,
-    undefined,
-    'should not retrieve a package name'
-  )
-  config.global = false
 })


### PR DESCRIPTION
renames read-local-package to read-package-name

The global check needed to be moved outside this function, because it
was handled differently (and will be even moreso when we implement diff
workspaces) in each function.  This allowed us to now pass in the prefix
itself instead of the npm object, so we can reuse this function to look
up package names when we refactor npm diff for workspaces.

