### PR TITLE
fix: friendlier errors for ERR_SOCKET_TIMEOUT

### DIFF
--- a/lib/utils/error-message.js
+++ b/lib/utils/error-message.js
@@ -269,6 +269,7 @@ module.exports = (er, npm) => {
     case 'ECONNRESET':
     case 'ENOTFOUND':
     case 'ETIMEDOUT':
+    case 'ERR_SOCKET_TIMEOUT':
     case 'EAI_FAIL':
       short.push(['network', er.message])
       detail.push([

--- a/tap-snapshots/test/lib/utils/error-message.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/error-message.js.test.cjs
@@ -1289,6 +1289,29 @@ Object {
 }
 `
 
+exports[`test/lib/utils/error-message.js TAP just simple messages > must match snapshot 23`] = `
+Object {
+  "detail": Array [
+    Array [
+      "network",
+      String(
+        This is a problem related to network connectivity.
+        In most cases you are behind a proxy or have bad network settings.
+        
+        If you are behind a proxy, please make sure that the
+        'proxy' config is set properly.  See: 'npm help config'
+      ),
+    ],
+  ],
+  "summary": Array [
+    Array [
+      "network",
+      "foo",
+    ],
+  ],
+}
+`
+
 exports[`test/lib/utils/error-message.js TAP just simple messages > must match snapshot 3`] = `
 Object {
   "detail": Array [

--- a/test/lib/utils/error-message.js
+++ b/test/lib/utils/error-message.js
@@ -97,6 +97,7 @@ t.test('just simple messages', t => {
     'ETOOMANYARGS',
     'ETARGET',
     'E403',
+    'ERR_SOCKET_TIMEOUT',
   ]
   t.plan(codes.length)
   codes.forEach(code => {


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
this is the equivalent of ETIMEDOUT, but the specific code when it gets raised from agentkeepalive

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
