### PR TITLE
chore(exit): log any un-ended timings

### DIFF
--- a/lib/base-command.js
+++ b/lib/base-command.js
@@ -75,7 +75,6 @@ class BaseCommand {
   }
 
   async setWorkspaces (filters) {
-    // TODO npm guards workspaces/global mode so we should use this.npm.prefix?
     const ws = await getWorkspaces(filters, { path: this.npm.localPrefix })
     this.workspaces = ws
     this.workspaceNames = [...ws.keys()]

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -50,7 +50,7 @@ const npm = module.exports = new class extends EventEmitter {
   constructor () {
     super()
     // TODO make this only ever load once (or unload) in tests
-    require('./utils/perf.js')
+    this.timers = require('./utils/perf.js').timers
     this.started = Date.now()
     this.command = null
     this.commands = proxyCmds

--- a/lib/utils/exit-handler.js
+++ b/lib/utils/exit-handler.js
@@ -32,9 +32,14 @@ process.on('timing', (name, value) => {
 })
 
 process.on('exit', code => {
+  // process.emit is synchronous, so the timeEnd handler will run before the
+  // unfinished timer check below
   process.emit('timeEnd', 'npm')
   log.disableProgress()
-  if (npm.config && npm.config.loaded && npm.config.get('timing')) {
+  for (const [name, timers] of npm.timers)
+    log.verbose('unfinished npm timer', name, timers)
+
+  if (npm.config.loaded && npm.config.get('timing')) {
     try {
       const file = path.resolve(npm.config.get('cache'), '_timing.json')
       const dir = path.dirname(npm.config.get('cache'))
@@ -69,7 +74,7 @@ process.on('exit', code => {
     }
   }
   // In timing mode we always write the log file
-  if (npm.config && npm.config.loaded && npm.config.get('timing') && !wroteLogFile)
+  if (npm.config.loaded && npm.config.get('timing') && !wroteLogFile)
     writeLogFile()
   if (wroteLogFile) {
     // just a line break
@@ -113,7 +118,7 @@ const exit = (code, noLog) => {
 
 const exitHandler = (err) => {
   log.disableProgress()
-  if (!npm.config || !npm.config.loaded) {
+  if (!npm.config.loaded) {
     // logging won't work unless we pretend that it's ready
     err = err || new Error('Exit prior to config file resolving.')
     console.error(err.stack || err.message)
@@ -180,7 +185,7 @@ const exitHandler = (err) => {
   for (const errline of [...msg.summary, ...msg.detail])
     log.error(...errline)
 
-  if (npm.config && npm.config.get('json')) {
+  if (npm.config.loaded && npm.config.get('json')) {
     const error = {
       error: {
         code: err.code,

--- a/lib/utils/perf.js
+++ b/lib/utils/perf.js
@@ -1,20 +1,21 @@
 const log = require('npmlog')
-const timings = new Map()
+const timers = new Map()
 
 process.on('time', (name) => {
-  timings.set(name, Date.now())
+  timers.set(name, Date.now())
 })
 
 process.on('timeEnd', (name) => {
-  if (timings.has(name)) {
-    const ms = Date.now() - timings.get(name)
+  if (timers.has(name)) {
+    const ms = Date.now() - timers.get(name)
     process.emit('timing', name, ms)
     log.timing(name, `Completed in ${ms}ms`)
-    timings.delete(name)
+    timers.delete(name)
   } else
     log.silly('timing', "Tried to end timer that doesn't exist:", name)
 })
 
+exports.timers = timers
 // for tests
 /* istanbul ignore next */
 exports.reset = () => {


### PR DESCRIPTION
It will be helpful to us when debugging the "exit handler never called"
bugs to know which timings were started but not ended.

Tests moved to use real npm.