### PR TITLE
chore: update bug_8 environment (#4156)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_8.yml
+++ b/.github/ISSUE_TEMPLATE/bug_8.yml
@@ -45,16 +45,16 @@ body:
     label: Environment
     description: |
       examples:
-        - **npm**: 7.6.3
-        - **Node**: 13.14.0
-        - **OS**: Ubuntu 20.04
-        - **platform**: Macbook Pro
+        - **`npm -v`**: **npm**: 7.6.3
+        - **`node -v`**: **Node.js**: 13.14.0
+        - **OS Name**: Ubuntu 20.04
+        - **System Model Name**: Macbook Pro
         - **`npm config ls`**: `; "user" config from ...`
     value: |
         - npm:
-        - Node:
-        - OS:
-        - platform:
+        - Node.js:
+        - OS Name:
+        - System Model Name:
         - npm config:
         ```ini
         ; copy and paste output from `npm config ls` here


### PR DESCRIPTION
Guiding how to update the environment in bug pull request much clear.

This was merged into `latest` instead of `release-next`