### PR TITLE
chore: limit CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,13 @@
 name: Node CI
 
-on: [push, pull_request]
-
+on:
+  pull_request:
+    branches:
+      - '*'
+  push:
+    branches:
+      - release-next
+      - latest
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We don't need duplicate builds on pull requests and pushes.  This should
cut our actions essentially down to half of what they are now.
