### PR TITLE
chore: dont flag node_modules or package-lock as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/node_modules/**    linguist-generated=false
+/package-lock.json  linguist-generated=false


### PR DESCRIPTION
Now that we make dependency upgrades as pull requests, this should make
them easier to review since GitHub will now render diffs for them by
default.