### PR TITLE
fix: `--lockfile-version` to handle string number

### DIFF
--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -1157,7 +1157,7 @@ define('location', {
 
 define('lockfile-version', {
   default: null,
-  type: [null, 1, 2, 3],
+  type: [null, Number],
   defaultDescription: `
     Version 2 if no lockfile or current lockfile version less than or equal to
     2, otherwise maintain current lockfile version


### PR DESCRIPTION
Running "npm install --lockfile-version 3" fails with the error messages:

```
npm WARN invalid config lockfile-version="3" set in command line options
npm WARN invalid config Must be one of: null, 1, 2, 3
```

This is probably because all CLI input is handled as strings and `nopt` strictly comparing those strings to numbers without casting them to numbers. Replacing the `[null, 1, 2, 3]` with `[null, Number]` makes `nopt` type cast and accept all numbers.

With this change eg. `--lockfile-version 6` will still fail later on, so it won't open the flood gates for all version numbers. Will still fail with this later in the script:

```
npm ERR! Invalid lockfileVersion config: 6
```

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References

Related to #3880
