### PR TITLE
fix: allow `--lockfile-version` config to be string and coerce to number

### DIFF
--- a/docs/content/using-npm/config.md
+++ b/docs/content/using-npm/config.md
@@ -987,7 +987,7 @@ When passed to `npm config` this refers to which config file to use.
 
 * Default: Version 2 if no lockfile or current lockfile version less than or
   equal to 2, otherwise maintain current lockfile version
-* Type: null, 1, 2, or 3
+* Type: null, 1, 2, 3, "1", "2", or "3"
 
 Set the lockfile format version to be used in package-lock.json and
 npm-shrinkwrap-json files. Possible options are:

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -1157,7 +1157,7 @@ define('location', {
 
 define('lockfile-version', {
   default: null,
-  type: [null, 1, 2, 3],
+  type: [null, 1, 2, 3, '1', '2', '3'],
   defaultDescription: `
     Version 2 if no lockfile or current lockfile version less than or equal to
     2, otherwise maintain current lockfile version
@@ -1179,7 +1179,9 @@ define('lockfile-version', {
     on disk than lockfile version 2, but not interoperable with older npm
     versions.  Ideal if all users are on npm version 7 and higher.
   `,
-  flatten,
+  flatten: (key, obj, flatOptions) => {
+    flatOptions.lockfileVersion = obj[key] && parseInt(obj[key], 10)
+  },
 })
 
 define('loglevel', {

--- a/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
@@ -1061,7 +1061,7 @@ exports[`test/lib/utils/config/definitions.js TAP > config description for lockf
 
 * Default: Version 2 if no lockfile or current lockfile version less than or
   equal to 2, otherwise maintain current lockfile version
-* Type: null, 1, 2, or 3
+* Type: null, 1, 2, 3, "1", "2", or "3"
 
 Set the lockfile format version to be used in package-lock.json and
 npm-shrinkwrap-json files. Possible options are:

--- a/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
@@ -861,7 +861,7 @@ When passed to \`npm config\` this refers to which config file to use.
 
 * Default: Version 2 if no lockfile or current lockfile version less than or
   equal to 2, otherwise maintain current lockfile version
-* Type: null, 1, 2, or 3
+* Type: null, 1, 2, 3, "1", "2", or "3"
 
 Set the lockfile format version to be used in package-lock.json and
 npm-shrinkwrap-json files. Possible options are:

--- a/test/lib/utils/config/definitions.js
+++ b/test/lib/utils/config/definitions.js
@@ -892,3 +892,12 @@ t.test('workspaces derived', t => {
   t.equal(flat.workspacesEnabled, false)
   t.end()
 })
+
+t.test('lockfile version', t => {
+  const flat = {}
+  definitions['lockfile-version'].flatten('lockfile-version', {
+    'lockfile-version': '3',
+  }, flat)
+  t.match(flat.lockfileVersion, 3, 'flattens to a number')
+  t.end()
+})


### PR DESCRIPTION
As all CLI input is considered to be string, eg. a
"npm install --lockfile-version 3" would fail with the error messages:

```
npm WARN invalid config lockfile-version="3" set in command line options
npm WARN invalid config Must be one of: null, 1, 2, 3
```

Until we have a config system that supports setting type and possible values
of configs, we have to specify all string and number values for the
`lockfile-version`, but we coerce all values to numbers in the flattener.

Co-authored-by: @voxpelli
Co-authored-by: @isaacs
