### PR TITLE
refactor: prefer native fs.promises

### DIFF
--- a/lib/ci.js
+++ b/lib/ci.js
@@ -4,7 +4,7 @@ const rimraf = util.promisify(require('rimraf'))
 const reifyFinish = require('./utils/reify-finish.js')
 const runScript = require('@npmcli/run-script')
 const fs = require('fs')
-const readdir = util.promisify(fs.readdir)
+const readdir = fs.promises.readdir || util.promisify(fs.readdir)
 
 const log = require('npmlog')
 

--- a/lib/install.js
+++ b/lib/install.js
@@ -2,7 +2,7 @@
 /* eslint-disable standard/no-callback-literal */
 const fs = require('fs')
 const util = require('util')
-const readdir = util.promisify(fs.readdir)
+const readdir = fs.promises.readdir || util.promisify(fs.readdir)
 const reifyFinish = require('./utils/reify-finish.js')
 const log = require('npmlog')
 const { resolve, join } = require('path')

--- a/lib/link.js
+++ b/lib/link.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const util = require('util')
-const readdir = util.promisify(fs.readdir)
+const readdir = fs.promises.readdir || util.promisify(fs.readdir)
 const { resolve } = require('path')
 
 const Arborist = require('@npmcli/arborist')

--- a/lib/pack.js
+++ b/lib/pack.js
@@ -7,7 +7,8 @@ const getWorkspaces = require('./workspaces/get-workspaces.js')
 
 const { getContents, logTar } = require('./utils/tar.js')
 
-const writeFile = util.promisify(require('fs').writeFile)
+const fs = require('fs')
+const writeFile = fs.promises.writeFile || util.promisify(fs.writeFile)
 
 const BaseCommand = require('./base-command.js')
 

--- a/lib/utils/file-exists.js
+++ b/lib/utils/file-exists.js
@@ -1,7 +1,7 @@
 const fs = require('fs')
 const util = require('util')
 
-const stat = util.promisify(fs.stat)
+const stat = fs.promises.stat || util.promisify(fs.stat)
 
 const fileExists = (file) => stat(file)
   .then((stat) => stat.isFile())

--- a/test/lib/install.js
+++ b/test/lib/install.js
@@ -139,6 +139,14 @@ t.test('completion to folder', async t => {
         else
           return ['package.json']
       },
+      promises: {
+        readdir: (path) => {
+          if (path === '/')
+            return ['arborist']
+          else
+            return ['package.json']
+        },
+      },
     },
   })
   const install = new Install({})


### PR DESCRIPTION
Prefer native built-in `fs.promises`, then fallback to `util.promisfy`.

## References

See also #2654 