### PR TITLE
fix(config): add flatOptions.npxCache

### DIFF
--- a/lib/exec.js
+++ b/lib/exec.js
@@ -67,7 +67,6 @@ class Exec extends BaseCommand {
   // can be named correctly
   async _exec (_args, { locationMsg, path, runPath }) {
     const args = [..._args]
-    const cache = this.npm.config.get('cache')
     const call = this.npm.config.get('call')
     const color = this.npm.config.get('color')
     const {
@@ -88,7 +87,6 @@ class Exec extends BaseCommand {
       ...flatOptions,
       args,
       call,
-      cache,
       color,
       localBin,
       locationMsg,

--- a/lib/init.js
+++ b/lib/init.js
@@ -106,7 +106,6 @@ class Init extends BaseCommand {
     }
 
     const newArgs = [packageName, ...otherArgs]
-    const cache = this.npm.config.get('cache')
     const { color } = this.npm.flatOptions
     const {
       flatOptions,
@@ -128,7 +127,6 @@ class Init extends BaseCommand {
     await libexec({
       ...flatOptions,
       args: newArgs,
-      cache,
       color,
       localBin,
       locationMsg,

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -322,6 +322,7 @@ define('cache', {
   `,
   flatten (key, obj, flatOptions) {
     flatOptions.cache = join(obj.cache, '_cacache')
+    flatOptions.npxCache = join(obj.cache, '_npx')
   },
 })
 

--- a/test/lib/exec.js
+++ b/test/lib/exec.js
@@ -24,11 +24,13 @@ let PROGRESS_ENABLED = true
 const LOG_WARN = []
 let PROGRESS_IGNORED = false
 const flatOptions = {
+  npxCache: 'npx-cache-dir',
+  cache: 'cache-dir',
   legacyPeerDeps: false,
   package: [],
 }
 const config = {
-  cache: 'cache-dir',
+  cache: 'bad-cache-dir', // this should never show up passed into libnpmexec
   yes: true,
   call: '',
   package: [],
@@ -134,6 +136,8 @@ t.test('npx foo, bin already exists locally', t => {
     t.match(RUN_SCRIPTS, [{
       pkg: { scripts: { npx: 'foo' }},
       args: ['one arg', 'two arg'],
+      cache: flatOptions.cache,
+      npxCache: flatOptions.npxCache,
       banner: false,
       path: process.cwd(),
       stdioString: true,

--- a/test/lib/init.js
+++ b/test/lib/init.js
@@ -12,10 +12,16 @@ const npmLog = {
   silly: () => null,
 }
 const config = {
+  cache: 'bad-cache-dir',
   'init-module': '~/.npm-init.js',
   yes: true,
 }
+const flatOptions = {
+  cache: 'test-config-dir/_cacache',
+  npxCache: 'test-config-dir/_npx',
+}
 const npm = mockNpm({
+  flatOptions,
   config,
   log: npmLog,
 })
@@ -82,16 +88,18 @@ t.test('classic interactive npm init', t => {
 })
 
 t.test('npm init <arg>', t => {
-  t.plan(1)
+  t.plan(3)
   npm.localPrefix = t.testdir({})
 
   const Init = t.mock('../../lib/init.js', {
-    libnpmexec: ({ args }) => {
+    libnpmexec: ({ args, cache, npxCache }) => {
       t.same(
         args,
         ['create-react-app'],
         'should npx with listed packages'
       )
+      t.same(cache, flatOptions.cache)
+      t.same(npxCache, flatOptions.npxCache)
     },
   })
   const init = new Init(npm)

--- a/test/lib/utils/config/definitions.js
+++ b/test/lib/utils/config/definitions.js
@@ -181,6 +181,7 @@ t.test('cache', t => {
   defsNix.cache.flatten('cache', { cache: '/some/cache/value' }, flat)
   const {join} = require('path')
   t.equal(flat.cache, join('/some/cache/value', '_cacache'))
+  t.equal(flat.npxCache, join('/some/cache/value', '_npx'))
 
   t.end()
 })


### PR DESCRIPTION
This adds a new `npxCache` flatOption for libnpmexec to look for to put
its `_npx` content.  libnpmexec will have to be patched to use that
value, and continue to pass `flatOptions.cache` to pacote et al.

The `flatOptions` cache is the one that is intended to be passed down
into other modules, as it has the `_cacache` suffix attached.  What was
happening before was that `npx` was creating a new alternate cache one
directory up from where everything else was, and also putting the `_npx`
content there.  It is possible this is the source of at least some of
our "npx doesn't find the right versions" bugs.