### PR TITLE
feat(config): Add --prune config option

### DIFF
--- a/docs/content/commands/npm-dedupe.md
+++ b/docs/content/commands/npm-dedupe.md
@@ -135,10 +135,6 @@ this warning is treated as a failure.
 If set to false, then ignore `package-lock.json` files when installing. This
 will also prevent _writing_ `package-lock.json` if `save` is true.
 
-When package package-locks are disabled, automatic pruning of extraneous
-modules will also be disabled. To remove extraneous modules with
-package-locks disabled use `npm prune`.
-
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->
 

--- a/docs/content/commands/npm-find-dupes.md
+++ b/docs/content/commands/npm-find-dupes.md
@@ -78,10 +78,6 @@ this warning is treated as a failure.
 If set to false, then ignore `package-lock.json` files when installing. This
 will also prevent _writing_ `package-lock.json` if `save` is true.
 
-When package package-locks are disabled, automatic pruning of extraneous
-modules will also be disabled. To remove extraneous modules with
-package-locks disabled use `npm prune`.
-
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->
 

--- a/docs/content/commands/npm-install-test.md
+++ b/docs/content/commands/npm-install-test.md
@@ -129,9 +129,16 @@ this warning is treated as a failure.
 If set to false, then ignore `package-lock.json` files when installing. This
 will also prevent _writing_ `package-lock.json` if `save` is true.
 
-When package package-locks are disabled, automatic pruning of extraneous
-modules will also be disabled. To remove extraneous modules with
-package-locks disabled use `npm prune`.
+<!-- automatically generated, do not edit manually -->
+<!-- see lib/utils/config/definitions.js -->
+
+#### `prune`
+
+* Default: true
+* Type: Boolean
+
+When set to `false`, automatic pruning of extraneous modules will be
+disabled.
 
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->

--- a/docs/content/commands/npm-install.md
+++ b/docs/content/commands/npm-install.md
@@ -513,9 +513,16 @@ this warning is treated as a failure.
 If set to false, then ignore `package-lock.json` files when installing. This
 will also prevent _writing_ `package-lock.json` if `save` is true.
 
-When package package-locks are disabled, automatic pruning of extraneous
-modules will also be disabled. To remove extraneous modules with
-package-locks disabled use `npm prune`.
+<!-- automatically generated, do not edit manually -->
+<!-- see lib/utils/config/definitions.js -->
+
+#### `prune`
+
+* Default: true
+* Type: Boolean
+
+When set to `false`, automatic pruning of extraneous modules will be
+disabled.
 
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->

--- a/docs/content/commands/npm-link.md
+++ b/docs/content/commands/npm-link.md
@@ -213,10 +213,6 @@ this warning is treated as a failure.
 If set to false, then ignore `package-lock.json` files when installing. This
 will also prevent _writing_ `package-lock.json` if `save` is true.
 
-When package package-locks are disabled, automatic pruning of extraneous
-modules will also be disabled. To remove extraneous modules with
-package-locks disabled use `npm prune`.
-
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->
 

--- a/docs/content/commands/npm-update.md
+++ b/docs/content/commands/npm-update.md
@@ -229,10 +229,6 @@ this warning is treated as a failure.
 If set to false, then ignore `package-lock.json` files when installing. This
 will also prevent _writing_ `package-lock.json` if `save` is true.
 
-When package package-locks are disabled, automatic pruning of extraneous
-modules will also be disabled. To remove extraneous modules with
-package-locks disabled use `npm prune`.
-
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->
 

--- a/docs/content/using-npm/config.md
+++ b/docs/content/using-npm/config.md
@@ -1186,10 +1186,6 @@ The package to install for [`npm exec`](/commands/npm-exec)
 If set to false, then ignore `package-lock.json` files when installing. This
 will also prevent _writing_ `package-lock.json` if `save` is true.
 
-When package package-locks are disabled, automatic pruning of extraneous
-modules will also be disabled. To remove extraneous modules with
-package-locks disabled use `npm prune`.
-
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->
 
