### PR TITLE
fix(docs): fix headline clash during navigation

### DIFF
--- a/docs/content/configuring-npm/package-json.md
+++ b/docs/content/configuring-npm/package-json.md
@@ -4,8 +4,6 @@ section: 5
 description: Specifics of npm's package.json handling
 ---
 
-### Description
-
 This document is all you need to know about what's required in your
 package.json file.  It must be actual JSON, not just a JavaScript object
 literal.


### PR DESCRIPTION
Remove `Description` headline to facilitate navigation to `description` property headline of `package.json`

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
