### PR TITLE
fix: add missing scope on flat options

### DIFF
--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -1782,7 +1782,10 @@ define('scope', {
   `,
   flatten (key, obj, flatOptions) {
     const value = obj[key]
-    flatOptions.projectScope = value && !/^@/.test(value) ? `@${value}` : value
+    const scope = value && !/^@/.test(value) ? `@${value}` : value
+    flatOptions.scope = scope
+    // projectScope is kept for compatibility with npm-registry-fetch
+    flatOptions.projectScope = scope
   },
 })
 

--- a/test/lib/utils/config/definitions.js
+++ b/test/lib/utils/config/definitions.js
@@ -488,15 +488,15 @@ t.test('maxSockets', t => {
   t.end()
 })
 
-t.test('projectScope', t => {
+t.test('scope', t => {
   const obj = { scope: 'asdf' }
   const flat = {}
   definitions.scope.flatten('scope', obj, flat)
-  t.strictSame(flat, { projectScope: '@asdf' }, 'prepend @ if needed')
+  t.strictSame(flat, { scope: '@asdf', projectScope: '@asdf' }, 'prepend @ if needed')
 
   obj.scope = '@asdf'
   definitions.scope.flatten('scope', obj, flat)
-  t.strictSame(flat, { projectScope: '@asdf' }, 'leave untouched if has @')
+  t.strictSame(flat, { scope: '@asdf', projectScope: '@asdf' }, 'leave untouched if has @')
 
   t.end()
 })


### PR DESCRIPTION
The following command does not add scope into the npmrc file on npm cli versions >=7.7.0 as described in https://github.com/npm/cli/issues/3515
```
npm adduser --scope=@myScope --registry https://myArtifactory
```

Apparently https://github.com/npm/cli/commit/6598bfe8697439e827d84981f8504febca64a55a refactors the config structure. `flatten` method of `scope` definition somehow sets `flatOptions.projectScope` but does not set `flatOptions.scope`. On the other hand, adduser command gets the scope parameter from the flat options, which is always resolving to undefined.
https://github.com/npm/cli/blob/latest/lib/commands/adduser.js#L28

I don't know if setting `flatOptions.projectScope` was a mistake or intended, hence I just kept it there. Alternatively, it could be renamed to `flatOptions.scope` instead of adding another line.

## References
Fixes https://github.com/npm/cli/issues/3515