### PR TITLE
docs: fix typo

### DIFF
--- a/docs/content/using-npm/scripts.md
+++ b/docs/content/using-npm/scripts.md
@@ -259,7 +259,7 @@ package.json file, then your package scripts would have the
 in your code with `process.env.npm_package_name` and
 `process.env.npm_package_version`, and so on for other fields.
 
-See [`package-json.md`](/configuring-npm/package-json) for more on package configs.
+See [`package.json`](/configuring-npm/package-json) for more on package configs.
 
 #### current lifecycle event
 


### PR DESCRIPTION
This PR has previously been made in the [documentation](https://github.com/npm/documentation/pull/53#event-5654531339) repository. @MylesBorins left the following comment before closing that PR.

> With that said I don't think this is a change we would land. in the rendered documentation it is not longer a markdown file.

I think the intention for the fix has been misunderstood. I'm assuming that the documentation runs through some kind of build process, where the Markdown files are converted to HTML. However, this PR does not try to change any of those links, but the text used on that link.

See this screenshot of the affected paragraph:

![Screenshot 2021-11-22 at 18 34 59](https://user-images.githubusercontent.com/1504938/142909093-b188d667-aab6-48b0-b4e1-898f434d98a9.png)

Elsewhere on the same page, the same link is used but with a different text. Here's another screenshot of that paragraph:

![Screenshot 2021-11-22 at 18 39 34](https://user-images.githubusercontent.com/1504938/142909193-100ab989-8006-461f-a241-89c947559c7d.png)

This text makes more sense and matches the title of the linked document, so the same should be applied to the other occurence of the link – this PR does just that.