### PR TITLE
fix(docs): do not include certain files

### DIFF
--- a/docs/content/configuring-npm/package-json.md
+++ b/docs/content/configuring-npm/package-json.md
@@ -286,12 +286,10 @@ Certain files are always included, regardless of settings:
 
 * `package.json`
 * `README`
-* `CHANGES` / `CHANGELOG` / `HISTORY`
 * `LICENSE` / `LICENCE`
-* `NOTICE`
 * The file in the "main" field
 
-`README`, `CHANGES`, `LICENSE` & `NOTICE` can have any case and extension.
+`README` & `LICENSE` can have any case and extension.
 
 Conversely, some files are always ignored:
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
I think npm@7 should update the documentation to avoid confusion.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Related to #3334