### PR TITLE
feat(install): very strict global npm engines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -127,6 +127,7 @@
         "node-gyp": "^7.1.2",
         "nopt": "^5.0.0",
         "npm-audit-report": "^2.1.5",
+        "npm-install-checks": "^4.0.0",
         "npm-package-arg": "^8.1.5",
         "npm-pick-manifest": "^6.1.1",
         "npm-profile": "^5.0.3",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "node-gyp": "^7.1.2",
     "nopt": "^5.0.0",
     "npm-audit-report": "^2.1.5",
+    "npm-install-checks": "^4.0.0",
     "npm-package-arg": "^8.1.5",
     "npm-pick-manifest": "^6.1.1",
     "npm-profile": "^5.0.3",


### PR DESCRIPTION
This will do an engines check when installing npm globally and fail if
the new npm is known not to work in the current node version.

It will not work for older npm versions because they don't have an
engines field (it wasn't added till npm@6.14.0). It will at least
prevent npm@7 from being installed in node@8.

## References
Closes https://github.com/npm/cli/issues/2612