### PR TITLE
fix(error-message): look for er.path not er.file

### DIFF
--- a/lib/utils/error-message.js
+++ b/lib/utils/error-message.js
@@ -99,9 +99,9 @@ module.exports = (er, npm) => {
 
     case 'EJSONPARSE':
       // Check whether we ran into a conflict in our own package.json
-      if (er.file === resolve(npm.prefix, 'package.json')) {
+      if (er.path === resolve(npm.prefix, 'package.json')) {
         const { isDiff } = require('parse-conflict-json')
-        const txt = require('fs').readFileSync(er.file, 'utf8')
+        const txt = require('fs').readFileSync(er.path, 'utf8')
           .replace(/\r\n/g, '\n')
         if (isDiff(txt)) {
           detail.push([

--- a/test/lib/utils/error-message.js
+++ b/test/lib/utils/error-message.js
@@ -292,7 +292,7 @@ t.test('json parse', t => {
     process.argv = ['arg', 'v']
     t.matchSnapshot(errorMessage(Object.assign(new Error('conflicted'), {
       code: 'EJSONPARSE',
-      file: resolve(dir, 'package.json'),
+      path: resolve(dir, 'package.json'),
     }), npm))
     t.end()
   })
@@ -314,7 +314,7 @@ t.test('json parse', t => {
     process.argv = ['arg', 'v']
     t.matchSnapshot(errorMessage(Object.assign(new Error('not json'), {
       code: 'EJSONPARSE',
-      file: resolve(dir, 'package.json'),
+      path: resolve(dir, 'package.json'),
     }), npm))
     t.end()
   })
@@ -330,7 +330,7 @@ t.test('json parse', t => {
     process.argv = ['arg', 'v']
     t.matchSnapshot(errorMessage(Object.assign(new Error('not json'), {
       code: 'EJSONPARSE',
-      file: `${dir}/blerg.json`,
+      path: `${dir}/blerg.json`,
     }), npm))
     t.end()
   })


### PR DESCRIPTION
The attribute is here, er.file was used in error on another lib, the lib
got changed, and this code wasn't fixed.