### PR TITLE
fix(arborist): shrinkwrap throws when trying to read a folder without permissions

### DIFF
--- a/workspaces/arborist/lib/shrinkwrap.js
+++ b/workspaces/arborist/lib/shrinkwrap.js
@@ -472,8 +472,12 @@ class Shrinkwrap {
       // all good!  hidden lockfile is the newest thing in here.
       return data
     }).catch(er => {
-      const rel = relpath(this.path, this.filename)
-      this.log.verbose('shrinkwrap', `failed to load ${rel}`, er)
+      if (typeof this.filename === 'string') {
+        const rel = relpath(this.path, this.filename)
+        this.log.verbose('shrinkwrap', `failed to load ${rel}`, er)
+      } else {
+        this.log.verbose('shrinkwrap', `failed to load ${this.path}`, er)
+      }
       this.loadingError = er
       this.loadedFromDisk = false
       this.ancientLockfile = false

--- a/workspaces/arborist/lib/shrinkwrap.js
+++ b/workspaces/arborist/lib/shrinkwrap.js
@@ -472,6 +472,7 @@ class Shrinkwrap {
       // all good!  hidden lockfile is the newest thing in here.
       return data
     }).catch(er => {
+      /* istanbul ignore else */
       if (typeof this.filename === 'string') {
         const rel = relpath(this.path, this.filename)
         this.log.verbose('shrinkwrap', `failed to load ${rel}`, er)

--- a/workspaces/arborist/test/shrinkwrap.js
+++ b/workspaces/arborist/test/shrinkwrap.js
@@ -5,7 +5,6 @@ const calcDepFlags = require('../lib/calc-dep-flags.js')
 const fs = require('fs')
 const Arborist = require('../lib/arborist/index.js')
 const rimraf = require('rimraf')
-const { execSync } = require('child_process')
 
 const t = require('tap')
 
@@ -1600,7 +1599,7 @@ t.test('setting lockfileVersion from the file contents', async t => {
   t.equal(Shrinkwrap.defaultLockfileVersion, 2, 'default is 2')
 
   t.test('load should return error correctly when it cant access folder',
-    { skip: process.platform === 'win32' ? 'skip chmod in windows' : false },
+  { skip: process.platform === 'win32' ? 'skip chmod in windows' : false },
     async t => {
       const dir = t.testdir({})
       try {

--- a/workspaces/arborist/test/shrinkwrap.js
+++ b/workspaces/arborist/test/shrinkwrap.js
@@ -1599,33 +1599,18 @@ t.test('setting lockfileVersion from the file contents', async t => {
 
   t.equal(Shrinkwrap.defaultLockfileVersion, 2, 'default is 2')
 
-  t.test('load should return error correctly when it cant access folder', async t => {
-    const dir = t.testdir({})
-    try {
-      const err = removePermissions(dir)
-      const res = await Shrinkwrap.load({ path: dir })
-      t.ok(res.loadingError, 'loading error should exist')
-      t.strictSame(res.loadingError.code, err)
-    } finally {
-      restorePermissions(dir)
-    }
-
-    function removePermissions(dir) {
-      if (process.platform === 'win32') {
-        execSync(`icacls ${dir} /deny "everyone:R"`)
-        return 'EPERM'
+  t.test('load should return error correctly when it cant access folder',
+    { skip: process.platform === 'win32' ? 'skip chmod in windows' : false },
+    async t => {
+      const dir = t.testdir({})
+      try {
+        fs.chmodSync(dir, '000')
+        const res = await Shrinkwrap.load({ path: dir })
+        t.ok(res.loadingError, 'loading error should exist')
+        t.strictSame(res.loadingError.errno, -13)
+        t.strictSame(res.loadingError.code, 'EACCES')
+      } finally {
+        fs.chmodSync(dir, '666')
       }
-  
-      fs.chmodSync(dir, '000')
-      return 'EACCES'
-    }
-
-    function restorePermissions(dir) {
-      if (process.platform === 'win32') {
-        execSync(`icacls ${dir} /grant "everyone:R"`)
-      } else {
-        fs.chmodSync(dir, '777')
-      }
-    }
-  })
+    })
 })

--- a/workspaces/arborist/test/shrinkwrap.js
+++ b/workspaces/arborist/test/shrinkwrap.js
@@ -1599,7 +1599,7 @@ t.test('setting lockfileVersion from the file contents', async t => {
   t.equal(Shrinkwrap.defaultLockfileVersion, 2, 'default is 2')
 
   t.test('load should return error correctly when it cant access folder',
-  { skip: process.platform === 'win32' ? 'skip chmod in windows' : false },
+    { skip: process.platform === 'win32' ? 'skip chmod in windows' : false },
     async t => {
       const dir = t.testdir({})
       try {

--- a/workspaces/arborist/test/shrinkwrap.js
+++ b/workspaces/arborist/test/shrinkwrap.js
@@ -1597,4 +1597,17 @@ t.test('setting lockfileVersion from the file contents', async t => {
   })
 
   t.equal(Shrinkwrap.defaultLockfileVersion, 2, 'default is 2')
+
+  t.test('load should return error correctly when it cant access folder', async t => {
+    const dir = t.testdir({})
+    try {
+      fs.chmodSync(dir, '000')
+      const res = await Shrinkwrap.load({ path: dir })
+      t.ok(res.loadingError, 'loading error should exist')
+      t.strictSame(res.loadingError.errno, -13)
+      t.strictSame(res.loadingError.code, 'EACCES')
+    } finally {
+      fs.chmodSync(dir, '777')
+    }
+  })
 })


### PR DESCRIPTION
This PR fixes a minor regression [introduced here](https://github.com/npm/arborist/pull/244/files#diff-1890f8f0aa793214ab66b5dfe13943c748ef142aea5d10d9b8ace12a65a092b8R421) where `Shrinkwrap.load` throws an error instead of returning correctly when arborist doesn't have access to the folder it's trying to read.

The issue is caused by trying to log `const rel = relpath(this.path, this.filename)` when `this.filename` is null. `this.filename` is set after `this[_maybeRead]()` executes, but when there are permission issues `this[_maybeRead]()` throws, and `this.filename` stays `null`, and `relpath` (and consequentially, `load`) throws `The "to" argument must be of type string` error.

I've changed the code to only execute `relpath` if `this.filename` is set correctly.