### PR TITLE
fix(ls): use virtual tree instead of actual for listing

### DIFF
--- a/lib/ls.js
+++ b/lib/ls.js
@@ -217,7 +217,7 @@ class LS extends ArboristWorkspaceCmd {
   }
 
   async initTree ({ arb, args }) {
-    const tree = await arb.loadActual()
+    const tree = await arb.loadVirtual()
     tree[_include] = args.length === 0
     tree[_depth] = 0
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

It seems that `npm list` is currently using the actual tree, which requires `node_modules` to exist - this in turn means you have to be able to do a successful `npm install` (i.e meeting all requirements such as node version, OS, C libs, etc) which greatly increases the cost of any tooling that involves `npm list`.

~This requirement was not present in npm v6.~ actually it was. 

Additionally this means that `npm list` will include dependencies that are in the lock but not on disk due to them not meeting requirements for install (i.e optional OS-specific dependencies like `fsevents`). This would match the tree I'm guessing `npm audit` checks against, as currently for one of our projects `npm audit` flags `node_modules/fsevents/node_modules/ini`, but doing `npm list ini` does not show any version of `ini` within the vulnerable range; with this change it does show up.

*However*, this could be the complete opposite of what `npm list` is meant to do, so some discussion might be needed 😓 

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

Resolves #3068