### PR TITLE
deps: agentkeepalive@4.2.0

### DIFF
--- a/node_modules/agentkeepalive/History.md
+++ b/node_modules/agentkeepalive/History.md
@@ -1,4 +1,13 @@
 
+4.2.0 / 2021-12-31
+==================
+
+**fixes**
+  * [[`f418c67`](http://github.com/node-modules/agentkeepalive/commit/f418c67a63c061c7261592d4553bc455e0b0d306)] - fix: change `freeSocketTimeout` default value to 4000 (#102) (fengmk2 <<fengmk2@gmail.com>>)
+
+**others**
+  * [[`bc2a1ce`](http://github.com/node-modules/agentkeepalive/commit/bc2a1cea0884b4d18b0d244bf00006d9107963df)] - doc(readme): making `timeout`'s default clear (#100) (Aaron <<aaronarinder@gmail.com>>)
+
 4.1.4 / 2021-02-05
 ==================
 

--- a/node_modules/agentkeepalive/lib/agent.js
+++ b/node_modules/agentkeepalive/lib/agent.js
@@ -31,9 +31,10 @@ class Agent extends OriginalAgent {
   constructor(options) {
     options = options || {};
     options.keepAlive = options.keepAlive !== false;
-    // default is keep-alive and 15s free socket timeout
+    // default is keep-alive and 4s free socket timeout
+    // see https://medium.com/ssense-tech/reduce-networking-errors-in-nodejs-23b4eb9f2d83
     if (options.freeSocketTimeout === undefined) {
-      options.freeSocketTimeout = 15000;
+      options.freeSocketTimeout = 4000;
     }
     // Legacy API: keepAliveTimeout should be rename to `freeSocketTimeout`
     if (options.keepAliveTimeout) {
@@ -51,8 +52,8 @@ class Agent extends OriginalAgent {
     // Sets the socket to timeout after timeout milliseconds of inactivity on the socket.
     // By default is double free socket timeout.
     if (options.timeout === undefined) {
-      // make sure socket default inactivity timeout >= 30s
-      options.timeout = Math.max(options.freeSocketTimeout * 2, 30000);
+      // make sure socket default inactivity timeout >= 8s
+      options.timeout = Math.max(options.freeSocketTimeout * 2, 8000);
     }
 
     // support humanize format

--- a/node_modules/agentkeepalive/package.json
+++ b/node_modules/agentkeepalive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentkeepalive",
-  "version": "4.1.4",
+  "version": "4.2.0",
   "description": "Missing keepalive http.Agent",
   "main": "index.js",
   "browser": "browser.js",
@@ -59,7 +59,7 @@
     "os": {
       "github": "linux"
     },
-    "version": "8, 10, 12, 14"
+    "version": "8, 10, 12, 14, 16"
   },
   "author": "fengmk2 <fengmk2@gmail.com> (https://fengmk2.com)",
   "license": "MIT"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1111,9 +1111,9 @@
       }
     },
     "node_modules/agentkeepalive": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.1.4.tgz",
-      "integrity": "sha512-+V/rGa3EuU74H6wR04plBb7Ks10FbtUQgRj/FQOG7uUIEuaINI+AiqJR1k6t3SVNs7o7ZjIdus6706qqzVq8jQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.0.tgz",
+      "integrity": "sha512-0PhAp58jZNw13UJv7NVdTGb0ZcghHUb3DrZ046JiiJY/BOaTTpbwdHq2VObPCBV8M2GPh7sgrJ3AQ8Ey468LJw==",
       "inBundle": true,
       "dependencies": {
         "debug": "^4.1.0",
@@ -11637,9 +11637,9 @@
       }
     },
     "agentkeepalive": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.1.4.tgz",
-      "integrity": "sha512-+V/rGa3EuU74H6wR04plBb7Ks10FbtUQgRj/FQOG7uUIEuaINI+AiqJR1k6t3SVNs7o7ZjIdus6706qqzVq8jQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.0.tgz",
+      "integrity": "sha512-0PhAp58jZNw13UJv7NVdTGb0ZcghHUb3DrZ046JiiJY/BOaTTpbwdHq2VObPCBV8M2GPh7sgrJ3AQ8Ey468LJw==",
       "requires": {
         "debug": "^4.1.0",
         "depd": "^1.1.2",


### PR DESCRIPTION
according to this issue https://github.com/node-modules/agentkeepalive/issues/57 this update fixes a race condition that could cause timeouts to cause problems. bringing in this update is worth a shot to potentially fix another source of `exit handler not called` errors.