### PR TITLE
fix: restore exit code on "npm outdated"

### DIFF
--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -87,7 +87,8 @@ class Outdated extends ArboristWorkspaceCmd {
     // sorts list alphabetically
     const outdated = this.list.sort((a, b) => a.name.localeCompare(b.name, 'en'))
 
-    process.exitCode = outdated.length ? 1 : 0
+    if (outdated.length > 0)
+      process.exitCode = 1
 
     // return if no outdated packages
     if (outdated.length === 0 && !this.npm.config.get('json'))

--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -87,6 +87,8 @@ class Outdated extends ArboristWorkspaceCmd {
     // sorts list alphabetically
     const outdated = this.list.sort((a, b) => a.name.localeCompare(b.name, 'en'))
 
+    process.exitCode = outdated.length ? 1 : 0
+
     // return if no outdated packages
     if (outdated.length === 0 && !this.npm.config.get('json'))
       return

--- a/smoke-tests/index.js
+++ b/smoke-tests/index.js
@@ -174,9 +174,13 @@ t.test('npm diff', async t => {
 
 t.test('npm outdated', async t => {
   const cmd = `${npmBin} outdated`
-  const cmdRes = await exec(cmd)
+  const cmdRes = await exec(cmd).catch(err => {
+    t.equal(err.code, 1, 'should exit with error code')
+    return err
+  })
 
-  t.matchSnapshot(cmdRes,
+  t.not(cmdRes.stderr, '', 'should have stderr output')
+  t.matchSnapshot(String(cmdRes.stdout),
     'should have expected outdated output')
 })
 

--- a/test/lib/outdated.js
+++ b/test/lib/outdated.js
@@ -102,6 +102,10 @@ const outdated = (dir, opts) => {
 
 t.beforeEach(() => logs = '')
 
+const { exitCode } = process
+
+t.afterEach(() => process.exitCode = exitCode)
+
 const redactCwd = (path) => {
   const normalizePath = p => p
     .replace(/\\+/g, '/')
@@ -175,6 +179,7 @@ t.test('should display outdated deps', t => {
     outdated(null, {
       config: { global: true },
     }).exec([], () => {
+      t.equal(process.exitCode, 1)
       t.matchSnapshot(logs)
       t.end()
     })
@@ -187,6 +192,7 @@ t.test('should display outdated deps', t => {
       },
       color: true,
     }).exec([], () => {
+      t.equal(process.exitCode, 1)
       t.matchSnapshot(logs)
       t.end()
     })
@@ -200,6 +206,7 @@ t.test('should display outdated deps', t => {
       },
       color: true,
     }).exec([], () => {
+      t.equal(process.exitCode, 1)
       t.matchSnapshot(logs)
       t.end()
     })
@@ -213,6 +220,7 @@ t.test('should display outdated deps', t => {
       },
       color: true,
     }).exec([], () => {
+      t.equal(process.exitCode, 1)
       t.matchSnapshot(logs)
       t.end()
     })
@@ -226,6 +234,7 @@ t.test('should display outdated deps', t => {
       },
       color: true,
     }).exec([], () => {
+      t.equal(process.exitCode, 1)
       t.matchSnapshot(logs)
       t.end()
     })
@@ -238,6 +247,7 @@ t.test('should display outdated deps', t => {
         long: true,
       },
     }).exec([], () => {
+      t.equal(process.exitCode, 1)
       t.matchSnapshot(logs)
       t.end()
     })
@@ -250,6 +260,7 @@ t.test('should display outdated deps', t => {
         json: true,
       },
     }).exec([], () => {
+      t.equal(process.exitCode, 1)
       t.matchSnapshot(logs)
       t.end()
     })
@@ -263,6 +274,7 @@ t.test('should display outdated deps', t => {
         long: true,
       },
     }).exec([], () => {
+      t.equal(process.exitCode, 1)
       t.matchSnapshot(logs)
       t.end()
     })
@@ -275,6 +287,7 @@ t.test('should display outdated deps', t => {
         parseable: true,
       },
     }).exec([], () => {
+      t.equal(process.exitCode, 1)
       t.matchSnapshot(logs)
       t.end()
     })
@@ -288,6 +301,7 @@ t.test('should display outdated deps', t => {
         long: true,
       },
     }).exec([], () => {
+      t.equal(process.exitCode, 1)
       t.matchSnapshot(logs)
       t.end()
     })
@@ -299,6 +313,7 @@ t.test('should display outdated deps', t => {
         all: true,
       },
     }).exec([], () => {
+      t.equal(process.exitCode, 1)
       t.matchSnapshot(logs)
       t.end()
     })
@@ -310,6 +325,7 @@ t.test('should display outdated deps', t => {
         global: false,
       },
     }).exec(['cat'], () => {
+      t.equal(process.exitCode, 1)
       t.matchSnapshot(logs)
       t.end()
     })
@@ -341,6 +357,7 @@ t.test('should return if no outdated deps', t => {
     global: false,
   }).exec([], () => {
     t.equal(logs.length, 0, 'no logs')
+    t.equal(process.exitCode, 0)
     t.end()
   })
 })
