### PR TITLE
fix(bundle-and-ignore): case sensitivity cleanup

### DIFF
--- a/node_modules/.gitignore
+++ b/node_modules/.gitignore
@@ -2,7 +2,9 @@
 /.package-lock.json
 package-lock.json
 CHANGELOG*
+changelog*
 README*
+readme*
 .editorconfig
 .idea/
 .npmignore

--- a/node_modules/socks/typings/common/receivebuffer.d.ts
+++ b/node_modules/socks/typings/common/receivebuffer.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="node" />
+declare class ReceiveBuffer {
+    private buffer;
+    private offset;
+    private originalSize;
+    constructor(size?: number);
+    get length(): number;
+    append(data: Buffer): number;
+    peek(length: number): Buffer;
+    get(length: number): Buffer;
+}
+export { ReceiveBuffer };

--- a/scripts/bundle-and-gitignore-deps.js
+++ b/scripts/bundle-and-gitignore-deps.js
@@ -30,7 +30,9 @@ arb.loadVirtual().then(tree => {
 /.package-lock.json
 package-lock.json
 CHANGELOG*
+changelog*
 README*
+readme*
 .editorconfig
 .idea/
 .npmignore


### PR DESCRIPTION
Two files got into node_modules in a way that changes if you are on a
system that is case sensitive. One was a readme that is now properly
being ignored, the other is a typescript file that is upper case in some
instances.