### PR TITLE
fix: "unpublished by undefined" caused by tightened privacy policies.

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -213,7 +213,7 @@ class View extends BaseCommand {
 
     if (pckmnt.time && pckmnt.time.unpublished) {
       const u = pckmnt.time.unpublished
-      const er = new Error('Unpublished by ' + u.name + ' on ' + u.time)
+      const er = new Error('Unpublished on ' + u.time)
       er.statusCode = 404
       er.code = 'E404'
       er.pkgid = pckmnt._id


### PR DESCRIPTION
<!-- What / Why -->
Now npm cli shows messages like this for unpublished projects when running `npm view` (note `Unpublished by undefined`): 

```
> npm view my-package
npm ERR! code E404
npm ERR! 404 Unpublished by undefined on 2021-10-05T10:00:00.000Z
npm ERR! 404 
npm ERR! 404  'my-package' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
```

This simple fix just removes the `by undefined` part.