### PR TITLE
Change the default save-prefix from ^ to none

### DIFF
--- a/docs/content/using-npm/config.md
+++ b/docs/content/using-npm/config.md
@@ -1394,7 +1394,7 @@ Save installed packages to a package.json file as `peerDependencies`
 
 #### `save-prefix`
 
-* Default: "^"
+* Default: No Prefix ("")
 * Type: String
 
 Configure how versions of packages installed to a package.json file via

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -1713,7 +1713,8 @@ define('save-peer', {
 })
 
 define('save-prefix', {
-  default: '^',
+  default: '',
+  defaultDescription: 'No Prefix (Empty String)',
   type: String,
   description: `
     Configure how versions of packages installed to a package.json file via

--- a/tap-snapshots/test/lib/commands/config.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/config.js.test.cjs
@@ -124,7 +124,7 @@ exports[`test/lib/commands/config.js TAP config list --json > output matches sna
   "save-exact": false,
   "save-optional": false,
   "save-peer": false,
-  "save-prefix": "^",
+  "save-prefix": "",
   "save-prod": false,
   "scope": "",
   "script-shell": null,
@@ -276,7 +276,7 @@ save-dev = false
 save-exact = false 
 save-optional = false 
 save-peer = false 
-save-prefix = "^" 
+save-prefix = "" 
 save-prod = false 
 scope = "" 
 script-shell = null 

--- a/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
@@ -1468,7 +1468,7 @@ Save installed packages to a package.json file as \`peerDependencies\`
 exports[`test/lib/utils/config/definitions.js TAP > config description for save-prefix 1`] = `
 #### \`save-prefix\`
 
-* Default: "^"
+* Default: No Prefix (Empty String)
 * Type: String
 
 Configure how versions of packages installed to a package.json file via

--- a/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
@@ -1268,7 +1268,7 @@ Save installed packages to a package.json file as \`peerDependencies\`
 
 #### \`save-prefix\`
 
-* Default: "^"
+* Default: No Prefix (Empty String)
 * Type: String
 
 Configure how versions of packages installed to a package.json file via


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

# TLDR
This PR changes the default behaviour of NPM to **not** save package versions with the `^` prefix.
Instead, packages would be saved with no prefix.

As a TL;DR, the implications of this is that **all dependencies will be pinned to the version you installed by default**. 

# Changing This Yourself
If you're reading this PR and want to apply it to your own environments, invoke `npm config set save-prefix=''`.

# Existing Behaviour
The `^1.0.0` range means that NPM will accept any package that is `1.0.0` or greater in the *MINOR* or *PATCH* field. This means `1.0.2` and `1.2.0` are legal matches, but `2.0.0` is not.

Since packages on NPM are expected to follow semver, this has the presumed intention of automatically opting users into security patches. For details I'll go into in a minute, there are no actual security benefits to this design decision.

NPMs design has changed a lot since its original iteration, and I feel it is important to note that this decision was made back in npmv1 (or older). This means **this design decision predates package-lock.json, --save being the default, and more**.

# Why change it?
There are massive security implications for this default. Semver is not enforceable, and what constitutes a `PATCH`/`MINOR` to one person might be a breaking change to another.

As an example, `mongodb`'s `3.6.4` update caused `monk` to [endlessly spit out warnings](https://github.com/Automattic/monk/issues/333). 

This can have pretty serious implications for people using NPM in production. Blindly running `npm install` on a different machine can result in different dependencies being installed to your local dev version! Sure, you installed `3.6.3`, but `^3.6.3` means that npm is perfectly within its right to get `3.6.4`. (n.b. `npm ci` should be used to avoid this behaviour, but why is the default dangerous?)

Although `package-lock.json` exists to solve this, `package-lock.json` is regenerated whenever an option touches `package.json` or `node_modules`. This means that `npm install`ing another module will result in all of your `^x.x.x` packages being bumped aswell.

# Security Implications
If a library is compromised somehow, the author can publish a PATCH/MINOR version that performs malicious actions. Given that semver is not enforceable (NPM cannot possibly say -- hey, this change is too major for a patch release), this means that the compromised library can essentially do whatever it wants to almost every single one of its dependents.

Since this happens automatically as the result of doing other things (i.e. anything that interacts with `package.json`), this means even installing a new, entirely separate package can result in the compromised library getting exec access.

# Scope for attack
NPM is based around micropackages. For any given package, there are likely to be hundreds or even thousands of tiny packages holding it up. Every single one of those libraries is a target for attackers, as compromising any of the ones that make up a larger package can result in full code execution on *millions* of machines or applications.

Furthermore, NPM does not enforce 2FA on accounts of package authors. If a package authors password is leaked online, they could have their account hijacked. Although this would be bad on its own, the fact that they can then upload malware that *near-automatically propogates* across the entire ecosystem moves the scope from *bad* to *incredibly bad*.

While changing the default from `^` to nothing does not fix all of these issues, it would stunt the spread of malicious patch updates, as it would only affect users newly directly installing the package, rather than installing any package that depends on it. This moves the difficulty up (in theory) from compromising any micropackage to compromising a larger package (say, `react`) in order to get such an impact.

# Examples
While `colors.js` is the example everyone is currently thinking about, this is not even close to the only time this has happened.

Here is a list of just some packages in recent memory that have leveraged this default behaviour to perform large scale attacks.

- [UAParser (October 22 2021)](https://www.npmjs.com/package/ua-parser-js)
- [coa (November 4 2021)](https://github.com/advisories/GHSA-73qr-pfmq-6rp8)
- [rc (November 4 2021)](https://github.com/advisories/GHSA-g2q5-5433-rhrf)
- [another-date-range-picker (September 1 2020)](https://github.com/advisories/GHSA-8rxg-9g6f-vq9p)
- [another-date-picker (September 1 2020)](https://github.com/advisories/GHSA-8rxg-9g6f-vq9p)
- [stream-combine (September 2 2020)](https://github.com/advisories/GHSA-w6xj-45gv-fw35)
- [angular-bmap (September 1 2020)](https://github.com/advisories/GHSA-w8hg-mxvh-9h57)

# Arguing against 'automatic patching'
A potential retort to this would be that the current behaviour causes users to get potential security patches automatically. However, this is not really the case.

Consider the case where a user has a bunch of packages, and `foobar@1.0.1` has a security vulnerability.
The user's package json has `"foobar": "^1.0.0"`.
A new version of `foobar` is released to deal with this security vulnerabilty.

The user is **not** safe in any way against their vulnerability until they do anything that interacts with their `package.json`. When they do, it is possible that `npm` will update the package to the latest patch version available, but it is not **required** to do so. If they have another dependency that perhaps isn't as lenient with its version of `foobar`, `npm` will not automatically apply the security patch.

Furthermore, this automatic application of the latest version **does not** update `package.json`. It would be perfectly legal for NPM to install `1.0.1` again, there's absolutely no guarantee that that would happen.

The amount of edge cases and scenarios involved with hoping `npm` pulls the right version out of a set of versions that *do contain significant security vulnerabilities* is *not* worth it. You should explicitly state that you want the security patch and *explicitly* have it in your `package.json` that you do not ever want version `v1.0.1`.

A tool like `npm audit` is already invoked on almost every operation. [Even if it is critically flawed](https://overreacted.io/npm-audit-broken-by-design/), it is still a useful way of alerting users to security issues that affect them, and encourage them to update their version of a package.

# Conclusion
In my opinion, the default behaviour should **always** be pinning dependencies to the exact version. Updating packages should be opt-in, not opt-out.