@@ -388,6 +405,7 @@ t.test('should skip missing non-prod deps', t => {
     global: false,
   }).exec([], () => {
     t.equal(logs.length, 0, 'no logs')
+    t.equal(process.exitCode, 0)
     t.end()
   })
 })
@@ -413,6 +431,7 @@ t.test('should skip invalid pkg ranges', t => {
 
   outdated(testDir, {}).exec([], () => {
     t.equal(logs.length, 0, 'no logs')
+    t.equal(process.exitCode, 0)
     t.end()
   })
 })
@@ -438,6 +457,7 @@ t.test('should skip git specs', t => {
 
   outdated(testDir, {}).exec([], () => {
     t.equal(logs.length, 0, 'no logs')
+    t.equal(process.exitCode, 0)
     t.end()
   })
 })
@@ -540,6 +560,7 @@ t.test('workspaces', async t => {
         rej(err)
 
       t.matchSnapshot(logs, 'should display ws outdated deps human output')
+      t.equal(process.exitCode, 1)
       res()
     })
   })
@@ -554,6 +575,7 @@ t.test('workspaces', async t => {
         rej(err)
 
       t.matchSnapshot(logs, 'should display ws outdated deps json output')
+      t.equal(process.exitCode, 1)
       res()
     })
   })
@@ -568,6 +590,7 @@ t.test('workspaces', async t => {
         rej(err)
 
       t.matchSnapshot(logs, 'should display ws outdated deps parseable output')
+      t.equal(process.exitCode, 1)
       res()
     })
   })
@@ -582,6 +605,7 @@ t.test('workspaces', async t => {
         rej(err)
 
       t.matchSnapshot(logs, 'should display all dependencies')
+      t.equal(process.exitCode, 1)
       res()
     })
   })
@@ -594,6 +618,7 @@ t.test('workspaces', async t => {
         rej(err)
 
       t.matchSnapshot(logs, 'should highlight ws in dependend by section')
+      t.equal(process.exitCode, 1)
       res()
     })
   })
@@ -604,6 +629,7 @@ t.test('workspaces', async t => {
         rej(err)
 
       t.matchSnapshot(logs, 'should display results filtered by ws')
+      t.equal(process.exitCode, 1)
       res()
     })
   })
@@ -618,6 +644,7 @@ t.test('workspaces', async t => {
         rej(err)
 
       t.matchSnapshot(logs, 'should display json results filtered by ws')
+      t.equal(process.exitCode, 1)
       res()
     })
   })
@@ -632,6 +659,7 @@ t.test('workspaces', async t => {
         rej(err)
 
       t.matchSnapshot(logs, 'should display parseable results filtered by ws')
+      t.equal(process.exitCode, 1)
       res()
     })
   })
@@ -647,6 +675,7 @@ t.test('workspaces', async t => {
 
       t.matchSnapshot(logs,
         'should display nested deps when filtering by ws and using --all')
+      t.equal(process.exitCode, 1)
       res()
     })
   })
@@ -658,6 +687,7 @@ t.test('workspaces', async t => {
 
       t.matchSnapshot(logs,
         'should display no results if ws has no deps to display')
+      t.equal(process.exitCode, 0)
       res()
     })
   })
@@ -669,6 +699,7 @@ t.test('workspaces', async t => {
 
       t.matchSnapshot(logs,
         'should display missing deps when filtering by ws')
+      t.equal(process.exitCode, 1)
       res()
     })
   })

--- a/test/lib/outdated.js
+++ b/test/lib/outdated.js
@@ -357,7 +357,6 @@ t.test('should return if no outdated deps', t => {
     global: false,
   }).exec([], () => {
     t.equal(logs.length, 0, 'no logs')
-    t.equal(process.exitCode, 0)
     t.end()
   })
 })
@@ -405,7 +404,6 @@ t.test('should skip missing non-prod deps', t => {
     global: false,
   }).exec([], () => {
     t.equal(logs.length, 0, 'no logs')
-    t.equal(process.exitCode, 0)
     t.end()
   })
 })
@@ -431,7 +429,6 @@ t.test('should skip invalid pkg ranges', t => {
 
   outdated(testDir, {}).exec([], () => {
     t.equal(logs.length, 0, 'no logs')
-    t.equal(process.exitCode, 0)
     t.end()
   })
 })
@@ -457,7 +454,6 @@ t.test('should skip git specs', t => {
 
   outdated(testDir, {}).exec([], () => {
     t.equal(logs.length, 0, 'no logs')
-    t.equal(process.exitCode, 0)
     t.end()
   })
 })
@@ -687,7 +683,6 @@ t.test('workspaces', async t => {
 
       t.matchSnapshot(logs,
         'should display no results if ws has no deps to display')
-      t.equal(process.exitCode, 0)
       res()
     })
   })


### PR DESCRIPTION
closes: https://github.com/npm/cli/issues/2556
ref: https://github.com/npm/cli/pull/1750

The xref'ed PR apparently dropped this behavior without any explanation.

* Not sure if this is the right branch to PR against.  Happy to switch to `release-latest` if appropriate.
* Debated whether to write helper functions since `exitCode` and `logs` are somewhat related in terms of the expected results.  I copy-pasted the `exitCode` check everywhere for the time being.