### PR TITLE
chore(ci): fix license validation CI step name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           node ./bin/npm-cli.js install --ignore-scripts --no-audit
           node ./bin/npm-cli.js rebuild
-      - name: Run linting
+      - name: Validate licenses
         run: node ./bin/npm-cli.js run licenses
 
   smoke-tests:


### PR DESCRIPTION
The script ran on the mentioned step validate the licenses but the step name says "Run linting"