### PR TITLE
fix: `npm dedupe` property 'path' of null error

### DIFF
--- a/node_modules/@npmcli/arborist/lib/place-dep.js
+++ b/node_modules/@npmcli/arborist/lib/place-dep.js
@@ -268,7 +268,7 @@ class PlaceDep {
       integrity: dep.integrity,
       legacyPeerDeps: this.legacyPeerDeps,
       error: dep.errors[0],
-      ...(dep.isLink ? { target: dep.target, realpath: dep.target.path } : {}),
+      ...(dep.isLink ? { target: dep.target, realpath: dep.realpath } : {}),
     })
 
     this.oldDep = target.children.get(this.name)


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
From what I noticed by console logging `dep` when running `npm dedupe`, when `dep.isLink` was `true`, `dep.target` was `null`. Also, `dep.realpath` exists, so I am not 100% sure, but making an educated guess that we are supposed to use that instead of trying to look for the real path in the target which is null.

Would appreciate feedback, if any!

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Fixes #3565 
