### PR TITLE
feat: add prefix for version output

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -44,7 +44,7 @@ module.exports = (process) => {
 
     // npm --version=cli
     if (npm.config.get('version', 'cli')) {
-      npm.output(npm.version)
+      npm.output(`v${npm.version}`)
       return errorHandler.exit(0)
     }
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

Today, after installing Brew on the new MacOS and then Node, I checked the version of both binaries.
I saw that `node -v` displays the version as` vX.X.X` but npm as `X.X.X`.

I decided to standardize it.
A simple change.