### PR TITLE
fix(docs): link foreground-scripts w/ loglevel

### DIFF
--- a/docs/content/using-npm/config.md
+++ b/docs/content/using-npm/config.md
@@ -776,6 +776,8 @@ What level of logs to report. On failure, *all* logs are written to
 Any logs of a higher level than the setting are shown. The default is
 "notice".
 
+See also the `foreground-scripts` config.
+
 #### `logs-max`
 
 * Default: 10

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -1128,6 +1128,8 @@ define('loglevel', {
 
     Any logs of a higher level than the setting are shown. The default is
     "notice".
+
+    See also the \`foreground-scripts\` config.
   `,
 })
 

--- a/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
@@ -655,6 +655,8 @@ What level of logs to report. On failure, *all* logs are written to
 Any logs of a higher level than the setting are shown. The default is
 "notice".
 
+See also the \`foreground-scripts\` config.
+
 #### \`logs-max\`
 
 * Default: 10


### PR DESCRIPTION
Since loglevel is the first place people usually look to find out why
their scripts have no output when they are in the background, this will
help point them to the config that addresses that situation.


## References
Related to https://github.com/npm/cli/issues/3347