### PR TITLE
docs: turn off smart quotes, update doctype and charset

### DIFF
--- a/docs/dockhand.js
+++ b/docs/dockhand.js
@@ -152,7 +152,7 @@ async function renderFile (childPath) {
 
   // Render the markdown into an HTML snippet using a GFM renderer.
   const content = cmark.renderHtmlSync(md, {
-    smart: true,
+    smart: false,
     githubPreLang: true,
     strikethroughDoubleTilde: true,
     unsafe: false,

--- a/docs/template.html
+++ b/docs/template.html
@@ -1,5 +1,7 @@
+<!DOCTYPE html>
 <html>
 <head>
+<meta charset="utf-8">
 <title>{{ title }}</title>
 <style>
 body {


### PR DESCRIPTION
<!-- What / Why -->

* When rendering HTML documentation, don't use smart quotes because they're icky and hard to copy/paste.
* Add a `<!DOCTYPE html>` and a `<meta charset="utf-8">` to be good HTML citizens.