### PR TITLE
docs: Add --if-present flag documentation to workspaces

### DIFF
--- a/docs/content/using-npm/workspaces.md
+++ b/docs/content/using-npm/workspaces.md
@@ -176,6 +176,16 @@ npm run test --workspaces
 
 Will run the `test` script in both `./packages/a` and `./packages/b`.
 
+### Ignoring missing scripts
+
+It is not required for all of the workspaces to implement scripts run with the `npm run` command.
+
+By running the command with the `--if-present` flag, npm will ignore workspaces missing target script.
+
+```
+npm run test --workspaces --if-present
+```
+
 ### See also
 
 * [npm install](/commands/npm-install)


### PR DESCRIPTION
<!-- What / Why -->

I've seen many developers run into the problem of not knowing about the "ignore-missing" flag on npm run-script while working with workspaces.

I think it would be a great addition to the workspace docs to mention it on their page too.


