### PR TITLE
fix(deprecate): add undeprecate support

### DIFF
--- a/lib/deprecate.js
+++ b/lib/deprecate.js
@@ -49,7 +49,8 @@ class Deprecate extends BaseCommand {
   }
 
   async deprecate ([pkg, msg]) {
-    if (!pkg || !msg)
+    // msg == null becase '' is a valid value, it indicates undeprecate
+    if (!pkg || msg == null)
       throw this.usageError()
 
     // fetch the data and make sure it exists.

--- a/test/lib/deprecate.js
+++ b/test/lib/deprecate.js
@@ -78,6 +78,21 @@ t.test('invalid semver range', t => {
   })
 })
 
+t.test('undeprecate', t => {
+  deprecate.exec(['foo', ''], (err) => {
+    if (err)
+      throw err
+    t.match(npmFetchBody, {
+      versions: {
+        '1.0.0': { deprecated: '' },
+        '1.0.1': { deprecated: '' },
+        '1.0.1-pre': { deprecated: '' },
+      },
+    }, 'undeprecates everything')
+    t.end()
+  })
+})
+
 t.test('deprecates given range', t => {
   t.teardown(() => {
     npmFetchBody = null


### PR DESCRIPTION
Setting a deprecation of an empty string is the way to undeprecate a
package, this was accidentally broken in a past refactoring, and is now
re-added with a test to ensure it is allowed.

## References
Closes https://github.com/npm/cli/issues/2730