### PR TITLE
fix(docs): add --foreground-scripts hint to prepare section

### DIFF
--- a/docs/content/using-npm/scripts.md
+++ b/docs/content/using-npm/scripts.md
@@ -54,7 +54,8 @@ situations. These scripts happen in addition to the `pre<event>`, `post<event>`,
  the prepare script will be run, before the package is packaged and
  installed.
 
-* As of `npm@7` these scripts run in the background
+* As of `npm@7` these scripts run in the background.
+  To run see the output, run with: `--foreground-scripts`.
 
 **prepublish** (DEPRECATED)
 * Does not run during `npm publish`, but does run during `npm ci`

--- a/docs/content/using-npm/scripts.md
+++ b/docs/content/using-npm/scripts.md
@@ -55,7 +55,7 @@ situations. These scripts happen in addition to the `pre<event>`, `post<event>`,
  installed.
 
 * As of `npm@7` these scripts run in the background.
-  To run see the output, run with: `--foreground-scripts`.
+  To see the output, run with: `--foreground-scripts`.
 
 **prepublish** (DEPRECATED)
 * Does not run during `npm publish`, but does run during `npm ci`


### PR DESCRIPTION
After switching to Npm@7, I was confused why it seemed like my `prepare` scripts were not running. Turns out they are running in the "background". The documentation does cover this but doesn't show how to revert to the old behavior. It takes some searching to find the desired flag. I thought it would help me to call out the new flag specifically.