### PR TITLE
fix(link): do not prune packages

### DIFF
--- a/lib/link.js
+++ b/lib/link.js
@@ -134,12 +134,14 @@ class Link extends ArboristWorkspaceCmd {
     // reify all the pending names as symlinks there
     const localArb = new Arborist({
       ...this.npm.flatOptions,
+      prune: false,
       log: this.npm.log,
       path: this.npm.prefix,
       save,
     })
     await localArb.reify({
       ...this.npm.flatOptions,
+      prune: false,
       path: this.npm.prefix,
       log: this.npm.log,
       add: names.map(l => `file:${resolve(globalTop, 'node_modules', l)}`),

--- a/test/lib/link.js
+++ b/test/lib/link.js
@@ -1,4 +1,5 @@
 const { resolve } = require('path')
+const fs = require('fs')
 
 const Arborist = require('@npmcli/arborist')
 const t = require('tap')
@@ -483,6 +484,55 @@ t.test('link pkg already in global space when prefix is a symlink', (t) => {
   link.exec(['@myscope/linked'], (err) => {
     t.error(err, 'should not error out')
   })
+})
+
+t.test('should not prune dependencies when linking packages', async t => {
+  const testdir = t.testdir({
+    'global-prefix': {
+      lib: {
+        node_modules: {
+          linked: t.fixture('symlink', '../../../linked'),
+        },
+      },
+    },
+    linked: {
+      'package.json': JSON.stringify({
+        name: 'linked',
+        version: '1.0.0',
+      }),
+    },
+    'my-project': {
+      node_modules: {
+        foo: {
+          'package.json': JSON.stringify({ name: 'foo', version: '1.0.0' }),
+        },
+      },
+      'package.json': JSON.stringify({
+        name: 'my-project',
+        version: '1.0.0',
+      }),
+    },
+  })
+  npm.globalDir = resolve(testdir, 'global-prefix', 'lib', 'node_modules')
+  npm.prefix = resolve(testdir, 'my-project')
+  reifyOutput = () => {}
+
+  const _cwd = process.cwd()
+  process.chdir(npm.prefix)
+
+  await new Promise((res, rej) => {
+    link.exec(['linked'], (err) => {
+      if (err)
+        rej(err)
+      res()
+    })
+  })
+
+  t.ok(
+    fs.statSync(resolve(testdir, 'my-project/node_modules/foo')),
+    'should not prune any extraneous dep when running npm link'
+  )
+  process.chdir(_cwd)
 })
 
 t.test('completion', async t => {


### PR DESCRIPTION
`npm link <pkg>` is meant to be used as a way to link a local package to
an install tree and it's very surprising to users that it may prune
extraneous deps from the project.

This change switches the default behavior to avoid pruning deps when
reifying the dependencies in npm link.

## References
Fixes: https://github.com/npm/cli/issues/2554

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
