### PR TITLE
chore: use better name on nodejs commits

### DIFF
--- a/.github/workflows/create-cli-deps-pr.yml
+++ b/.github/workflows/create-cli-deps-pr.yml
@@ -52,7 +52,7 @@ jobs:
             base_branch="v14.x-staging"
           fi 
 
-          git config user.name "npm-robot"
+          git config user.name "npm team"
           git config user.email "ops+robot@npmjs.com"
           git checkout -b "npm-$npm_tag"
 


### PR DESCRIPTION
Currently, the name: `npm-robot` is being used in nodejs changelogs as
the atttribution author name for npm-update commits. This makes it so
that entries in the changelog referring to our updates reads like:

```
upgrade npm to 7.18.1 (npm-robot) #39065
```

This change makes it so that the name used in commits is `npm team`,
this way the changelogs entry should read instead as:

```
upgrade npm to 7.18.1 (npm team) #39065
```

## References
Example: https://nodejs.org/en/blog/release/v16.4.0/

cc @darcyclarke @gimli01 @targos @richardlau @BethGriggs