### PR TITLE
fix(exit-handler): always warn if not called

### DIFF
--- a/lib/utils/exit-handler.js
+++ b/lib/utils/exit-handler.js
@@ -52,16 +52,17 @@ process.on('exit', code => {
 
   if (!code)
     npm.log.info('ok')
-  else {
+  else
     npm.log.verbose('code', code)
-    if (!exitHandlerCalled) {
-      npm.log.error('', 'Exit handler never called!')
-      console.error('')
-      npm.log.error('', 'This is an error with npm itself. Please report this error at:')
-      npm.log.error('', '    <https://github.com/npm/cli/issues>')
-      // TODO this doesn't have an npm.config.loaded guard
-      writeLogFile()
-    }
+
+  if (!exitHandlerCalled) {
+    process.exitCode = code || 1
+    npm.log.error('', 'Exit handler never called!')
+    console.error('')
+    npm.log.error('', 'This is an error with npm itself. Please report this error at:')
+    npm.log.error('', '    <https://github.com/npm/cli/issues>')
+    // TODO this doesn't have an npm.config.loaded guard
+    writeLogFile()
   }
   // In timing mode we always write the log file
   if (npm.config.loaded && npm.config.get('timing') && !wroteLogFile)

--- a/test/lib/utils/exit-handler.js
+++ b/test/lib/utils/exit-handler.js
@@ -336,15 +336,14 @@ t.test('defaults to log error msg if stack is missing', (t) => {
   t.end()
 })
 
-t.test('exits cleanly when emitting exit event', (t) => {
-  t.plan(1)
+t.test('exits uncleanly when only emitting exit event', (t) => {
+  t.plan(2)
 
   npm.log.level = 'silent'
   process.emit('exit')
-  t.match(
-    npm.log.record.find(r => r.level === 'info'),
-    { prefix: 'ok', message: '' }
-  )
+  const logData = fs.readFileSync(logFile, 'utf8')
+  t.match(logData, 'Exit handler never called!')
+  t.match(process.exitCode, 1, 'exitCode coerced to 1')
   t.end()
 })
 


### PR DESCRIPTION
If the exit handler wasn't called it is always a problem, even if there
is no exit code.