### PR TITLE
feat(arborist): add `toJSON`/`toString` methods to get shrinkwrap file contents without saving

### DIFF
--- a/workspaces/arborist/lib/shrinkwrap.js
+++ b/workspaces/arborist/lib/shrinkwrap.js
@@ -1085,18 +1085,29 @@ class Shrinkwrap {
     return lock
   }
 
-  save (options = {}) {
+  toJSON () {
     if (!this.data) {
-      throw new Error('run load() before saving data')
+      throw new Error('run load() before getting or setting data')
     }
 
+    return this.commit()
+  }
+
+  toString (options = {}) {
+    const data = this.toJSON()
     const { format = true } = options
     const defaultIndent = this.indent || 2
     const indent = format === true ? defaultIndent
       : format || 0
     const eol = format ? this.newline || '\n' : ''
-    const data = this.commit()
-    const json = stringify(data, swKeyOrder, indent).replace(/\n/g, eol)
+    return stringify(data, swKeyOrder, indent).replace(/\n/g, eol)
+  }
+
+  save (options = {}) {
+    if (!this.data) {
+      throw new Error('run load() before saving data')
+    }
+    const json = this.toString(options)
     return Promise.all([
       writeFile(this.filename, json).catch(er => {
         if (this.hiddenLockfile) {

--- a/workspaces/arborist/tap-snapshots/test/shrinkwrap.js.test.cjs
+++ b/workspaces/arborist/tap-snapshots/test/shrinkwrap.js.test.cjs
@@ -14240,6 +14240,25 @@ exports[`test/shrinkwrap.js TAP saving dependency-free shrinkwrap object load fi
 
 `
 
+exports[`test/shrinkwrap.js TAP saving dependency-free shrinkwrap object load the unindented file, and generate expected contents > indented json object output 1`] = `
+Object {
+  "dependencies": Object {},
+  "lockfileVersion": 2,
+  "packages": Object {},
+  "requires": true,
+}
+`
+
+exports[`test/shrinkwrap.js TAP saving dependency-free shrinkwrap object load the unindented file, and generate expected contents > indented json string output 1`] = `
+{
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {},
+  "dependencies": {}
+}
+
+`
+
 exports[`test/shrinkwrap.js TAP saving dependency-free shrinkwrap object load the unindented file, and save it back default > indented json output 1`] = `
 {
   "lockfileVersion": 2,

--- a/workspaces/arborist/test/shrinkwrap.js
+++ b/workspaces/arborist/test/shrinkwrap.js
@@ -223,6 +223,10 @@ t.test('throws when attempting to access data before loading', t => {
   t.throws(() =>
     new Shrinkwrap().add(), Error('run load() before getting or setting data'))
   t.throws(() =>
+    new Shrinkwrap().toJSON(), Error('run load() before getting or setting data'))
+  t.throws(() =>
+    new Shrinkwrap().toString(), Error('run load() before getting or setting data'))
+  t.throws(() =>
     new Shrinkwrap().save(), Error('run load() before saving data'))
   t.end()
 })
@@ -479,6 +483,21 @@ t.test('saving dependency-free shrinkwrap object', t => {
     await sw.save({ format: false })
     fs.statSync(sw.filename)
     t.matchSnapshot(fs.readFileSync(sw.filename, 'utf8'), 'no indent json output')
+  })
+
+  t.test('load the unindented file, and generate expected contents', async t => {
+    const sw = await Shrinkwrap.load({ path: dir })
+    t.equal(
+      sw.filename,
+      resolve(`${dir}/package-lock.json`),
+      'correct filepath on shrinkwrap instance'
+    )
+    t.equal(sw.indent, '')
+    const json = await sw.toJSON()
+    t.matchSnapshot(json, 'indented json object output')
+
+    const jsonString = await sw.toString()
+    t.matchSnapshot(jsonString, 'indented json string output')
   })
 
   t.test('load the unindented file, and save it back default', async t => {


### PR DESCRIPTION
This allows me to build a tool that gets the lockfile's contents without touching the filesystem.