### PR TITLE
fix(view): Show the correct publish date for versions selected by range

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -336,7 +336,7 @@ class View extends BaseCommand {
         email: color.cyan(manifest._npmUser.email),
       }),
       modified: !packument.time ? undefined
-      : color.yellow(relativeDate(packument.time[packument.version])),
+      : color.yellow(relativeDate(packument.time[manifest.version])),
       maintainers: (packument.maintainers || []).map((u) => unparsePerson({
         name: color.yellow(u.name),
         email: color.cyan(u.email),

--- a/tap-snapshots/test/lib/view.js.test.cjs
+++ b/tap-snapshots/test/lib/view.js.test.cjs
@@ -82,7 +82,7 @@ dist
 dist-tags:
 [1m[32mlatest[39m[22m: 1.0.0
 
-published {TIME} ago[39m
+published [33myesterday[39m
 `
 
 exports[`test/lib/view.js TAP should log info of package in current working dir specific version > must match snapshot 1`] = `
@@ -99,7 +99,7 @@ dist
 dist-tags:
 [1m[32mlatest[39m[22m: 1.0.0
 
-published {TIME} ago[39m
+published [33myesterday[39m
 `
 
 exports[`test/lib/view.js TAP should log package info package from git > must match snapshot 1`] = `
@@ -302,7 +302,24 @@ dist
 dist-tags:
 [1m[32mlatest[39m[22m: 1.0.0
 
-published {TIME} ago[39m
+published [33myesterday[39m
+`
+
+exports[`test/lib/view.js TAP should log package info package with semver range > must match snapshot 1`] = `
+
+
+[4m[1m[32mblue[39m@[32m1.0.0[39m[22m[24m | [1m[31mProprietary[39m[22m | deps: [32mnone[39m | versions: [33m2[39m
+
+dist
+.tarball:[36mhttp://hm.blue.com/1.0.0.tgz[39m
+.shasum:[33m123[39m
+.integrity:[33m---[39m
+.unpackedSize:[33m1 B[39m
+
+dist-tags:
+[1m[32mlatest[39m[22m: 1.0.0
+
+published [33myesterday[39m
 `
 
 exports[`test/lib/view.js TAP workspaces all workspaces --json > must match snapshot 1`] = `

--- a/test/lib/view.js
+++ b/test/lib/view.js
@@ -17,6 +17,9 @@ const cleanLogs = () => {
   console.log = fn
 }
 
+// 25 hours ago
+const yesterday = new Date(Date.now() - 1000 * 60 * 60 * 25)
+
 const packument = (nv, opts) => {
   if (!opts.fullMetadata)
     throw new Error('must fetch fullMetadata')
@@ -40,7 +43,7 @@ const packument = (nv, opts) => {
         latest: '1.0.0',
       },
       time: {
-        '1.0.0': '2019-08-06T16:21:09.842Z',
+        '1.0.0': yesterday,
       },
       versions: {
         '1.0.0': {
@@ -327,6 +330,13 @@ t.test('should log package info', t => {
 
   t.test('package with no repo or homepage', t => {
     view.exec(['blue@1.0.0'], () => {
+      t.matchSnapshot(logs)
+      t.end()
+    })
+  })
+
+  t.test('package with semver range', t => {
+    view.exec(['blue@^1.0.0'], () => {
       t.matchSnapshot(logs)
       t.end()
     })


### PR DESCRIPTION
Before, `npm view npm@^6` would incorrectly report “published over a year from now” for every entry. Now it reports the correct dates.