### PR TITLE
[arborist] [Fix] `build-ideal-tree`: ensure indentation is preserved

### DIFF
--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -333,8 +333,7 @@ module.exports = cls => class IdealTreeBuilder extends cls {
             root.meta.lockfileVersion = defaultLockfileVersion
           }
         }
-        // ensure indentation is inferred properly
-        root.meta.indent = root.package[Symbol.for('indent')]
+        root.meta.inferFormattingOptions(root.package)
         return root
       })
 

--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -333,6 +333,8 @@ module.exports = cls => class IdealTreeBuilder extends cls {
             root.meta.lockfileVersion = defaultLockfileVersion
           }
         }
+        // ensure indentation is inferred properly
+        root.meta.indent = root.package[Symbol.for('indent')]
         return root
       })
 

--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -176,7 +176,7 @@ module.exports = cls => class IdealTreeBuilder extends cls {
   // public method
   async buildIdealTree (options = {}) {
     if (this.idealTree) {
-      return Promise.resolve(this.idealTree)
+      return this.idealTree
     }
 
     // allow the user to set reify options on the ctor as well.
@@ -194,8 +194,7 @@ module.exports = cls => class IdealTreeBuilder extends cls {
     process.emit('time', 'idealTree')
 
     if (!options.add && !options.rm && !options.update && this[_global]) {
-      const er = new Error('global requires add, rm, or update option')
-      return Promise.reject(er)
+      throw new Error('global requires add, rm, or update option')
     }
 
     // first get the virtual tree, if possible.  If there's a lockfile, then

--- a/workspaces/arborist/lib/shrinkwrap.js
+++ b/workspaces/arborist/lib/shrinkwrap.js
@@ -424,6 +424,18 @@ class Shrinkwrap {
       .map(fn => fn && maybeStatFile(fn)))
   }
 
+  inferFormattingOptions (packageJSONData) {
+    // don't use detect-indent, just pick the first line.
+    // if the file starts with {" then we have an indent of '', ie, none
+    // which will default to 2 at save time.
+    const {
+      [Symbol.for('indent')]: indent,
+      [Symbol.for('newline')]: newline,
+    } = packageJSONData
+    this.indent = indent !== undefined ? indent : this.indent
+    this.newline = newline !== undefined ? newline : this.newline
+  }
+
   load () {
     // we don't need to load package-lock.json except for top of tree nodes,
     // only npm-shrinkwrap.json.
@@ -451,15 +463,7 @@ class Shrinkwrap {
 
       return data ? parseJSON(data) : {}
     }).then(async data => {
-      // don't use detect-indent, just pick the first line.
-      // if the file starts with {" then we have an indent of '', ie, none
-      // which will default to 2 at save time.
-      const {
-        [Symbol.for('indent')]: indent,
-        [Symbol.for('newline')]: newline,
-      } = data
-      this.indent = indent !== undefined ? indent : this.indent
-      this.newline = newline !== undefined ? newline : this.newline
+      this.inferFormattingOptions(data)
 
       if (!this.hiddenLockfile || !data.packages) {
         return data

--- a/workspaces/arborist/test/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/test/arborist/build-ideal-tree.js
@@ -3682,3 +3682,16 @@ t.test('overrides', t => {
 
   t.end()
 })
+
+t.test('store files with a custom indenting', async t => {
+  const tabIndentedPackageJson =
+    fs.readFileSync(
+      resolve(__dirname, '../fixtures/tab-indented-package-json/package.json'),
+      'utf8'
+    ).replace(/\r\n/g, '\n')
+  const path = t.testdir({
+    'package.json': tabIndentedPackageJson,
+  })
+  const tree = await buildIdeal(path)
+  t.matchSnapshot(String(tree.meta))
+})


### PR DESCRIPTION
It turns out that `new Arborist().buildIdealTree().meta.toString()` does not take into account the indentation in the package.json (tabs, in my case) the way `npm install --package-lock-only` does.

This fixes that. I also included a bonus commit that removes redundant Promise stuff inside an `async function`.

I'm happy to add a test if you suggest where to do so; it seems like it'd require a directory with a `package.json` that's indented by tabs, and to confirm that the resulting shrinkwrap contents is also indented by tabs.

(related to #4181)