### PR TITLE
Release/v7.19.1

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -785,3 +785,4 @@ Daniel Park <gimli01@github.com>
 Daniel Park <daniel.park@endevors.io>
 Luke Karrys <luke@lukekarrys.com>
 Ivan <ivanaguilar01@live.com.mx>
+Aluneed <31174087+aluneed@users.noreply.github.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,38 @@
+## v7.19.1 (2021-07-01)
+
+### BUG FIXES
+
+* [`013f0262d`](https://github.com/npm/cli/commit/013f0262db3e16605820f6117749fd3ebc70f6d1)
+  [#3469](https://github.com/npm/cli/issues/3469)
+  fix(exitHandler): write code to logfile
+  ([@wraithgar](https://github.com/wraithgar))
+* [`0dd0341ac`](https://github.com/npm/cli/commit/0dd0341ac9a65a2df8fc262ad9a56b7351f99d66)
+  [#3474](https://github.com/npm/cli/issues/3474)
+  fix(ping): make "npm ping" echo a right time
+  ([@aluneed](https://github.com/aluneed))
+* [`d2e298f3c`](https://github.com/npm/cli/commit/d2e298f3cbab278071480f94ff7d916d42cbf43b)
+  [#3484](https://github.com/npm/cli/issues/3484)
+  fix(deprecate): add undeprecate support
+  ([@wraithgar](https://github.com/wraithgar))
+
+  ### DOCUMENTATION
+
+* [`9dd32d08e`](https://github.com/npm/cli/commit/9dd32d08e09c21c9a4517161abfc7eed6518faf2)
+  [#3485](https://github.com/npm/cli/issues/3485)
+  fix(docs): remove npm package config override
+  ([@wraithgar](https://github.com/wraithgar))
+* [`a4e095618`](https://github.com/npm/cli/commit/a4e095618cda72244a18aaff9d6660b9082a2b84)
+  [#3486](https://github.com/npm/cli/issues/3486)
+  fix(docs): remove .hooks scripts
+  ([@wraithgar](https://github.com/wraithgar))
+
+### TESTING
+
+* [`5f8ccccef`](https://github.com/npm/cli/commit/5f8ccccef9fc19229320df8cbcae9fcea8d31388)
+  [#3483](https://github.com/npm/cli/issues/3483)
+  chore(tests): clean snapshot for lib/view.js tests
+  ([@wraithgar](https://github.com/wraithgar))
+
 ## v7.19.0 (2021-06-24)
 
 ### FEATURES

--- a/docs/content/configuring-npm/package-json.md
+++ b/docs/content/configuring-npm/package-json.md
@@ -549,12 +549,8 @@ had the following:
 }
 ```
 
-and then had a "start" command that then referenced the
-`npm_package_config_port` environment variable, then the user could
-override that by doing `npm config set foo:port 8001`.
-
-See [`config`](/using-npm/config) and [`scripts`](/using-npm/scripts) for
-more on package configs.
+It could also have a "start" command that referenced the
+`npm_package_config_port` environment variable.
 
 ### dependencies
 

--- a/docs/content/using-npm/scripts.md
+++ b/docs/content/using-npm/scripts.md
@@ -245,41 +245,7 @@ package.json file, then your package scripts would have the
 in your code with `process.env.npm_package_name` and
 `process.env.npm_package_version`, and so on for other fields.
 
-#### configuration
-
-Configuration parameters are put in the environment with the
-`npm_config_` prefix. For instance, you can view the effective `root`
-config by checking the `npm_config_root` environment variable.
-
-#### Special: package.json "config" object
-
-The package.json "config" keys are overwritten in the environment if
-there is a config param of `<name>[@<version>]:<key>`.  For example,
-if the package.json has this:
-
-```json
-{
-  "name" : "foo",
-  "config" : {
-    "port" : "8080"
-  },
-  "scripts" : {
-    "start" : "node server.js"
-  }
-}
-```
-
-and the server.js is this:
-
-```javascript
-http.createServer(...).listen(process.env.npm_package_config_port)
-```
-
-then the user could change the behavior by doing:
-
-```bash
-  npm config set foo:port 80
-  ```
+See [`package-json.md`](/using-npm/package-json) for more on package configs.
 
 #### current lifecycle event
 

--- a/docs/content/using-npm/scripts.md
+++ b/docs/content/using-npm/scripts.md
@@ -307,19 +307,6 @@ Note that these script files don't have to be nodejs or even
 javascript programs. They just have to be some kind of executable
 file.
 
-### Hook Scripts
-
-If you want to run a specific script at a specific lifecycle event for
-ALL packages, then you can use a hook script.
-
-Place an executable file at `node_modules/.hooks/{eventname}`, and
-it'll get run for all packages when they are going through that point
-in the package lifecycle for any packages installed in that root.
-
-Hook scripts are run exactly the same way as package.json scripts.
-That is, they are in a separate child process, with the env described
-above.
-
 ### Best Practices
 
 * Don't exit with a non-zero error code unless you *really* mean it.

--- a/lib/deprecate.js
+++ b/lib/deprecate.js
@@ -49,7 +49,8 @@ class Deprecate extends BaseCommand {
   }
 
   async deprecate ([pkg, msg]) {
-    if (!pkg || !msg)
+    // msg == null becase '' is a valid value, it indicates undeprecate
+    if (!pkg || msg == null)
       throw this.usageError()
 
     // fetch the data and make sure it exists.

--- a/lib/ping.js
+++ b/lib/ping.js
@@ -27,7 +27,7 @@ class Ping extends BaseCommand {
     const start = Date.now()
     const details = await pingUtil(this.npm.flatOptions)
     const time = Date.now() - start
-    log.notice('PONG', `${time / 1000}ms`)
+    log.notice('PONG', `${time}ms`)
     if (this.npm.config.get('json')) {
       this.npm.output(JSON.stringify({
         registry: this.npm.config.get('registry'),

--- a/lib/utils/exit-handler.js
+++ b/lib/utils/exit-handler.js
@@ -58,6 +58,7 @@ process.on('exit', code => {
   if (!code)
     log.info('ok')
   else {
+    log.verbose('code', code)
     if (!exitHandlerCalled) {
       log.error('', 'Exit handler never called!')
       console.error('')
@@ -66,7 +67,6 @@ process.on('exit', code => {
       // TODO this doesn't have an npm.config.loaded guard
       writeLogFile()
     }
-    log.verbose('code', code)
   }
   // In timing mode we always write the log file
   if (npm.config && npm.config.loaded && npm.config.get('timing') && !wroteLogFile)
@@ -107,8 +107,6 @@ const exit = (code, noLog) => {
   // background at this point, and this makes sure anything left dangling
   // for whatever reason gets thrown away, instead of leaving the CLI open
   process.stdout.write('', () => {
-    // `|| process.exitCode` supports a single use case, where we set the exit
-    // code to 1 if npm is called with no arguments
     process.exit(code)
   })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm",
-  "version": "7.19.0",
+  "version": "7.19.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "npm",
-      "version": "7.19.0",
+      "version": "7.19.1",
       "bundleDependencies": [
         "@npmcli/arborist",
         "@npmcli/ci-detect",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.19.0",
+  "version": "7.19.1",
   "name": "npm",
   "description": "a package manager for JavaScript",
   "workspaces": [

--- a/tap-snapshots/test/lib/utils/exit-handler.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/exit-handler.js.test.cjs
@@ -6,18 +6,15 @@
  */
 'use strict'
 exports[`test/lib/utils/exit-handler.js TAP handles unknown error > should have expected log contents for unknown error 1`] = `
-0 verbose code 1
-1 error foo A complete log of this run can be found in:
-1 error foo     {CWD}/test/lib/utils/tap-testdir-exit-handler/_logs/expecteddate-debug.log
-2 verbose stack Error: ERROR
-3 verbose cwd {CWD}
-4 verbose Foo 1.0.0
-5 verbose argv "/node" "{CWD}/test/lib/utils/exit-handler.js"
-6 verbose node v1.0.0
-7 verbose npm  v1.0.0
-8 error foo code ERROR
-9 error foo ERR ERROR
-10 error foo ERR ERROR
-11 verbose exit 1
+0 verbose stack Error: ERROR
+1 verbose cwd {CWD}
+2 verbose Foo 1.0.0
+3 verbose argv "/node" "{CWD}/test/lib/utils/exit-handler.js"
+4 verbose node v1.0.0
+5 verbose npm  v1.0.0
+6 error foo code ERROR
+7 error foo ERR ERROR
+8 error foo ERR ERROR
+9 verbose exit 1
 
 `

--- a/tap-snapshots/test/lib/view.js.test.cjs
+++ b/tap-snapshots/test/lib/view.js.test.cjs
@@ -82,7 +82,7 @@ dist
 dist-tags:
 [1m[32mlatest[39m[22m: 1.0.0
 
-published [33ma year ago[39m
+published {TIME} ago[39m
 `
 
 exports[`test/lib/view.js TAP should log info of package in current working dir specific version > must match snapshot 1`] = `
@@ -99,7 +99,7 @@ dist
 dist-tags:
 [1m[32mlatest[39m[22m: 1.0.0
 
-published [33ma year ago[39m
+published {TIME} ago[39m
 `
 
 exports[`test/lib/view.js TAP should log package info package from git > must match snapshot 1`] = `
@@ -302,7 +302,7 @@ dist
 dist-tags:
 [1m[32mlatest[39m[22m: 1.0.0
 
-published [33ma year ago[39m
+published {TIME} ago[39m
 `
 
 exports[`test/lib/view.js TAP workspaces all workspaces --json > must match snapshot 1`] = `

--- a/test/lib/deprecate.js
+++ b/test/lib/deprecate.js
@@ -78,6 +78,21 @@ t.test('invalid semver range', t => {
   })
 })
 
+t.test('undeprecate', t => {
+  deprecate.exec(['foo', ''], (err) => {
+    if (err)
+      throw err
+    t.match(npmFetchBody, {
+      versions: {
+        '1.0.0': { deprecated: '' },
+        '1.0.1': { deprecated: '' },
+        '1.0.1-pre': { deprecated: '' },
+      },
+    }, 'undeprecates everything')
+    t.end()
+  })
+})
+
 t.test('deprecates given range', t => {
   t.teardown(() => {
     npmFetchBody = null

--- a/test/lib/utils/exit-handler.js
+++ b/test/lib/utils/exit-handler.js
@@ -109,6 +109,10 @@ process = Object.assign(
 // in order for tap to exit properly
 t.teardown(() => {
   process = _process
+})
+
+t.afterEach(() => {
+  // clear out the 'A complete log' message
   npmlog.record.length = 0
 })
 

--- a/test/lib/view.js
+++ b/test/lib/view.js
@@ -1,5 +1,7 @@
 const t = require('tap')
 
+t.cleanSnapshot = str => str.replace(/published .*? ago/g, 'published {TIME} ago')
+
 // run the same as tap does when running directly with node
 process.stdout.columns = undefined
 


### PR DESCRIPTION
## v7.19.1 (2021-07-01)

### BUG FIXES

* [`013f0262d`](https://github.com/npm/cli/commit/013f0262db3e16605820f6117749fd3ebc70f6d1) [#3469](https://github.com/npm/cli/issues/3469) fix(exitHandler): write code to logfile ([@wraithgar](https://github.com/wraithgar))
* [`0dd0341ac`](https://github.com/npm/cli/commit/0dd0341ac9a65a2df8fc262ad9a56b7351f99d66) [#3474](https://github.com/npm/cli/issues/3474) fix(ping): make "npm ping" echo a right time ([@aluneed](https://github.com/aluneed))
* [`d2e298f3c`](https://github.com/npm/cli/commit/d2e298f3cbab278071480f94ff7d916d42cbf43b) [#3484](https://github.com/npm/cli/issues/3484) fix(deprecate): add undeprecate support ([@wraithgar](https://github.com/wraithgar))

  ### DOCUMENTATION

* [`9dd32d08e`](https://github.com/npm/cli/commit/9dd32d08e09c21c9a4517161abfc7eed6518faf2) [#3485](https://github.com/npm/cli/issues/3485) fix(docs): remove npm package config override ([@wraithgar](https://github.com/wraithgar))
* [`a4e095618`](https://github.com/npm/cli/commit/a4e095618cda72244a18aaff9d6660b9082a2b84) [#3486](https://github.com/npm/cli/issues/3486) fix(docs): remove .hooks scripts ([@wraithgar](https://github.com/wraithgar))

### TESTING

* [`5f8ccccef`](https://github.com/npm/cli/commit/5f8ccccef9fc19229320df8cbcae9fcea8d31388) [#3483](https://github.com/npm/cli/issues/3483) chore(tests): clean snapshot for lib/view.js tests ([@wraithgar](https://github.com/wraithgar))
