### PR TITLE
v7.20.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## v7.20.4 (2021-08-05)
+
+### BUG FIXES
+
+* [`6a8086e25`](https://github.com/npm/cli/commit/6a8086e258aa209b877e182db4b75f11de5b291d)
+  [#3463](https://github.com/npm/cli/issues/3463)
+  fix(tests): move more tests to use real npm
+  ([@wraithgar](https://github.com/wraithgar))
+
+### DEPENDENCIES
+
+* [`15fae4941`](https://github.com/npm/cli/commit/15fae4941475f4398e47d9cc4eb6a73683e15aac)
+  `tar@6.1.6`:
+  * fix: properly handle top-level files when using strip
+  * Avoid an unlikely but theoretically possible redos
+  * WriteEntry backpressure
+  * fix(unpack): always resume parsing after an entry error
+  * fix(unpack): fix hang on large file on open() fail
+  * fix: properly prefix hard links
+* [`745326de0`](https://github.com/npm/cli/commit/745326de0fae9f27f1deaf7729777aae48ac29fc)
+  `libnpmexec@2.0.1`:
+  * Clear progress bar which overlays confirm prompt
+* [`e82bcd4e8`](https://github.com/npm/cli/commit/e82bcd4e8355d083f8f3eedb6251a5f3053d6dfd)
+  `graceful-fs@4.2.7`:
+  * fix: start retrying immediately, stop after 10 attempts
+
 ## v7.20.3 (2021-07-29)
 
 ### BUG FIXES

--- a/lib/set.js
+++ b/lib/set.js
@@ -22,7 +22,7 @@ class Set extends BaseCommand {
 
   exec (args, cb) {
     if (!args.length)
-      return cb(this.usage)
+      return cb(this.usageError())
     this.npm.commands.config(['set'].concat(args), cb)
   }
 }

--- a/lib/test.js
+++ b/lib/test.js
@@ -19,15 +19,5 @@ class Test extends LifecycleCmd {
       'script-shell',
     ]
   }
-
-  exec (args, cb) {
-    super.exec(args, er => {
-      if (er && er.code === 'ELIFECYCLE') {
-        /* eslint-disable standard/no-callback-literal */
-        cb('Test failed.  See above for more details.')
-      } else
-        cb(er)
-    })
-  }
 }
 module.exports = Test

--- a/node_modules/.gitignore
+++ b/node_modules/.gitignore
@@ -325,6 +325,7 @@ readme*
 /source-map
 /source-map-support
 /space-separated-tokens
+/spawk
 /spawn-wrap
 /spdx-compare
 /spdx-expression-validate

--- a/node_modules/chalk/package.json
+++ b/node_modules/chalk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "chalk",
-	"version": "4.1.1",
+	"version": "4.1.2",
 	"description": "Terminal string styling done right",
 	"license": "MIT",
 	"repository": "chalk/chalk",

--- a/node_modules/chalk/readme.md
+++ b/node_modules/chalk/readme.md
@@ -33,7 +33,7 @@
 		<br>
 		<br>
 		<a href="https://retool.com/?utm_campaign=sindresorhus">
-			<img src="https://sindresorhus.com/assets/thanks/retool-logo.svg" width="210"/>
+			<img src="https://sindresorhus.com/assets/thanks/retool-logo.svg" width="230"/>
 		</a>
 		<br>
 		<br>
@@ -46,6 +46,12 @@
 				<span>Stop struggling with scattered API keys, hacking together home-brewed tools,</span>
 				<br>
 				<span>and avoiding access controls. Keep your team and servers in sync with Doppler.</span>
+			</div>
+		</a>
+		<br>
+		<a href="https://uibakery.io/?utm_source=chalk&utm_medium=sponsor&utm_campaign=github">
+			<div>
+				<img src="https://sindresorhus.com/assets/thanks/uibakery-logo.jpg" width="270" alt="UI Bakery">
 			</div>
 		</a>
 	</p>

--- a/node_modules/graceful-fs/graceful-fs.js
+++ b/node_modules/graceful-fs/graceful-fs.js
@@ -114,14 +114,13 @@ function patch (fs) {
 
     return go$readFile(path, options, cb)
 
-    function go$readFile (path, options, cb) {
+    function go$readFile (path, options, cb, attempts = 0) {
       return fs$readFile(path, options, function (err) {
         if (err && (err.code === 'EMFILE' || err.code === 'ENFILE'))
-          enqueue([go$readFile, [path, options, cb]])
+          enqueue([go$readFile, [path, options, cb], attempts + 1, err])
         else {
           if (typeof cb === 'function')
             cb.apply(this, arguments)
-          retry()
         }
       })
     }
@@ -135,14 +134,13 @@ function patch (fs) {
 
     return go$writeFile(path, data, options, cb)
 
-    function go$writeFile (path, data, options, cb) {
+    function go$writeFile (path, data, options, cb, attempts = 0) {
       return fs$writeFile(path, data, options, function (err) {
         if (err && (err.code === 'EMFILE' || err.code === 'ENFILE'))
-          enqueue([go$writeFile, [path, data, options, cb]])
+          enqueue([go$writeFile, [path, data, options, cb], attempts + 1, err])
         else {
           if (typeof cb === 'function')
             cb.apply(this, arguments)
-          retry()
         }
       })
     }
@@ -157,14 +155,13 @@ function patch (fs) {
 
     return go$appendFile(path, data, options, cb)
 
-    function go$appendFile (path, data, options, cb) {
+    function go$appendFile (path, data, options, cb, attempts = 0) {
       return fs$appendFile(path, data, options, function (err) {
         if (err && (err.code === 'EMFILE' || err.code === 'ENFILE'))
-          enqueue([go$appendFile, [path, data, options, cb]])
+          enqueue([go$appendFile, [path, data, options, cb], attempts + 1, err])
         else {
           if (typeof cb === 'function')
             cb.apply(this, arguments)
-          retry()
         }
       })
     }
@@ -178,47 +175,41 @@ function patch (fs) {
       cb = flags
       flags = 0
     }
-    return fs$copyFile(src, dest, flags, function (err) {
-      if (err && (err.code === 'EMFILE' || err.code === 'ENFILE'))
-        enqueue([fs$copyFile, [src, dest, flags, cb]])
-      else {
-        if (typeof cb === 'function')
-          cb.apply(this, arguments)
-        retry()
-      }
-    })
+    return go$copyFile(src, dest, flags, cb)
+
+    function go$copyFile (src, dest, flags, cb, attempts = 0) {
+      return fs$copyFile(src, dest, flags, function (err) {
+        if (err && (err.code === 'EMFILE' || err.code === 'ENFILE'))
+          enqueue([go$copyFile, [src, dest, flags, cb], attempts + 1, err])
+        else {
+          if (typeof cb === 'function')
+            cb.apply(this, arguments)
+        }
+      })
+    }
   }
 
   var fs$readdir = fs.readdir
   fs.readdir = readdir
   function readdir (path, options, cb) {
-    var args = [path]
-    if (typeof options !== 'function') {
-      args.push(options)
-    } else {
-      cb = options
+    if (typeof options === 'function')
+      cb = options, options = null
+
+    return go$readdir(path, options, cb)
+
+    function go$readdir (path, options, cb, attempts = 0) {
+      return fs$readdir(path, options, function (err, files) {
+        if (err && (err.code === 'EMFILE' || err.code === 'ENFILE'))
+          enqueue([go$readdir, [path, options, cb], attempts + 1, err])
+        else {
+          if (files && files.sort)
+            files.sort()
+
+          if (typeof cb === 'function')
+            cb.call(this, err, files)
+        }
+      })
     }
-    args.push(go$readdir$cb)
-
-    return go$readdir(args)
-
-    function go$readdir$cb (err, files) {
-      if (files && files.sort)
-        files.sort()
-
-      if (err && (err.code === 'EMFILE' || err.code === 'ENFILE'))
-        enqueue([go$readdir, [args]])
-
-      else {
-        if (typeof cb === 'function')
-          cb.apply(this, arguments)
-        retry()
-      }
-    }
-  }
-
-  function go$readdir (args) {
-    return fs$readdir.apply(fs, args)
   }
 
   if (process.version.substr(0, 4) === 'v0.8') {
@@ -343,14 +334,13 @@ function patch (fs) {
 
     return go$open(path, flags, mode, cb)
 
-    function go$open (path, flags, mode, cb) {
+    function go$open (path, flags, mode, cb, attempts = 0) {
       return fs$open(path, flags, mode, function (err, fd) {
         if (err && (err.code === 'EMFILE' || err.code === 'ENFILE'))
-          enqueue([go$open, [path, flags, mode, cb]])
+          enqueue([go$open, [path, flags, mode, cb], attempts + 1, err])
         else {
           if (typeof cb === 'function')
             cb.apply(this, arguments)
-          retry()
         }
       })
     }
@@ -362,12 +352,24 @@ function patch (fs) {
 function enqueue (elem) {
   debug('ENQUEUE', elem[0].name, elem[1])
   fs[gracefulQueue].push(elem)
+  retry()
 }
 
 function retry () {
+  if (fs[gracefulQueue].length === 0)
+    return
+
   var elem = fs[gracefulQueue].shift()
   if (elem) {
-    debug('RETRY', elem[0].name, elem[1])
-    elem[0].apply(null, elem[1])
+    const [fn, args, attempts, err] = elem
+    if (attempts < 10) {
+      debug('RETRY', fn.name, args, `ATTEMPT #${attempts}`)
+      fn.call(null, ...args, attempts)
+    } else {
+      const cb = args.pop()
+      if (typeof cb === 'function')
+        cb.call(null, err)
+    }
   }
+  setImmediate(retry)
 }

--- a/node_modules/graceful-fs/package.json
+++ b/node_modules/graceful-fs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "graceful-fs",
   "description": "A drop-in replacement for fs, making various improvements.",
-  "version": "4.2.6",
+  "version": "4.2.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/isaacs/node-graceful-fs"

--- a/node_modules/libnpmexec/lib/index.js
+++ b/node_modules/libnpmexec/lib/index.js
@@ -165,6 +165,8 @@ const exec = async (opts) => {
           const prompt = `Need to install the following packages:\n${
           addList
         }Ok to proceed? `
+          if (typeof log.clearProgress === 'function')
+            log.clearProgress()
           const confirm = await read({ prompt, default: 'y' })
           if (confirm.trim().toLowerCase().charAt(0) !== 'y')
             throw new Error('canceled')

--- a/node_modules/libnpmexec/package.json
+++ b/node_modules/libnpmexec/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libnpmexec",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "files": [
     "lib"
   ],

--- a/node_modules/tar/lib/extract.js
+++ b/node_modules/tar/lib/extract.js
@@ -6,6 +6,7 @@ const Unpack = require('./unpack.js')
 const fs = require('fs')
 const fsm = require('fs-minipass')
 const path = require('path')
+const stripSlash = require('./strip-trailing-slashes.js')
 
 module.exports = (opt_, files, cb) => {
   if (typeof opt_ === 'function')
@@ -41,7 +42,7 @@ module.exports = (opt_, files, cb) => {
 // construct a filter that limits the file entries listed
 // include child entries if a dir is included
 const filesFilter = (opt, files) => {
-  const map = new Map(files.map(f => [f.replace(/\/+$/, ''), true]))
+  const map = new Map(files.map(f => [stripSlash(f), true]))
   const filter = opt.filter
 
   const mapHas = (file, r) => {
@@ -55,8 +56,8 @@ const filesFilter = (opt, files) => {
   }
 
   opt.filter = filter
-    ? (file, entry) => filter(file, entry) && mapHas(file.replace(/\/+$/, ''))
-    : file => mapHas(file.replace(/\/+$/, ''))
+    ? (file, entry) => filter(file, entry) && mapHas(stripSlash(file))
+    : file => mapHas(stripSlash(file))
 }
 
 const extractFileSync = opt => {

--- a/node_modules/tar/lib/list.js
+++ b/node_modules/tar/lib/list.js
@@ -9,6 +9,7 @@ const Parser = require('./parse.js')
 const fs = require('fs')
 const fsm = require('fs-minipass')
 const path = require('path')
+const stripSlash = require('./strip-trailing-slashes.js')
 
 module.exports = (opt_, files, cb) => {
   if (typeof opt_ === 'function')
@@ -54,7 +55,7 @@ const onentryFunction = opt => {
 // construct a filter that limits the file entries listed
 // include child entries if a dir is included
 const filesFilter = (opt, files) => {
-  const map = new Map(files.map(f => [f.replace(/\/+$/, ''), true]))
+  const map = new Map(files.map(f => [stripSlash(f), true]))
   const filter = opt.filter
 
   const mapHas = (file, r) => {
@@ -68,8 +69,8 @@ const filesFilter = (opt, files) => {
   }
 
   opt.filter = filter
-    ? (file, entry) => filter(file, entry) && mapHas(file.replace(/\/+$/, ''))
-    : file => mapHas(file.replace(/\/+$/, ''))
+    ? (file, entry) => filter(file, entry) && mapHas(stripSlash(file))
+    : file => mapHas(stripSlash(file))
 }
 
 const listFileSync = opt => {

--- a/node_modules/tar/lib/pack.js
+++ b/node_modules/tar/lib/pack.js
@@ -134,9 +134,6 @@ const Pack = warner(class Pack extends MiniPass {
 
   [ADDTARENTRY] (p) {
     const absolute = path.resolve(this.cwd, p.path)
-    if (this.prefix)
-      p.path = this.prefix + '/' + p.path.replace(/^\.(\/+|$)/, '')
-
     // in this case, we don't have to wait for the stat
     if (!this.filter(p.path, p))
       p.resume()
@@ -153,9 +150,6 @@ const Pack = warner(class Pack extends MiniPass {
 
   [ADDFSENTRY] (p) {
     const absolute = path.resolve(this.cwd, p)
-    if (this.prefix)
-      p = this.prefix + '/' + p.replace(/^\.(\/+|$)/, '')
-
     this[QUEUE].push(new PackJob(p, absolute))
     this[PROCESS]()
   }
@@ -298,6 +292,7 @@ const Pack = warner(class Pack extends MiniPass {
       statCache: this.statCache,
       noMtime: this.noMtime,
       mtime: this.mtime,
+      prefix: this.prefix,
     }
   }
 
@@ -323,10 +318,7 @@ const Pack = warner(class Pack extends MiniPass {
 
     if (job.readdir) {
       job.readdir.forEach(entry => {
-        const p = this.prefix ?
-          job.path.slice(this.prefix.length + 1) || './'
-          : job.path
-
+        const p = job.path
         const base = p === './' ? '' : p.replace(/\/*$/, '/')
         this[ADDFSENTRY](base + entry)
       })
@@ -381,10 +373,7 @@ class PackSync extends Pack {
 
     if (job.readdir) {
       job.readdir.forEach(entry => {
-        const p = this.prefix ?
-          job.path.slice(this.prefix.length + 1) || './'
-          : job.path
-
+        const p = job.path
         const base = p === './' ? '' : p.replace(/\/*$/, '/')
         this[ADDFSENTRY](base + entry)
       })

--- a/node_modules/tar/lib/strip-trailing-slashes.js
+++ b/node_modules/tar/lib/strip-trailing-slashes.js
@@ -1,0 +1,24 @@
+// this is the only approach that was significantly faster than using
+// str.replace(/\/+$/, '') for strings ending with a lot of / chars and
+// containing multiple / chars.
+const batchStrings = [
+  '/'.repeat(1024),
+  '/'.repeat(512),
+  '/'.repeat(256),
+  '/'.repeat(128),
+  '/'.repeat(64),
+  '/'.repeat(32),
+  '/'.repeat(16),
+  '/'.repeat(8),
+  '/'.repeat(4),
+  '/'.repeat(2),
+  '/',
+]
+
+module.exports = str => {
+  for (const s of batchStrings) {
+    while (str.length >= s.length && str.slice(-1 * s.length) === s)
+      str = str.slice(0, -1 * s.length)
+  }
+  return str
+}

--- a/node_modules/tar/lib/unpack.js
+++ b/node_modules/tar/lib/unpack.js
@@ -205,6 +205,8 @@ class Unpack extends Parser {
       if (parts.length < this.strip)
         return false
       entry.path = parts.slice(this.strip).join('/')
+      if (entry.path === '' && entry.type !== 'Directory' && entry.type !== 'GNUDumpDir')
+        return false
 
       if (entry.type === 'Link') {
         const linkparts = entry.linkpath.split(/\/|\\/)
@@ -333,17 +335,35 @@ class Unpack extends Parser {
       mode: mode,
       autoClose: false,
     })
-    stream.on('error', er => this[ONERROR](er, entry))
+    stream.on('error', er => {
+      if (stream.fd)
+        fs.close(stream.fd, () => {})
+      // flush all the data out so that we aren't left hanging
+      // if the error wasn't actually fatal.  otherwise the parse
+      // is blocked, and we never proceed.
+      stream.write = () => true
+      this[ONERROR](er, entry)
+      fullyDone()
+    })
 
     let actions = 1
     const done = er => {
-      if (er)
-        return this[ONERROR](er, entry)
+      if (er) {
+        /* istanbul ignore else - we should always have a fd by now */
+        if (stream.fd)
+          fs.close(stream.fd, () => {})
+        this[ONERROR](er, entry)
+        fullyDone()
+        return
+      }
 
       if (--actions === 0) {
         fs.close(stream.fd, er => {
+          if (er)
+            this[ONERROR](er, entry)
+          else
+            this[UNPEND]()
           fullyDone()
-          er ? this[ONERROR](er, entry) : this[UNPEND]()
         })
       }
     }
@@ -378,7 +398,10 @@ class Unpack extends Parser {
 
     const tx = this.transform ? this.transform(entry) || entry : entry
     if (tx !== entry) {
-      tx.on('error', er => this[ONERROR](er, entry))
+      tx.on('error', er => {
+        this[ONERROR](er, entry)
+        fullyDone()
+      })
       entry.pipe(tx)
     }
     tx.pipe(stream)
@@ -388,8 +411,9 @@ class Unpack extends Parser {
     const mode = entry.mode & 0o7777 || this.dmode
     this[MKDIR](entry.absolute, mode, er => {
       if (er) {
+        this[ONERROR](er, entry)
         fullyDone()
-        return this[ONERROR](er, entry)
+        return
       }
 
       let actions = 1
@@ -480,8 +504,9 @@ class Unpack extends Parser {
 
     this[MKDIR](path.dirname(entry.absolute), this.dmode, er => {
       if (er) {
+        this[ONERROR](er, entry)
         done()
-        return this[ONERROR](er, entry)
+        return
       }
       fs.lstat(entry.absolute, (er, st) => {
         if (st && (this.keep || this.newer && st.mtime > entry.mtime)) {
@@ -489,7 +514,6 @@ class Unpack extends Parser {
           done()
         } else if (er || this[ISREUSABLE](entry, st))
           this[MAKEFS](null, entry, done)
-
         else if (st.isDirectory()) {
           if (entry.type === 'Directory') {
             if (!this.noChmod && (!entry.mode || (st.mode & 0o7777) === entry.mode))
@@ -507,8 +531,11 @@ class Unpack extends Parser {
   }
 
   [MAKEFS] (er, entry, done) {
-    if (er)
-      return this[ONERROR](er, entry)
+    if (er) {
+      this[ONERROR](er, entry)
+      done()
+      return
+    }
 
     switch (entry.type) {
       case 'File':
@@ -532,10 +559,12 @@ class Unpack extends Parser {
     // XXX: get the type ('file' or 'dir') for windows
     fs[link](linkpath, entry.absolute, er => {
       if (er)
-        return this[ONERROR](er, entry)
+        this[ONERROR](er, entry)
+      else {
+        this[UNPEND]()
+        entry.resume()
+      }
       done()
-      this[UNPEND]()
-      entry.resume()
     })
   }
 }

--- a/node_modules/tar/lib/write-entry.js
+++ b/node_modules/tar/lib/write-entry.js
@@ -5,6 +5,13 @@ const Header = require('./header.js')
 const fs = require('fs')
 const path = require('path')
 
+const prefixPath = (path, prefix) => {
+  if (!prefix)
+    return path
+  path = path.replace(/^\.([/\\]|$)/, '')
+  return prefix + '/' + path
+}
+
 const maxReadSize = 16 * 1024 * 1024
 const PROCESS = Symbol('process')
 const FILE = Symbol('file')
@@ -21,6 +28,9 @@ const OPENFILE = Symbol('openfile')
 const ONOPENFILE = Symbol('onopenfile')
 const CLOSE = Symbol('close')
 const MODE = Symbol('mode')
+const AWAITDRAIN = Symbol('awaitDrain')
+const ONDRAIN = Symbol('ondrain')
+const PREFIX = Symbol('prefix')
 const warner = require('./warn-mixin.js')
 const winchars = require('./winchars.js')
 const stripAbsolutePath = require('./strip-absolute-path.js')
@@ -48,6 +58,16 @@ const WriteEntry = warner(class WriteEntry extends MiniPass {
     this.noPax = !!opt.noPax
     this.noMtime = !!opt.noMtime
     this.mtime = opt.mtime || null
+    this.prefix = opt.prefix || null
+
+    this.fd = null
+    this.blockLen = null
+    this.blockRemain = null
+    this.buf = null
+    this.offset = null
+    this.length = null
+    this.pos = null
+    this.remain = null
 
     if (typeof opt.onwarn === 'function')
       this.on('warn', opt.onwarn)
@@ -117,13 +137,19 @@ const WriteEntry = warner(class WriteEntry extends MiniPass {
     return modeFix(mode, this.type === 'Directory', this.portable)
   }
 
+  [PREFIX] (path) {
+    return prefixPath(path, this.prefix)
+  }
+
   [HEADER] () {
     if (this.type === 'Directory' && this.portable)
       this.noMtime = true
 
     this.header = new Header({
-      path: this.path,
-      linkpath: this.linkpath,
+      path: this[PREFIX](this.path),
+      // only apply the prefix to hard links.
+      linkpath: this.type === 'Link' ? this[PREFIX](this.linkpath)
+      : this.linkpath,
       // only the permissions and setuid/setgid/sticky bitflags
       // not the higher-order bits that specify file type
       mode: this[MODE](this.stat.mode),
@@ -139,13 +165,14 @@ const WriteEntry = warner(class WriteEntry extends MiniPass {
     })
 
     if (this.header.encode() && !this.noPax) {
-      this.write(new Pax({
+      super.write(new Pax({
         atime: this.portable ? null : this.header.atime,
         ctime: this.portable ? null : this.header.ctime,
         gid: this.portable ? null : this.header.gid,
         mtime: this.noMtime ? null : this.mtime || this.header.mtime,
-        path: this.path,
-        linkpath: this.linkpath,
+        path: this[PREFIX](this.path),
+        linkpath: this.type === 'Link' ? this[PREFIX](this.linkpath)
+        : this.linkpath,
         size: this.header.size,
         uid: this.portable ? null : this.header.uid,
         uname: this.portable ? null : this.header.uname,
@@ -154,7 +181,7 @@ const WriteEntry = warner(class WriteEntry extends MiniPass {
         nlink: this.portable ? null : this.stat.nlink,
       }).encode())
     }
-    this.write(this.header.block)
+    super.write(this.header.block)
   }
 
   [DIRECTORY] () {
@@ -214,74 +241,107 @@ const WriteEntry = warner(class WriteEntry extends MiniPass {
   }
 
   [ONOPENFILE] (fd) {
-    const blockLen = 512 * Math.ceil(this.stat.size / 512)
-    const bufLen = Math.min(blockLen, this.maxReadSize)
-    const buf = Buffer.allocUnsafe(bufLen)
-    this[READ](fd, buf, 0, buf.length, 0, this.stat.size, blockLen)
+    this.fd = fd
+    this.blockLen = 512 * Math.ceil(this.stat.size / 512)
+    this.blockRemain = this.blockLen
+    const bufLen = Math.min(this.blockLen, this.maxReadSize)
+    this.buf = Buffer.allocUnsafe(bufLen)
+    this.offset = 0
+    this.pos = 0
+    this.remain = this.stat.size
+    this.length = this.buf.length
+    this[READ]()
   }
 
-  [READ] (fd, buf, offset, length, pos, remain, blockRemain) {
+  [READ] () {
+    const { fd, buf, offset, length, pos } = this
     fs.read(fd, buf, offset, length, pos, (er, bytesRead) => {
       if (er) {
         // ignoring the error from close(2) is a bad practice, but at
         // this point we already have an error, don't need another one
-        return this[CLOSE](fd, () => this.emit('error', er))
+        return this[CLOSE](() => this.emit('error', er))
       }
-      this[ONREAD](fd, buf, offset, length, pos, remain, blockRemain, bytesRead)
+      this[ONREAD](bytesRead)
     })
   }
 
-  [CLOSE] (fd, cb) {
-    fs.close(fd, cb)
+  [CLOSE] (cb) {
+    fs.close(this.fd, cb)
   }
 
-  [ONREAD] (fd, buf, offset, length, pos, remain, blockRemain, bytesRead) {
-    if (bytesRead <= 0 && remain > 0) {
+  [ONREAD] (bytesRead) {
+    if (bytesRead <= 0 && this.remain > 0) {
       const er = new Error('encountered unexpected EOF')
       er.path = this.absolute
       er.syscall = 'read'
       er.code = 'EOF'
-      return this[CLOSE](fd, () => this.emit('error', er))
+      return this[CLOSE](() => this.emit('error', er))
     }
 
-    if (bytesRead > remain) {
+    if (bytesRead > this.remain) {
       const er = new Error('did not encounter expected EOF')
       er.path = this.absolute
       er.syscall = 'read'
       er.code = 'EOF'
-      return this[CLOSE](fd, () => this.emit('error', er))
+      return this[CLOSE](() => this.emit('error', er))
     }
 
     // null out the rest of the buffer, if we could fit the block padding
-    if (bytesRead === remain) {
-      for (let i = bytesRead; i < length && bytesRead < blockRemain; i++) {
-        buf[i + offset] = 0
+    // at the end of this loop, we've incremented bytesRead and this.remain
+    // to be incremented up to the blockRemain level, as if we had expected
+    // to get a null-padded file, and read it until the end.  then we will
+    // decrement both remain and blockRemain by bytesRead, and know that we
+    // reached the expected EOF, without any null buffer to append.
+    if (bytesRead === this.remain) {
+      for (let i = bytesRead; i < this.length && bytesRead < this.blockRemain; i++) {
+        this.buf[i + this.offset] = 0
         bytesRead++
-        remain++
+        this.remain++
       }
     }
 
-    const writeBuf = offset === 0 && bytesRead === buf.length ?
-      buf : buf.slice(offset, offset + bytesRead)
-    remain -= bytesRead
-    blockRemain -= bytesRead
-    pos += bytesRead
-    offset += bytesRead
+    const writeBuf = this.offset === 0 && bytesRead === this.buf.length ?
+      this.buf : this.buf.slice(this.offset, this.offset + bytesRead)
 
-    this.write(writeBuf)
+    const flushed = this.write(writeBuf)
+    if (!flushed)
+      this[AWAITDRAIN](() => this[ONDRAIN]())
+    else
+      this[ONDRAIN]()
+  }
 
-    if (!remain) {
-      if (blockRemain)
-        this.write(Buffer.alloc(blockRemain))
-      return this[CLOSE](fd, er => er ? this.emit('error', er) : this.end())
+  [AWAITDRAIN] (cb) {
+    this.once('drain', cb)
+  }
+
+  write (writeBuf) {
+    if (this.blockRemain < writeBuf.length) {
+      const er = new Error('writing more data than expected')
+      er.path = this.absolute
+      return this.emit('error', er)
+    }
+    this.remain -= writeBuf.length
+    this.blockRemain -= writeBuf.length
+    this.pos += writeBuf.length
+    this.offset += writeBuf.length
+    return super.write(writeBuf)
+  }
+
+  [ONDRAIN] () {
+    if (!this.remain) {
+      if (this.blockRemain)
+        super.write(Buffer.alloc(this.blockRemain))
+      return this[CLOSE](er => er ? this.emit('error', er) : this.end())
     }
 
-    if (offset >= length) {
-      buf = Buffer.allocUnsafe(length)
-      offset = 0
+    if (this.offset >= this.length) {
+      // if we only have a smaller bit left to read, alloc a smaller buffer
+      // otherwise, keep it the same length it was before.
+      this.buf = Buffer.allocUnsafe(Math.min(this.blockRemain, this.buf.length))
+      this.offset = 0
     }
-    length = buf.length - offset
-    this[READ](fd, buf, offset, length, pos, remain, blockRemain)
+    this.length = this.buf.length - this.offset
+    this[READ]()
   }
 })
 
@@ -298,25 +358,30 @@ class WriteEntrySync extends WriteEntry {
     this[ONOPENFILE](fs.openSync(this.absolute, 'r'))
   }
 
-  [READ] (fd, buf, offset, length, pos, remain, blockRemain) {
+  [READ] () {
     let threw = true
     try {
+      const { fd, buf, offset, length, pos } = this
       const bytesRead = fs.readSync(fd, buf, offset, length, pos)
-      this[ONREAD](fd, buf, offset, length, pos, remain, blockRemain, bytesRead)
+      this[ONREAD](bytesRead)
       threw = false
     } finally {
       // ignoring the error from close(2) is a bad practice, but at
       // this point we already have an error, don't need another one
       if (threw) {
         try {
-          this[CLOSE](fd, () => {})
+          this[CLOSE](() => {})
         } catch (er) {}
       }
     }
   }
 
-  [CLOSE] (fd, cb) {
-    fs.closeSync(fd)
+  [AWAITDRAIN] (cb) {
+    cb()
+  }
+
+  [CLOSE] (cb) {
+    fs.closeSync(this.fd)
     cb()
   }
 }
@@ -335,6 +400,8 @@ const WriteEntryTar = warner(class WriteEntryTar extends MiniPass {
     this.type = readEntry.type
     if (this.type === 'Directory' && this.portable)
       this.noMtime = true
+
+    this.prefix = opt.prefix || null
 
     this.path = readEntry.path
     this.mode = this[MODE](readEntry.mode)
@@ -364,8 +431,9 @@ const WriteEntryTar = warner(class WriteEntryTar extends MiniPass {
     this.blockRemain = readEntry.startBlockSize
 
     this.header = new Header({
-      path: this.path,
-      linkpath: this.linkpath,
+      path: this[PREFIX](this.path),
+      linkpath: this.type === 'Link' ? this[PREFIX](this.linkpath)
+      : this.linkpath,
       // only the permissions and setuid/setgid/sticky bitflags
       // not the higher-order bits that specify file type
       mode: this.mode,
@@ -392,8 +460,9 @@ const WriteEntryTar = warner(class WriteEntryTar extends MiniPass {
         ctime: this.portable ? null : this.ctime,
         gid: this.portable ? null : this.gid,
         mtime: this.noMtime ? null : this.mtime,
-        path: this.path,
-        linkpath: this.linkpath,
+        path: this[PREFIX](this.path),
+        linkpath: this.type === 'Link' ? this[PREFIX](this.linkpath)
+        : this.linkpath,
         size: this.size,
         uid: this.portable ? null : this.uid,
         uname: this.portable ? null : this.uname,
@@ -405,6 +474,10 @@ const WriteEntryTar = warner(class WriteEntryTar extends MiniPass {
 
     super.write(this.header.block)
     readEntry.pipe(this)
+  }
+
+  [PREFIX] (path) {
+    return prefixPath(path, this.prefix)
   }
 
   [MODE] (mode) {
@@ -421,7 +494,7 @@ const WriteEntryTar = warner(class WriteEntryTar extends MiniPass {
 
   end () {
     if (this.blockRemain)
-      this.write(Buffer.alloc(this.blockRemain))
+      super.write(Buffer.alloc(this.blockRemain))
     return super.end()
   }
 })

--- a/node_modules/tar/package.json
+++ b/node_modules/tar/package.json
@@ -2,7 +2,7 @@
   "author": "Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)",
   "name": "tar",
   "description": "tar for node",
-  "version": "6.1.2",
+  "version": "6.1.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/npm/node-tar.git"

--- a/package-lock.json
+++ b/package-lock.json
@@ -144,7 +144,7 @@
         "rimraf": "^3.0.2",
         "semver": "^7.3.5",
         "ssri": "^8.0.1",
-        "tar": "^6.1.2",
+        "tar": "^6.1.6",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "treeverse": "^1.0.4",
@@ -9466,9 +9466,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.2.tgz",
-      "integrity": "sha512-EwKEgqJ7nJoS+s8QfLYVGMDmAsj+StbI2AM/RTHeUSsOw6Z8bwNBRv5z3CY0m7laC5qUAqruLX5AhMuc5deY3Q==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.6.tgz",
+      "integrity": "sha512-oaWyu5dQbHaYcyZCTfyPpC+VmI62/OM2RTUYavTk1MDr1cwW5Boi3baeYQKiZbY2uSQJGr+iMOzb/JFxLrft+g==",
       "inBundle": true,
       "dependencies": {
         "chownr": "^2.0.0",
@@ -17412,9 +17412,9 @@
       }
     },
     "tar": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.2.tgz",
-      "integrity": "sha512-EwKEgqJ7nJoS+s8QfLYVGMDmAsj+StbI2AM/RTHeUSsOw6Z8bwNBRv5z3CY0m7laC5qUAqruLX5AhMuc5deY3Q==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.6.tgz",
+      "integrity": "sha512-oaWyu5dQbHaYcyZCTfyPpC+VmI62/OM2RTUYavTk1MDr1cwW5Boi3baeYQKiZbY2uSQJGr+iMOzb/JFxLrft+g==",
       "requires": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm",
-  "version": "7.20.3",
+  "version": "7.20.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "npm",
-      "version": "7.20.3",
+      "version": "7.20.4",
       "bundleDependencies": [
         "@npmcli/arborist",
         "@npmcli/ci-detect",

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,7 +94,7 @@
         "archy": "~1.0.0",
         "byte-size": "^7.0.1",
         "cacache": "^15.2.0",
-        "chalk": "^4.1.0",
+        "chalk": "^4.1.2",
         "chownr": "^2.0.0",
         "cli-columns": "^3.1.2",
         "cli-table3": "^0.6.0",
@@ -1637,9 +1637,9 @@
       }
     },
     "node_modules/chalk": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "inBundle": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -11680,9 +11680,9 @@
       "dev": true
     },
     "chalk": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -163,6 +163,7 @@
         "eslint-plugin-promise": "^5.1.0",
         "eslint-plugin-standard": "^5.0.0",
         "licensee": "^8.2.0",
+        "spawk": "^1.7.1",
         "tap": "^15.0.9"
       },
       "engines": {
@@ -7104,6 +7105,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/spawk": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/spawk/-/spawk-1.7.1.tgz",
+      "integrity": "sha512-qkPqVdPp5ICEeSYKB/qCkwIBB0IWQuouEvYenQvpTq15fqSQgutpH453NjEImrpCWTwQwj2bQjGp8YGHapEiWw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/spawn-wrap": {
@@ -15720,6 +15730,12 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
       "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
+      "dev": true
+    },
+    "spawk": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/spawk/-/spawk-1.7.1.tgz",
+      "integrity": "sha512-qkPqVdPp5ICEeSYKB/qCkwIBB0IWQuouEvYenQvpTq15fqSQgutpH453NjEImrpCWTwQwj2bQjGp8YGHapEiWw==",
       "dev": true
     },
     "spawn-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,7 @@
         "cli-table3": "^0.6.0",
         "columnify": "~1.5.4",
         "glob": "^7.1.7",
-        "graceful-fs": "^4.2.6",
+        "graceful-fs": "^4.2.7",
         "hosted-git-info": "^4.0.2",
         "ini": "^2.0.0",
         "init-package-json": "^2.0.3",
@@ -3465,9 +3465,9 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.7.tgz",
+      "integrity": "sha512-b1suB8r7mlSJQIBs6typf13fz55WYPeE7/KYlQUvqB7E3hUkXhz4D8FVHkENHTqG8+mD2yyT9HgT5bNkGNiqeQ==",
       "inBundle": true
     },
     "node_modules/har-schema": {
@@ -13040,9 +13040,9 @@
       "dev": true
     },
     "graceful-fs": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.7.tgz",
+      "integrity": "sha512-b1suB8r7mlSJQIBs6typf13fz55WYPeE7/KYlQUvqB7E3hUkXhz4D8FVHkENHTqG8+mD2yyT9HgT5bNkGNiqeQ=="
     },
     "har-schema": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -109,7 +109,7 @@
         "leven": "^3.1.0",
         "libnpmaccess": "^4.0.2",
         "libnpmdiff": "^2.0.4",
-        "libnpmexec": "^2.0.0",
+        "libnpmexec": "^2.0.1",
         "libnpmfund": "^1.1.0",
         "libnpmhook": "^6.0.2",
         "libnpmorg": "^2.0.2",
@@ -4644,9 +4644,9 @@
       "link": true
     },
     "node_modules/libnpmexec": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/libnpmexec/-/libnpmexec-2.0.0.tgz",
-      "integrity": "sha512-9zHswx//Lp2ao+huWF2aL+6v4haMncyxNusk6Us2fbLNnPh3+rgSkv38LJ2v8gmKS2kAnkUmQf8pHjcZ+7Z3NA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/libnpmexec/-/libnpmexec-2.0.1.tgz",
+      "integrity": "sha512-4SqBB7eJvJWmUKNF42Q5qTOn20DRjEE4TgvEh2yneKlAiRlwlhuS9MNR45juWwmoURJlf2K43bozlVt7OZiIOw==",
       "inBundle": true,
       "dependencies": {
         "@npmcli/arborist": "^2.3.0",
@@ -13878,9 +13878,9 @@
       }
     },
     "libnpmexec": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/libnpmexec/-/libnpmexec-2.0.0.tgz",
-      "integrity": "sha512-9zHswx//Lp2ao+huWF2aL+6v4haMncyxNusk6Us2fbLNnPh3+rgSkv38LJ2v8gmKS2kAnkUmQf8pHjcZ+7Z3NA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/libnpmexec/-/libnpmexec-2.0.1.tgz",
+      "integrity": "sha512-4SqBB7eJvJWmUKNF42Q5qTOn20DRjEE4TgvEh2yneKlAiRlwlhuS9MNR45juWwmoURJlf2K43bozlVt7OZiIOw==",
       "requires": {
         "@npmcli/arborist": "^2.3.0",
         "@npmcli/ci-detect": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.20.3",
+  "version": "7.20.4",
   "name": "npm",
   "description": "a package manager for JavaScript",
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "rimraf": "^3.0.2",
     "semver": "^7.3.5",
     "ssri": "^8.0.1",
-    "tar": "^6.1.2",
+    "tar": "^6.1.6",
     "text-table": "~0.2.0",
     "tiny-relative-date": "^1.3.0",
     "treeverse": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "cli-table3": "^0.6.0",
     "columnify": "~1.5.4",
     "glob": "^7.1.7",
-    "graceful-fs": "^4.2.6",
+    "graceful-fs": "^4.2.7",
     "hosted-git-info": "^4.0.2",
     "ini": "^2.0.0",
     "init-package-json": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "leven": "^3.1.0",
     "libnpmaccess": "^4.0.2",
     "libnpmdiff": "^2.0.4",
-    "libnpmexec": "^2.0.0",
+    "libnpmexec": "^2.0.1",
     "libnpmfund": "^1.1.0",
     "libnpmhook": "^6.0.2",
     "libnpmorg": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -199,6 +199,7 @@
     "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-standard": "^5.0.0",
     "licensee": "^8.2.0",
+    "spawk": "^1.7.1",
     "tap": "^15.0.9"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "archy": "~1.0.0",
     "byte-size": "^7.0.1",
     "cacache": "^15.2.0",
-    "chalk": "^4.1.0",
+    "chalk": "^4.1.2",
     "chownr": "^2.0.0",
     "cli-columns": "^3.1.2",
     "cli-table3": "^0.6.0",

--- a/test/fixtures/mock-npm.js
+++ b/test/fixtures/mock-npm.js
@@ -9,6 +9,10 @@ for (const level in npmlog.levels)
 const { title, execPath } = process
 
 const RealMockNpm = (t, otherMocks = {}) => {
+  t.afterEach(() => {
+    outputs.length = 0
+    logs.length = 0
+  })
   t.teardown(() => {
     npm.perfStop()
     npmlog.record.length = 0
@@ -22,6 +26,9 @@ const RealMockNpm = (t, otherMocks = {}) => {
   })
   const logs = []
   const outputs = []
+  const joinedOutput = () => {
+    return outputs.map(o => o.join(' ')).join('\n')
+  }
   const npm = t.mock('../../lib/npm.js', otherMocks)
   const command = async (command, args = []) => {
     return new Promise((resolve, reject) => {
@@ -43,7 +50,7 @@ const RealMockNpm = (t, otherMocks = {}) => {
     }
   }
   npm.output = (...msg) => outputs.push(msg)
-  return { npm, logs, outputs, command }
+  return { npm, logs, outputs, command, joinedOutput }
 }
 
 const realConfig = require('../../lib/utils/config')

--- a/test/lib/get.js
+++ b/test/lib/get.js
@@ -1,16 +1,16 @@
 const t = require('tap')
+const { real: mockNpm } = require('../fixtures/mock-npm')
 
-t.test('should retrieve values from npm.commands.config', (t) => {
-  const Get = t.mock('../../lib/get.js')
-  const get = new Get({
-    commands: {
-      config: ([action, arg]) => {
-        t.equal(action, 'get', 'should use config get action')
-        t.equal(arg, 'foo', 'should use expected key')
-        t.end()
-      },
-    },
-  })
-
-  get.exec(['foo'])
+t.test('should retrieve values from config', async t => {
+  const { joinedOutput, command, npm } = mockNpm(t)
+  const name = 'editor'
+  const value = 'vigor'
+  await npm.load()
+  npm.config.set(name, value)
+  await command('get', [name])
+  t.equal(
+    joinedOutput(),
+    value,
+    'outputs config item'
+  )
 })

--- a/test/lib/load-all.js
+++ b/test/lib/load-all.js
@@ -1,15 +1,24 @@
 const t = require('tap')
 const glob = require('glob')
 const { resolve } = require('path')
+const { real: mockNpm } = require('../fixtures/mock-npm')
 
 const full = process.env.npm_lifecycle_event === 'check-coverage'
 
 if (!full)
   t.pass('nothing to do here, not checking for full coverage')
 else {
-  // some files do config.get() on load, so have to load npm first
-  const npm = require('../../lib/npm.js')
-  t.test('load npm first', t => npm.load(t.end))
+  const { npm } = mockNpm(t)
+
+  t.teardown(() => {
+    const exitHandler = require('../../lib/utils/exit-handler.js')
+    exitHandler.setNpm(npm)
+    exitHandler()
+  })
+
+  t.test('load npm first', async t => {
+    await npm.load()
+  })
 
   t.test('load all the files', t => {
     // just load all the files so we measure coverage for the missing tests
@@ -19,13 +28,6 @@ else {
       t.pass('loaded ' + f)
     }
     t.pass('loaded all files')
-    t.end()
-  })
-
-  t.test('call the exit handler so we dont freak out', t => {
-    const exitHandler = require('../../lib/utils/exit-handler.js')
-    exitHandler.setNpm(npm)
-    exitHandler()
     t.end()
   })
 }

--- a/test/lib/prefix.js
+++ b/test/lib/prefix.js
@@ -1,19 +1,13 @@
 const t = require('tap')
+const { real: mockNpm } = require('../fixtures/mock-npm')
 
-t.test('prefix', (t) => {
-  t.plan(3)
-  const dir = '/prefix/dir'
-
-  const Prefix = require('../../lib/prefix.js')
-  const prefix = new Prefix({
-    prefix: dir,
-    output: (output) => {
-      t.equal(output, dir, 'prints the correct directory')
-    },
-  })
-
-  prefix.exec([], (err) => {
-    t.error(err, 'npm prefix')
-    t.ok('should have printed directory')
-  })
+t.test('prefix', async (t) => {
+  const { joinedOutput, command, npm } = mockNpm(t)
+  await npm.load()
+  await command('prefix')
+  t.equal(
+    joinedOutput(),
+    npm.prefix,
+    'outputs npm.prefix'
+  )
 })

--- a/test/lib/prune.js
+++ b/test/lib/prune.js
@@ -1,7 +1,9 @@
 const t = require('tap')
+const { real: mockNpm } = require('../fixtures/mock-npm')
 
-t.test('should prune using Arborist', (t) => {
-  const Prune = t.mock('../../lib/prune.js', {
+t.test('should prune using Arborist', async (t) => {
+  t.plan(4)
+  const { command, npm } = mockNpm(t, {
     '@npmcli/arborist': function (args) {
       t.ok(args, 'gets options object')
       t.ok(args.path, 'gets path option')
@@ -13,16 +15,6 @@ t.test('should prune using Arborist', (t) => {
       t.ok(arb, 'gets arborist tree')
     },
   })
-  const prune = new Prune({
-    prefix: 'foo',
-    flatOptions: {
-      foo: 'bar',
-    },
-  })
-  prune.exec(null, er => {
-    if (er)
-      throw er
-    t.ok(true, 'callback is called')
-    t.end()
-  })
+  await npm.load()
+  await command('prune')
 })

--- a/test/lib/restart.js
+++ b/test/lib/restart.js
@@ -1,16 +1,36 @@
 const t = require('tap')
-let runArgs
-const npm = {
-  commands: {
-    'run-script': (args, cb) => {
-      runArgs = args
-      cb()
-    },
-  },
-}
-const Restart = require('../../lib/restart.js')
-const restart = new Restart(npm)
-restart.exec(['foo'], () => {
-  t.match(runArgs, ['restart', 'foo'])
-  t.end()
+const spawk = require('spawk')
+const { real: mockNpm } = require('../fixtures/mock-npm')
+
+spawk.preventUnmatched()
+t.teardown(() => {
+  spawk.unload()
+})
+
+// TODO this ... smells.  npm "script-shell" config mentions defaults but those
+// are handled by run-script, not npm.  So for now we have to tie tests to some
+// pretty specific internals of runScript
+const makeSpawnArgs = require('@npmcli/run-script/lib/make-spawn-args.js')
+
+t.test('should run stop script from package.json', async t => {
+  const prefix = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'x',
+      version: '1.2.3',
+      scripts: {
+        restart: 'node ./test-restart.js',
+      },
+    }),
+  })
+  const { command, npm } = mockNpm(t)
+  await npm.load()
+  npm.log.level = 'silent'
+  npm.localPrefix = prefix
+  const [scriptShell] = makeSpawnArgs({ path: prefix })
+  const script = spawk.spawn(scriptShell, (args) => {
+    t.ok(args.includes('node ./test-restart.js "foo"'), 'ran stop script with extra args')
+    return true
+  })
+  await command('restart', ['foo'])
+  t.ok(script.called, 'script ran')
 })

--- a/test/lib/root.js
+++ b/test/lib/root.js
@@ -1,19 +1,13 @@
 const t = require('tap')
+const { real: mockNpm } = require('../fixtures/mock-npm')
 
-t.test('root', (t) => {
-  t.plan(3)
-  const dir = '/root/dir'
-
-  const Root = require('../../lib/root.js')
-  const root = new Root({
-    dir,
-    output: (output) => {
-      t.equal(output, dir, 'prints the correct directory')
-    },
-  })
-
-  root.exec([], (err) => {
-    t.error(err, 'npm root')
-    t.ok('should have printed directory')
-  })
+t.test('prefix', async (t) => {
+  const { joinedOutput, command, npm } = mockNpm(t)
+  await npm.load()
+  await command('root')
+  t.equal(
+    joinedOutput(),
+    npm.dir,
+    'outputs npm.dir'
+  )
 })

--- a/test/lib/set.js
+++ b/test/lib/set.js
@@ -1,5 +1,32 @@
 const t = require('tap')
 
+// can't run this until npm set can save to npm.localPrefix
+t.skip('npm set', async t => {
+  const { real: mockNpm } = require('../fixtures/mock-npm')
+  const { joinedOutput, command, npm } = mockNpm(t)
+  await npm.load()
+
+  t.test('no args', async t => {
+    t.rejects(
+      command('set'),
+      /Usage:/,
+      'prints usage'
+    )
+  })
+
+  t.test('test-config-item', async t => {
+    npm.localPrefix = t.testdir({})
+    t.not(npm.config.get('test-config-item', 'project'), 'test config value', 'config is not already new value')
+    // This will write to ~/.npmrc!
+    // Don't unskip until we can write to project level
+    await command('set', ['test-config-item=test config value'])
+    t.equal(joinedOutput(), '', 'outputs nothing')
+    t.equal(npm.config.get('test-config-item', 'project'), 'test config value', 'config is set to new value')
+  })
+})
+
+// Everything after this can go away once the above test is unskipped
+
 let configArgs = null
 const npm = {
   commands: {

--- a/test/lib/start.js
+++ b/test/lib/start.js
@@ -1,16 +1,36 @@
 const t = require('tap')
-let runArgs
-const npm = {
-  commands: {
-    'run-script': (args, cb) => {
-      runArgs = args
-      cb()
-    },
-  },
-}
-const Start = require('../../lib/start.js')
-const start = new Start(npm)
-start.exec(['foo'], () => {
-  t.match(runArgs, ['start', 'foo'])
-  t.end()
+const spawk = require('spawk')
+const { real: mockNpm } = require('../fixtures/mock-npm')
+
+spawk.preventUnmatched()
+t.teardown(() => {
+  spawk.unload()
+})
+
+// TODO this ... smells.  npm "script-shell" config mentions defaults but those
+// are handled by run-script, not npm.  So for now we have to tie tests to some
+// pretty specific internals of runScript
+const makeSpawnArgs = require('@npmcli/run-script/lib/make-spawn-args.js')
+
+t.test('should run stop script from package.json', async t => {
+  const prefix = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'x',
+      version: '1.2.3',
+      scripts: {
+        start: 'node ./test-start.js',
+      },
+    }),
+  })
+  const { command, npm } = mockNpm(t)
+  await npm.load()
+  npm.log.level = 'silent'
+  npm.localPrefix = prefix
+  const [scriptShell] = makeSpawnArgs({ path: prefix })
+  const script = spawk.spawn(scriptShell, (args) => {
+    t.ok(args.includes('node ./test-start.js "foo"'), 'ran start script with extra args')
+    return true
+  })
+  await command('start', ['foo'])
+  t.ok(script.called, 'script ran')
 })

--- a/test/lib/stop.js
+++ b/test/lib/stop.js
@@ -1,16 +1,36 @@
 const t = require('tap')
-let runArgs
-const npm = {
-  commands: {
-    'run-script': (args, cb) => {
-      runArgs = args
-      cb()
-    },
-  },
-}
-const Stop = require('../../lib/stop.js')
-const stop = new Stop(npm)
-stop.exec(['foo'], () => {
-  t.match(runArgs, ['stop', 'foo'])
-  t.end()
+const spawk = require('spawk')
+const { real: mockNpm } = require('../fixtures/mock-npm')
+
+spawk.preventUnmatched()
+t.teardown(() => {
+  spawk.unload()
+})
+
+// TODO this ... smells.  npm "script-shell" config mentions defaults but those
+// are handled by run-script, not npm.  So for now we have to tie tests to some
+// pretty specific internals of runScript
+const makeSpawnArgs = require('@npmcli/run-script/lib/make-spawn-args.js')
+
+t.test('should run stop script from package.json', async t => {
+  const prefix = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'x',
+      version: '1.2.3',
+      scripts: {
+        stop: 'node ./test-stop.js',
+      },
+    }),
+  })
+  const { command, npm } = mockNpm(t)
+  await npm.load()
+  npm.log.level = 'silent'
+  npm.localPrefix = prefix
+  const [scriptShell] = makeSpawnArgs({ path: prefix })
+  const script = spawk.spawn(scriptShell, (args) => {
+    t.ok(args.includes('node ./test-stop.js "foo"'), 'ran stop script with extra args')
+    return true
+  })
+  await command('stop', ['foo'])
+  t.ok(script.called, 'script ran')
 })


### PR DESCRIPTION
## v7.20.4 (2021-08-05)

### BUG FIXES

* [`6a8086e25`](https://github.com/npm/cli/commit/6a8086e258aa209b877e182db4b75f11de5b291d) [#3463](https://github.com/npm/cli/issues/3463) fix(tests): move more tests to use real npm ([@wraithgar](https://github.com/wraithgar))

### DEPENDENCIES

* [`15fae4941`](https://github.com/npm/cli/commit/15fae4941475f4398e47d9cc4eb6a73683e15aac) `tar@6.1.6`:
  * fix: properly handle top-level files when using strip
  * Avoid an unlikely but theoretically possible redos
  * WriteEntry backpressure
  * fix(unpack): always resume parsing after an entry error
  * fix(unpack): fix hang on large file on open() fail
  * fix: properly prefix hard links
* [`745326de0`](https://github.com/npm/cli/commit/745326de0fae9f27f1deaf7729777aae48ac29fc) `libnpmexec@2.0.1`:
  * Clear progress bar which overlays confirm prompt
* [`e82bcd4e8`](https://github.com/npm/cli/commit/e82bcd4e8355d083f8f3eedb6251a5f3053d6dfd) `graceful-fs@4.2.7`:
  * fix: start retrying immediately, stop after 10 attempts
