### PR TITLE
fix: update from upstream

### DIFF
--- a/.github/workflows/create-cli-deps-pr.yml
+++ b/.github/workflows/create-cli-deps-pr.yml
@@ -30,10 +30,15 @@ jobs:
           ref: master
           repository: "npm/node"
           token: ${{ secrets.NPM_ROBOT_USER_PAT }}
-      - name: Fetch upstream
-        run: |
-          git remote add upstream git@github.com:npm/node.git
-          git pull upstream master --rebase
+      - name: Pull (Fast-Forward) upstream
+        id: sync
+        uses: aormsby/Fork-Sync-With-Upstream-action@v2.1
+        with:
+          upstream_repository: nodejs/node
+          upstream_branch: master
+          target_branch: master
+          git_pull_args: --rebase
+          github_token: ${{ secrets.NPM_ROBOT_USER_PAT }}   # optional, for accessing repos that require authentication
       - name: Run dependency updates and create PR
         run: |
           npm_tag=""

--- a/.github/workflows/create-cli-deps-pr.yml
+++ b/.github/workflows/create-cli-deps-pr.yml
@@ -32,7 +32,7 @@ jobs:
           token: ${{ secrets.NPM_ROBOT_USER_PAT }}
       - name: Fetch upstream
         run: |
-          git remote add upstream git@github.com:nodejs/node.git
+          git remote add upstream git@github.com:npm/node.git
           git pull upstream master --rebase
       - name: Run dependency updates and create PR
         run: |

--- a/.github/workflows/create-cli-deps-pr.yml
+++ b/.github/workflows/create-cli-deps-pr.yml
@@ -37,7 +37,7 @@ jobs:
           upstream_repository: nodejs/node
           upstream_branch: master
           target_branch: master
-          git_pull_args: --rebase
+          git_pull_args: --ff-only                    # optional arg use, defaults to simple 'pull'
           github_token: ${{ secrets.NPM_ROBOT_USER_PAT }}   # optional, for accessing repos that require authentication
       - name: Run dependency updates and create PR
         run: |

--- a/.github/workflows/create-cli-deps-pr.yml
+++ b/.github/workflows/create-cli-deps-pr.yml
@@ -81,4 +81,4 @@ jobs:
           git push origin "npm-$npm_tag"
           gh_release_body=`gh release view v"$npm_tag" -R npm/cli --json body | jq -r '.body'`
 
-          gh pr create -R "nodejs/node" -B "$base_branch" -H "npm:npm-$npm_tag" --title "deps: upgrade npm to $npm_tag" --body "$gh_release_body"
+          gh pr create -R "gimli01/node" -B "$base_branch" -H "npm:npm-$npm_tag" --title "deps: upgrade npm to $npm_tag" --body "$gh_release_body"

--- a/.github/workflows/create-cli-deps-pr.yml
+++ b/.github/workflows/create-cli-deps-pr.yml
@@ -30,6 +30,10 @@ jobs:
           ref: master
           repository: "npm/node"
           token: ${{ secrets.NPM_ROBOT_USER_PAT }}
+      - name: Fetch upstream
+        run: |
+          git remote add upstream git@github.com:nodejs/node.git
+          git pull upstream master --rebase
       - name: Run dependency updates and create PR
         run: |
           npm_tag=""

--- a/.github/workflows/create-cli-deps-pr.yml
+++ b/.github/workflows/create-cli-deps-pr.yml
@@ -86,4 +86,4 @@ jobs:
           git push origin "npm-$npm_tag"
           gh_release_body=`gh release view v"$npm_tag" -R npm/cli --json body | jq -r '.body'`
 
-          gh pr create -R "gimli01/node" -B "$base_branch" -H "npm:npm-$npm_tag" --title "deps: upgrade npm to $npm_tag" --body "$gh_release_body"
+          gh pr create -R "nodejs/node" -B "$base_branch" -H "npm:npm-$npm_tag" --title "deps: upgrade npm to $npm_tag" --body "$gh_release_body"


### PR DESCRIPTION
We need to pull from our upstream's `master` branch in order to remove the manual step required in syncing `master` before we run the automation workflow.

- Adds step that runs GH action which syncs from `nodejs/node:master` 

![image](https://user-images.githubusercontent.com/17421466/120710814-764d6980-c473-11eb-9eaa-ebd82e4c959f.png)

