### PR TITLE
fix --if-present cascading to child npm run scripts

### DIFF
--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -97,7 +97,7 @@ class RunScript extends BaseCommand {
       !Object.prototype.hasOwnProperty.call(scripts, event) &&
       !(event === 'start' && await isServerPackage(path))
     ) {
-      if (this.npm.config.get('if-present'))
+      if (this.npm.config.get('if-present', 'cli'))
         return
 
       const suggestions = await didYouMean(this.npm, path, event)


### PR DESCRIPTION
This is an attempt to fix https://github.com/npm/cli/issues/3352 

Given a package.json like: 

```json
{
  "scripts": {
    "present": "npm run  not-present"
  }
}
```

`npm run --if-present present` would result in exit code 0, even though the second npm run call doesn't specify the `--if-present` flag.

With this PR, this would now throw throw an error:

```
npm ERR! Missing script: "not-present"
```

If `--if-present` is specified in the second script, this will continue to successfully return.

```json
{
  "scripts": {
    "present": "npm run  --if-present not-present"
  }
}
```

`npm run --if-present present` returns exit code 0.



A few notes:

I have no idea if the change might have an adverse effect on anything else or if it's the right approach at all. Feedback is welcome! :) 
I was also wondering if similar changes need to be applied to other flags (like `--silent`), but probably not?

I have tried to write tests, but I'm a bit stuck because https://github.com/npm/cli/blob/f9381de43f7aecb728227655c599085d696ffaf9/test/lib/run-script.js#L16 uses a mocked version of the config which doesn't distinguish between cli and other config.
Also I'm not sure the mocked npm could be used if a script uses `npm run some-other-script` inside that test? 


