### PR TITLE
fix(exitHandler): write code to logfile

### DIFF
--- a/lib/utils/exit-handler.js
+++ b/lib/utils/exit-handler.js
@@ -58,6 +58,7 @@ process.on('exit', code => {
   if (!code)
     log.info('ok')
   else {
+    log.verbose('code', code)
     if (!exitHandlerCalled) {
       log.error('', 'Exit handler never called!')
       console.error('')
@@ -66,7 +67,6 @@ process.on('exit', code => {
       // TODO this doesn't have an npm.config.loaded guard
       writeLogFile()
     }
-    log.verbose('code', code)
   }
   // In timing mode we always write the log file
   if (npm.config && npm.config.loaded && npm.config.get('timing') && !wroteLogFile)
@@ -107,8 +107,6 @@ const exit = (code, noLog) => {
   // background at this point, and this makes sure anything left dangling
   // for whatever reason gets thrown away, instead of leaving the CLI open
   process.stdout.write('', () => {
-    // `|| process.exitCode` supports a single use case, where we set the exit
-    // code to 1 if npm is called with no arguments
     process.exit(code)
   })
 }

--- a/tap-snapshots/test/lib/utils/exit-handler.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/exit-handler.js.test.cjs
@@ -6,18 +6,15 @@
  */
 'use strict'
 exports[`test/lib/utils/exit-handler.js TAP handles unknown error > should have expected log contents for unknown error 1`] = `
-0 verbose code 1
-1 error foo A complete log of this run can be found in:
-1 error foo     {CWD}/test/lib/utils/tap-testdir-exit-handler/_logs/expecteddate-debug.log
-2 verbose stack Error: ERROR
-3 verbose cwd {CWD}
-4 verbose Foo 1.0.0
-5 verbose argv "/node" "{CWD}/test/lib/utils/exit-handler.js"
-6 verbose node v1.0.0
-7 verbose npm  v1.0.0
-8 error foo code ERROR
-9 error foo ERR ERROR
-10 error foo ERR ERROR
-11 verbose exit 1
+0 verbose stack Error: ERROR
+1 verbose cwd {CWD}
+2 verbose Foo 1.0.0
+3 verbose argv "/node" "{CWD}/test/lib/utils/exit-handler.js"
+4 verbose node v1.0.0
+5 verbose npm  v1.0.0
+6 error foo code ERROR
+7 error foo ERR ERROR
+8 error foo ERR ERROR
+9 verbose exit 1
 
 `

--- a/test/lib/utils/exit-handler.js
+++ b/test/lib/utils/exit-handler.js
@@ -109,6 +109,10 @@ process = Object.assign(
 // in order for tap to exit properly
 t.teardown(() => {
   process = _process
+})
+
+t.afterEach(() => {
+  // clear out the 'A complete log' message
   npmlog.record.length = 0
 })
 


### PR DESCRIPTION
This moves the logging of the exit code to before the logfile is
written, when the exit handler was not called.  This will ensure that
the code shows up in the debug logs.
