### PR TITLE
Release/v7.15.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [10.x, 12.x, 14.x, 16.x]
         platform:
           - os: ubuntu-latest
             shell: bash
@@ -83,7 +83,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['10.1', 10.x, '12.1', 12.x, '14.1', 14.x]
+        node-version: ['10.1', 10.x, '12.1', 12.x, '14.1', 14.x, '16.1', 16.x]
         platform:
           - os: ubuntu-latest
             shell: bash

--- a/AUTHORS
+++ b/AUTHORS
@@ -782,3 +782,4 @@ Nariyasu Heseri <heserisiyookang@gmail.com>
 rethab <rethab@protonmail.ch>
 Spencer Wilson <5624115+spencerwilson@users.noreply.github.com>
 Daniel Park <gimli01@github.com>
+Daniel Park <daniel.park@endevors.io>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## v7.15.1 (2021-05-31)
+
+### BUG FIXES
+
+* [`598a17a26`](https://github.com/npm/cli/commit/598a17a2671c9e3bc204dddd6488169c9a72c6a1)
+  [#3329](https://github.com/npm/cli/issues/3329)
+  fix(libnpmexec): don't detach output from npm
+  ([@wraithgar](https://github.com/wraithgar))
+
+### DEPENDENCIES
+
+* [`c4fc03e9e`](https://github.com/npm/cli/commit/c4fc03e9eb3a6386e8feacb67c19f0a1578dfe38)
+  `@npmcli/arborist@2.6.1`
+    * fixes reifying deps with mismatching version ranges between
+      actual and virtual trees
+* [`9159fa62a`](https://github.com/npm/cli/commit/9159fa62a10dee09daef178fc7be161a02824004)
+  `libnpmexec@1.2.0`
+
 ## v7.15.0 (2021-05-27)
 
 ### FEATURES

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -8,7 +8,7 @@ const npmlog = require('npmlog')
 const pacote = require('pacote')
 const pickManifest = require('npm-pick-manifest')
 
-const readLocalPkg = require('./utils/read-local-package.js')
+const readPackageName = require('./utils/read-package-name.js')
 const BaseCommand = require('./base-command.js')
 
 class Diff extends BaseCommand {
@@ -97,7 +97,7 @@ class Diff extends BaseCommand {
     let noPackageJson
     let pkgName
     try {
-      pkgName = await readLocalPkg(this.npm)
+      pkgName = await readPackageName(this.npm.prefix)
     } catch (e) {
       npmlog.verbose('diff', 'could not read project dir package.json')
       noPackageJson = true
@@ -120,7 +120,7 @@ class Diff extends BaseCommand {
     let noPackageJson
     let pkgName
     try {
-      pkgName = await readLocalPkg(this.npm)
+      pkgName = await readPackageName(this.npm.prefix)
     } catch (e) {
       npmlog.verbose('diff', 'could not read project dir package.json')
       noPackageJson = true
@@ -238,7 +238,7 @@ class Diff extends BaseCommand {
     if (semverA && semverB) {
       let pkgName
       try {
-        pkgName = await readLocalPkg(this.npm)
+        pkgName = await readPackageName(this.npm.prefix)
       } catch (e) {
         npmlog.verbose('diff', 'could not read project dir package.json')
       }

--- a/lib/dist-tag.js
+++ b/lib/dist-tag.js
@@ -4,7 +4,7 @@ const regFetch = require('npm-registry-fetch')
 const semver = require('semver')
 
 const otplease = require('./utils/otplease.js')
-const readLocalPkgName = require('./utils/read-local-package.js')
+const readPackageName = require('./utils/read-package-name.js')
 const getWorkspaces = require('./workspaces/get-workspaces.js')
 const BaseCommand = require('./base-command.js')
 
@@ -64,7 +64,7 @@ class DistTag extends BaseCommand {
       // should be listing the existing tags
       return this.list(cmdName, opts)
     } else
-      throw this.usage
+      throw this.usageError()
   }
 
   execWorkspaces (args, filters, cb) {
@@ -102,7 +102,7 @@ class DistTag extends BaseCommand {
     log.verbose('dist-tag add', defaultTag, 'to', spec.name + '@' + version)
 
     if (!spec.name || !version || !defaultTag)
-      throw this.usage
+      throw this.usageError()
 
     const t = defaultTag.trim()
 
@@ -135,7 +135,7 @@ class DistTag extends BaseCommand {
     log.verbose('dist-tag del', tag, 'from', spec.name)
 
     if (!spec.name)
-      throw this.usage
+      throw this.usageError()
 
     const tags = await this.fetchTags(spec, opts)
     if (!tags[tag]) {
@@ -157,9 +157,11 @@ class DistTag extends BaseCommand {
 
   async list (spec, opts) {
     if (!spec) {
-      const pkg = await readLocalPkgName(this.npm)
+      if (this.npm.config.get('global'))
+        throw this.usageError()
+      const pkg = await readPackageName(this.npm.prefix)
       if (!pkg)
-        throw this.usage
+        throw this.usageError()
 
       return this.list(pkg, opts)
     }

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -76,8 +76,8 @@ class Exec extends BaseCommand {
       localBin,
       log,
       globalBin,
-      output,
     } = this.npm
+    const output = (...outputArgs) => this.npm.output(...outputArgs)
     const scriptShell = this.npm.config.get('script-shell') || undefined
     const packages = this.npm.config.get('package')
     const yes = this.npm.config.get('yes')

--- a/lib/init.js
+++ b/lib/init.js
@@ -113,8 +113,13 @@ class Init extends BaseCommand {
       localBin,
       log,
       globalBin,
-      output,
     } = this.npm
+    // this function is definitely called.  But because of coverage map stuff
+    // it ends up both uncovered, and the coverage report doesn't even mention.
+    // the tests do assert that some output happens, so we know this line is
+    // being hit.
+    /* istanbul ignore next */
+    const output = (...outputArgs) => this.npm.output(...outputArgs)
     const locationMsg = await getLocationMsg({ color, path })
     const runPath = path
     const scriptShell = this.npm.config.get('script-shell') || undefined

--- a/lib/owner.js
+++ b/lib/owner.js
@@ -4,7 +4,7 @@ const npmFetch = require('npm-registry-fetch')
 const pacote = require('pacote')
 
 const otplease = require('./utils/otplease.js')
-const readLocalPkg = require('./utils/read-local-package.js')
+const readLocalPkgName = require('./utils/read-package-name.js')
 const BaseCommand = require('./base-command.js')
 
 class Owner extends BaseCommand {
@@ -47,7 +47,9 @@ class Owner extends BaseCommand {
 
     // reaches registry in order to autocomplete rm
     if (argv[2] === 'rm') {
-      const pkgName = await readLocalPkg(this.npm)
+      if (this.npm.config.get('global'))
+        return []
+      const pkgName = await readLocalPkgName(this.npm.prefix)
       if (!pkgName)
         return []
 
@@ -84,7 +86,10 @@ class Owner extends BaseCommand {
 
   async ls (pkg, opts) {
     if (!pkg) {
-      const pkgName = await readLocalPkg(this.npm)
+      if (this.npm.config.get('global'))
+        throw this.usageError()
+
+      const pkgName = await readLocalPkgName(this.npm.prefix)
       if (!pkgName)
         throw this.usageError()
 
@@ -113,7 +118,9 @@ class Owner extends BaseCommand {
       throw this.usageError()
 
     if (!pkg) {
-      const pkgName = await readLocalPkg(this.npm)
+      if (this.npm.config.get('global'))
+        throw this.usageError()
+      const pkgName = await readLocalPkgName(this.npm.prefix)
       if (!pkgName)
         throw this.usageError()
 
@@ -131,7 +138,9 @@ class Owner extends BaseCommand {
       throw this.usageError()
 
     if (!pkg) {
-      const pkgName = await readLocalPkg(this.npm)
+      if (this.npm.config.get('global'))
+        throw this.usageError()
+      const pkgName = await readLocalPkgName(this.npm.prefix)
       if (!pkgName)
         throw this.usageError()
 

--- a/lib/utils/read-package-name.js
+++ b/lib/utils/read-package-name.js
@@ -1,10 +1,7 @@
 const { resolve } = require('path')
 const readJson = require('read-package-json-fast')
-async function readLocalPackageName (npm) {
-  if (npm.config.get('global'))
-    return
-
-  const filepath = resolve(npm.prefix, 'package.json')
+async function readLocalPackageName (prefix) {
+  const filepath = resolve(prefix, 'package.json')
   const json = await readJson(filepath)
   return json.name
 }

--- a/node_modules/@npmcli/arborist/lib/shrinkwrap.js
+++ b/node_modules/@npmcli/arborist/lib/shrinkwrap.js
@@ -714,6 +714,7 @@ class Shrinkwrap {
         resolved,
         integrity,
         hasShrinkwrap,
+        version,
       } = this.get(node.path)
 
       const pathFixed = !resolved ? null
@@ -727,8 +728,12 @@ class Shrinkwrap {
         node.resolved === pathFixed
       const integrityOk = !integrity || !node.integrity ||
         node.integrity === integrity
+      const versionOk = !version || !node.version || version === node.version
 
-      if ((resolved || integrity) && resolvedOk && integrityOk) {
+      const allOk = (resolved || integrity || version) &&
+        resolvedOk && integrityOk && versionOk
+
+      if (allOk) {
         node.resolved = node.resolved || pathFixed || null
         node.integrity = node.integrity || integrity || null
         node.hasShrinkwrap = node.hasShrinkwrap || hasShrinkwrap || false

--- a/node_modules/@npmcli/arborist/package.json
+++ b/node_modules/@npmcli/arborist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@npmcli/arborist",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Manage node_modules trees",
   "dependencies": {
     "@npmcli/installed-package-contents": "^1.0.7",

--- a/node_modules/libnpmexec/CHANGELOG.md
+++ b/node_modules/libnpmexec/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## v1.1.0
+
+- Add add walk up dir lookup logic to satisfy local bins,
+similar to `@npmcli/run-script`
+
+## v1.0.1
+
+- Fix `scriptShell` option name.
+
+## v1.0.0
+
+- Initial implementation, moves the code that used to live in the **npm cli**,
+ref: https://github.com/npm/cli/blob/release/v7.10.0/lib/exec.js into this
+separate module, providing a programmatic API to the **npm exec** functionality.
+

--- a/node_modules/libnpmexec/README.md
+++ b/node_modules/libnpmexec/README.md
@@ -39,7 +39,7 @@ await libexec({
   - `packages`: A list of packages to be used (possibly fetch from the registry) **Array<String>**, defaults to `[]`
   - `path`: Location to where to read local project info (`package.json`) **String**, defaults to `.`
   - `runPath`: Location to where to execute the script **String**, defaults to `.`
-  - `scriptShell`: Default shell to be used **String**
+  - `scriptShell`: Default shell to be used **String**, defaults to `sh` on POSIX systems, `process.env.ComSpec` OR `cmd` on Windows
   - `yes`: Should skip download confirmation prompt when fetching missing packages from the registry? **Boolean**
   - `registry`, `cache`, and more options that are forwarded to [@npmcli/arborist](https://github.com/npm/arborist/) and [pacote](https://github.com/npm/pacote/#options) **Object**
 

--- a/node_modules/libnpmexec/lib/index.js
+++ b/node_modules/libnpmexec/lib/index.js
@@ -16,6 +16,7 @@ const getBinFromManifest = require('./get-bin-from-manifest.js')
 const manifestMissing = require('./manifest-missing.js')
 const noTTY = require('./no-tty.js')
 const runScript = require('./run-script.js')
+const isWindows = require('./is-windows.js')
 
 /* istanbul ignore next */
 const PATH = (
@@ -34,7 +35,7 @@ const exec = async (opts) => {
     packages: _packages = [],
     path = '.',
     runPath = '.',
-    scriptShell = undefined,
+    scriptShell = isWindows ? process.env.ComSpec || 'cmd' : 'sh',
     yes = undefined,
     ...flatOptions
   } = opts

--- a/node_modules/libnpmexec/lib/is-windows.js
+++ b/node_modules/libnpmexec/lib/is-windows.js
@@ -1,0 +1,1 @@
+module.exports = process.platform === 'win32'

--- a/node_modules/libnpmexec/package.json
+++ b/node_modules/libnpmexec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libnpmexec",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "files": [
     "lib"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,7 +103,7 @@
         "leven": "^3.1.0",
         "libnpmaccess": "^4.0.2",
         "libnpmdiff": "^2.0.4",
-        "libnpmexec": "^1.1.1",
+        "libnpmexec": "^1.2.0",
         "libnpmfund": "^1.1.0",
         "libnpmhook": "^6.0.2",
         "libnpmorg": "^2.0.2",
@@ -4650,9 +4650,9 @@
       }
     },
     "node_modules/libnpmexec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/libnpmexec/-/libnpmexec-1.1.1.tgz",
-      "integrity": "sha512-uw6H2dzC6F6fdq7lAxfzXPimHCJ3/g6ycFKcv2Q2QXuNZ94EDmNPpMO6f4mwiC5F6Lyy/WK0IL7AZwRhmSvUdQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/libnpmexec/-/libnpmexec-1.2.0.tgz",
+      "integrity": "sha512-LkxnH2wsMUI4thsgUK0r+EFZ5iCjKlp21J68dFY7AzD5uaaIPqO3lqVvYbyl1Umz1R4rY9t3vFa1fF3hzo6Y2Q==",
       "inBundle": true,
       "dependencies": {
         "@npmcli/arborist": "^2.3.0",
@@ -13690,9 +13690,9 @@
       }
     },
     "libnpmexec": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/libnpmexec/-/libnpmexec-1.1.1.tgz",
-      "integrity": "sha512-uw6H2dzC6F6fdq7lAxfzXPimHCJ3/g6ycFKcv2Q2QXuNZ94EDmNPpMO6f4mwiC5F6Lyy/WK0IL7AZwRhmSvUdQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/libnpmexec/-/libnpmexec-1.2.0.tgz",
+      "integrity": "sha512-LkxnH2wsMUI4thsgUK0r+EFZ5iCjKlp21J68dFY7AzD5uaaIPqO3lqVvYbyl1Umz1R4rY9t3vFa1fF3hzo6Y2Q==",
       "requires": {
         "@npmcli/arborist": "^2.3.0",
         "@npmcli/ci-detect": "^1.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -154,7 +154,7 @@
         "@mdx-js/mdx": "^1.6.22",
         "cmark-gfm": "^0.8.5",
         "eslint": "^7.26.0",
-        "eslint-plugin-import": "^2.22.1",
+        "eslint-plugin-import": "^2.23.4",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^5.1.0",
         "eslint-plugin-standard": "^5.0.0",
@@ -2611,9 +2611,9 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.23.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.3.tgz",
-      "integrity": "sha512-wDxdYbSB55F7T5CC7ucDjY641VvKmlRwT0Vxh7PkY1mI4rclVRFWYfsrjDgZvwYYDZ5ee0ZtfFKXowWjqvEoRQ==",
+      "version": "2.23.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.4.tgz",
+      "integrity": "sha512-6/wP8zZRsnQFiR3iaPFgh5ImVRM1WN5NUWfTIRqwOdeiGJlBcSk82o1FEVq8yXmy4lkIzTo7YhHCIxlU/2HyEQ==",
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.3",
@@ -12286,9 +12286,9 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.23.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.3.tgz",
-      "integrity": "sha512-wDxdYbSB55F7T5CC7ucDjY641VvKmlRwT0Vxh7PkY1mI4rclVRFWYfsrjDgZvwYYDZ5ee0ZtfFKXowWjqvEoRQ==",
+      "version": "2.23.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.4.tgz",
+      "integrity": "sha512-6/wP8zZRsnQFiR3iaPFgh5ImVRM1WN5NUWfTIRqwOdeiGJlBcSk82o1FEVq8yXmy4lkIzTo7YhHCIxlU/2HyEQ==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm",
-  "version": "7.15.0",
+  "version": "7.15.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "npm",
-      "version": "7.15.0",
+      "version": "7.15.1",
       "bundleDependencies": [
         "@npmcli/arborist",
         "@npmcli/ci-detect",

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,7 @@
       ],
       "license": "Artistic-2.0",
       "dependencies": {
-        "@npmcli/arborist": "^2.6.0",
+        "@npmcli/arborist": "^2.6.1",
         "@npmcli/ci-detect": "^1.2.0",
         "@npmcli/config": "^2.2.0",
         "@npmcli/run-script": "^1.8.5",
@@ -712,9 +712,9 @@
       }
     },
     "node_modules/@npmcli/arborist": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-2.6.0.tgz",
-      "integrity": "sha512-6njRVuPMgGRvQUmsXwGdp1ItZtJuSdt5ouoQe4AeFTTZoMufKWLeXFDOlWj7qbMAzqw+guNEAZwBiwm04J7T2g==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-2.6.1.tgz",
+      "integrity": "sha512-OOlntFIOAo7RplEQaYXlA5U5NXE+EwZtnTCsit4Wtme5+llGiea6GBytuV8dOzdPMPlNx3fQQjBUE9E8k76yjQ==",
       "inBundle": true,
       "dependencies": {
         "@npmcli/installed-package-contents": "^1.0.7",
@@ -10811,9 +10811,9 @@
       "dev": true
     },
     "@npmcli/arborist": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-2.6.0.tgz",
-      "integrity": "sha512-6njRVuPMgGRvQUmsXwGdp1ItZtJuSdt5ouoQe4AeFTTZoMufKWLeXFDOlWj7qbMAzqw+guNEAZwBiwm04J7T2g==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-2.6.1.tgz",
+      "integrity": "sha512-OOlntFIOAo7RplEQaYXlA5U5NXE+EwZtnTCsit4Wtme5+llGiea6GBytuV8dOzdPMPlNx3fQQjBUE9E8k76yjQ==",
       "requires": {
         "@npmcli/installed-package-contents": "^1.0.7",
         "@npmcli/map-workspaces": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
     "@mdx-js/mdx": "^1.6.22",
     "cmark-gfm": "^0.8.5",
     "eslint": "^7.26.0",
-    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-import": "^2.23.4",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-standard": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@npmcli/arborist": "^2.6.0",
+    "@npmcli/arborist": "^2.6.1",
     "@npmcli/ci-detect": "^1.2.0",
     "@npmcli/config": "^2.2.0",
     "@npmcli/run-script": "^1.8.5",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "leven": "^3.1.0",
     "libnpmaccess": "^4.0.2",
     "libnpmdiff": "^2.0.4",
-    "libnpmexec": "^1.1.1",
+    "libnpmexec": "^1.2.0",
     "libnpmfund": "^1.1.0",
     "libnpmhook": "^6.0.2",
     "libnpmorg": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.15.0",
+  "version": "7.15.1",
   "name": "npm",
   "description": "a package manager for JavaScript",
   "keywords": [

--- a/smoke-tests/server.js
+++ b/smoke-tests/server.js
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 const {join, dirname} = require('path')
 const {existsSync, readFileSync, writeFileSync} = require('fs')
 const PORT = 12345 + (+process.env.TAP_CHILD_ID || 0)

--- a/tap-snapshots/test/lib/dist-tag.js.test.cjs
+++ b/tap-snapshots/test/lib/dist-tag.js.test.cjs
@@ -6,7 +6,8 @@
  */
 'use strict'
 exports[`test/lib/dist-tag.js TAP add missing args > should exit usage error message 1`] = `
-npm dist-tag
+Error: 
+Usage: npm dist-tag
 
 Modify package distribution tags
 
@@ -21,11 +22,14 @@ Options:
 
 alias: dist-tags
 
-Run "npm help dist-tag" for more info
+Run "npm help dist-tag" for more info {
+  "code": "EUSAGE",
+}
 `
 
 exports[`test/lib/dist-tag.js TAP add missing pkg name > should exit usage error message 1`] = `
-npm dist-tag
+Error: 
+Usage: npm dist-tag
 
 Modify package distribution tags
 
@@ -40,7 +44,9 @@ Options:
 
 alias: dist-tags
 
-Run "npm help dist-tag" for more info
+Run "npm help dist-tag" for more info {
+  "code": "EUSAGE",
+}
 `
 
 exports[`test/lib/dist-tag.js TAP add new tag > should return success msg 1`] = `
@@ -53,7 +59,8 @@ dist-tag add 1.0.0 to @scoped/another@7.7.7
 `
 
 exports[`test/lib/dist-tag.js TAP borked cmd usage > should show usage error 1`] = `
-npm dist-tag
+Error: 
+Usage: npm dist-tag
 
 Modify package distribution tags
 
@@ -68,7 +75,31 @@ Options:
 
 alias: dist-tags
 
-Run "npm help dist-tag" for more info
+Run "npm help dist-tag" for more info {
+  "code": "EUSAGE",
+}
+`
+
+exports[`test/lib/dist-tag.js TAP ls global > should throw basic usage 1`] = `
+Error: 
+Usage: npm dist-tag
+
+Modify package distribution tags
+
+Usage:
+npm dist-tag add <pkg>@<version> [<tag>]
+npm dist-tag rm <pkg> <tag>
+npm dist-tag ls [<pkg>]
+
+Options:
+[-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
+[-ws|--workspaces]
+
+alias: dist-tags
+
+Run "npm help dist-tag" for more info {
+  "code": "EUSAGE",
+}
 `
 
 exports[`test/lib/dist-tag.js TAP ls in current package > should list available tags for current package 1`] = `
@@ -78,7 +109,8 @@ latest: 1.0.0
 `
 
 exports[`test/lib/dist-tag.js TAP ls on missing name in current package > should throw usage error message 1`] = `
-npm dist-tag
+Error: 
+Usage: npm dist-tag
 
 Modify package distribution tags
 
@@ -93,7 +125,9 @@ Options:
 
 alias: dist-tags
 
-Run "npm help dist-tag" for more info
+Run "npm help dist-tag" for more info {
+  "code": "EUSAGE",
+}
 `
 
 exports[`test/lib/dist-tag.js TAP ls on missing package > should log no dist-tag found msg 1`] = `
@@ -133,7 +167,8 @@ exports[`test/lib/dist-tag.js TAP remove existing tag > should return success ms
 `
 
 exports[`test/lib/dist-tag.js TAP remove missing pkg name > should exit usage error message 1`] = `
-npm dist-tag
+Error: 
+Usage: npm dist-tag
 
 Modify package distribution tags
 
@@ -148,7 +183,9 @@ Options:
 
 alias: dist-tags
 
-Run "npm help dist-tag" for more info
+Run "npm help dist-tag" for more info {
+  "code": "EUSAGE",
+}
 `
 
 exports[`test/lib/dist-tag.js TAP remove non-existing tag > should log error msg 1`] = `

--- a/tap-snapshots/test/lib/init.js.test.cjs
+++ b/tap-snapshots/test/lib/init.js.test.cjs
@@ -6,13 +6,28 @@
  */
 'use strict'
 exports[`test/lib/init.js TAP workspaces no args > should print helper info 1`] = `
-
+Array [
+  Array [
+    String(
+      This utility will walk you through creating a package.json file.
+      It only covers the most common items, and tries to guess sensible defaults.
+      
+      See \`npm help init\` for definitive documentation on these fields
+      and exactly what they do.
+      
+      Use \`npm install <pkg>\` afterwards to install a package and
+      save it as a dependency in the package.json file.
+      
+      Press ^C at any time to quit.
+    ),
+  ],
+]
 `
 
 exports[`test/lib/init.js TAP workspaces no args, existing folder > should print helper info 1`] = `
-
+Array []
 `
 
 exports[`test/lib/init.js TAP workspaces with arg but missing workspace folder > should print helper info 1`] = `
-
+Array []
 `

--- a/test/fixtures/mock-npm.js
+++ b/test/fixtures/mock-npm.js
@@ -4,35 +4,54 @@
 
 const realConfig = require('../../lib/utils/config')
 
-const mockLog = {
-  clearProgress: () => {},
-  disableProgress: () => {},
-  enableProgress: () => {},
-  http: () => {},
-  info: () => {},
-  levels: [],
-  notice: () => {},
-  pause: () => {},
-  silly: () => {},
-  verbose: () => {},
-  warn: () => {},
-}
-const mockNpm = (base = {}) => {
-  const config = base.config || {}
-  const flatOptions = base.flatOptions || {}
-  return {
-    log: mockLog,
-    ...base,
-    flatOptions,
-    config: {
+class MockNpm {
+  constructor (base = {}) {
+    this._mockOutputs = []
+    this.isMockNpm = true
+    this.base = base
+
+    const config = base.config || {}
+
+    for (const attr in base) {
+      if (attr !== 'config') {
+        this[attr] = base[attr]
+      }
+    }
+
+    this.flatOptions = base.flatOptions || {}
+    this.config = {
       // for now just set `find` to what config.find should return
       // this works cause `find` is not an existing config entry
       find: (k) => ({...realConfig.defaults, ...config})[k],
       get: (k) => ({...realConfig.defaults, ...config})[k],
       set: (k, v) => config[k] = v,
       list: [{ ...realConfig.defaults, ...config}]
-    },
+    }
+    if (!this.log) {
+      this.log = {
+        clearProgress: () => {},
+        disableProgress: () => {},
+        enableProgress: () => {},
+        http: () => {},
+        info: () => {},
+        levels: [],
+        notice: () => {},
+        pause: () => {},
+        silly: () => {},
+        verbose: () => {},
+        warn: () => {},
+      }
+    }
+  }
+
+  output(...msg) {
+    if (this.base.output)
+      return this.base.output(msg)
+    this._mockOutputs.push(msg)
   }
 }
 
-module.exports = mockNpm
+// TODO export MockNpm, and change tests to use new MockNpm()
+module.exports = (base = {}) => {
+  return new MockNpm(base)
+}

--- a/test/lib/dist-tag.js
+++ b/test/lib/dist-tag.js
@@ -93,6 +93,20 @@ t.test('ls in current package', (t) => {
   })
 })
 
+t.test('ls global', (t) => {
+  t.teardown(() => {
+    config.global = false
+  })
+  config.global = true
+  distTag.exec(['ls'], (err) => {
+    t.matchSnapshot(
+      err,
+      'should throw basic usage'
+    )
+    t.end()
+  })
+})
+
 t.test('no args in current package', (t) => {
   npm.prefix = t.testdir({
     'package.json': JSON.stringify({

--- a/test/lib/exec.js
+++ b/test/lib/exec.js
@@ -307,7 +307,7 @@ t.test('npm exec <noargs>, run interactive shell', t => {
         throw er
 
       t.match(RUN_SCRIPTS, [{
-        pkg: { scripts: { npx: undefined } },
+        pkg: { scripts: { npx: /sh|cmd/ } },
       }])
 
       LOG_WARN.length = 0

--- a/test/lib/exec.js
+++ b/test/lib/exec.js
@@ -1,8 +1,6 @@
 const t = require('tap')
 const mockNpm = require('../fixtures/mock-npm')
 const { resolve, delimiter } = require('path')
-const OUTPUT = []
-const output = (...msg) => OUTPUT.push(msg)
 
 const ARB_CTOR = []
 const ARB_ACTUAL_TREE = {}
@@ -36,6 +34,7 @@ const config = {
   package: [],
   'script-shell': 'shell-cmd',
 }
+
 const npm = mockNpm({
   flatOptions,
   config,
@@ -53,7 +52,6 @@ const npm = mockNpm({
       LOG_WARN.push(args)
     },
   },
-  output,
 })
 
 const RUN_SCRIPTS = []
@@ -225,7 +223,7 @@ t.test('npm exec <noargs>, run interactive shell', t => {
     ARB_CTOR.length = 0
     MKDIRPS.length = 0
     ARB_REIFY.length = 0
-    OUTPUT.length = 0
+    npm._mockOutputs.length = 0
     exec.exec([], er => {
       if (er)
         throw er
@@ -256,7 +254,7 @@ t.test('npm exec <noargs>, run interactive shell', t => {
     process.stdin.isTTY = true
     run(t, true, () => {
       t.strictSame(LOG_WARN, [])
-      t.strictSame(OUTPUT, [
+      t.strictSame(npm._mockOutputs, [
         [`\nEntering npm script environment at location:\n${process.cwd()}\nType 'exit' or ^D when finished\n`],
       ], 'printed message about interactive shell')
       t.end()
@@ -270,7 +268,7 @@ t.test('npm exec <noargs>, run interactive shell', t => {
 
     run(t, true, () => {
       t.strictSame(LOG_WARN, [])
-      t.strictSame(OUTPUT, [
+      t.strictSame(npm._mockOutputs, [
         [`\u001b[0m\u001b[0m\n\u001b[0mEntering npm script environment\u001b[0m\u001b[0m at location:\u001b[0m\n\u001b[0m\u001b[2m${process.cwd()}\u001b[22m\u001b[0m\u001b[1m\u001b[22m\n\u001b[1mType 'exit' or ^D when finished\u001b[22m\n\u001b[1m\u001b[22m`],
       ], 'printed message about interactive shell')
       t.end()
@@ -282,7 +280,7 @@ t.test('npm exec <noargs>, run interactive shell', t => {
     process.stdin.isTTY = false
     run(t, true, () => {
       t.strictSame(LOG_WARN, [])
-      t.strictSame(OUTPUT, [], 'no message about interactive shell')
+      t.strictSame(npm._mockOutputs, [], 'no message about interactive shell')
       t.end()
     })
   })
@@ -294,7 +292,7 @@ t.test('npm exec <noargs>, run interactive shell', t => {
       t.strictSame(LOG_WARN, [
         ['exec', 'Interactive mode disabled in CI environment'],
       ])
-      t.strictSame(OUTPUT, [], 'no message about interactive shell')
+      t.strictSame(npm._mockOutputs, [], 'no message about interactive shell')
       t.end()
     })
   })
@@ -316,7 +314,7 @@ t.test('npm exec <noargs>, run interactive shell', t => {
       ARB_CTOR.length = 0
       MKDIRPS.length = 0
       ARB_REIFY.length = 0
-      OUTPUT.length = 0
+      npm._mockOutputs.length = 0
       RUN_SCRIPTS.length = 0
       t.end()
     })
@@ -1195,7 +1193,7 @@ t.test('workspaces', t => {
           return rej(er)
 
         t.strictSame(LOG_WARN, [])
-        t.strictSame(OUTPUT, [
+        t.strictSame(npm._mockOutputs, [
           [`\nEntering npm script environment in workspace a@1.0.0 at location:\n${resolve(npm.localPrefix, 'packages/a')}\nType 'exit' or ^D when finished\n`],
         ], 'printed message about interactive shell')
         res()
@@ -1203,14 +1201,14 @@ t.test('workspaces', t => {
     })
 
     config.color = true
-    OUTPUT.length = 0
+    npm._mockOutputs.length = 0
     await new Promise((res, rej) => {
       exec.execWorkspaces([], ['a'], er => {
         if (er)
           return rej(er)
 
         t.strictSame(LOG_WARN, [])
-        t.strictSame(OUTPUT, [
+        t.strictSame(npm._mockOutputs, [
           [`\u001b[0m\u001b[0m\n\u001b[0mEntering npm script environment\u001b[0m\u001b[0m in workspace \u001b[32ma@1.0.0\u001b[39m at location:\u001b[0m\n\u001b[0m\u001b[2m${resolve(npm.localPrefix, 'packages/a')}\u001b[22m\u001b[0m\u001b[1m\u001b[22m\n\u001b[1mType 'exit' or ^D when finished\u001b[22m\n\u001b[1m\u001b[22m`],
         ], 'printed message about interactive shell')
         res()

--- a/test/lib/init.js
+++ b/test/lib/init.js
@@ -3,7 +3,6 @@ const { resolve } = require('path')
 const t = require('tap')
 const mockNpm = require('../fixtures/mock-npm')
 
-let result = ''
 const npmLog = {
   disableProgress: () => null,
   enableProgress: () => null,
@@ -19,9 +18,6 @@ const config = {
 const npm = mockNpm({
   config,
   log: npmLog,
-  output: (...msg) => {
-    result += msg.join('\n')
-  },
 })
 const mocks = {
   '../../lib/utils/usage.js': () => 'usage instructions',
@@ -33,7 +29,6 @@ const _consolelog = console.log
 const noop = () => {}
 
 t.afterEach(() => {
-  result = ''
   config.yes = true
   config.package = undefined
   npm.log = npmLog
@@ -322,6 +317,9 @@ t.test('npm init error', t => {
 
 t.test('workspaces', t => {
   t.test('no args', t => {
+    t.teardown(() => {
+      npm._mockOutputs.length = 0
+    })
     npm.localPrefix = t.testdir({
       'package.json': JSON.stringify({
         name: 'top-level',
@@ -340,12 +338,15 @@ t.test('workspaces', t => {
       if (err)
         throw err
 
-      t.matchSnapshot(result, 'should print helper info')
+      t.matchSnapshot(npm._mockOutputs, 'should print helper info')
       t.end()
     })
   })
 
   t.test('no args, existing folder', t => {
+    t.teardown(() => {
+      npm._mockOutputs.length = 0
+    })
     // init-package-json prints directly to console.log
     // this avoids poluting test output with those logs
     console.log = noop
@@ -369,12 +370,15 @@ t.test('workspaces', t => {
       if (err)
         throw err
 
-      t.matchSnapshot(result, 'should print helper info')
+      t.matchSnapshot(npm._mockOutputs, 'should print helper info')
       t.end()
     })
   })
 
   t.test('with arg but missing workspace folder', t => {
+    t.teardown(() => {
+      npm._mockOutputs.length = 0
+    })
     // init-package-json prints directly to console.log
     // this avoids poluting test output with those logs
     console.log = noop
@@ -401,7 +405,7 @@ t.test('workspaces', t => {
       if (err)
         throw err
 
-      t.matchSnapshot(result, 'should print helper info')
+      t.matchSnapshot(npm._mockOutputs, 'should print helper info')
       t.end()
     })
   })

--- a/test/lib/utils/read-package-name.js
+++ b/test/lib/utils/read-package-name.js
@@ -1,13 +1,8 @@
 const t = require('tap')
 const mockNpm = require('../../fixtures/mock-npm')
+const npm = mockNpm()
 
-const config = {
-  json: false,
-  global: false,
-}
-const npm = mockNpm({ config })
-
-const readLocalPackageName = require('../../../lib/utils/read-local-package.js')
+const readPackageName = require('../../../lib/utils/read-package-name.js')
 
 t.test('read local package.json', async (t) => {
   npm.prefix = t.testdir({
@@ -16,7 +11,7 @@ t.test('read local package.json', async (t) => {
       version: '1.0.0',
     }),
   })
-  const packageName = await readLocalPackageName(npm)
+  const packageName = await readPackageName(npm.prefix)
   t.equal(
     packageName,
     'my-local-package',
@@ -31,22 +26,10 @@ t.test('read local scoped-package.json', async (t) => {
       version: '1.0.0',
     }),
   })
-  const packageName = await readLocalPackageName(npm)
+  const packageName = await readPackageName(npm.prefix)
   t.equal(
     packageName,
     '@my-scope/my-local-package',
     'should retrieve scoped package name'
   )
-})
-
-t.test('read using --global', async (t) => {
-  npm.prefix = t.testdir({})
-  config.global = true
-  const packageName = await readLocalPackageName(npm)
-  t.equal(
-    packageName,
-    undefined,
-    'should not retrieve a package name'
-  )
-  config.global = false
 })


### PR DESCRIPTION
## v7.15.1 (2021-05-31)

### BUG FIXES

* [`2fb189c08`](https://github.com/npm/cli/commit/2fb189c086d903d6a76abad4dc817d81e4d0b29f) [#3329](https://github.com/npm/cli/issues/3329) fix(libnpmexec): don't detach output from npm ([@wraithgar](https://github.com/wraithgar))

### DEPENDENCIES

* [`1290ea31c`](https://github.com/npm/cli/commit/1290ea31cb437ce8fd3a4bb212c55c0067262e49) `@npmcli/arborist@2.6.1`
    * fixes reifying deps with mismatching version ranges between actual and virtual trees
* [`e06f16761`](https://github.com/npm/cli/commit/e06f1676157f1b7aa0d2d22cb17cd91c1af55800) `libnpmexec@1.2.0`
