### PR TITLE
fix: better error message for duplicate workspace names

### DIFF
--- a/node_modules/@npmcli/map-workspaces/index.js
+++ b/node_modules/@npmcli/map-workspaces/index.js
@@ -129,7 +129,12 @@ async function mapWorkspaces (opts = {}) {
         if (seen.has(name) && seen.get(name) !== packagePathname) {
           throw getError({
             Type: Error,
-            message: 'must not have multiple workspaces with the same name',
+            message: [
+              'must not have multiple workspaces with the same name',
+              `package '${name}' has conflicts in the following paths:`,
+              '    ' + seen.get(name),
+              '    ' + packagePathname
+            ].join('\n'),
             code: 'EDUPLICATEWORKSPACE'
           })
         }


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Error code `EDUPLICATEWORKSPACE` does not provide any paths or package name for which duplicate workspace exists. This could be challenging to debug, it would be better to have the paths where the duplicates exist to help the user debug the issue easily.

Changes made: Error message now includes the name and package path in the output.

Sample output on encountering this error after the changes:

```zsh
$ ./npm/bin/npm-cli.js install
npm ERR! code EDUPLICATEWORKSPACE
npm ERR! must not have multiple workspaces with the same name
npm ERR! package 'test-package' has conflicts in the following paths:
npm ERR!     /Users/paradoxinfinite/Documents/npm-test/test-package1
npm ERR!     /Users/paradoxinfinite/Documents/npm-test/test-package2

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/paradoxinfinite/.npm/_logs/2021-08-07T18_45_56_615Z-debug.log
```

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Related to #2544 