### PR TITLE
fix(workspaces): explicitly error in global mode

### DIFF
--- a/lib/audit.js
+++ b/lib/audit.js
@@ -58,7 +58,7 @@ class Audit extends ArboristWorkspaceCmd {
       audit: true,
       path: this.npm.prefix,
       reporter,
-      workspaces: this.workspaces,
+      workspaces: this.workspaceNames,
     }
 
     const arb = new Arborist(opts)

--- a/lib/base-command.js
+++ b/lib/base-command.js
@@ -1,6 +1,7 @@
 // Base class for npm.commands[cmd]
 const usageUtil = require('./utils/usage.js')
 const ConfigDefinitions = require('./utils/config/definitions.js')
+const getWorkspaces = require('./workspaces/get-workspaces.js')
 
 class BaseCommand {
   constructor (npm) {
@@ -71,6 +72,14 @@ class BaseCommand {
       new Error('This command does not support workspaces.'),
       { code: 'ENOWORKSPACES' }
     )
+  }
+
+  async setWorkspaces (filters) {
+    // TODO npm guards workspaces/global mode so we should use this.npm.prefix?
+    const ws = await getWorkspaces(filters, { path: this.npm.localPrefix })
+    this.workspaces = ws
+    this.workspaceNames = [...ws.keys()]
+    this.workspacePaths = [...ws.values()]
   }
 }
 module.exports = BaseCommand

--- a/lib/ci.js
+++ b/lib/ci.js
@@ -55,7 +55,7 @@ class CI extends ArboristWorkspaceCmd {
       path: where,
       log: this.npm.log,
       save: false, // npm ci should never modify the lockfile or package.json
-      workspaces: this.workspaces,
+      workspaces: this.workspaceNames,
     }
 
     const arb = new Arborist(opts)

--- a/lib/dedupe.js
+++ b/lib/dedupe.js
@@ -50,7 +50,7 @@ class Dedupe extends ArboristWorkspaceCmd {
       log: this.npm.log,
       path: where,
       dryRun,
-      workspaces: this.workspaces,
+      workspaces: this.workspaceNames,
     }
     const arb = new Arborist(opts)
     await arb.dedupe(opts)

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -8,7 +8,6 @@ const npmlog = require('npmlog')
 const pacote = require('pacote')
 const pickManifest = require('npm-pick-manifest')
 
-const getWorkspaces = require('./workspaces/get-workspaces.js')
 const readPackageName = require('./utils/read-package-name.js')
 const BaseCommand = require('./base-command.js')
 
