### PR TITLE
fix: #3737

### DIFF
--- a/lib/search/format-package-stream.js
+++ b/lib/search/format-package-stream.js
@@ -42,7 +42,7 @@ class JSONOutputStream extends Minipass {
   }
 
   end () {
-    super.write(this._didFirst ? ']\n' : '\n]\n')
+    super.write(this._didFirst ? ']\n' : '\n[]\n')
     super.end()
   }
 }

--- a/test/lib/search.js
+++ b/test/lib/search.js
@@ -130,6 +130,37 @@ t.test('search <name> --json', (t) => {
   src.end()
 })
 
+t.test('search <invalid-module> --json', (t) => {
+  const src = new Minipass()
+  src.objectMode = true
+
+  npm.flatOptions.json = true
+  config.json = true
+  const libnpmsearch = {
+    stream () {
+      return src
+    },
+  }
+
+  const Search = t.mock('../../lib/search.js', {
+    ...mocks,
+    libnpmsearch,
+  })
+  const search = new Search(npm)
+
+  search.exec(['foo'], (err) => {
+    if (err)
+      throw err
+
+    t.equal(result, '\n[]\n', 'should have expected empty square brackets')
+
+    config.json = false
+    t.end()
+  })
+
+  src.end()
+})
+
 t.test('search <name> --searchexclude --searchopts', t => {
   npm.flatOptions.search = {
     ...flatOptions.search,


### PR DESCRIPTION
return valid json with npm search module_not_exists --json

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
Fixes #3737
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
