### PR TITLE
Use configured registry when checking manifest for npm install

### DIFF
--- a/lib/install.js
+++ b/lib/install.js
@@ -135,7 +135,8 @@ class Install extends ArboristWorkspaceCmd {
     // be very strict about engines when trying to update npm itself
     const npmInstall = args.find(arg => arg.startsWith('npm@') || arg === 'npm')
     if (isGlobalInstall && npmInstall) {
-      const npmManifest = await pacote.manifest(npmInstall)
+      const npmOptions = this.npm.flatOptions
+      const npmManifest = await pacote.manifest(npmInstall, npmOptions)
       try {
         checks.checkEngine(npmManifest, npmManifest.version, process.version)
       } catch (e) {


### PR DESCRIPTION
This fix resolves #3758.

The package pacote accepts options as it's second parameter for the manifest call and these options allow you to pass the desired registry to use. The npm config object already has this information, so it's just passed in now.
