### PR TITLE
fix(ping): make "npm ping" echo a right time

### DIFF
--- a/lib/ping.js
+++ b/lib/ping.js
@@ -27,7 +27,7 @@ class Ping extends BaseCommand {
     const start = Date.now()
     const details = await pingUtil(this.npm.flatOptions)
     const time = Date.now() - start
-    log.notice('PONG', `${time / 1000}ms`)
+    log.notice('PONG', `${time}ms`)
     if (this.npm.config.get('json')) {
       this.npm.output(JSON.stringify({
         registry: this.npm.config.get('registry'),


### PR DESCRIPTION
There is no need to make the time divided by 1000 because of the time unit 'ms'. 
Currently a typical command and response:
PS C:\projects> npm ping
npm notice PING http://registry.npmjs.org/
npm notice PONG 0.752ms

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
