### PR TITLE
fix(unpublish): Show warning when last version is being removed

### DIFF
--- a/test/lib/commands/unpublish.js
+++ b/test/lib/commands/unpublish.js
@@ -3,6 +3,23 @@ const { fake: mockNpm } = require('../../fixtures/mock-npm')
 
 let result = ''
 const noop = () => null
+const versions = async () => {
+  return {
+    versions: {
+      '1.0.0': {},
+      '1.0.1': {},
+    },
+  }
+}
+
+const singleVersion = async () => {
+  return {
+    versions: {
+      '1.0.0': {},
+    },
+  }
+}
+
 const config = {
   force: false,
   loglevel: 'silly',
@@ -26,7 +43,7 @@ const npm = mockNpm({
 const mocks = {
   libnpmaccess: { lsPackages: noop },
   libnpmpublish: { unpublish: noop },
-  'npm-registry-fetch': { json: noop },
+  'npm-registry-fetch': { json: versions },
   '../../../lib/utils/otplease.js': async (opts, fn) => fn(opts),
   '../../../lib/utils/get-identity.js': async () => 'foo',
   'proc-log': { silly () {}, verbose () {} },
@@ -529,4 +546,33 @@ t.test('completion', async t => {
       expect: [],
     })
   })
+})
+
+t.test('show error on unpublish <pkg>@version with package.json and the last version', async t => {
+  const Unpublish = t.mock('../../../lib/commands/unpublish.js', {
+    ...mocks,
+    'npm-registry-fetch': { json: singleVersion },
+    path: { resolve: () => testDir, join: () => testDir + '/package.json' },
+  })
+  const unpublish = new Unpublish(npm)
+  await t.rejects(
+    unpublish.exec(['pkg@1.0.0']),
+    'Refusing to delete the last version of the package. ' +
+      'It will block from republishing a new version for 24 hours.\n' +
+      'Run with --force to do this.'
+  )
+})
+
+t.test('show error on unpublish <pkg>@version when the last version', async t => {
+  const Unpublish = t.mock('../../../lib/commands/unpublish.js', {
+    ...mocks,
+    'npm-registry-fetch': { json: singleVersion },
+  })
+  const unpublish = new Unpublish(npm)
+  await t.rejects(
+    unpublish.exec(['pkg@1.0.0']),
+    'Refusing to delete the last version of the package. ' +
+      'It will block from republishing a new version for 24 hours.\n' +
+      'Run with --force to do this.'
+  )
 })


### PR DESCRIPTION
Issue:
When we use `npm unpublish` command with the last version of a package, we don't get a warning and we can't republish until 24 hours pass. 

Solution:
I wanted to give a warning to the user and force them to use `--force` if they are really sure about this action. 

Fixes https://github.com/npm/rfcs/discussions/355