### PR TITLE
Release/v8.1.2

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -805,3 +805,4 @@ Edward Thomson <ethomson@github.com>
 Behnam Mohammadi <itten@live.com>
 gfyoung <gfyoung17+GitHub@gmail.com>
 Luke Karrys <lukekarrys@gmail.com>
+Pelle Wessman <pelle@kodfabrik.se>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## v8.1.2 (2021-10-28)
+
+### BUG FIXES
+
+* [`cb9f43551`](https://github.com/npm/cli/commit/cb9f43551f46bf27095cd7bd6c1885a441004cd2)
+  [#3949](https://github.com/npm/cli/issues/3949)
+  allow `--lockfile-version` config to be string and coerce to number ([@lukekarrys](https://github.com/lukekarrys))
+* [`070901d7a`](https://github.com/npm/cli/commit/070901d7a6e3110a04ef41d8fcf14ffbfcce1496)
+  [#3943](https://github.com/npm/cli/issues/3943)
+  fix(publish): clean args before logging
+  ([@wraithgar](https://github.com/wraithgar))
+
+### DEPENDENCIES
+
+* [`8af94726b`](https://github.com/npm/cli/commit/8af94726b098031c7c0cae7ed50cc4e2e3499181)
+  [#3953](https://github.com/npm/cli/issues/3953)
+  `arborist@4.0.3`
+  * [`38cee94`](https://github.com/npm/arborist/commit/38cee94afa53d578830cc282348a803a8a6eefad)
+    [#340](https://github.com/npm/arborist/pull/340)
+    fix: set lockfileVersion from file during reset
+  * [`d310bd3`](https://github.com/npm/arborist/commit/d310bd3290c3a81e8285ceeb6eda9c9b5aa867d7)
+    [#339](https://github.com/npm/arborist/pull/339)
+    fix: always set originalLockfileVersion when doing shrinkwrap reset 
+
 ## v8.1.1 (2021-10-21)
 
 ### DEPENDENCIES

--- a/docs/content/using-npm/config.md
+++ b/docs/content/using-npm/config.md
@@ -987,7 +987,7 @@ When passed to `npm config` this refers to which config file to use.
 
 * Default: Version 2 if no lockfile or current lockfile version less than or
   equal to 2, otherwise maintain current lockfile version
-* Type: null, 1, 2, or 3
+* Type: null, 1, 2, 3, "1", "2", or "3"
 
 Set the lockfile format version to be used in package-lock.json and
 npm-shrinkwrap-json files. Possible options are:

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -8,6 +8,7 @@ const pacote = require('pacote')
 const npa = require('npm-package-arg')
 const npmFetch = require('npm-registry-fetch')
 const chalk = require('chalk')
+const replaceInfo = require('./utils/replace-info.js')
 
 const otplease = require('./utils/otplease.js')
 const { getContents, logTar } = require('./utils/tar.js')
@@ -68,7 +69,7 @@ class Publish extends BaseCommand {
     if (args.length !== 1)
       throw this.usageError()
 
-    log.verbose('publish', args)
+    log.verbose('publish', replaceInfo(args))
 
     const unicode = this.npm.config.get('unicode')
     const dryRun = this.npm.config.get('dry-run')

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -1157,7 +1157,7 @@ define('location', {
 
 define('lockfile-version', {
   default: null,
-  type: [null, 1, 2, 3],
+  type: [null, 1, 2, 3, '1', '2', '3'],
   defaultDescription: `
     Version 2 if no lockfile or current lockfile version less than or equal to
     2, otherwise maintain current lockfile version
@@ -1179,7 +1179,9 @@ define('lockfile-version', {
     on disk than lockfile version 2, but not interoperable with older npm
     versions.  Ideal if all users are on npm version 7 and higher.
   `,
-  flatten,
+  flatten: (key, obj, flatOptions) => {
+    flatOptions.lockfileVersion = obj[key] && parseInt(obj[key], 10)
+  },
 })
 
 define('loglevel', {

--- a/node_modules/@npmcli/arborist/lib/shrinkwrap.js
+++ b/node_modules/@npmcli/arborist/lib/shrinkwrap.js
@@ -238,21 +238,31 @@ class Shrinkwrap {
     return swKeyOrder
   }
 
-  static reset (options) {
+  static async reset (options) {
     // still need to know if it was loaded from the disk, but don't
     // bother reading it if we're gonna just throw it away.
     const s = new Shrinkwrap(options)
     s.reset()
 
-    return s[_maybeStat]().then(([sw, lock]) => {
-      s.filename = resolve(s.path,
-        (s.hiddenLockfile ? 'node_modules/.package-lock'
-        : s.shrinkwrapOnly || sw ? 'npm-shrinkwrap'
-        : 'package-lock') + '.json')
-      s.loadedFromDisk = !!(sw || lock)
-      s.type = basename(s.filename)
-      return s
-    })
+    const [sw, lock] = await s[_maybeStat]()
+
+    s.filename = resolve(s.path,
+      (s.hiddenLockfile ? 'node_modules/.package-lock'
+      : s.shrinkwrapOnly || sw ? 'npm-shrinkwrap'
+      : 'package-lock') + '.json')
+    s.loadedFromDisk = !!(sw || lock)
+    s.type = basename(s.filename)
+
+    try {
+      if (s.loadedFromDisk && !s.lockfileVersion) {
+        const json = parseJSON(await maybeReadFile(s.filename))
+        if (json.lockfileVersion > defaultLockfileVersion) {
+          s.lockfileVersion = json.lockfileVersion
+        }
+      }
+    } catch (e) {}
+
+    return s
   }
 
   static metaFromNode (node, path) {
@@ -380,9 +390,10 @@ class Shrinkwrap {
   reset () {
     this.tree = null
     this[_awaitingUpdate] = new Map()
-    this.originalLockfileVersion = this.lockfileVersion
+    const lockfileVersion = this.lockfileVersion || defaultLockfileVersion
+    this.originalLockfileVersion = lockfileVersion
     this.data = {
-      lockfileVersion: this.lockfileVersion || defaultLockfileVersion,
+      lockfileVersion,
       requires: true,
       packages: {},
       dependencies: {},

--- a/node_modules/@npmcli/arborist/package.json
+++ b/node_modules/@npmcli/arborist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@npmcli/arborist",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "Manage node_modules trees",
   "dependencies": {
     "@isaacs/string-locale-compare": "^1.0.1",
@@ -45,11 +45,10 @@
     "tcompare": "^5.0.6"
   },
   "scripts": {
-    "test": "npm run test-only --",
-    "test-only": "tap",
-    "posttest": "npm run lint --",
+    "test": "tap",
+    "posttest": "npm run lint",
     "snap": "tap",
-    "postsnap": "npm run lintfix --",
+    "postsnap": "npm run lintfix",
     "test-proxy": "ARBORIST_TEST_PROXY=1 tap --snapshot",
     "preversion": "npm test",
     "postversion": "npm publish",
@@ -88,7 +87,7 @@
       "--no-warnings",
       "--no-deprecation"
     ],
-    "timeout": "240"
+    "timeout": "360"
   },
   "engines": {
     "node": "^12.13.0 || ^14.15.0 || >=16"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "npm",
-      "version": "8.1.1",
+      "version": "8.1.2",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,7 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^4.0.2",
+        "@npmcli/arborist": "^4.0.3",
         "@npmcli/ci-detect": "^1.4.0",
         "@npmcli/config": "^2.3.0",
         "@npmcli/map-workspaces": "^2.0.0",
@@ -772,9 +772,9 @@
       }
     },
     "node_modules/@npmcli/arborist": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-4.0.2.tgz",
-      "integrity": "sha512-tmuUNr66acGh8oOo6rKLNOaleeUDSymxTBQJFzDpRET8kG1nzLwIRMpV+CZkzmQ0tbCQ1NMyDvBeyu+kaJ+Dtw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-4.0.3.tgz",
+      "integrity": "sha512-gFz/dNJtpv2bYXlupcUpEaWlFDRUNmvVnQNbE6dY4ild6beZ2SkG4R5/CM4GZZwj9HD2TyfGjO350Ja+xlLzuA==",
       "inBundle": true,
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.0.1",
@@ -11082,9 +11082,9 @@
       "dev": true
     },
     "@npmcli/arborist": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-4.0.2.tgz",
-      "integrity": "sha512-tmuUNr66acGh8oOo6rKLNOaleeUDSymxTBQJFzDpRET8kG1nzLwIRMpV+CZkzmQ0tbCQ1NMyDvBeyu+kaJ+Dtw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@npmcli/arborist/-/arborist-4.0.3.tgz",
+      "integrity": "sha512-gFz/dNJtpv2bYXlupcUpEaWlFDRUNmvVnQNbE6dY4ild6beZ2SkG4R5/CM4GZZwj9HD2TyfGjO350Ja+xlLzuA==",
       "requires": {
         "@isaacs/string-locale-compare": "^1.0.1",
         "@npmcli/installed-package-contents": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "8.1.1",
+  "version": "8.1.2",
   "name": "npm",
   "description": "a package manager for JavaScript",
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@isaacs/string-locale-compare": "^1.1.0",
-    "@npmcli/arborist": "^4.0.2",
+    "@npmcli/arborist": "^4.0.3",
     "@npmcli/ci-detect": "^1.4.0",
     "@npmcli/config": "^2.3.0",
     "@npmcli/map-workspaces": "^2.0.0",

--- a/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
@@ -1061,7 +1061,7 @@ exports[`test/lib/utils/config/definitions.js TAP > config description for lockf
 
 * Default: Version 2 if no lockfile or current lockfile version less than or
   equal to 2, otherwise maintain current lockfile version
-* Type: null, 1, 2, or 3
+* Type: null, 1, 2, 3, "1", "2", or "3"
 
 Set the lockfile format version to be used in package-lock.json and
 npm-shrinkwrap-json files. Possible options are:

--- a/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
@@ -861,7 +861,7 @@ When passed to \`npm config\` this refers to which config file to use.
 
 * Default: Version 2 if no lockfile or current lockfile version less than or
   equal to 2, otherwise maintain current lockfile version
-* Type: null, 1, 2, or 3
+* Type: null, 1, 2, 3, "1", "2", or "3"
 
 Set the lockfile format version to be used in package-lock.json and
 npm-shrinkwrap-json files. Possible options are:

--- a/test/lib/utils/config/definitions.js
+++ b/test/lib/utils/config/definitions.js
@@ -892,3 +892,12 @@ t.test('workspaces derived', t => {
   t.equal(flat.workspacesEnabled, false)
   t.end()
 })
+
+t.test('lockfile version', t => {
+  const flat = {}
+  definitions['lockfile-version'].flatten('lockfile-version', {
+    'lockfile-version': '3',
+  }, flat)
+  t.match(flat.lockfileVersion, 3, 'flattens to a number')
+  t.end()
+})


### PR DESCRIPTION
### BUG FIXES

* [`cb9f43551`](https://github.com/npm/cli/commit/cb9f43551f46bf27095cd7bd6c1885a441004cd2) [#3949](https://github.com/npm/cli/issues/3949) allow `--lockfile-version` config to be string and coerce to number ([@lukekarrys](https://github.com/lukekarrys))
* [`070901d7a`](https://github.com/npm/cli/commit/070901d7a6e3110a04ef41d8fcf14ffbfcce1496) [#3943](https://github.com/npm/cli/issues/3943) fix(publish): clean args before logging ([@wraithgar](https://github.com/wraithgar))

### DEPENDENCIES

* [`8af94726b`](https://github.com/npm/cli/commit/8af94726b098031c7c0cae7ed50cc4e2e3499181) [#3953](https://github.com/npm/cli/issues/3953) `arborist@4.0.3`
  * [`38cee94`](https://github.com/npm/arborist/commit/38cee94afa53d578830cc282348a803a8a6eefad) [#340](https://github.com/npm/arborist/pull/340) fix: set lockfileVersion from file during reset
  * [`d310bd3`](https://github.com/npm/arborist/commit/d310bd3290c3a81e8285ceeb6eda9c9b5aa867d7) [#339](https://github.com/npm/arborist/pull/339) fix: always set originalLockfileVersion when doing shrinkwrap reset