### PR TITLE
fix(docs): fix “see also” link on “npm deprecate” page

### DIFF
--- a/docs/content/commands/npm-deprecate.md
+++ b/docs/content/commands/npm-deprecate.md
@@ -76,4 +76,4 @@ password, npm will prompt on the command line for one.
 * [npm publish](/commands/npm-publish)
 * [npm registry](/using-npm/registry)
 * [npm owner](/commands/npm-owner)
-* [npm owner](/commands/npm-adduser)
+* [npm adduser](/commands/npm-adduser)


### PR DESCRIPTION
At the bottom of doc page for `npm deprecate`, one of the &ldquo;see also&rdquo; links has the wrong text. [Check it out in the live docs](https://docs.npmjs.com/cli/v7/commands/npm-deprecate#see-also).

This PR fixes that.