### PR TITLE
fix: update incorrect variable name

### DIFF
--- a/.github/workflows/create-cli-deps-pr.yml
+++ b/.github/workflows/create-cli-deps-pr.yml
@@ -77,4 +77,4 @@ jobs:
           git push origin "npm-$npm_tag"
           gh_release_body=`gh release view v"$npm_tag" -R npm/cli --json body | jq -r '.body'`
 
-          gh pr create -R "nodejs/node" -B "$base_branch" -H "npm:npm-$npm_tag" --title "deps: upgrade npm to $npm_tag" --body "$json_body"
+          gh pr create -R "nodejs/node" -B "$base_branch" -H "npm:npm-$npm_tag" --title "deps: upgrade npm to $npm_tag" --body "$gh_release_body"


### PR DESCRIPTION
- Updates `$json_body` to `$gh_release_body`

This fixes an issue where the workflow was not sending the body of the release due to an incorrect variable name.
