### PR TITLE
docs: fix typo in `save-peer` description

### DIFF
--- a/docs/content/using-npm/config.md
+++ b/docs/content/using-npm/config.md
@@ -1387,7 +1387,7 @@ Save installed packages to a package.json file as `optionalDependencies`.
 * Default: false
 * Type: Boolean
 
-Save installed packages. to a package.json file as `peerDependencies`
+Save installed packages to a package.json file as `peerDependencies`
 
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -1681,7 +1681,7 @@ define('save-peer', {
   default: false,
   type: Boolean,
   description: `
-    Save installed packages. to a package.json file as \`peerDependencies\`
+    Save installed packages to a package.json file as \`peerDependencies\`
   `,
   flatten (key, obj, flatOptions) {
     if (!obj[key]) {

--- a/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
@@ -1462,7 +1462,7 @@ exports[`test/lib/utils/config/definitions.js TAP > config description for save-
 * Default: false
 * Type: Boolean
 
-Save installed packages. to a package.json file as \`peerDependencies\`
+Save installed packages to a package.json file as \`peerDependencies\`
 `
 
 exports[`test/lib/utils/config/definitions.js TAP > config description for save-prefix 1`] = `

--- a/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
@@ -1261,7 +1261,7 @@ Save installed packages to a package.json file as \`optionalDependencies\`.
 * Default: false
 * Type: Boolean
 
-Save installed packages. to a package.json file as \`peerDependencies\`
+Save installed packages to a package.json file as \`peerDependencies\`
 
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->


### PR DESCRIPTION
Corrected the typo and then ran `TAP_SNAPSHOT=1 npm test`.