### PR TITLE
fix(ls/search) --json arg error also sent to stdout

### DIFF
--- a/lib/ls.js
+++ b/lib/ls.js
@@ -192,30 +192,29 @@ class LS extends ArboristWorkspaceCmd {
     const shouldThrow = problems.size &&
       ![...problems].every(problem => problem.startsWith('extraneous:'))
 
-    let output
+    let out
     if (json) {
       let error
-      if (shouldThrow)  {
+      if (shouldThrow) {
         const code = 'ELSPROBLEMS'
         const errorMsg = errorMessage(
-          { code: code, message: [...problems].join(EOL) }, 
+          { code: code, message: [...problems].join(EOL) },
           this.npm
         )
         error = {
           code: code,
-          summary: errorMsg.summary.map( line => line.slice(1).join(' ')).join('\n'),
-          detail: "" 
+          summary: errorMsg.summary.map(line => line.slice(1).join(' ')).join('\n'),
+          detail: '',
         }
       }
 
-      output = jsonOutput({ path, problems, result, rootError, seenItems, error })
-    }
-    else if (parseable)
-      output = parseableOutput({ seenNodes, global, long })
+      out = jsonOutput({ path, problems, result, rootError, seenItems, error })
+    } else if (parseable)
+      out = parseableOutput({ seenNodes, global, long })
     else
-      output = humanOutput({ color, result, seenItems, unicode })
+      out = humanOutput({ color, result, seenItems, unicode })
 
-    this.npm.output(output)
+    this.npm.output(out)
 
     // if filtering items, should exit with error code on no results
     if (result && !result[_include] && args.length)
@@ -534,7 +533,7 @@ const humanOutput = ({ color, result, seenItems, unicode }) => {
   return color ? chalk.reset(archyOutput) : archyOutput
 }
 
-const jsonOutput = ({ path, problems, result, rootError, seenItems, error }) => {
+const jsonOutput = ({ path, problems, result, rootError, seenItems, err }) => {
   if (problems.size)
     result.problems = [...problems]
 
@@ -546,8 +545,8 @@ const jsonOutput = ({ path, problems, result, rootError, seenItems, error }) => 
     result.invalid = true
   }
 
-  if (error !== undefined )
-    result.error = error
+  if (err !== undefined)
+    result.error = err
 
   // we need to traverse the entire tree in order to determine which items
   // should be included (since a nested transitive included dep will make it

--- a/lib/ls.js
+++ b/lib/ls.js
@@ -194,21 +194,21 @@ class LS extends ArboristWorkspaceCmd {
 
     let out
     if (json) {
-      let error
+      let err
       if (shouldThrow) {
         const code = 'ELSPROBLEMS'
         const errorMsg = errorMessage(
           { code: code, message: [...problems].join(EOL) },
           this.npm
         )
-        error = {
+        err = {
           code: code,
           summary: errorMsg.summary.map(line => line.slice(1).join(' ')).join('\n'),
           detail: '',
         }
       }
 
-      out = jsonOutput({ path, problems, result, rootError, seenItems, error })
+      out = jsonOutput({ path, problems, result, rootError, seenItems, err })
     } else if (parseable)
       out = parseableOutput({ seenNodes, global, long })
     else

--- a/lib/ls.js
+++ b/lib/ls.js
@@ -7,6 +7,7 @@ const chalk = require('chalk')
 const Arborist = require('@npmcli/arborist')
 const { breadth } = require('treeverse')
 const npa = require('npm-package-arg')
+const errorMessage = require('./utils/error-message')
 
 const completion = require('./utils/completion/installed-deep.js')
 
@@ -188,13 +189,33 @@ class LS extends ArboristWorkspaceCmd {
     const [rootError] = tree.errors.filter(e =>
       e.code === 'EJSONPARSE' && e.path === resolve(path, 'package.json'))
 
-    this.npm.output(
-      json
-        ? jsonOutput({ path, problems, result, rootError, seenItems })
-        : parseable
-          ? parseableOutput({ seenNodes, global, long })
-          : humanOutput({ color, result, seenItems, unicode })
-    )
+    const shouldThrow = problems.size &&
+      ![...problems].every(problem => problem.startsWith('extraneous:'))
+
+    let output
+    if (json) {
+      let error
+      if (shouldThrow)  {
+        const code = 'ELSPROBLEMS'
+        const errorMsg = errorMessage(
+          { code: code, message: [...problems].join(EOL) }, 
+          this.npm
+        )
+        error = {
+          code: code,
+          summary: errorMsg.summary.map( line => line.slice(1).join(' ')).join('\n'),
+          detail: "" 
+        }
+      }
+
+      output = jsonOutput({ path, problems, result, rootError, seenItems, error })
+    }
+    else if (parseable)
+      output = parseableOutput({ seenNodes, global, long })
+    else
+      output = humanOutput({ color, result, seenItems, unicode })
+
+    this.npm.output(output)
 
     // if filtering items, should exit with error code on no results
     if (result && !result[_include] && args.length)
@@ -206,9 +227,6 @@ class LS extends ArboristWorkspaceCmd {
         { code: 'EJSONPARSE' }
       )
     }
-
-    const shouldThrow = problems.size &&
-      ![...problems].every(problem => problem.startsWith('extraneous:'))
 
     if (shouldThrow) {
       throw Object.assign(
@@ -516,7 +534,7 @@ const humanOutput = ({ color, result, seenItems, unicode }) => {
   return color ? chalk.reset(archyOutput) : archyOutput
 }
 
-const jsonOutput = ({ path, problems, result, rootError, seenItems }) => {
+const jsonOutput = ({ path, problems, result, rootError, seenItems, error }) => {
   if (problems.size)
     result.problems = [...problems]
 
@@ -527,6 +545,9 @@ const jsonOutput = ({ path, problems, result, rootError, seenItems }) => {
     ]
     result.invalid = true
   }
+
+  if (error !== undefined )
+    result.error = error
 
   // we need to traverse the entire tree in order to determine which items
   // should be included (since a nested transitive included dep will make it

--- a/lib/search.js
+++ b/lib/search.js
@@ -82,7 +82,7 @@ class Search extends BaseCommand {
           summary: errorMsg.summary.map(line => line.slice(1).join(' ')).join('\n'),
           detail: '',
         }
-        this.npm.output(JSON.stringify(error, null, 2))
+        this.npm.output(JSON.stringify({ error: error }, null, 2))
       }
 
       throw new Error('search must be called with arguments')

--- a/lib/search.js
+++ b/lib/search.js
@@ -2,6 +2,7 @@ const Minipass = require('minipass')
 const Pipeline = require('minipass-pipeline')
 const libSearch = require('libnpmsearch')
 const log = require('npmlog')
+const errorMessage = require('./utils/error-message')
 
 const formatPackageStream = require('./search/format-package-stream.js')
 const packageFilter = require('./search/package-filter.js')
@@ -70,8 +71,22 @@ class Search extends BaseCommand {
       exclude: prepareExcludes(this.npm.flatOptions.search.exclude),
     }
 
-    if (opts.include.length === 0)
+    if (opts.include.length === 0) {
+      if (this.npm.config.get('json')) {
+        const errorMsg = errorMessage(
+          { code: null, message: 'search must be called with arguments' },
+          this.npm
+        )
+        const error = {
+          code: null,
+          summary: errorMsg.summary.map(line => line.slice(1).join(' ')).join('\n'),
+          detail: '',
+        }
+        this.npm.output(JSON.stringify(error, null, 2))
+      }
+
       throw new Error('search must be called with arguments')
+    }
 
     // Used later to figure out whether we had any packages go out
     let anyOutput = false

--- a/test/lib/ls.js
+++ b/test/lib/ls.js
@@ -3036,6 +3036,11 @@ t.test('ls --json', (t) => {
             'invalid: foo@1.0.0 {CWD}/tap-testdir-ls-ls---json-missing-invalid-extraneous/node_modules/foo',
             'missing: ipsum@^1.0.0, required by test-npm-ls@1.0.0',
           ],
+          error: {                                                                                       
+               code: "ELSPROBLEMS",                                                                                
+                summary: "extraneous: chai@1.0.0 {CWD}/tap-testdir-ls-ls---json-missing-invalid-extraneous/node_modules/chai/ninvalid: foo@1.0.0 {CWD}/tap-testdir-ls-ls---json-missing-invalid-extraneous/node_modules/foo/nmissing: ipsum@^1.0.0, required by test-npm-ls@1.0.0",
+                detail: "",                                                                                         
+          },
           dependencies: {
             foo: {
               version: '1.0.0',
@@ -3732,6 +3737,11 @@ t.test('ls --json', (t) => {
           problems: [
             'invalid: peer-dep@1.0.0 {CWD}/tap-testdir-ls-ls---json-unmet-peer-dep/node_modules/peer-dep',
           ],
+          error: {                                                                                       
+            code: "ELSPROBLEMS",                                                                                
+            summary: "invalid: peer-dep@1.0.0 {CWD}/tap-testdir-ls-ls---json-unmet-peer-dep/node_modules/peer-dep",
+            detail: "",                                                                                         
+          },
           dependencies: {
             'peer-dep': {
               version: '1.0.0',
@@ -3793,6 +3803,11 @@ t.test('ls --json', (t) => {
           problems: [
             'invalid: optional-dep@1.0.0 {CWD}/tap-testdir-ls-ls---json-unmet-optional-dep/node_modules/optional-dep', // mismatching optional deps get flagged in problems
           ],
+          error: {                                                                                       
+            code: "ELSPROBLEMS",                                                                                
+            summary: "invalid: optional-dep@1.0.0 {CWD}/tap-testdir-ls-ls---json-unmet-optional-dep/node_modules/optional-dep",
+            detail: "",                                                                                         
+          }, 
           dependencies: {
             'optional-dep': {
               version: '1.0.0',
@@ -4727,6 +4742,11 @@ t.test('ls --package-lock-only', (t) => {
               'invalid: foo@1.0.0 {CWD}/tap-testdir-ls-ls---package-lock-only-ls---package-lock-only---json-missing-invalid-extraneous/node_modules/foo',
               'missing: ipsum@^1.0.0, required by test-npm-ls@1.0.0',
             ],
+            error: {                                                                                       
+              code: "ELSPROBLEMS",                                                                                
+              summary: "invalid: foo@1.0.0 {CWD}/tap-testdir-ls-ls---package-lock-only-ls---package-lock-only---json-missing-invalid-extraneous/node_modules/foo/nmissing: ipsum@^1.0.0, required by test-npm-ls@1.0.0",
+              detail: "",                                                                                         
+            },
             dependencies: {
               foo: {
                 version: '1.0.0',

--- a/test/lib/ls.js
+++ b/test/lib/ls.js
@@ -3036,10 +3036,10 @@ t.test('ls --json', (t) => {
             'invalid: foo@1.0.0 {CWD}/tap-testdir-ls-ls---json-missing-invalid-extraneous/node_modules/foo',
             'missing: ipsum@^1.0.0, required by test-npm-ls@1.0.0',
           ],
-          error: {                                                                                       
-               code: "ELSPROBLEMS",                                                                                
-                summary: "extraneous: chai@1.0.0 {CWD}/tap-testdir-ls-ls---json-missing-invalid-extraneous/node_modules/chai/ninvalid: foo@1.0.0 {CWD}/tap-testdir-ls-ls---json-missing-invalid-extraneous/node_modules/foo/nmissing: ipsum@^1.0.0, required by test-npm-ls@1.0.0",
-                detail: "",                                                                                         
+          error: {
+            code: 'ELSPROBLEMS',
+            summary: 'extraneous: chai@1.0.0 {CWD}/tap-testdir-ls-ls---json-missing-invalid-extraneous/node_modules/chai/ninvalid: foo@1.0.0 {CWD}/tap-testdir-ls-ls---json-missing-invalid-extraneous/node_modules/foo/nmissing: ipsum@^1.0.0, required by test-npm-ls@1.0.0',
+            detail: '',
           },
           dependencies: {
             foo: {
@@ -3737,10 +3737,10 @@ t.test('ls --json', (t) => {
           problems: [
             'invalid: peer-dep@1.0.0 {CWD}/tap-testdir-ls-ls---json-unmet-peer-dep/node_modules/peer-dep',
           ],
-          error: {                                                                                       
-            code: "ELSPROBLEMS",                                                                                
-            summary: "invalid: peer-dep@1.0.0 {CWD}/tap-testdir-ls-ls---json-unmet-peer-dep/node_modules/peer-dep",
-            detail: "",                                                                                         
+          error: {
+            code: 'ELSPROBLEMS',
+            summary: 'invalid: peer-dep@1.0.0 {CWD}/tap-testdir-ls-ls---json-unmet-peer-dep/node_modules/peer-dep',
+            detail: '',
           },
           dependencies: {
             'peer-dep': {
@@ -3803,11 +3803,11 @@ t.test('ls --json', (t) => {
           problems: [
             'invalid: optional-dep@1.0.0 {CWD}/tap-testdir-ls-ls---json-unmet-optional-dep/node_modules/optional-dep', // mismatching optional deps get flagged in problems
           ],
-          error: {                                                                                       
-            code: "ELSPROBLEMS",                                                                                
-            summary: "invalid: optional-dep@1.0.0 {CWD}/tap-testdir-ls-ls---json-unmet-optional-dep/node_modules/optional-dep",
-            detail: "",                                                                                         
-          }, 
+          error: {
+            code: 'ELSPROBLEMS',
+            summary: 'invalid: optional-dep@1.0.0 {CWD}/tap-testdir-ls-ls---json-unmet-optional-dep/node_modules/optional-dep',
+            detail: '',
+          },
           dependencies: {
             'optional-dep': {
               version: '1.0.0',
@@ -4742,10 +4742,10 @@ t.test('ls --package-lock-only', (t) => {
               'invalid: foo@1.0.0 {CWD}/tap-testdir-ls-ls---package-lock-only-ls---package-lock-only---json-missing-invalid-extraneous/node_modules/foo',
               'missing: ipsum@^1.0.0, required by test-npm-ls@1.0.0',
             ],
-            error: {                                                                                       
-              code: "ELSPROBLEMS",                                                                                
-              summary: "invalid: foo@1.0.0 {CWD}/tap-testdir-ls-ls---package-lock-only-ls---package-lock-only---json-missing-invalid-extraneous/node_modules/foo/nmissing: ipsum@^1.0.0, required by test-npm-ls@1.0.0",
-              detail: "",                                                                                         
+            error: {
+              code: 'ELSPROBLEMS',
+              summary: 'invalid: foo@1.0.0 {CWD}/tap-testdir-ls-ls---package-lock-only-ls---package-lock-only---json-missing-invalid-extraneous/node_modules/foo/nmissing: ipsum@^1.0.0, required by test-npm-ls@1.0.0',
+              detail: '',
             },
             dependencies: {
               foo: {

--- a/test/lib/search.js
+++ b/test/lib/search.js
@@ -87,9 +87,11 @@ t.test('no args --json', t => {
     t.same(
       parsedResult,
       {
-        code: null,
-        detail: '',
-        summary: 'search must be called with arguments',
+        error: {
+          code: null,
+          detail: '',
+          summary: 'search must be called with arguments',
+        },
       },
       'should output error to STDOUT'
     )

--- a/test/lib/search.js
+++ b/test/lib/search.js
@@ -57,6 +57,48 @@ t.test('no args', t => {
   })
 })
 
+t.test('no args --json', t => {
+  const src = new Minipass()
+  src.objectMode = true
+
+  npm.flatOptions.json = true
+  config.json = true
+  const libnpmsearch = {
+    stream () {
+      return src
+    },
+  }
+
+  const Search = t.mock('../../lib/search.js', {
+    ...mocks,
+    libnpmsearch,
+  })
+  const search = new Search(npm)
+
+  search.exec([], err => {
+    const parsedResult = JSON.parse(result)
+
+    t.match(
+      err,
+      /search must be called with arguments/,
+      'should throw usage instructions'
+    )
+
+    t.same(
+      parsedResult,
+      {
+        code: null,
+        detail: '',
+        summary: 'search must be called with arguments',
+      },
+      'should output error to STDOUT'
+    )
+
+    config.json = false
+    t.end()
+  })
+})
+
 t.test('search <name>', t => {
   const src = new Minipass()
   src.objectMode = true


### PR DESCRIPTION
## What

Added output to STDOUT via `npm.output()` when:

- `npm search --json`: outputs an error to STDOUT in json format.
- `npm ls --json` & a dependency can't be resolved: the json output to STDOUT has an error embedded.

## Why

Preserve backwards compatibility for scripts done for 6.x that rely on an error in STDOUT.

## References
  Fixes #2740 