### PR TITLE
fix(docs): update npm-publish access flag info

### DIFF
--- a/docs/content/commands/npm-publish.md
+++ b/docs/content/commands/npm-publish.md
@@ -132,6 +132,11 @@ If you want your scoped package to be publicly viewable (and installable)
 set `--access=public`. The only valid values for `access` are `public` and
 `restricted`. Unscoped packages _always_ have an access level of `public`.
 
+Note: Using the `--access` flag on the `npm publish` command will only set
+the package access level on the initial publish of the package. Any subsequent `npm publish`
+commands using the `--access` flag will not have an effect to the access level.
+To make changes to the access level after the initial publish use `npm access`.
+
 #### `dry-run`
 
 * Default: false


### PR DESCRIPTION
The only way to turn a public package that's been published to private (or vice versa) is to use `npm access` Using the access flag on the `npm publish` command after the initial publish, has no effect on the access level. The documentation on [npm-publish](https://docs.npmjs.com/cli/v7/commands/npm-publish) should note these characteristics. 


## References ##
Closes #1341
