### PR TITLE
chore: remove usage of unnecessary util.promisify

### DIFF
--- a/lib/utils/reify-finish.js
+++ b/lib/utils/reify-finish.js
@@ -1,8 +1,6 @@
 const reifyOutput = require('./reify-output.js')
 const ini = require('ini')
-const util = require('util')
-const fs = require('fs')
-const { writeFile } = fs.promises || { writeFile: util.promisify(fs.writeFile) }
+const { writeFile } = require('fs').promises
 const {resolve} = require('path')
 
 const reifyFinish = async (npm, arb) => {

--- a/test/lib/utils/reify-finish.js
+++ b/test/lib/utils/reify-finish.js
@@ -76,11 +76,3 @@ t.test('should write if everything above passes', async t => {
   const data = fs.readFileSync(`${path}/npmrc`, 'utf8').replace(/\r\n/g, '\n')
   t.matchSnapshot(data, 'written config')
 })
-
-t.test('works without fs.promises', async t => {
-  t.doesNotThrow(() => t.mock('../../../lib/utils/reify-finish.js', {
-    fs: { ...fs, promises: null },
-    '../../../lib/npm.js': npm,
-    '../../../lib/utils/reify-output.js': reifyOutput,
-  }))
-})


### PR DESCRIPTION
This is safe to do now that we've dropped node 10 support.