### PR TITLE
chore(errorHandler): rename to exit handler

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -19,8 +19,8 @@ module.exports = (process) => {
   checkForUnsupportedNode()
 
   const npm = require('../lib/npm.js')
-  const errorHandler = require('../lib/utils/error-handler.js')
-  errorHandler.setNpm(npm)
+  const exitHandler = require('../lib/utils/exit-handler.js')
+  exitHandler.setNpm(npm)
 
   // if npm is called as "npmg" or "npm_g", then
   // run in global mode.
@@ -32,20 +32,22 @@ module.exports = (process) => {
   log.info('using', 'npm@%s', npm.version)
   log.info('using', 'node@%s', process.version)
 
-  process.on('uncaughtException', errorHandler)
-  process.on('unhandledRejection', errorHandler)
+  process.on('uncaughtException', exitHandler)
+  process.on('unhandledRejection', exitHandler)
+
+  const updateNotifier = require('../lib/utils/update-notifier.js')
 
   // now actually fire up npm and run the command.
   // this is how to use npm programmatically:
-  const updateNotifier = require('../lib/utils/update-notifier.js')
   npm.load(async er => {
+    // Any exceptions here will be picked up by the uncaughtException handler
     if (er)
-      return errorHandler(er)
+      return exitHandler(er)
 
     // npm --version=cli
     if (npm.config.get('version', 'cli')) {
       npm.output(npm.version)
-      return errorHandler.exit(0)
+      return exitHandler()
     }
 
     // npm --versions=cli
@@ -57,22 +59,21 @@ module.exports = (process) => {
     updateNotifier(npm)
 
     const cmd = npm.argv.shift()
-    const impl = npm.commands[cmd]
-    if (impl)
-      impl(npm.argv, errorHandler)
-    else {
-      try {
-        if (cmd) {
-          const didYouMean = require('./utils/did-you-mean.js')
-          const suggestions = await didYouMean(npm, npm.localPrefix, cmd)
-          npm.output(`Unknown command: "${cmd}"${suggestions}\n\nTo see a list of supported npm commands, run:\n  npm help`)
-        } else
-          npm.output(npm.usage)
-        process.exitCode = 1
-        return errorHandler()
-      } catch (err) {
-        errorHandler(err)
-      }
+    if (!cmd) {
+      npm.output(npm.usage)
+      process.exitCode = 1
+      return exitHandler()
     }
+
+    const impl = npm.commands[cmd]
+    if (!impl) {
+      const didYouMean = require('./utils/did-you-mean.js')
+      const suggestions = await didYouMean(npm, npm.localPrefix, cmd)
+      npm.output(`Unknown command: "${cmd}"${suggestions}\n\nTo see a list of supported npm commands, run:\n  npm help`)
+      process.exitCode = 1
+      return exitHandler()
+    }
+
+    impl(npm.argv, exitHandler)
   })
 }

--- a/lib/utils/explain-eresolve.js
+++ b/lib/utils/explain-eresolve.js
@@ -1,4 +1,4 @@
-// this is called when an ERESOLVE error is caught in the error-handler,
+// this is called when an ERESOLVE error is caught in the exit-handler,
 // or when there's a log.warn('eresolve', msg, explanation), to turn it
 // into a human-intelligible explanation of what's wrong and how to fix.
 const { writeFileSync } = require('fs')

--- a/tap-snapshots/test/lib/utils/exit-handler.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/exit-handler.js.test.cjs
@@ -5,14 +5,14 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/lib/utils/error-handler.js TAP handles unknown error > should have expected log contents for unknown error 1`] = `
+exports[`test/lib/utils/exit-handler.js TAP handles unknown error > should have expected log contents for unknown error 1`] = `
 0 verbose code 1
 1 error foo A complete log of this run can be found in:
-1 error foo     {CWD}/test/lib/utils/tap-testdir-error-handler/_logs/expecteddate-debug.log
+1 error foo     {CWD}/test/lib/utils/tap-testdir-exit-handler/_logs/expecteddate-debug.log
 2 verbose stack Error: ERROR
 3 verbose cwd {CWD}
 4 verbose Foo 1.0.0
-5 verbose argv "/node" "{CWD}/test/lib/utils/error-handler.js"
+5 verbose argv "/node" "{CWD}/test/lib/utils/exit-handler.js"
 6 verbose node v1.0.0
 7 verbose npm  v1.0.0
 8 error foo code ERROR

--- a/test/lib/explore.js
+++ b/test/lib/explore.js
@@ -43,15 +43,11 @@ const mockRunScript = ({ pkg, banner, path, event, stdio }) => {
 }
 
 const output = []
-let ERROR_HANDLER_CALLED = null
 const logs = []
 const getExplore = (windows) => {
   const Explore = t.mock('../../lib/explore.js', {
     '../../lib/utils/is-windows.js': windows,
     path: require('path')[windows ? 'win32' : 'posix'],
-    '../../lib/utils/error-handler.js': er => {
-      ERROR_HANDLER_CALLED = er
-    },
     'read-package-json-fast': mockRPJ,
     '@npmcli/run-script': mockRunScript,
   })
@@ -83,11 +79,9 @@ t.test('basic interactive', t => {
       throw er
 
     t.strictSame({
-      ERROR_HANDLER_CALLED,
       RPJ_CALLED,
       RUN_SCRIPT_EXEC,
     }, {
-      ERROR_HANDLER_CALLED: null,
       RPJ_CALLED: 'c:\\npm\\dir\\pkg\\package.json',
       RUN_SCRIPT_EXEC: 'shell-command',
     })
@@ -102,11 +96,9 @@ t.test('basic interactive', t => {
       throw er
 
     t.strictSame({
-      ERROR_HANDLER_CALLED,
       RPJ_CALLED,
       RUN_SCRIPT_EXEC,
     }, {
-      ERROR_HANDLER_CALLED: null,
       RPJ_CALLED: '/npm/dir/pkg/package.json',
       RUN_SCRIPT_EXEC: 'shell-command',
     })
@@ -136,11 +128,9 @@ t.test('interactive tracks exit code', t => {
       throw er
 
     t.strictSame({
-      ERROR_HANDLER_CALLED,
       RPJ_CALLED,
       RUN_SCRIPT_EXEC,
     }, {
-      ERROR_HANDLER_CALLED: null,
       RPJ_CALLED: 'c:\\npm\\dir\\pkg\\package.json',
       RUN_SCRIPT_EXEC: 'shell-command',
     })
@@ -156,11 +146,9 @@ t.test('interactive tracks exit code', t => {
       throw er
 
     t.strictSame({
-      ERROR_HANDLER_CALLED,
       RPJ_CALLED,
       RUN_SCRIPT_EXEC,
     }, {
-      ERROR_HANDLER_CALLED: null,
       RPJ_CALLED: '/npm/dir/pkg/package.json',
       RUN_SCRIPT_EXEC: 'shell-command',
     })
@@ -224,11 +212,9 @@ t.test('basic non-interactive', t => {
       throw er
 
     t.strictSame({
-      ERROR_HANDLER_CALLED,
       RPJ_CALLED,
       RUN_SCRIPT_EXEC,
     }, {
-      ERROR_HANDLER_CALLED: null,
       RPJ_CALLED: 'c:\\npm\\dir\\pkg\\package.json',
       RUN_SCRIPT_EXEC: 'ls',
     })
@@ -241,11 +227,9 @@ t.test('basic non-interactive', t => {
       throw er
 
     t.strictSame({
-      ERROR_HANDLER_CALLED,
       RPJ_CALLED,
       RUN_SCRIPT_EXEC,
     }, {
-      ERROR_HANDLER_CALLED: null,
       RPJ_CALLED: '/npm/dir/pkg/package.json',
       RUN_SCRIPT_EXEC: 'ls',
     })
@@ -310,7 +294,6 @@ t.test('signal fails non-interactive', t => {
 t.test('usage if no pkg provided', t => {
   t.teardown(() => {
     output.length = 0
-    ERROR_HANDLER_CALLED = null
   })
   const noPkg = [
     [],
@@ -326,11 +309,9 @@ t.test('usage if no pkg provided', t => {
       posixExplore.exec(args, er => {
         t.match(er, 'Usage:')
         t.strictSame({
-          ERROR_HANDLER_CALLED: null,
           RPJ_CALLED,
           RUN_SCRIPT_EXEC,
         }, {
-          ERROR_HANDLER_CALLED: null,
           RPJ_CALLED: '/npm/dir/pkg/package.json',
           RUN_SCRIPT_EXEC: 'ls',
         })
@@ -345,11 +326,9 @@ t.test('pkg not installed', t => {
 
   posixExplore.exec(['pkg', 'ls'], er => {
     t.strictSame({
-      ERROR_HANDLER_CALLED,
       RPJ_CALLED,
       RUN_SCRIPT_EXEC,
     }, {
-      ERROR_HANDLER_CALLED: null,
       RPJ_CALLED: '/npm/dir/pkg/package.json',
       RUN_SCRIPT_EXEC: 'ls',
     })

--- a/test/lib/load-all.js
+++ b/test/lib/load-all.js
@@ -22,10 +22,10 @@ else {
     t.end()
   })
 
-  t.test('call the error handle so we dont freak out', t => {
-    const errorHandler = require('../../lib/utils/error-handler.js')
-    errorHandler.setNpm(npm)
-    errorHandler()
+  t.test('call the exit handler so we dont freak out', t => {
+    const exitHandler = require('../../lib/utils/exit-handler.js')
+    exitHandler.setNpm(npm)
+    exitHandler()
     t.end()
   })
 }

--- a/test/lib/utils/exit-handler.js
+++ b/test/lib/utils/exit-handler.js
@@ -121,8 +121,8 @@ const mocks = {
   }),
 }
 
-let errorHandler = t.mock('../../../lib/utils/error-handler.js', mocks)
-errorHandler.setNpm(npm)
+let exitHandler = t.mock('../../../lib/utils/exit-handler.js', mocks)
+exitHandler.setNpm(npm)
 
 t.test('default exit code', (t) => {
   t.plan(1)
@@ -165,7 +165,7 @@ t.test('handles unknown error', (t) => {
   writeFileAtomic.sync = (filename, content) => {
     t.equal(
       redactCwd(filename),
-      '{CWD}/test/lib/utils/tap-testdir-error-handler/_logs/expecteddate-debug.log',
+      '{CWD}/test/lib/utils/tap-testdir-exit-handler/_logs/expecteddate-debug.log',
       'should use expected log filename'
     )
     t.matchSnapshot(
@@ -174,7 +174,7 @@ t.test('handles unknown error', (t) => {
     )
   }
 
-  errorHandler(err)
+  exitHandler(err)
 
   t.teardown(() => {
     writeFileAtomic.sync = sync
@@ -197,7 +197,7 @@ t.test('npm.config not ready', (t) => {
     )
   }
 
-  errorHandler()
+  exitHandler()
 
   t.teardown(() => {
     console.error = _error
@@ -219,7 +219,7 @@ t.test('fail to write logfile', (t) => {
   })
 
   t.doesNotThrow(
-    () => errorHandler(err),
+    () => exitHandler(err),
     'should not throw on cache write failure'
   )
 })
@@ -244,7 +244,7 @@ t.test('console.log output using --json', (t) => {
     )
   }
 
-  errorHandler(new Error('Error: EBADTHING Something happened'))
+  exitHandler(new Error('Error: EBADTHING Something happened'))
 
   t.teardown(() => {
     console.error = _error
@@ -271,7 +271,7 @@ t.test('throw a non-error obj', (t) => {
     t.equal(code, 1, 'should exit with code 1')
   }
 
-  errorHandler(weirdError)
+  exitHandler(weirdError)
 
   t.teardown(() => {
     process.exit = _exit
@@ -295,7 +295,7 @@ t.test('throw a string error', (t) => {
     t.equal(code, 1, 'should exit with code 1')
   }
 
-  errorHandler(error)
+  exitHandler(error)
 
   t.teardown(() => {
     process.exit = _exit
@@ -315,7 +315,7 @@ t.test('update notification', (t) => {
     t.equal(msg, updateMsg, 'should show update message')
   }
 
-  errorHandler(err)
+  exitHandler(err)
 
   t.teardown(() => {
     npmlog.notice = _notice
@@ -355,7 +355,7 @@ t.test('it worked', (t) => {
   const _exit = process.exit
   process.exit = (code) => {
     process.exit = _exit
-    t.equal(code, 0, 'should exit with code 0')
+    t.false(code, 'should exit with no code')
 
     const _info = npmlog.info
     npmlog.info = (msg) => {
@@ -371,14 +371,14 @@ t.test('it worked', (t) => {
     config.values.timing = true
   })
 
-  errorHandler.exit(0)
+  exitHandler()
 })
 
 t.test('uses code from errno', (t) => {
   t.plan(1)
 
-  errorHandler = t.mock('../../../lib/utils/error-handler.js', mocks)
-  errorHandler.setNpm(npm)
+  exitHandler = t.mock('../../../lib/utils/exit-handler.js', mocks)
+  exitHandler.setNpm(npm)
 
   npmlog.level = 'silent'
   const _exit = process.exit
@@ -386,7 +386,7 @@ t.test('uses code from errno', (t) => {
     t.equal(code, 127, 'should use set errno')
   }
 
-  errorHandler(Object.assign(
+  exitHandler(Object.assign(
     new Error('Error with errno'),
     {
       errno: 127,
@@ -402,8 +402,8 @@ t.test('uses code from errno', (t) => {
 t.test('uses exitCode as code if using a number', (t) => {
   t.plan(1)
 
-  errorHandler = t.mock('../../../lib/utils/error-handler.js', mocks)
-  errorHandler.setNpm(npm)
+  exitHandler = t.mock('../../../lib/utils/exit-handler.js', mocks)
+  exitHandler.setNpm(npm)
 
   npmlog.level = 'silent'
   const _exit = process.exit
@@ -411,7 +411,7 @@ t.test('uses exitCode as code if using a number', (t) => {
     t.equal(code, 404, 'should use code if a number')
   }
 
-  errorHandler(Object.assign(
+  exitHandler(Object.assign(
     new Error('Error with code type number'),
     {
       code: 404,
@@ -424,25 +424,25 @@ t.test('uses exitCode as code if using a number', (t) => {
   })
 })
 
-t.test('call errorHandler with no error', (t) => {
+t.test('call exitHandler with no error', (t) => {
   t.plan(1)
 
-  errorHandler = t.mock('../../../lib/utils/error-handler.js', mocks)
-  errorHandler.setNpm(npm)
+  exitHandler = t.mock('../../../lib/utils/exit-handler.js', mocks)
+  exitHandler.setNpm(npm)
 
   const _exit = process.exit
   process.exit = (code) => {
-    t.equal(code, 0, 'should exit with code 0')
+    t.equal(code, undefined, 'should exit with code undefined')
   }
 
   t.teardown(() => {
     process.exit = _exit
   })
 
-  errorHandler()
+  exitHandler()
 })
 
-t.test('callback called twice', (t) => {
+t.test('exit handler called twice', (t) => {
   t.plan(2)
 
   const _verbose = npmlog.verbose
@@ -450,13 +450,13 @@ t.test('callback called twice', (t) => {
     t.equal(key, 'stack', 'should log stack in verbose level')
     t.match(
       value,
-      /Error: Callback called more than once./,
+      /Error: Exit handler called more than once./,
       'should have expected error msg'
     )
     npmlog.verbose = _verbose
   }
 
-  errorHandler()
+  exitHandler()
 })
 
 t.test('defaults to log error msg if stack is missing', (t) => {
@@ -480,35 +480,17 @@ t.test('defaults to log error msg if stack is missing', (t) => {
     t.equal(msg, 'Error with no stack', 'should use error msg')
   }
 
-  errorHandler(noStackErr)
+  exitHandler(noStackErr)
 })
 
-t.test('set it worked', (t) => {
-  t.plan(1)
-
-  errorHandler = t.mock('../../../lib/utils/error-handler.js', mocks)
-  errorHandler.setNpm(npm)
-
-  const _exit = process.exit
-  process.exit = () => {
-    t.ok('ok')
-  }
-
-  t.teardown(() => {
-    process.exit = _exit
-  })
-
-  errorHandler.exit(0, true)
-})
-
-t.test('use exitCode when emitting exit event', (t) => {
+t.test('exits cleanly when emitting exit event', (t) => {
   t.plan(1)
 
   npmlog.level = 'silent'
   const _exit = process.exit
   process.exit = (code) => {
     process.exit = _exit
-    t.equal(code, 1, 'should exit with code 1')
+    t.same(code, null, 'should exit with code null')
   }
 
   t.teardown(() => {
@@ -549,7 +531,7 @@ t.test('do no fancy handling for shellouts', t => {
 
   t.test('shellout with a numeric error code', t => {
     EXPECT_EXIT = 5
-    errorHandler(Object.assign(new Error(), { code: 5 }))
+    exitHandler(Object.assign(new Error(), { code: 5 }))
     t.equal(EXPECT_EXIT, 0, 'called process.exit')
     // should log no warnings or errors, verbose/silly is fine.
     t.strictSame(loudNoises(), [], 'no noisy warnings')
@@ -558,7 +540,7 @@ t.test('do no fancy handling for shellouts', t => {
 
   t.test('shellout without a numeric error code (something in npm)', t => {
     EXPECT_EXIT = 1
-    errorHandler(Object.assign(new Error(), { code: 'banana stand' }))
+    exitHandler(Object.assign(new Error(), { code: 'banana stand' }))
     t.equal(EXPECT_EXIT, 0, 'called process.exit')
     // should log some warnings and errors, because something weird happened
     t.strictNotSame(loudNoises(), [], 'bring the noise')
@@ -567,7 +549,7 @@ t.test('do no fancy handling for shellouts', t => {
 
   t.test('shellout with code=0 (extra weird?)', t => {
     EXPECT_EXIT = 1
-    errorHandler(Object.assign(new Error(), { code: 0 }))
+    exitHandler(Object.assign(new Error(), { code: 0 }))
     t.equal(EXPECT_EXIT, 0, 'called process.exit')
     // should log some warnings and errors, because something weird happened
     t.strictNotSame(loudNoises(), [], 'bring the noise')


### PR DESCRIPTION
Code cleanup here too. No functionality was changed, but tests were tweaked to account for the lessened surface area.

NOTE: this changes our infamous `cb() never called` error to reflect reality a little more closely.