### PR TITLE
Clear progress bar which overlays confirm prompt

### DIFF
--- a/node_modules/libnpmexec/lib/index.js
+++ b/node_modules/libnpmexec/lib/index.js
@@ -165,6 +165,7 @@ const exec = async (opts) => {
           const prompt = `Need to install the following packages:\n${
           addList
         }Ok to proceed? `
+          typeof log.clearProgress == 'function' && log.clearProgress()
           const confirm = await read({ prompt, default: 'y' })
           if (confirm.trim().toLowerCase().charAt(0) !== 'y')
             throw new Error('canceled')


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
## What Changed
Invoke `log.clearProgress()` to clear progress bar which overlays confirm prompt.

## References
Fixes #3461 
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
