### PR TITLE
chore: fix publish tests

### DIFF
--- a/tap-snapshots/test/lib/publish.js.test.cjs
+++ b/tap-snapshots/test/lib/publish.js.test.cjs
@@ -15,7 +15,6 @@ exports[`test/lib/publish.js TAP private workspaces colorless > should publish a
 Array [
   Object {
     "_id": "@npmcli/b@1.0.0",
-    "gitHead": "{GITHEAD}",
     "name": "@npmcli/b",
     "readme": "ERROR: No README data found!",
     "version": "1.0.0",
@@ -33,7 +32,6 @@ exports[`test/lib/publish.js TAP private workspaces with color > should publish 
 Array [
   Object {
     "_id": "@npmcli/b@1.0.0",
-    "gitHead": "{GITHEAD}",
     "name": "@npmcli/b",
     "readme": "ERROR: No README data found!",
     "version": "1.0.0",
@@ -72,7 +70,6 @@ exports[`test/lib/publish.js TAP workspaces all workspaces > should publish all 
 Array [
   Object {
     "_id": "workspace-a@1.2.3-a",
-    "gitHead": "{GITHEAD}",
     "name": "workspace-a",
     "readme": "ERROR: No README data found!",
     "repository": Object {
@@ -86,7 +83,6 @@ Array [
     "bugs": Object {
       "url": "https://github.com/npm/workspace-b/issues",
     },
-    "gitHead": "{GITHEAD}",
     "homepage": "https://github.com/npm/workspace-b#readme",
     "name": "workspace-b",
     "readme": "ERROR: No README data found!",
@@ -98,7 +94,6 @@ Array [
   },
   Object {
     "_id": "workspace-n@1.2.3-n",
-    "gitHead": "{GITHEAD}",
     "name": "workspace-n",
     "readme": "ERROR: No README data found!",
     "version": "1.2.3-n",
@@ -128,7 +123,6 @@ exports[`test/lib/publish.js TAP workspaces json > should publish all workspaces
 Array [
   Object {
     "_id": "workspace-a@1.2.3-a",
-    "gitHead": "{GITHEAD}",
     "name": "workspace-a",
     "readme": "ERROR: No README data found!",
     "repository": Object {
@@ -142,7 +136,6 @@ Array [
     "bugs": Object {
       "url": "https://github.com/npm/workspace-b/issues",
     },
-    "gitHead": "{GITHEAD}",
     "homepage": "https://github.com/npm/workspace-b#readme",
     "name": "workspace-b",
     "readme": "ERROR: No README data found!",
@@ -154,7 +147,6 @@ Array [
   },
   Object {
     "_id": "workspace-n@1.2.3-n",
-    "gitHead": "{GITHEAD}",
     "name": "workspace-n",
     "readme": "ERROR: No README data found!",
     "version": "1.2.3-n",
@@ -172,7 +164,6 @@ exports[`test/lib/publish.js TAP workspaces one workspace > should publish given
 Array [
   Object {
     "_id": "workspace-a@1.2.3-a",
-    "gitHead": "{GITHEAD}",
     "name": "workspace-a",
     "readme": "ERROR: No README data found!",
     "repository": Object {

--- a/test/lib/publish.js
+++ b/test/lib/publish.js
@@ -9,14 +9,10 @@ const fs = require('fs')
 const log = require('npmlog')
 log.level = 'silent'
 
-const cleanGithead = (result) => {
-  return result.map((r) => {
-    if (r.gitHead)
-      r.gitHead = '{GITHEAD}'
-
-    return r
-  })
+t.cleanSnapshot = (data) => {
+  return data.replace(/^ *"gitHead": .*$\n/gm, '')
 }
+
 const {definitions} = require('../../lib/utils/config')
 const defaults = Object.entries(definitions).reduce((defaults, [key, def]) => {
   defaults[key] = def.default
@@ -589,7 +585,7 @@ t.test('workspaces', (t) => {
     log.level = 'info'
     publish.execWorkspaces([], [], (err) => {
       t.notOk(err)
-      t.matchSnapshot(cleanGithead(publishes), 'should publish all workspaces')
+      t.matchSnapshot(publishes, 'should publish all workspaces')
       t.matchSnapshot(outputs, 'should output all publishes')
       t.end()
     })
@@ -599,7 +595,7 @@ t.test('workspaces', (t) => {
     log.level = 'info'
     publish.execWorkspaces([], ['workspace-a'], (err) => {
       t.notOk(err)
-      t.matchSnapshot(cleanGithead(publishes), 'should publish given workspace')
+      t.matchSnapshot(publishes, 'should publish given workspace')
       t.matchSnapshot(outputs, 'should output one publish')
       t.end()
     })
@@ -618,7 +614,7 @@ t.test('workspaces', (t) => {
     npm.config.set('json', true)
     publish.execWorkspaces([], [], (err) => {
       t.notOk(err)
-      t.matchSnapshot(cleanGithead(publishes), 'should publish all workspaces')
+      t.matchSnapshot(publishes, 'should publish all workspaces')
       t.matchSnapshot(outputs, 'should output all publishes as json')
       t.end()
     })
@@ -707,7 +703,7 @@ t.test('private workspaces', (t) => {
     npm.color = true
     publish.execWorkspaces([], [], (err) => {
       t.notOk(err)
-      t.matchSnapshot(cleanGithead(publishes), 'should publish all non-private workspaces')
+      t.matchSnapshot(publishes, 'should publish all non-private workspaces')
       t.matchSnapshot(outputs, 'should output all publishes')
       npm.color = false
       t.end()
@@ -734,7 +730,7 @@ t.test('private workspaces', (t) => {
 
     publish.execWorkspaces([], [], (err) => {
       t.notOk(err)
-      t.matchSnapshot(cleanGithead(publishes), 'should publish all non-private workspaces')
+      t.matchSnapshot(publishes, 'should publish all non-private workspaces')
       t.matchSnapshot(outputs, 'should output all publishes')
       t.end()
     })


### PR DESCRIPTION
When the tests are run but the code is not inside a git repo, the
results are different. This removes the `gitHead` altogether from the
publish results so it works in all environments
