### PR TITLE
fix: use Intl.Collator for string sorting when available

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -8,6 +8,7 @@ const semver = require('semver')
 const BaseCommand = require('./base-command.js')
 const npa = require('npm-package-arg')
 const jsonParse = require('json-parse-even-better-errors')
+const localeCompare = require('@isaacs/string-locale-compare')('en')
 
 const searchCachePackage = async (path, spec, cacheKeys) => {
   const parsed = npa(spec)
@@ -212,10 +213,10 @@ class Cache extends BaseCommand {
         for (const key of keySet)
           results.add(key)
       }
-      [...results].sort((a, b) => a.localeCompare(b, 'en')).forEach(key => this.npm.output(key))
+      [...results].sort(localeCompare).forEach(key => this.npm.output(key))
       return
     }
-    cacheKeys.sort((a, b) => a.localeCompare(b, 'en')).forEach(key => this.npm.output(key))
+    cacheKeys.sort(localeCompare).forEach(key => this.npm.output(key))
   }
 }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -10,6 +10,7 @@ const writeFile = promisify(fs.writeFile)
 const { spawn } = require('child_process')
 const { EOL } = require('os')
 const ini = require('ini')
+const localeCompare = require('@isaacs/string-locale-compare')('en')
 
 // take an array of `[key, value, k2=v2, k3, v3, ...]` and turn into
 // { key: value, k2: v2, k3: v3 }
