### PR TITLE
fix(install.sh): don't remove old npm first

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -162,8 +162,6 @@ cd "$TMP" \
   && curl -qSsL -o npm.tgz "$url" \
   && $tar -xzf npm.tgz \
   && cd "$TMP"/package \
-  && echo "removing existing npm" \
-  && "$node" bin/npm-cli.js rm npm -gf --loglevel=silent \
   && echo "installing npm@$t" \
   && "$node" bin/npm-cli.js install -gf ../npm.tgz \
   && cd "$BACK" \


### PR DESCRIPTION
The install script will gracefully fail if things don't work.  This is
especially important for versions of npm that won't work in your current
node version.
