### PR TITLE
doc: add npm-init aliases

### DIFF
--- a/docs/content/commands/npm-init.md
+++ b/docs/content/commands/npm-init.md
@@ -11,6 +11,8 @@ npm init [--yes|-y|--scope]
 npm init <@scope> (same as `npm exec <@scope>/create`)
 npm init [<@scope>/]<name> (same as `npm exec [<@scope>/]create-<name>`)
 npm init [-w <dir>] [args...]
+
+aliases: create, innit
 ```
 
 ### Description


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

The create alias for npm-init is a good way to make it compatible with other package managers.
How about adding it to the documentation?

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Related to #4189 