### PR TITLE
fix: include index.js in files array

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "packages/*"
   ],
   "files": [
+    "index.js",
     "bin",
     "docs/content/**/*.md",
     "docs/output/**/*.html",


### PR DESCRIPTION
This repairs the ability to `node .` from the installed package.

`require('npm')` will still not work, as this was disabled in v8.0.0
