### PR TITLE
fix(ls): respect prod config for workspaces deps

### DIFF
--- a/lib/ls.js
+++ b/lib/ls.js
@@ -141,6 +141,7 @@ class LS extends ArboristWorkspaceCmd {
           : [...(node.target || node).edgesOut.values()]
             .filter(filterBySelectedWorkspaces)
             .filter(filterByEdgesTypes({
+              currentDepth,
               dev,
               development,
               link,
@@ -387,6 +388,7 @@ const getJsonOutputItem = (node, { global, long }) => {
 }
 
 const filterByEdgesTypes = ({
+  currentDepth,
   dev,
   development,
   link,
@@ -398,11 +400,11 @@ const filterByEdgesTypes = ({
 }) => {
   // filter deps by type, allows for: `npm ls --dev`, `npm ls --prod`,
   // `npm ls --link`, `npm ls --only=dev`, etc
-  const filterDev = node === tree &&
+  const filterDev = currentDepth === 0 &&
     (dev || development || /^dev(elopment)?$/.test(only))
-  const filterProd = node === tree &&
+  const filterProd = currentDepth === 0 &&
     (prod || production || /^prod(uction)?$/.test(only))
-  const filterLink = node === tree && link
+  const filterLink = currentDepth === 0 && link
 
   return (edge) =>
     (filterDev ? edge.dev : true) &&

--- a/tap-snapshots/test/lib/ls.js.test.cjs
+++ b/tap-snapshots/test/lib/ls.js.test.cjs
@@ -496,6 +496,7 @@ workspaces-tree@1.0.0 {CWD}/tap-testdir-ls-ls-loading-a-tree-containing-workspac
 exports[`test/lib/ls.js TAP ls loading a tree containing workspaces > should filter using workspace config 1`] = `
 workspaces-tree@1.0.0 {CWD}/tap-testdir-ls-ls-loading-a-tree-containing-workspaces
 \`-- a@1.0.0 -> ./a
+  +-- baz@1.0.0
   +-- c@1.0.0
   \`-- d@1.0.0 -> ./d
     \`-- foo@1.1.1
@@ -504,6 +505,21 @@ workspaces-tree@1.0.0 {CWD}/tap-testdir-ls-ls-loading-a-tree-containing-workspac
 `
 
 exports[`test/lib/ls.js TAP ls loading a tree containing workspaces > should list --all workspaces properly 1`] = `
+workspaces-tree@1.0.0 {CWD}/tap-testdir-ls-ls-loading-a-tree-containing-workspaces
++-- a@1.0.0 -> ./a
+| +-- baz@1.0.0
+| +-- c@1.0.0
+| \`-- d@1.0.0 deduped -> ./d
++-- b@1.0.0 -> ./b
++-- d@1.0.0 -> ./d
+| \`-- foo@1.1.1
+|   \`-- bar@1.0.0
++-- e@1.0.0 -> ./group/e
+\`-- f@1.0.0 -> ./group/f
+
+`
+
+exports[`test/lib/ls.js TAP ls loading a tree containing workspaces > should list only prod deps of workspaces 1`] = `
 workspaces-tree@1.0.0 {CWD}/tap-testdir-ls-ls-loading-a-tree-containing-workspaces
 +-- a@1.0.0 -> ./a
 | +-- c@1.0.0
@@ -520,6 +536,7 @@ workspaces-tree@1.0.0 {CWD}/tap-testdir-ls-ls-loading-a-tree-containing-workspac
 exports[`test/lib/ls.js TAP ls loading a tree containing workspaces > should list workspaces properly with default configs 1`] = `
 [0mworkspaces-tree@1.0.0 {CWD}/tap-testdir-ls-ls-loading-a-tree-containing-workspaces[0m
 [0m+-- [32ma@1.0.0[39m -> ./a[0m
+[0m| +-- baz@1.0.0[0m
 [0m| +-- c@1.0.0[0m
 [0m| \`-- d@1.0.0 [90mdeduped[39m -> ./d[0m
 [0m+-- [32mb@1.0.0[39m -> ./b[0m

--- a/test/lib/ls.js
+++ b/test/lib/ls.js
@@ -1449,6 +1449,9 @@ t.test('ls', (t) => {
         bar: {
           'package.json': JSON.stringify({ name: 'bar', version: '1.0.0' }),
         },
+        baz: {
+          'package.json': JSON.stringify({ name: 'baz', version: '1.0.0' }),
+        },
       },
       a: {
         'package.json': JSON.stringify({
@@ -1457,6 +1460,9 @@ t.test('ls', (t) => {
           dependencies: {
             c: '^1.0.0',
             d: '^1.0.0',
+          },
+          devDependencies: {
+            baz: '^1.0.0',
           },
         }),
       },
@@ -1516,6 +1522,21 @@ t.test('ls', (t) => {
 
         t.matchSnapshot(redactCwd(result),
           'should list --all workspaces properly')
+        res()
+      })
+    })
+
+    // --production
+    await new Promise((res, rej) => {
+      config.production = true
+      ls.exec([], (err) => {
+        if (err)
+          rej(err)
+
+        t.matchSnapshot(redactCwd(result),
+          'should list only prod deps of workspaces')
+
+        config.production = false
         res()
       })
     })


### PR DESCRIPTION
`npm ls --prod` is currently not omitting devDependencies for configured
workspaces, this changes it by properly checking for the tweaked
`currentDepth` value instead of the tree root check that was in place.

## References
Fixes: https://github.com/npm/cli/issues/3382

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
