### PR TITLE
docs: By default npm ignores .gitignore and .npmignore

### DIFF
--- a/docs/content/using-npm/developers.md
+++ b/docs/content/using-npm/developers.md
@@ -119,7 +119,9 @@ need to add them to `.npmignore` explicitly:
 * `._*`
 * `.DS_Store`
 * `.git`
+* `.gitignore`
 * `.hg`
+* `.npmignore`
 * `.npmrc`
 * `.lock-wscript`
 * `.svn`


### PR DESCRIPTION
There is no need too add ` .gitignore` or `.npmignore` to the `.npmignore` file. They are ignored by default. 
The behaviour can be reproduced by running `npm pack` or `npm publish`.
