### PR TITLE
chore(tests): expose real mock npm object

### DIFF
--- a/test/lib/audit.js
+++ b/test/lib/audit.js
@@ -1,5 +1,5 @@
 const t = require('tap')
-const mockNpm = require('../fixtures/mock-npm')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 
 t.test('should audit using Arborist', t => {
   let ARB_ARGS = null

--- a/test/lib/bin.js
+++ b/test/lib/bin.js
@@ -1,5 +1,5 @@
 const t = require('tap')
-const mockNpm = require('../fixtures/mock-npm')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 
 t.test('bin', (t) => {
   t.plan(4)

--- a/test/lib/birthday.js
+++ b/test/lib/birthday.js
@@ -1,5 +1,5 @@
 const t = require('tap')
-const mockNpm = require('../fixtures/mock-npm')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 
 const config = {
   yes: false,

--- a/test/lib/cache.js
+++ b/test/lib/cache.js
@@ -1,5 +1,5 @@
 const t = require('tap')
-const mockNpm = require('../fixtures/mock-npm')
+const { fake: mockNpm } = require('../fixtures/mock-npm.js')
 const path = require('path')
 
 const usageUtil = () => 'usage instructions'

--- a/test/lib/ci.js
+++ b/test/lib/ci.js
@@ -4,7 +4,7 @@ const readdir = util.promisify(fs.readdir)
 
 const t = require('tap')
 
-const mockNpm = require('../fixtures/mock-npm')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 
 t.test('should ignore scripts with --ignore-scripts', (t) => {
   const SCRIPTS = []

--- a/test/lib/dedupe.js
+++ b/test/lib/dedupe.js
@@ -1,21 +1,20 @@
 const t = require('tap')
-const mockNpm = require('../fixtures/mock-npm')
+const { real: mockNpm } = require('../fixtures/mock-npm')
 
-t.test('should throw in global mode', (t) => {
-  const Dedupe = t.mock('../../lib/dedupe.js')
-  const npm = mockNpm({
-    config: { 'dry-run': false, global: true },
-  })
-  const dedupe = new Dedupe(npm)
-
-  dedupe.exec([], er => {
-    t.match(er, { code: 'EDEDUPEGLOBAL' }, 'throws EDEDUPEGLOBAL')
-    t.end()
-  })
+t.test('should throw in global mode', async (t) => {
+  const { npm, command } = mockNpm(t)
+  await npm.load()
+  npm.config.set('global', true)
+  t.rejects(
+    command('dedupe'),
+    { code: 'EDEDUPEGLOBAL' },
+    'throws EDEDUPEGLOBALE'
+  )
 })
 
-t.test('should remove dupes using Arborist', (t) => {
-  const Dedupe = t.mock('../../lib/dedupe.js', {
+t.test('should remove dupes using Arborist', async (t) => {
+  t.plan(5)
+  const { npm, command } = mockNpm(t, {
     '@npmcli/arborist': function (args) {
       t.ok(args, 'gets options object')
       t.ok(args.path, 'gets path option')
@@ -28,37 +27,24 @@ t.test('should remove dupes using Arborist', (t) => {
       t.ok(arb, 'gets arborist tree')
     },
   })
-  const npm = mockNpm({
-    prefix: 'foo',
-    config: {
-      'dry-run': 'true',
-    },
-  })
-  const dedupe = new Dedupe(npm)
-  dedupe.exec([], er => {
-    if (er)
-      throw er
-    t.ok(true, 'callback is called')
-    t.end()
-  })
+  await npm.load()
+  npm.config.set('prefix', 'foo')
+  npm.config.set('dry-run', 'true')
+  await command('dedupe')
 })
 
-t.test('should remove dupes using Arborist - no arguments', (t) => {
-  const Dedupe = t.mock('../../lib/dedupe.js', {
+t.test('should remove dupes using Arborist - no arguments', async (t) => {
+  t.plan(1)
+  const { npm, command } = mockNpm(t, {
     '@npmcli/arborist': function (args) {
       t.ok(args.dryRun, 'gets dryRun from config')
       this.dedupe = () => {}
     },
     '../../lib/utils/reify-output.js': () => {},
+    '../../lib/utils/reify-finish.js': () => {},
   })
-  const npm = mockNpm({
-    prefix: 'foo',
-    config: {
-      'dry-run': 'true',
-    },
-  })
-  const dedupe = new Dedupe(npm)
-  dedupe.exec(null, () => {
-    t.end()
-  })
+  await npm.load()
+  npm.config.set('prefix', 'foo')
+  npm.config.set('dry-run', true)
+  await command('dedupe')
 })

--- a/test/lib/diff.js
+++ b/test/lib/diff.js
@@ -1,6 +1,6 @@
-const { resolve, join } = require('path')
 const t = require('tap')
-const mockNpm = require('../fixtures/mock-npm')
+const { resolve, join } = require('path')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 
 const noop = () => null
 let libnpmdiff = noop

--- a/test/lib/dist-tag.js
+++ b/test/lib/dist-tag.js
@@ -1,5 +1,5 @@
-const mockNpm = require('../fixtures/mock-npm')
 const t = require('tap')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 
 let result = ''
 let log = ''

--- a/test/lib/docs.js
+++ b/test/lib/docs.js
@@ -1,5 +1,5 @@
 const t = require('tap')
-const mockNpm = require('../fixtures/mock-npm.js')
+const { fake: mockNpm } = require('../fixtures/mock-npm.js')
 const { join, sep } = require('path')
 
 const pkgDirs = t.testdir({

--- a/test/lib/exec.js
+++ b/test/lib/exec.js
@@ -1,5 +1,5 @@
 const t = require('tap')
-const mockNpm = require('../fixtures/mock-npm')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 const { resolve, delimiter } = require('path')
 
 const ARB_CTOR = []

--- a/test/lib/fund.js
+++ b/test/lib/fund.js
@@ -1,5 +1,5 @@
 const t = require('tap')
-const mockNpm = require('../fixtures/mock-npm')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 
 const version = '1.0.0'
 const funding = {

--- a/test/lib/help-search.js
+++ b/test/lib/help-search.js
@@ -1,6 +1,6 @@
 const t = require('tap')
 const { join } = require('path')
-const mockNpm = require('../fixtures/mock-npm')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 const ansicolors = require('ansicolors')
 
 const OUTPUT = []

--- a/test/lib/init.js
+++ b/test/lib/init.js
@@ -1,7 +1,7 @@
+const t = require('tap')
 const fs = require('fs')
 const { resolve } = require('path')
-const t = require('tap')
-const mockNpm = require('../fixtures/mock-npm')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 
 const npmLog = {
   disableProgress: () => null,

--- a/test/lib/install.js
+++ b/test/lib/install.js
@@ -1,7 +1,7 @@
 const t = require('tap')
 
 const Install = require('../../lib/install.js')
-const mockNpm = require('../fixtures/mock-npm')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 
 t.test('should install using Arborist', (t) => {
   const SCRIPTS = []

--- a/test/lib/link.js
+++ b/test/lib/link.js
@@ -1,9 +1,9 @@
+const t = require('tap')
 const { resolve } = require('path')
 const fs = require('fs')
 
 const Arborist = require('@npmcli/arborist')
-const t = require('tap')
-const mockNpm = require('../fixtures/mock-npm')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 
 const redactCwd = (path) => {
   const normalizePath = p => p

--- a/test/lib/load-all-commands.js
+++ b/test/lib/load-all-commands.js
@@ -3,17 +3,16 @@
 // name, a description, and if it has completion it is a function.  That it
 // renders also ensures that any params we've defined in our commands work.
 const t = require('tap')
-const npm = t.mock('../../lib/npm.js')
+const { real: mockNpm } = require('../fixtures/mock-npm.js')
 const { cmdList } = require('../../lib/utils/cmd-list.js')
 
-let npmOutput = []
-npm.output = (msg) => {
-  npmOutput = msg
-}
+const { npm, outputs } = mockNpm(t)
+
 t.test('load each command', t => {
-  t.plan(cmdList.length + 1)
+  t.plan(cmdList.length)
   npm.load((er) => {
-    t.notOk(er)
+    if (er)
+      throw er
     npm.config.set('usage', true)
     for (const cmd of cmdList.sort((a, b) => a.localeCompare(b, 'en'))) {
       t.test(cmd, t => {
@@ -26,13 +25,14 @@ t.test('load each command', t => {
         t.match(impl.usage, cmd, 'usage contains the command')
         impl([], (err) => {
           t.notOk(err)
-          t.match(npmOutput, impl.usage, 'usage is what is output')
+          t.match(outputs[0][0], impl.usage, 'usage is what is output')
           // This ties usage to a snapshot so we have to re-run snap if usage
           // changes, which rebuilds the man pages
-          t.matchSnapshot(npmOutput)
+          t.matchSnapshot(outputs[0][0])
           t.end()
         })
       })
+      outputs.length = 0
     }
   })
 })

--- a/test/lib/logout.js
+++ b/test/lib/logout.js
@@ -1,5 +1,5 @@
-const mockNpm = require('../fixtures/mock-npm')
 const t = require('tap')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 
 const config = {
   registry: 'https://registry.npmjs.org/',

--- a/test/lib/ls.js
+++ b/test/lib/ls.js
@@ -3,7 +3,7 @@
 // of them contain the tap testdir folders, which are auto-generated and
 // may change when node-tap is updated.
 const t = require('tap')
-const mockNpm = require('../fixtures/mock-npm')
+const { fake: mockNpm } = require('../fixtures/mock-npm.js')
 
 const { resolve } = require('path')
 const { utimesSync } = require('fs')

--- a/test/lib/outdated.js
+++ b/test/lib/outdated.js
@@ -1,5 +1,5 @@
 const t = require('tap')
-const mockNpm = require('../fixtures/mock-npm')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 
 const packument = spec => {
   const mocks = {

--- a/test/lib/owner.js
+++ b/test/lib/owner.js
@@ -1,5 +1,5 @@
 const t = require('tap')
-const mockNpm = require('../fixtures/mock-npm.js')
+const { fake: mockNpm } = require('../fixtures/mock-npm.js')
 
 let result = ''
 let readPackageNamePrefix = null

--- a/test/lib/pack.js
+++ b/test/lib/pack.js
@@ -1,5 +1,5 @@
 const t = require('tap')
-const mockNpm = require('../fixtures/mock-npm')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 const pacote = require('pacote')
 const path = require('path')
 

--- a/test/lib/ping.js
+++ b/test/lib/ping.js
@@ -1,5 +1,5 @@
 const t = require('tap')
-const mockNpm = require('../fixtures/mock-npm')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 
 t.test('pings', (t) => {
   t.plan(8)

--- a/test/lib/profile.js
+++ b/test/lib/profile.js
@@ -1,5 +1,5 @@
 const t = require('tap')
-const mockNpm = require('../fixtures/mock-npm')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 
 let result = ''
 const config = {

--- a/test/lib/publish.js
+++ b/test/lib/publish.js
@@ -1,5 +1,5 @@
 const t = require('tap')
-const mockNpm = require('../fixtures/mock-npm')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 const fs = require('fs')
 
 // The way we set loglevel is kind of convoluted, and there is no way to affect

--- a/test/lib/rebuild.js
+++ b/test/lib/rebuild.js
@@ -1,7 +1,7 @@
+const t = require('tap')
 const fs = require('fs')
 const { resolve } = require('path')
-const mockNpm = require('../fixtures/mock-npm')
-const t = require('tap')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 
 let result = ''
 

--- a/test/lib/repo.js
+++ b/test/lib/repo.js
@@ -1,5 +1,5 @@
 const t = require('tap')
-const mockNpm = require('../fixtures/mock-npm.js')
+const { fake: mockNpm } = require('../fixtures/mock-npm.js')
 const { join, sep } = require('path')
 
 const pkgDirs = t.testdir({

--- a/test/lib/run-script.js
+++ b/test/lib/run-script.js
@@ -1,6 +1,6 @@
-const { resolve } = require('path')
 const t = require('tap')
-const mockNpm = require('../fixtures/mock-npm')
+const { resolve } = require('path')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 
 const normalizePath = p => p
   .replace(/\\+/g, '/')

--- a/test/lib/search.js
+++ b/test/lib/search.js
@@ -1,6 +1,6 @@
-const Minipass = require('minipass')
 const t = require('tap')
-const mockNpm = require('../fixtures/mock-npm')
+const Minipass = require('minipass')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 const libnpmsearchResultFixture =
   require('../fixtures/libnpmsearch-stream-result.js')
 

--- a/test/lib/set-script.js
+++ b/test/lib/set-script.js
@@ -1,7 +1,7 @@
 const t = require('tap')
 const fs = require('fs')
 const parseJSON = require('json-parse-even-better-errors')
-const mockNpm = require('../fixtures/mock-npm.js')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 const { resolve } = require('path')
 
 const flatOptions = {}

--- a/test/lib/shrinkwrap.js
+++ b/test/lib/shrinkwrap.js
@@ -1,6 +1,6 @@
 const t = require('tap')
 const fs = require('fs')
-const mockNpm = require('../fixtures/mock-npm')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 
 const config = {
   global: false,

--- a/test/lib/star.js
+++ b/test/lib/star.js
@@ -1,5 +1,5 @@
-const mockNpm = require('../fixtures/mock-npm')
 const t = require('tap')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 
 let result = ''
 

--- a/test/lib/uninstall.js
+++ b/test/lib/uninstall.js
@@ -1,7 +1,7 @@
+const t = require('tap')
 const fs = require('fs')
 const { resolve } = require('path')
-const t = require('tap')
-const mockNpm = require('../fixtures/mock-npm')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 
 const npm = mockNpm({
   globalDir: '',

--- a/test/lib/unpublish.js
+++ b/test/lib/unpublish.js
@@ -1,5 +1,5 @@
 const t = require('tap')
-const mockNpm = require('../fixtures/mock-npm')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 
 let result = ''
 const noop = () => null

--- a/test/lib/update.js
+++ b/test/lib/update.js
@@ -1,6 +1,6 @@
-const { resolve } = require('path')
 const t = require('tap')
-const mockNpm = require('../fixtures/mock-npm')
+const { resolve } = require('path')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 
 const config = {
   depth: 0,

--- a/test/lib/utils/read-package-name.js
+++ b/test/lib/utils/read-package-name.js
@@ -1,17 +1,15 @@
 const t = require('tap')
-const mockNpm = require('../../fixtures/mock-npm')
-const npm = mockNpm()
 
 const readPackageName = require('../../../lib/utils/read-package-name.js')
 
 t.test('read local package.json', async (t) => {
-  npm.prefix = t.testdir({
+  const prefix = t.testdir({
     'package.json': JSON.stringify({
       name: 'my-local-package',
       version: '1.0.0',
     }),
   })
-  const packageName = await readPackageName(npm.prefix)
+  const packageName = await readPackageName(prefix)
   t.equal(
     packageName,
     'my-local-package',
@@ -20,13 +18,13 @@ t.test('read local package.json', async (t) => {
 })
 
 t.test('read local scoped-package.json', async (t) => {
-  npm.prefix = t.testdir({
+  const prefix = t.testdir({
     'package.json': JSON.stringify({
       name: '@my-scope/my-local-package',
       version: '1.0.0',
     }),
   })
-  const packageName = await readPackageName(npm.prefix)
+  const packageName = await readPackageName(prefix)
   t.equal(
     packageName,
     '@my-scope/my-local-package',

--- a/test/lib/version.js
+++ b/test/lib/version.js
@@ -1,5 +1,5 @@
 const t = require('tap')
-const mockNpm = require('../fixtures/mock-npm')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 
 let result = []
 

--- a/test/lib/view.js
+++ b/test/lib/view.js
@@ -3,7 +3,7 @@ const t = require('tap')
 // run the same as tap does when running directly with node
 process.stdout.columns = undefined
 
-const mockNpm = require('../fixtures/mock-npm')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 
 let logs
 const cleanLogs = () => {

--- a/test/lib/whoami.js
+++ b/test/lib/whoami.js
@@ -1,5 +1,5 @@
 const t = require('tap')
-const mockNpm = require('../fixtures/mock-npm')
+const { fake: mockNpm } = require('../fixtures/mock-npm')
 
 t.test('whoami', (t) => {
   t.plan(3)


### PR DESCRIPTION
Consolidates existing "real npm" mocks, labels it real. We can now
migrate tests to this one at a time instead of trying to make one giant
PR that does it all at once.