### PR TITLE
fix: add `index.js` to `files` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "docs/content/**/*.md",
     "docs/output/**/*.html",
     "lib",
-    "man"
+    "man",
+    "index.js"
   ],
   "keywords": [
     "install",


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

In this [COMMIT](https://github.com/npm/cli/commit/a13d9d53ddf3e0f52f4a39fe116653bf40cf99e5), the `index.js` file is added as bootstrap, but it is not added to the `files` field in `package.json`, the file is lost after being published.

Users will receive a similar error when using NPM v8.0 or later.

```bash
Error: Cannot find module '/path/to/package/node_modules/npm/index.js'
```

