### PR TITLE
fix(update-notifier): don't force black background

### DIFF
--- a/lib/utils/update-notifier.js
+++ b/lib/utils/update-notifier.js
@@ -111,9 +111,8 @@ const updateNotifier = async (npm, spec = 'latest') => {
     `${oldc} -> ${latestc}\n` +
     `Changelog: ${changelogc}\n` +
     `Run ${cmdc} to update!\n`
-  const messagec = !useColor ? message : chalk.bgBlack.white(message)
 
-  return messagec
+  return message
 }
 
 // only update the notification timeout if we actually finished checking

--- a/tap-snapshots/test/lib/utils/update-notifier.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/update-notifier.js.test.cjs
@@ -6,11 +6,11 @@
  */
 'use strict'
 exports[`test/lib/utils/update-notifier.js TAP notification situations major to current > color 1`] = `
-[40m[37m[39m[49m
-[40m[37mNew [31mmajor[39m[37m version of npm available! [31m122.420.69[39m[37m -> [32m123.420.69[39m[37m[39m[49m
-[40m[37mChangelog: [36mhttps://github.com/npm/cli/releases/tag/v123.420.69[39m[37m[39m[49m
-[40m[37mRun [32mnpm install -g npm@123.420.69[39m[37m to update![39m[49m
-[40m[37m[39m[49m
+
+New [31mmajor[39m version of npm available! [31m122.420.69[39m -> [32m123.420.69[39m
+Changelog: [36mhttps://github.com/npm/cli/releases/tag/v123.420.69[39m
+Run [32mnpm install -g npm@123.420.69[39m to update!
+
 `
 
 exports[`test/lib/utils/update-notifier.js TAP notification situations major to current > no color 1`] = `
@@ -22,11 +22,11 @@ Run \`npm install -g npm@123.420.69\` to update!
 `
 
 exports[`test/lib/utils/update-notifier.js TAP notification situations minor to current > color 1`] = `
-[40m[37m[39m[49m
-[40m[37mNew [33mminor[39m[37m version of npm available! [31m123.419.69[39m[37m -> [32m123.420.69[39m[37m[39m[49m
-[40m[37mChangelog: [36mhttps://github.com/npm/cli/releases/tag/v123.420.69[39m[37m[39m[49m
-[40m[37mRun [32mnpm install -g npm@123.420.69[39m[37m to update![39m[49m
-[40m[37m[39m[49m
+
+New [33mminor[39m version of npm available! [31m123.419.69[39m -> [32m123.420.69[39m
+Changelog: [36mhttps://github.com/npm/cli/releases/tag/v123.420.69[39m
+Run [32mnpm install -g npm@123.420.69[39m to update!
+
 `
 
 exports[`test/lib/utils/update-notifier.js TAP notification situations minor to current > no color 1`] = `
@@ -38,11 +38,11 @@ Run \`npm install -g npm@123.420.69\` to update!
 `
 
 exports[`test/lib/utils/update-notifier.js TAP notification situations minor to next version > color 1`] = `
-[40m[37m[39m[49m
-[40m[37mNew [33mminor[39m[37m version of npm available! [31m123.420.70[39m[37m -> [32m123.421.70[39m[37m[39m[49m
-[40m[37mChangelog: [36mhttps://github.com/npm/cli/releases/tag/v123.421.70[39m[37m[39m[49m
-[40m[37mRun [32mnpm install -g npm@123.421.70[39m[37m to update![39m[49m
-[40m[37m[39m[49m
+
+New [33mminor[39m version of npm available! [31m123.420.70[39m -> [32m123.421.70[39m
+Changelog: [36mhttps://github.com/npm/cli/releases/tag/v123.421.70[39m
+Run [32mnpm install -g npm@123.421.70[39m to update!
+
 `
 
 exports[`test/lib/utils/update-notifier.js TAP notification situations minor to next version > no color 1`] = `
@@ -54,11 +54,11 @@ Run \`npm install -g npm@123.421.70\` to update!
 `
 
 exports[`test/lib/utils/update-notifier.js TAP notification situations new beta available > color 1`] = `
-[40m[37m[39m[49m
-[40m[37mNew [32mprerelease[39m[37m version of npm available! [31m124.0.0-beta.0[39m[37m -> [32m124.0.0-beta.99999[39m[37m[39m[49m
-[40m[37mChangelog: [36mhttps://github.com/npm/cli/releases/tag/v124.0.0-beta.99999[39m[37m[39m[49m
-[40m[37mRun [32mnpm install -g npm@124.0.0-beta.99999[39m[37m to update![39m[49m
-[40m[37m[39m[49m
+
+New [32mprerelease[39m version of npm available! [31m124.0.0-beta.0[39m -> [32m124.0.0-beta.99999[39m
+Changelog: [36mhttps://github.com/npm/cli/releases/tag/v124.0.0-beta.99999[39m
+Run [32mnpm install -g npm@124.0.0-beta.99999[39m to update!
+
 `
 
 exports[`test/lib/utils/update-notifier.js TAP notification situations new beta available > no color 1`] = `
@@ -70,11 +70,11 @@ Run \`npm install -g npm@124.0.0-beta.99999\` to update!
 `
 
 exports[`test/lib/utils/update-notifier.js TAP notification situations patch to current > color 1`] = `
-[40m[37m[39m[49m
-[40m[37mNew [32mpatch[39m[37m version of npm available! [31m123.420.68[39m[37m -> [32m123.420.69[39m[37m[39m[49m
-[40m[37mChangelog: [36mhttps://github.com/npm/cli/releases/tag/v123.420.69[39m[37m[39m[49m
-[40m[37mRun [32mnpm install -g npm@123.420.69[39m[37m to update![39m[49m
-[40m[37m[39m[49m
+
+New [32mpatch[39m version of npm available! [31m123.420.68[39m -> [32m123.420.69[39m
+Changelog: [36mhttps://github.com/npm/cli/releases/tag/v123.420.69[39m
+Run [32mnpm install -g npm@123.420.69[39m to update!
+
 `
 
 exports[`test/lib/utils/update-notifier.js TAP notification situations patch to current > no color 1`] = `
@@ -86,11 +86,11 @@ Run \`npm install -g npm@123.420.69\` to update!
 `
 
 exports[`test/lib/utils/update-notifier.js TAP notification situations patch to next version > color 1`] = `
-[40m[37m[39m[49m
-[40m[37mNew [32mpatch[39m[37m version of npm available! [31m123.421.69[39m[37m -> [32m123.421.70[39m[37m[39m[49m
-[40m[37mChangelog: [36mhttps://github.com/npm/cli/releases/tag/v123.421.70[39m[37m[39m[49m
-[40m[37mRun [32mnpm install -g npm@123.421.70[39m[37m to update![39m[49m
-[40m[37m[39m[49m
+
+New [32mpatch[39m version of npm available! [31m123.421.69[39m -> [32m123.421.70[39m
+Changelog: [36mhttps://github.com/npm/cli/releases/tag/v123.421.70[39m
+Run [32mnpm install -g npm@123.421.70[39m to update!
+
 `
 
 exports[`test/lib/utils/update-notifier.js TAP notification situations patch to next version > no color 1`] = `


### PR DESCRIPTION
This looks very wrong on white terminals.

npmlog still makes its `notice` logs do this but that will have to be
fixed in the npmlog repo.


## References
Related to https://github.com/npm/cli/issues/3091