### PR TITLE
feat(arborist) omit resolved from registry dependencies

### DIFF
--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -310,6 +310,7 @@ module.exports = cls => class IdealTreeBuilder extends cls {
         ? Shrinkwrap.reset({
           path: this.path,
           lockfileVersion: this.options.lockfileVersion,
+          resolveOptions: this.options,
         }).then(meta => Object.assign(root, { meta }))
         : this.loadVirtual({ root }))
 
@@ -354,6 +355,7 @@ module.exports = cls => class IdealTreeBuilder extends cls {
     const meta = new Shrinkwrap({
       path: this.path,
       lockfileVersion: this.options.lockfileVersion,
+      resolveOptions: this.options,
     })
     meta.reset()
     root.meta = meta

--- a/workspaces/arborist/lib/arborist/load-actual.js
+++ b/workspaces/arborist/lib/arborist/load-actual.js
@@ -147,6 +147,7 @@ module.exports = cls => class ActualLoader extends cls {
     const meta = await Shrinkwrap.load({
       path: this[_actualTree].path,
       hiddenLockfile: true,
+      resolveOptions: this.options,
     })
     if (meta.loadedFromDisk) {
       this[_actualTree].meta = meta
@@ -155,6 +156,7 @@ module.exports = cls => class ActualLoader extends cls {
       const meta = await Shrinkwrap.load({
         path: this[_actualTree].path,
         lockfileVersion: this.options.lockfileVersion,
+        resolveOptions: this.options,
       })
       this[_actualTree].meta = meta
       return this[_loadActualActually]({ root, ignoreMissing })

--- a/workspaces/arborist/lib/arborist/load-virtual.js
+++ b/workspaces/arborist/lib/arborist/load-virtual.js
@@ -57,6 +57,7 @@ module.exports = cls => class VirtualLoader extends cls {
     const s = await Shrinkwrap.load({
       path: this.path,
       lockfileVersion: this.options.lockfileVersion,
+      resolveOptions: this.options,
     })
     if (!s.loadedFromDisk && !options.root) {
       const er = new Error('loadVirtual requires existing shrinkwrap file')

--- a/workspaces/arborist/lib/node.js
+++ b/workspaces/arborist/lib/node.js
@@ -522,6 +522,18 @@ class Node {
     return this === this.root || this === this.root.target
   }
 
+  get isRegistryDependency () {
+    if (this.edgesIn.size === 0) {
+      return false
+    }
+    for (const edge of this.edgesIn) {
+      if (!npa(edge.spec).registry) {
+        return false
+      }
+    }
+    return true
+  }
+
   * ancestry () {
     for (let anc = this; anc; anc = anc.resolveParent) {
       yield anc

--- a/workspaces/arborist/lib/override-resolves.js
+++ b/workspaces/arborist/lib/override-resolves.js
@@ -1,0 +1,11 @@
+function overrideResolves (resolved, opts = {}) {
+  const { omitLockfileRegistryResolved = false } = opts
+
+  if (omitLockfileRegistryResolved) {
+    return undefined
+  }
+
+  return resolved
+}
+
+module.exports = { overrideResolves }

--- a/workspaces/arborist/lib/override-resolves.js
+++ b/workspaces/arborist/lib/override-resolves.js
@@ -1,8 +1,49 @@
-function overrideResolves (resolved, opts = {}) {
-  const { omitLockfileRegistryResolved = false } = opts
+const npa = require('npm-package-arg')
 
-  if (omitLockfileRegistryResolved) {
+function overrideResolves (node, resolved, opts = {}) {
+  const {
+    omitLockfileRegistryResolved = false,
+    recordDefaultRegistry = false,
+  } = opts
+
+  const isRegistryDependency = node.isRegistryDependency
+
+  // omit the resolved url of registry dependencies. this makes installs slower
+  // because npm must resolve the url for each package version but it allows
+  // users to use a lockfile across registries that host tarballs at different
+  // paths.
+  if (isRegistryDependency && omitLockfileRegistryResolved) {
     return undefined
+  }
+
+  // replace the configured registry with the default registry. the default
+  // registry is a magic value meaning the current registry, so recording
+  // resolved with the default registry allows users to switch to a
+  // different registry without removing their lockfile. The path portion
+  // of the resolved url is preserved so this trick only works when the
+  // different registries host tarballs at the same relative paths.
+  if (isRegistryDependency && recordDefaultRegistry) {
+    const scope = npa(node.packageName).scope
+    const registry = scope && opts[`${scope}:registry`]
+      ? opts[`${scope}:registry`]
+      : opts.registry
+
+    // normalize registry url - strip trailing slash.
+    // TODO improve normalization for both the configured registry and resolved
+    // url. consider port, protocol, more path normalization.
+    const normalized = registry.endsWith('/')
+      ? registry.slice(0, -1)
+      : registry
+
+    // only replace the host if the resolved url is for the configured
+    // registry. registries may host tarballs on another server. return
+    // undefined so npm will re-resolve the url from the current registry when
+    // it reads the lockfile.
+    if (resolved.startsWith(normalized)) {
+      return 'https://registry.npmjs.org' + resolved.slice(normalized.length)
+    } else {
+      return undefined
+    }
   }
 
   return resolved

--- a/workspaces/arborist/lib/shrinkwrap.js
+++ b/workspaces/arborist/lib/shrinkwrap.js
@@ -300,13 +300,8 @@ class Shrinkwrap {
     })
 
     const resolved = consistentResolve(node.resolved, node.path, path, true)
-    // hide resolved from registry dependencies.
-    if (!resolved) {
-      // no-op
-    } else if (node.isRegistryDependency) {
-      meta.resolved = overrideResolves(resolved, options)
-    } else {
-      meta.resolved = resolved
+    if (resolved) {
+      meta.resolved = overrideResolves(node, resolved, options)
     }
 
     if (node.extraneous) {
@@ -1027,7 +1022,7 @@ class Shrinkwrap {
         spec.type !== 'git' &&
         spec.type !== 'file' &&
         spec.type !== 'remote') {
-      lock.resolved = overrideResolves(node.resolved, this.resolveOptions)
+      lock.resolved = overrideResolves(node, node.resolved, this.resolveOptions)
     }
 
     if (node.integrity) {

--- a/workspaces/arborist/lib/shrinkwrap.js
+++ b/workspaces/arborist/lib/shrinkwrap.js
@@ -95,6 +95,7 @@ const specFromResolved = resolved => {
 const relpath = require('./relpath.js')
 
 const consistentResolve = require('./consistent-resolve.js')
+const { overrideResolves } = require('./override-resolves.js')
 
 const maybeReadFile = file => {
   return readFile(file, 'utf8').then(d => d, er => {
@@ -265,7 +266,7 @@ class Shrinkwrap {
     return s
   }
 
-  static metaFromNode (node, path) {
+  static metaFromNode (node, path, options = {}) {
     if (node.isLink) {
       return {
         resolved: relpath(path, node.realpath),
@@ -299,7 +300,12 @@ class Shrinkwrap {
     })
 
     const resolved = consistentResolve(node.resolved, node.path, path, true)
-    if (resolved) {
+    // hide resolved from registry dependencies.
+    if (!resolved) {
+      // no-op
+    } else if (node.isRegistryDependency) {
+      meta.resolved = overrideResolves(resolved, options)
+    } else {
       meta.resolved = resolved
     }
 
@@ -331,6 +337,7 @@ class Shrinkwrap {
       hiddenLockfile = false,
       log = procLog,
       lockfileVersion,
+      resolveOptions = {},
     } = options
 
     this.lockfileVersion = hiddenLockfile ? 3
@@ -349,6 +356,7 @@ class Shrinkwrap {
     this.yarnLock = null
     this.hiddenLockfile = hiddenLockfile
     this.loadingError = null
+    this.resolveOptions = resolveOptions
     // only load npm-shrinkwrap.json in dep trees, not package-lock
     this.shrinkwrapOnly = shrinkwrapOnly
   }
@@ -827,7 +835,7 @@ class Shrinkwrap {
           resolved,
           integrity,
           hasShrinkwrap,
-        } = Shrinkwrap.metaFromNode(node, this.path)
+        } = Shrinkwrap.metaFromNode(node, this.path, this.resolveOptions)
         node.resolved = node.resolved || resolved || null
         node.integrity = node.integrity || integrity || null
         node.hasShrinkwrap = node.hasShrinkwrap || hasShrinkwrap || false
@@ -883,7 +891,10 @@ class Shrinkwrap {
   [_updateWaitingNode] (loc) {
     const node = this[_awaitingUpdate].get(loc)
     this[_awaitingUpdate].delete(loc)
-    this.data.packages[loc] = Shrinkwrap.metaFromNode(node, this.path)
+    this.data.packages[loc] = Shrinkwrap.metaFromNode(
+      node,
+      this.path,
+      this.resolveOptions)
   }
 
   commit () {
@@ -891,7 +902,10 @@ class Shrinkwrap {
       if (this.yarnLock) {
         this.yarnLock.fromTree(this.tree)
       }
-      const root = Shrinkwrap.metaFromNode(this.tree.target, this.path)
+      const root = Shrinkwrap.metaFromNode(
+        this.tree.target,
+        this.path,
+        this.resolveOptions)
       this.data.packages = {}
       if (Object.keys(root).length) {
         this.data.packages[''] = root
@@ -902,7 +916,10 @@ class Shrinkwrap {
           continue
         }
         const loc = relpath(this.path, node.path)
-        this.data.packages[loc] = Shrinkwrap.metaFromNode(node, this.path)
+        this.data.packages[loc] = Shrinkwrap.metaFromNode(
+          node,
+          this.path,
+          this.resolveOptions)
       }
     } else if (this[_awaitingUpdate].size > 0) {
       for (const loc of this[_awaitingUpdate].keys()) {
@@ -1010,7 +1027,7 @@ class Shrinkwrap {
         spec.type !== 'git' &&
         spec.type !== 'file' &&
         spec.type !== 'remote') {
-      lock.resolved = node.resolved
+      lock.resolved = overrideResolves(node.resolved, this.resolveOptions)
     }
 
     if (node.integrity) {

--- a/workspaces/arborist/test/node.js
+++ b/workspaces/arborist/test/node.js
@@ -2842,3 +2842,26 @@ t.test('overrides', (t) => {
 
   t.end()
 })
+
+t.test('node with no edges in is not a registry dep', async t => {
+  const node = new Node({ path: '/foo' })
+  t.equal(node.isRegistryDependency, false)
+})
+
+t.test('node with non registry edge in is not a registry dep', async t => {
+  const root = new Node({ path: '/some/path', pkg: { dependencies: { registry: '', tar: '' } } })
+  const node = new Node({ pkg: { name: 'node', version: '1.0.0' }, parent: root })
+
+  new Node({ pkg: { name: 'registry', dependencies: { node: '^1.0.0' } }, parent: root })
+  new Node({ pkg: { name: 'tar', dependencies: { node: 'file:node' } }, parent: root })
+
+  t.equal(node.isRegistryDependency, false)
+})
+
+t.test('node with only registry edges in a registry dep', async t => {
+  const root = new Node({ path: '/some/path', pkg: { dependencies: { registry: '', tar: '' } } })
+  const node = new Node({ pkg: { name: 'node', version: '1.0.0' }, parent: root })
+  new Node({ pkg: { name: 'registry', dependencies: { node: '^1.0.0' } }, parent: root })
+
+  t.equal(node.isRegistryDependency, true)
+})


### PR DESCRIPTION
## THIS PR HAS BEEN MIGRATED
Originally at npm/arborist#352
Originally by @everett1992

Start npm/rfcs#486. This implements `$disable-write-resolves` without
creating an option. Next I'll figure out how to plumb a npm config
option thru to shrinkwrap.
