### PR TITLE
fix(docs): revert auto-generated portion of docs

### DIFF
--- a/docs/content/commands/npm-publish.md
+++ b/docs/content/commands/npm-publish.md
@@ -132,11 +132,6 @@ If you want your scoped package to be publicly viewable (and installable)
 set `--access=public`. The only valid values for `access` are `public` and
 `restricted`. Unscoped packages _always_ have an access level of `public`.
 
-Note: Using the `--access` flag on the `npm publish` command will only set
-the package access level on the initial publish of the package. Any subsequent `npm publish`
-commands using the `--access` flag will not have an effect to the access level.
-To make changes to the access level after the initial publish use `npm access`.
-
 #### `dry-run`
 
 * Default: false


### PR DESCRIPTION
The content in this portion of the docs is auto-generated.


## References
Reverts https://github.com/npm/cli/pull/3630