@@ -90,9 +89,8 @@ class Diff extends BaseCommand {
   }
 
   async diffWorkspaces (args, filters) {
-    const workspaces =
-      await getWorkspaces(filters, { path: this.npm.localPrefix })
-    for (const workspacePath of workspaces.values()) {
+    await this.setWorkspaces(filters)
+    for (const workspacePath of this.workspacePaths) {
       this.top = workspacePath
       this.prefix = workspacePath
       await this.diff(args)
@@ -104,7 +102,6 @@ class Diff extends BaseCommand {
   async packageName (path) {
     let name
     try {
-      // TODO this won't work as expected in global mode
       name = await readPackageName(this.prefix)
     } catch (e) {
       npmlog.verbose('diff', 'could not read project dir package.json')

--- a/lib/dist-tag.js
+++ b/lib/dist-tag.js
@@ -5,7 +5,6 @@ const semver = require('semver')
 
 const otplease = require('./utils/otplease.js')
 const readPackageName = require('./utils/read-package-name.js')
-const getWorkspaces = require('./workspaces/get-workspaces.js')
 const BaseCommand = require('./base-command.js')
 
 class DistTag extends BaseCommand {
@@ -180,10 +179,9 @@ class DistTag extends BaseCommand {
   }
 
   async listWorkspaces (filters) {
-    const workspaces =
-      await getWorkspaces(filters, { path: this.npm.localPrefix })
+    await this.setWorkspaces(filters)
 
-    for (const [name] of workspaces) {
+    for (const name of this.workspaceNames) {
       try {
         this.npm.output(`${name}:`)
         await this.list(npa(name), this.npm.flatOptions)

--- a/lib/docs.js
+++ b/lib/docs.js
@@ -2,7 +2,6 @@ const log = require('npmlog')
 const pacote = require('pacote')
 const openUrl = require('./utils/open-url.js')
 const hostedFromMani = require('./utils/hosted-git-info-from-manifest.js')
-const getWorkspaces = require('./workspaces/get-workspaces.js')
 
 const BaseCommand = require('./base-command.js')
 class Docs extends BaseCommand {
@@ -42,9 +41,8 @@ class Docs extends BaseCommand {
   }
 
   async docsWorkspaces (args, filters) {
-    const workspaces =
-      await getWorkspaces(filters, { path: this.npm.localPrefix })
-    return this.docs([...workspaces.values()])
+    await this.setWorkspaces(filters)
+    return this.docs(this.workspacePaths)
   }
 
   async getDocs (pkg) {

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -1,7 +1,6 @@
 const libexec = require('libnpmexec')
 const BaseCommand = require('./base-command.js')
 const getLocationMsg = require('./exec/get-workspace-location-msg.js')
-const getWorkspaces = require('./workspaces/get-workspaces.js')
 
 // it's like this:
 //
@@ -105,16 +104,15 @@ class Exec extends BaseCommand {
   }
 
   async _execWorkspaces (args, filters) {
-    const workspaces =
-      await getWorkspaces(filters, { path: this.npm.localPrefix })
+    await this.setWorkspaces(filters)
     const color = this.npm.config.get('color')
 
-    for (const workspacePath of workspaces.values()) {
-      const locationMsg = await getLocationMsg({ color, path: workspacePath })
+    for (const path of this.workspacePaths) {
+      const locationMsg = await getLocationMsg({ color, path })
       await this._exec(args, {
         locationMsg,
-        path: workspacePath,
-        runPath: workspacePath,
+        path,
+        runPath: path,
       })
     }
   }

--- a/lib/explain.js
+++ b/lib/explain.js
@@ -46,8 +46,8 @@ class Explain extends ArboristWorkspaceCmd {
     const arb = new Arborist({ path: this.npm.prefix, ...this.npm.flatOptions })
     const tree = await arb.loadActual()
 
-    if (this.workspaces && this.workspaces.length)
-      this.filterSet = arb.workspaceDependencySet(tree, this.workspaces)
+    if (this.workspaceNames && this.workspaceNames.length)
+      this.filterSet = arb.workspaceDependencySet(tree, this.workspaceNames)
 
     const nodes = new Set()
     for (const arg of args) {

--- a/lib/fund.js
+++ b/lib/fund.js
@@ -95,7 +95,7 @@ class Fund extends ArboristWorkspaceCmd {
     const fundingInfo = getFundingInfo(tree, {
       ...this.flatOptions,
       log: this.npm.log,
-      workspaces: this.workspaces,
+      workspaces: this.workspaceNames,
     })
 
     if (this.npm.config.get('json'))

--- a/lib/install.js
+++ b/lib/install.js
@@ -144,7 +144,7 @@ class Install extends ArboristWorkspaceCmd {
       auditLevel: null,
       path: where,
       add: args,
-      workspaces: this.workspaces,
+      workspaces: this.workspaceNames,
     }
     const arb = new Arborist(opts)
     await arb.reify(opts)

--- a/lib/link.js
+++ b/lib/link.js
@@ -146,7 +146,7 @@ class Link extends ArboristWorkspaceCmd {
       log: this.npm.log,
       add: names.map(l => `file:${resolve(globalTop, 'node_modules', l)}`),
       save,
-      workspaces: this.workspaces,
+      workspaces: this.workspaceNames,
     })
 
     await reifyFinish(this.npm, localArb)

--- a/lib/ls.js
+++ b/lib/ls.js
@@ -94,8 +94,8 @@ class LS extends ArboristWorkspaceCmd {
     // We only have to filter the first layer of edges, so we don't
     // explore anything that isn't part of the selected workspace set.
     let wsNodes
-    if (this.workspaces && this.workspaces.length)
-      wsNodes = arb.workspaceNodes(tree, this.workspaces)
+    if (this.workspaceNames && this.workspaceNames.length)
+      wsNodes = arb.workspaceNodes(tree, this.workspaceNames)
     const filterBySelectedWorkspaces = edge => {
       if (!wsNodes || !wsNodes.length)
         return true

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -108,6 +108,9 @@ const npm = module.exports = new class extends EventEmitter {
       this.output(impl.usage)
       cb()
     } else if (filterByWorkspaces) {
+      if (this.config.get('global'))
+        return cb(new Error('Workspaces not supported for global packages'))
+
       impl.execWorkspaces(args, this.config.get('workspace'), er => {
         process.emit('timeEnd', `command:${cmd}`)
         cb(er)

--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -59,8 +59,10 @@ class Outdated extends ArboristWorkspaceCmd {
     this.list = []
     this.tree = await arb.loadActual()
 
-    if (this.workspaces && this.workspaces.length)
-      this.filterSet = arb.workspaceDependencySet(this.tree, this.workspaces)
+    if (this.workspaceNames && this.workspaceNames.length) {
+      this.filterSet =
+        arb.workspaceDependencySet(this.tree, this.workspaceNames)
+    }
 
     if (args.length !== 0) {
       // specific deps

--- a/lib/pack.js
+++ b/lib/pack.js
@@ -3,7 +3,6 @@ const log = require('npmlog')
 const pacote = require('pacote')
 const libpack = require('libnpmpack')
 const npa = require('npm-package-arg')
-const getWorkspaces = require('./workspaces/get-workspaces.js')
 
 const { getContents, logTar } = require('./utils/tar.js')
 
@@ -97,9 +96,8 @@ class Pack extends BaseCommand {
       return this.pack(args)
     }
 
-    const workspaces =
-      await getWorkspaces(filters, { path: this.npm.localPrefix })
-    return this.pack([...workspaces.values(), ...args.filter(a => a !== '.')])
+    await this.setWorkspaces(filters)
+    return this.pack([...this.workspacePaths, ...args.filter(a => a !== '.')])
   }
 }
 module.exports = Pack

--- a/lib/prune.js
+++ b/lib/prune.js
@@ -34,7 +34,7 @@ class Prune extends ArboristWorkspaceCmd {
       ...this.npm.flatOptions,
       path: where,
       log: this.npm.log,
-      workspaces: this.workspaces,
+      workspaces: this.workspaceNames,
     }
     const arb = new Arborist(opts)
     await arb.prune(opts)

--- a/lib/rebuild.js
+++ b/lib/rebuild.js
@@ -47,7 +47,7 @@ class Rebuild extends ArboristWorkspaceCmd {
       ...this.npm.flatOptions,
       path: where,
       // TODO when extending ReifyCmd
-      // workspaces: this.workspaces,
+      // workspaces: this.workspaceNames,
     })
 
     if (args.length) {

--- a/lib/repo.js
+++ b/lib/repo.js
@@ -1,6 +1,5 @@
 const log = require('npmlog')
 const pacote = require('pacote')
-const getWorkspaces = require('./workspaces/get-workspaces.js')
 const { URL } = require('url')
 
 const hostedFromMani = require('./utils/hosted-git-info-from-manifest.js')
@@ -44,9 +43,8 @@ class Repo extends BaseCommand {
   }
 
   async repoWorkspaces (args, filters) {
-    const workspaces =
-      await getWorkspaces(filters, { path: this.npm.localPrefix })
-    return this.repo([...workspaces.values()])
+    await this.setWorkspaces(filters)
+    return this.repo(this.workspacePaths)
   }
 
   async get (pkg) {

--- a/lib/uninstall.js
+++ b/lib/uninstall.js
@@ -66,7 +66,7 @@ class Uninstall extends ArboristWorkspaceCmd {
       path,
       log: this.npm.log,
       rm: args,
-      workspaces: this.workspaces,
+      workspaces: this.workspaceNames,
     }
     const arb = new Arborist(opts)
     await arb.reify(opts)

--- a/lib/unpublish.js
+++ b/lib/unpublish.js
@@ -6,7 +6,6 @@ const npmFetch = require('npm-registry-fetch')
 const libunpub = require('libnpmpublish').unpublish
 const readJson = util.promisify(require('read-package-json'))
 
-const getWorkspaces = require('./workspaces/get-workspaces.js')
 const otplease = require('./utils/otplease.js')
 const getIdentity = require('./utils/get-identity.js')
 
@@ -129,8 +128,7 @@ class Unpublish extends BaseCommand {
   }
 
   async unpublishWorkspaces (args, filters) {
-    const workspaces =
-      await getWorkspaces(filters, { path: this.npm.localPrefix })
+    await this.setWorkspaces(filters)
 
     const force = this.npm.config.get('force')
     if (!force) {
@@ -140,7 +138,7 @@ class Unpublish extends BaseCommand {
       )
     }
 
-    for (const [name] of workspaces.entries())
+    for (const name of this.workspaceNames)
       await this.unpublish([name])
   }
 }

--- a/lib/update.js
+++ b/lib/update.js
@@ -66,7 +66,7 @@ class Update extends ArboristWorkspaceCmd {
       ...this.npm.flatOptions,
       log: this.npm.log,
       path: where,
-      workspaces: this.workspaces,
+      workspaces: this.workspaceNames,
     })
 
     await arb.reify({ update })

--- a/lib/workspaces/arborist-cmd.js
+++ b/lib/workspaces/arborist-cmd.js
@@ -3,7 +3,6 @@
 // be able to run a filtered Arborist.reify() at some point.
 
 const BaseCommand = require('../base-command.js')
-const getWorkspaces = require('./get-workspaces.js')
 class ArboristCmd extends BaseCommand {
   /* istanbul ignore next - see test/lib/load-all-commands.js */
   static get params () {
@@ -14,10 +13,8 @@ class ArboristCmd extends BaseCommand {
   }
 
   execWorkspaces (args, filters, cb) {
-    getWorkspaces(filters, { path: this.npm.localPrefix })
-      .then(workspaces => {
-        this.workspaces = [...workspaces.keys()]
-        this.workspacePaths = [...workspaces.values()]
+    this.setWorkspaces(filters)
+      .then(() => {
         this.exec(args, cb)
       })
       .catch(er => cb(er))

--- a/test/lib/workspaces/arborist-cmd.js
+++ b/test/lib/workspaces/arborist-cmd.js
@@ -49,7 +49,7 @@ t.test('arborist-cmd', async t => {
 
   // check filtering for a single workspace name
   cmd.exec = function (args, cb) {
-    t.same(this.workspaces, ['a'], 'should set array with single ws name')
+    t.same(this.workspaceNames, ['a'], 'should set array with single ws name')
     t.same(args, ['foo'], 'should get received args')
     cb()
   }
@@ -59,7 +59,7 @@ t.test('arborist-cmd', async t => {
 
   // check filtering single workspace by path
   cmd.exec = function (args, cb) {
-    t.same(this.workspaces, ['a'],
+    t.same(this.workspaceNames, ['a'],
       'should set array with single ws name from path')
     cb()
   }
@@ -69,7 +69,7 @@ t.test('arborist-cmd', async t => {
 
   // check filtering single workspace by full path
   cmd.exec = function (args, cb) {
-    t.same(this.workspaces, ['a'],
+    t.same(this.workspaceNames, ['a'],
       'should set array with single ws name from full path')
     cb()
   }
@@ -79,7 +79,7 @@ t.test('arborist-cmd', async t => {
 
   // filtering multiple workspaces by name
   cmd.exec = function (args, cb) {
-    t.same(this.workspaces, ['a', 'c'],
+    t.same(this.workspaceNames, ['a', 'c'],
       'should set array with multiple listed ws names')
     cb()
   }
@@ -89,7 +89,7 @@ t.test('arborist-cmd', async t => {
 
   // filtering multiple workspaces by path names
   cmd.exec = function (args, cb) {
-    t.same(this.workspaces, ['a', 'c'],
+    t.same(this.workspaceNames, ['a', 'c'],
       'should set array with multiple ws names from paths')
     cb()
   }
@@ -99,7 +99,7 @@ t.test('arborist-cmd', async t => {
 
   // filtering multiple workspaces by parent path name
   cmd.exec = function (args, cb) {
-    t.same(this.workspaces, ['c', 'd'],
+    t.same(this.workspaceNames, ['c', 'd'],
       'should set array with multiple ws names from a parent folder name')
     cb()
   }


### PR DESCRIPTION
Also includes a preliminary refactor to consolidate workspace logic now that every command that supports workspaces has it implemented.

If we wanted npm.js itself to automatically call setWorkspaces we would want it to come after a check to see if the command even supports it in the first place, so that the "workspaces not implemented" error takes priority.  This is a good first step consolidation, and gets us to the point where adding the global check was a one-liner.

### References
Closes https://github.com/npm/statusboard/issues/314
Closes https://github.com/npm/statusboard/issues/312