@@ -1289,6 +1285,17 @@ Set to `false` to suppress the progress bar.
 A proxy to use for outgoing http requests. If the `HTTP_PROXY` or
 `http_proxy` environment variables are set, proxy settings will be honored
 by the underlying `request` library.
+
+<!-- automatically generated, do not edit manually -->
+<!-- see lib/utils/config/definitions.js -->
+
+#### `prune`
+
+* Default: true
+* Type: Boolean
+
+When set to `false`, automatic pruning of extraneous modules will be
+disabled.
 
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -33,6 +33,7 @@ class Install extends ArboristWorkspaceCmd {
       'legacy-bundling',
       'strict-peer-deps',
       'package-lock',
+      'prune',
       'omit',
       'ignore-scripts',
       'audit',

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -1396,10 +1396,6 @@ define('package-lock', {
     If set to false, then ignore \`package-lock.json\` files when installing.
     This will also prevent _writing_ \`package-lock.json\` if \`save\` is
     true.
-
-    When package package-locks are disabled, automatic pruning of extraneous
-    modules will also be disabled.  To remove extraneous modules with
-    package-locks disabled use \`npm prune\`.
   `,
   flatten: (key, obj, flatOptions) => {
     flatten(key, obj, flatOptions)
@@ -1526,6 +1522,16 @@ define('proxy', {
     A proxy to use for outgoing http requests. If the \`HTTP_PROXY\` or
     \`http_proxy\` environment variables are set, proxy settings will be
     honored by the underlying \`request\` library.
+  `,
+  flatten,
+})
+
+define('prune', {
+  default: true,
+  type: Boolean,
+  description: `
+    When set to \`false\`, automatic pruning of extraneous
+    modules will be disabled.
   `,
   flatten,
 })

--- a/tap-snapshots/test/lib/commands/config.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/config.js.test.cjs
@@ -115,6 +115,7 @@ exports[`test/lib/commands/config.js TAP config list --json > output matches sna
   "production": null,
   "progress": true,
   "proxy": null,
+  "prune": true,
   "read-only": false,
   "rebuild-bundle": true,
   "registry": "https://registry.npmjs.org/",
@@ -267,6 +268,7 @@ preid = ""
 production = null 
 progress = true 
 proxy = null 
+prune = true 
 read-only = false 
 rebuild-bundle = true 
 registry = "https://registry.npmjs.org/" 

--- a/tap-snapshots/test/lib/load-all-commands.js.test.cjs
+++ b/tap-snapshots/test/lib/load-all-commands.js.test.cjs
@@ -448,7 +448,7 @@ npm install <github username>/<github project>
 Options:
 [-S|--save|--no-save|--save-prod|--save-dev|--save-optional|--save-peer]
 [-E|--save-exact] [-g|--global] [--global-style] [--legacy-bundling]
-[--strict-peer-deps] [--no-package-lock]
+[--strict-peer-deps] [--no-package-lock] [--no-prune]
 [--omit <dev|optional|peer> [--omit <dev|optional|peer> ...]] [--ignore-scripts]
 [--no-audit] [--no-bin-links] [--no-fund] [--dry-run]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
@@ -495,7 +495,7 @@ npm install-test <github username>/<github project>
 Options:
 [-S|--save|--no-save|--save-prod|--save-dev|--save-optional|--save-peer]
 [-E|--save-exact] [-g|--global] [--global-style] [--legacy-bundling]
-[--strict-peer-deps] [--no-package-lock]
+[--strict-peer-deps] [--no-package-lock] [--no-prune]
 [--omit <dev|optional|peer> [--omit <dev|optional|peer> ...]] [--ignore-scripts]
 [--no-audit] [--no-bin-links] [--no-fund] [--dry-run]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]

--- a/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
@@ -110,6 +110,7 @@ Array [
   "production",
   "progress",
   "proxy",
+  "prune",
   "read-only",
   "rebuild-bundle",
   "registry",
@@ -1267,10 +1268,6 @@ exports[`test/lib/utils/config/definitions.js TAP > config description for packa
 
 If set to false, then ignore \`package-lock.json\` files when installing. This
 will also prevent _writing_ \`package-lock.json\` if \`save\` is true.
-
-When package package-locks are disabled, automatic pruning of extraneous
-modules will also be disabled. To remove extraneous modules with
-package-locks disabled use \`npm prune\`.
 `
 
 exports[`test/lib/utils/config/definitions.js TAP > config description for package-lock-only 1`] = `
@@ -1373,6 +1370,16 @@ exports[`test/lib/utils/config/definitions.js TAP > config description for proxy
 A proxy to use for outgoing http requests. If the \`HTTP_PROXY\` or
 \`http_proxy\` environment variables are set, proxy settings will be honored
 by the underlying \`request\` library.
+`
+
+exports[`test/lib/utils/config/definitions.js TAP > config description for prune 1`] = `
+#### \`prune\`
+
+* Default: true
+* Type: Boolean
+
+When set to \`false\`, automatic pruning of extraneous modules will be
+disabled.
 `
 
 exports[`test/lib/utils/config/definitions.js TAP > config description for read-only 1`] = `

--- a/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
@@ -1060,10 +1060,6 @@ The package to install for [\`npm exec\`](/commands/npm-exec)
 If set to false, then ignore \`package-lock.json\` files when installing. This
 will also prevent _writing_ \`package-lock.json\` if \`save\` is true.
 
-When package package-locks are disabled, automatic pruning of extraneous
-modules will also be disabled. To remove extraneous modules with
-package-locks disabled use \`npm prune\`.
-
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->
 
@@ -1163,6 +1159,17 @@ Set to \`false\` to suppress the progress bar.
 A proxy to use for outgoing http requests. If the \`HTTP_PROXY\` or
 \`http_proxy\` environment variables are set, proxy settings will be honored
 by the underlying \`request\` library.
+
+<!-- automatically generated, do not edit manually -->
+<!-- see lib/utils/config/definitions.js -->
+
+#### \`prune\`
+
+* Default: true
+* Type: Boolean
+
+When set to \`false\`, automatic pruning of extraneous modules will be
+disabled.
 
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->

--- a/tap-snapshots/test/lib/utils/npm-usage.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/npm-usage.js.test.cjs
@@ -557,7 +557,7 @@ All commands:
                     Options:
                     [-S|--save|--no-save|--save-prod|--save-dev|--save-optional|--save-peer]
                     [-E|--save-exact] [-g|--global] [--global-style] [--legacy-bundling]
-                    [--strict-peer-deps] [--no-package-lock]
+                    [--strict-peer-deps] [--no-package-lock] [--no-prune]
                     [--omit <dev|optional|peer> [--omit <dev|optional|peer> ...]] [--ignore-scripts]
                     [--no-audit] [--no-bin-links] [--no-fund] [--dry-run]
                     [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
@@ -600,7 +600,7 @@ All commands:
                     Options:
                     [-S|--save|--no-save|--save-prod|--save-dev|--save-optional|--save-peer]
                     [-E|--save-exact] [-g|--global] [--global-style] [--legacy-bundling]
-                    [--strict-peer-deps] [--no-package-lock]
+                    [--strict-peer-deps] [--no-package-lock] [--no-prune]
                     [--omit <dev|optional|peer> [--omit <dev|optional|peer> ...]] [--ignore-scripts]
                     [--no-audit] [--no-bin-links] [--no-fund] [--dry-run]
                     [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]


### PR DESCRIPTION
Closes #3906 

As the ticket above says, the `npm i` command with `--package-lock false` option has changed its behavior since npm@7, which no longer prevents automatic pruning and currently there is no option to disable the automatic pruning process.

This pull requests add a new config option `prune`, when it's set to false, the automatic pruning will be disabled. With this option user will be able to install packages without getting the `node_modules` folder pruned.

Also the pull requests updated the description of `package-lock` option to match the current behavior of the config