### PR TITLE
fix(config): fix noproxy

### DIFF
--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -1204,7 +1204,10 @@ define('noproxy', {
     Also accepts a comma-delimited string.
   `,
   flatten (key, obj, flatOptions) {
-    flatOptions.noProxy = obj[key].join(',')
+    if (Array.isArray(obj[key]))
+      flatOptions.noProxy = obj[key].join(',')
+    else
+      flatOptions.noProxy = obj[key]
   },
 })
 

--- a/test/lib/utils/config/definitions.js
+++ b/test/lib/utils/config/definitions.js
@@ -463,8 +463,16 @@ t.test('search options', t => {
   t.end()
 })
 
-t.test('noProxy', t => {
+t.test('noProxy - array', t => {
   const obj = { noproxy: ['1.2.3.4,2.3.4.5', '3.4.5.6'] }
+  const flat = {}
+  definitions.noproxy.flatten('noproxy', obj, flat)
+  t.strictSame(flat, { noProxy: '1.2.3.4,2.3.4.5,3.4.5.6' })
+  t.end()
+})
+
+t.test('noProxy - string', t => {
+  const obj = { noproxy: '1.2.3.4,2.3.4.5,3.4.5.6' }
   const flat = {}
   definitions.noproxy.flatten('noproxy', obj, flat)
   t.strictSame(flat, { noProxy: '1.2.3.4,2.3.4.5,3.4.5.6' })


### PR DESCRIPTION
The flattener worked for everything except for when you are using
`npm config set` itself.  Now it works for both.


## References
Closes https://github.com/npm/cli/issues/3506