### PR TITLE
fix: don't try to open file:/// urls

### DIFF
--- a/lib/utils/open-url.js
+++ b/lib/utils/open-url.js
@@ -25,7 +25,7 @@ const open = async (npm, url, errMsg) => {
   }
 
   try {
-    if (!/^(https?|file):$/.test(new URL(url).protocol)) {
+    if (!/^https?:$/.test(new URL(url).protocol)) {
       throw new Error()
     }
   } catch (_) {

--- a/test/lib/utils/open-url.js
+++ b/test/lib/utils/open-url.js
@@ -41,7 +41,7 @@ t.test('opens a url', async t => {
   t.same(OUTPUT, [], 'printed no output')
 })
 
-t.test('returns error for non-https and non-file url', async t => {
+t.test('returns error for non-https url', async t => {
   t.teardown(() => {
     openerUrl = null
     openerOpts = null
@@ -49,6 +49,22 @@ t.test('returns error for non-https and non-file url', async t => {
   })
   await t.rejects(
     openUrl(npm, 'ftp://www.npmjs.com', 'npm home'),
+    /Invalid URL/,
+    'got the correct error'
+  )
+  t.equal(openerUrl, null, 'did not open')
+  t.same(openerOpts, null, 'did not open')
+  t.same(OUTPUT, [], 'printed no output')
+})
+
+t.test('returns error for file url', async t => {
+  t.teardown(() => {
+    openerUrl = null
+    openerOpts = null
+    OUTPUT.length = 0
+  })
+  await t.rejects(
+    openUrl(npm, 'file:///usr/local/bin/ls', 'npm home'),
     /Invalid URL/,
     'got the correct error'
   )


### PR DESCRIPTION
These are never valid in the contexts from which this lib is called.
Namely these are the bugs, docs, fund, help, and repo commands, and for
oauth logins.