@@ -209,7 +210,7 @@ class Config extends BaseCommand {
 ; Configs like \`//<hostname>/:_authToken\` are auth that is restricted
 ; to the registry host specified.
 
-${data.split('\n').sort((a, b) => a.localeCompare(b, 'en')).join('\n').trim()}
+${data.split('\n').sort(localeCompare).join('\n').trim()}
 
 ;;;;
 ; all available options shown below with default values
@@ -238,7 +239,7 @@ ${defData}
       if (where === 'default' && !long)
         continue
 
-      const keys = Object.keys(data).sort((a, b) => a.localeCompare(b, 'en'))
+      const keys = Object.keys(data).sort(localeCompare)
       if (!keys.length)
         continue
 

--- a/lib/help.js
+++ b/lib/help.js
@@ -3,6 +3,7 @@ const path = require('path')
 const openUrl = require('./utils/open-url.js')
 const { promisify } = require('util')
 const glob = promisify(require('glob'))
+const localeCompare = require('@isaacs/string-locale-compare')('en')
 
 const BaseCommand = require('./base-command.js')
 
@@ -82,7 +83,7 @@ class Help extends BaseCommand {
       if (aManNumber !== bManNumber)
         return aManNumber - bManNumber
 
-      return a.localeCompare(b, 'en')
+      return localeCompare(a, b)
     })
     const man = mans[0]
 

--- a/lib/ls.js
+++ b/lib/ls.js
@@ -22,6 +22,7 @@ const _problems = Symbol('problems')
 const _required = Symbol('required')
 const _type = Symbol('type')
 const ArboristWorkspaceCmd = require('./workspaces/arborist-cmd.js')
+const localeCompare = require('@isaacs/string-locale-compare')('en')
 
 class LS extends ArboristWorkspaceCmd {
   /* istanbul ignore next - see test/lib/load-all-commands.js */
@@ -503,8 +504,7 @@ const augmentNodesWithMetadata = ({
   return node
 }
 
-const sortAlphabetically = (a, b) =>
-  a.pkgid.localeCompare(b.pkgid, 'en')
+const sortAlphabetically = ({ pkgid: a }, { pkgid: b }) => localeCompare(a, b)
 
 const humanOutput = ({ color, result, seenItems, unicode }) => {
   // we need to traverse the entire tree in order to determine which items

--- a/lib/outdated.js
+++ b/lib/outdated.js
@@ -6,6 +6,7 @@ const color = require('chalk')
 const styles = require('ansistyles')
 const npa = require('npm-package-arg')
 const pickManifest = require('npm-pick-manifest')
+const localeCompare = require('@isaacs/string-locale-compare')('en')
 
 const Arborist = require('@npmcli/arborist')
 
@@ -85,7 +86,7 @@ class Outdated extends ArboristWorkspaceCmd {
     }))
 
     // sorts list alphabetically
-    const outdated = this.list.sort((a, b) => a.name.localeCompare(b.name, 'en'))
+    const outdated = this.list.sort((a, b) => localeCompare(a.name, b.name))
 
     if (outdated.length > 0)
       process.exitCode = 1

--- a/lib/utils/completion/installed-deep.js
+++ b/lib/utils/completion/installed-deep.js
@@ -1,5 +1,6 @@
 const { resolve } = require('path')
 const Arborist = require('@npmcli/arborist')
+const localeCompare = require('@isaacs/string-locale-compare')('en')
 
 const installedDeep = async (npm) => {
   const {
@@ -15,8 +16,7 @@ const installedDeep = async (npm) => {
         return i
       })
       .filter(i => (i.depth - 1) <= depth)
-      .sort((a, b) => a.depth - b.depth)
-      .sort((a, b) => a.depth === b.depth ? a.name.localeCompare(b.name, 'en') : 0)
+      .sort((a, b) => (a.depth - b.depth) || localeCompare(a.name, b.name))
 
   const res = new Set()
   const gArb = new Arborist({ global: true, path: resolve(npm.globalDir, '..') })

--- a/lib/utils/config/describe-all.js
+++ b/lib/utils/config/describe-all.js
@@ -1,4 +1,5 @@
 const definitions = require('./definitions.js')
+const localeCompare = require('@isaacs/string-locale-compare')('en')
 const describeAll = () => {
   // sort not-deprecated ones to the top
   /* istanbul ignore next - typically already sorted in the definitions file,
@@ -7,7 +8,7 @@ const describeAll = () => {
   const sort = ([keya, {deprecated: depa}], [keyb, {deprecated: depb}]) => {
     return depa && !depb ? 1
       : !depa && depb ? -1
-      : keya.localeCompare(keyb, 'en')
+      : localeCompare(keya, keyb)
   }
   return Object.entries(definitions).sort(sort)
     .map(([key, def]) => def.describe())

--- a/lib/utils/npm-usage.js
+++ b/lib/utils/npm-usage.js
@@ -1,5 +1,6 @@
 const { dirname } = require('path')
 const { cmdList } = require('./cmd-list')
+const localeCompare = require('@isaacs/string-locale-compare')('en')
 
 module.exports = (npm) => {
   const usesBrowser = npm.config.get('viewer') === 'browser'
@@ -62,7 +63,7 @@ const usages = (npm) => {
     maxLen = Math.max(maxLen, c.length)
     return set
   }, [])
-    .sort((a, b) => a[0].localeCompare(b[0], 'en'))
+    .sort(([a], [b]) => localeCompare(a, b))
     .map(([c, usage]) => `\n    ${c}${' '.repeat(maxLen - c.length + 1)}${
       (usage.split('\n').join('\n' + ' '.repeat(maxLen + 5)))}`)
     .join('\n')

--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -3,6 +3,10 @@ const ssri = require('ssri')
 const npmlog = require('npmlog')
 const formatBytes = require('./format-bytes.js')
 const columnify = require('columnify')
+const localeCompare = require('@isaacs/string-locale-compare')('en', {
+  sensitivity: 'case',
+  numeric: true,
+})
 
 const logTar = (tarball, opts = {}) => {
   const { unicode = false, log = npmlog } = opts
@@ -75,12 +79,7 @@ const getContents = async (manifest, tarball) => {
     algorithms: ['sha1', 'sha512'],
   })
 
-  const comparator = (a, b) => {
-    return a.path.localeCompare(b.path, 'en', {
-      sensitivity: 'case',
-      numeric: true,
-    })
-  }
+  const comparator = ({ path: a }, { path: b }) => localeCompare(a, b)
 
   const isUpper = (str) => {
     const ch = str.charAt(0)

--- a/node_modules/@isaacs/string-locale-compare/package.json
+++ b/node_modules/@isaacs/string-locale-compare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@isaacs/string-locale-compare",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "files": [
     "index.js"
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
         "packages/*"
       ],
       "dependencies": {
+        "@isaacs/string-locale-compare": "^1.1.0",
         "@npmcli/arborist": "^2.9.0",
         "@npmcli/ci-detect": "^1.2.0",
         "@npmcli/config": "^2.3.0",
@@ -619,9 +620,9 @@
       "dev": true
     },
     "node_modules/@isaacs/string-locale-compare": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/string-locale-compare/-/string-locale-compare-1.0.1.tgz",
-      "integrity": "sha512-AknEkBKSyAcIpl7SIUp12bs1rOmTDp9ojfDI9hvXl6qHqUCcaswkZOslbfdEbzI+8OPatiixY9AFKaUUpgGoBw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz",
+      "integrity": "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==",
       "inBundle": true
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -10908,9 +10909,9 @@
       "dev": true
     },
     "@isaacs/string-locale-compare": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/string-locale-compare/-/string-locale-compare-1.0.1.tgz",
-      "integrity": "sha512-AknEkBKSyAcIpl7SIUp12bs1rOmTDp9ojfDI9hvXl6qHqUCcaswkZOslbfdEbzI+8OPatiixY9AFKaUUpgGoBw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz",
+      "integrity": "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ=="
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
+    "@isaacs/string-locale-compare": "^1.1.0",
     "@npmcli/arborist": "^2.9.0",
     "@npmcli/ci-detect": "^1.2.0",
     "@npmcli/config": "^2.3.0",


### PR DESCRIPTION
The npm/cli form of https://github.com/npm/arborist/pull/324

Required adding options support to package used for this.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
