### PR TITLE
fix: add index.js to files field and update version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "8.0.0",
+  "version": "8.0.1",
   "name": "npm",
   "description": "a package manager for JavaScript",
   "workspaces": [
@@ -11,7 +11,8 @@
     "docs/content/**/*.md",
     "docs/output/**/*.html",
     "lib",
-    "man"
+    "man",
+    "index.js"
   ],
   "keywords": [
     "install",


### PR DESCRIPTION
The 8.0.0 version of the output file is missing the `index.js` file, and the main field in the `package.json` configuration is set to index.js, so after installing a package like nrm, using nrm will report an error saying that the index.js module is missing .

I added the configuration of `index.js` and updated the minor version number.