### PR TITLE
feat: display `publishConfig` during `config list`

### DIFF
--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -2,7 +2,7 @@
 const configDefs = require('../utils/config/index.js')
 
 const mkdirp = require('mkdirp-infer-owner')
-const { dirname } = require('path')
+const { dirname, resolve } = require('path')
 const { promisify } = require('util')
 const fs = require('fs')
 const readFile = promisify(fs.readFile)
@@ -11,6 +11,7 @@ const { spawn } = require('child_process')
 const { EOL } = require('os')
 const ini = require('ini')
 const localeCompare = require('@isaacs/string-locale-compare')('en')
+const rpj = require('read-package-json-fast')
 const log = require('../utils/log-shim.js')
 
 // take an array of `[key, value, k2=v2, k3, v3, ...]` and turn into
@@ -267,6 +268,23 @@ ${defData}
         `; HOME = ${process.env.HOME}`,
         '; Run `npm config ls -l` to show all defaults.'
       )
+      msg.push('')
+    }
+
+    if (!this.npm.config.get('global')) {
+      const pkgPath = resolve(this.npm.prefix, 'package.json')
+      const pkg = await rpj(pkgPath).catch(() => ({}))
+
+      if (pkg.publishConfig) {
+        msg.push(`; "publishConfig" from ${pkgPath}`)
+        msg.push('; This set of config values will be used at publish-time.', '')
+        const pkgKeys = Object.keys(pkg.publishConfig).sort(localeCompare)
+        for (const k of pkgKeys) {
+          const v = publicVar(k) ? JSON.stringify(pkg.publishConfig[k]) : '(protected)'
+          msg.push(`${k} = ${v}`)
+        }
+        msg.push('')
+      }
     }
 
     this.npm.output(msg.join('\n').trim())

--- a/tap-snapshots/test/lib/commands/config.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/config.js.test.cjs
@@ -342,3 +342,44 @@ userconfig = "{HOME}/.npmrc"
 ; HOME = {HOME}
 ; Run \`npm config ls -l\` to show all defaults.
 `
+
+exports[`test/lib/commands/config.js TAP config list with publishConfig > output matches snapshot 1`] = `
+; "cli" config from command line options
+
+cache = "{NPMDIR}/test/lib/commands/tap-testdir-config-config-list-with-publishConfig-sandbox/cache" 
+prefix = "{LOCALPREFIX}" 
+userconfig = "{HOME}/.npmrc" 
+
+; node bin location = {EXECPATH}
+; cwd = {NPMDIR}
+; HOME = {HOME}
+; Run \`npm config ls -l\` to show all defaults.
+
+; "publishConfig" from {LOCALPREFIX}/package.json
+; This set of config values will be used at publish-time.
+
+_authToken = (protected)
+registry = "https://some.registry"
+; "env" config from environment
+
+; cache = "{NPMDIR}/test/lib/commands/tap-testdir-config-config-list-with-publishConfig-sandbox/cache" ; overridden by cli
+global-prefix = "{LOCALPREFIX}" 
+globalconfig = "{GLOBALPREFIX}/npmrc" 
+init-module = "{HOME}/.npm-init.js" 
+local-prefix = "{LOCALPREFIX}" 
+; prefix = "{LOCALPREFIX}" ; overridden by cli
+user-agent = "npm/{NPM-VERSION} node/{NODE-VERSION} {PLATFORM} {ARCH} workspaces/false" 
+; userconfig = "{HOME}/.npmrc" ; overridden by cli
+
+; "cli" config from command line options
+
+cache = "{NPMDIR}/test/lib/commands/tap-testdir-config-config-list-with-publishConfig-sandbox/cache" 
+global = true 
+prefix = "{LOCALPREFIX}" 
+userconfig = "{HOME}/.npmrc" 
+
+; node bin location = {EXECPATH}
+; cwd = {NPMDIR}
+; HOME = {HOME}
+; Run \`npm config ls -l\` to show all defaults.
+`

--- a/test/lib/commands/config.js
+++ b/test/lib/commands/config.js
@@ -107,6 +107,26 @@ t.test('config list --json', async t => {
   t.matchSnapshot(sandbox.output, 'output matches snapshot')
 })
 
+t.test('config list with publishConfig', async t => {
+  const temp = t.testdir({
+    project: {
+      'package.json': JSON.stringify({
+        publishConfig: {
+          registry: 'https://some.registry',
+          _authToken: 'mytoken',
+        },
+      }),
+    },
+  })
+  const project = join(temp, 'project')
+
+  const sandbox = new Sandbox(t, { project })
+  await sandbox.run('config', ['list', ''])
+  await sandbox.run('config', ['list', '--global'])
+
+  t.matchSnapshot(sandbox.output, 'output matches snapshot')
+})
+
 t.test('config delete no args', async t => {
   const sandbox = new Sandbox(t)
 


### PR DESCRIPTION
Closes: npm/statusboard#417

If the file at `$NPM_CONFIG_PREFIX/package.json` contains a
`publishConfig`, the key/value pairs will be printed along with the rest
of the output from `npm config ls`.
