### PR TITLE
implement options affecting `resolved` value in lock files.

### DIFF
--- a/docs/content/using-npm/config.md
+++ b/docs/content/using-npm/config.md
@@ -1161,6 +1161,22 @@ variable will be set to `'production'` for all lifecycle scripts.
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->
 
+#### `omit-lockfile-registry-resolved`
+
+* Default: false
+* Type: Boolean
+
+Set to true to omit 'resolved' key from registry dependencies in lock files.
+
+This setting is useful in projects that may install dependencies from
+different registries but would use a lockfile to lock package versions. This
+option makes installing slower because npm must fetch package manifest to
+resolve the package version's tarball. See 'record-default-registry' for an
+alternative.
+
+<!-- automatically generated, do not edit manually -->
+<!-- see lib/utils/config/definitions.js -->
+
 #### `otp`
 
 * Default: null
@@ -1329,6 +1345,22 @@ access tokens with the `npm token create` command.
 * Type: Boolean
 
 Rebuild bundled dependencies after installation.
+
+<!-- automatically generated, do not edit manually -->
+<!-- see lib/utils/config/definitions.js -->
+
+#### `record-default-registry`
+
+* Default: false
+* Type: Boolean
+
+Set to true to replace the actual registry in urls resolved from registires
+with the default registry when recording lock files.
+
+This setting is useful in projects that may install dependencies from
+different registries but would use a lockfile to lock package versions. This
+option supports registries that host tarballs at the same path. If even the
+path may change see 'omit-lockfile-registry-resolved'.
 
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -2304,3 +2304,33 @@ define('yes', {
     the command line.
   `,
 })
+
+define('omit-lockfile-registry-resolved', {
+  default: false,
+  type: Boolean,
+  description: `
+    Set to true to omit 'resolved' key from registry dependencies in lock files.
+
+    This setting is useful in projects that may install dependencies from
+    different registries but would use a lockfile to lock package versions.
+    This option makes installing slower because npm must fetch package manifest
+    to resolve the package version's tarball.
+    See 'record-default-registry' for an alternative.
+  `,
+  flatten,
+})
+
+define('record-default-registry', {
+  default: false,
+  type: Boolean,
+  description: `
+    Set to true to replace the actual registry in urls resolved from registires
+    with the default registry when recording lock files.
+
+    This setting is useful in projects that may install dependencies from
+    different registries but would use a lockfile to lock package versions.
+    This option supports registries that host tarballs at the same path. If
+    even the path may change see 'omit-lockfile-registry-resolved'.
+  `,
+  flatten,
+})

--- a/tap-snapshots/test/lib/commands/config.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/config.js.test.cjs
@@ -158,6 +158,8 @@ exports[`test/lib/commands/config.js TAP config list --json > output matches sna
   "workspaces": null,
   "workspaces-update": true,
   "yes": null,
+  "omit-lockfile-registry-resolved": false,
+  "record-default-registry": false,
   "metrics-registry": "https://registry.npmjs.org/"
 }
 `
@@ -255,6 +257,7 @@ noproxy = [""]
 npm-version = "{NPM-VERSION}" 
 offline = false 
 omit = [] 
+omit-lockfile-registry-resolved = false 
 only = null 
 optional = null 
 otp = null 
@@ -272,6 +275,7 @@ progress = true
 proxy = null 
 read-only = false 
 rebuild-bundle = true 
+record-default-registry = false 
 registry = "https://registry.npmjs.org/" 
 save = true 
 save-bundle = false 

--- a/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
@@ -154,6 +154,8 @@ Array [
   "workspaces",
   "workspaces-update",
   "yes",
+  "omit-lockfile-registry-resolved",
+  "record-default-registry",
 ]
 `
 
@@ -1223,6 +1225,21 @@ If the resulting omit list includes \`'dev'\`, then the \`NODE_ENV\` environment
 variable will be set to \`'production'\` for all lifecycle scripts.
 `
 
+exports[`test/lib/utils/config/definitions.js TAP > config description for omit-lockfile-registry-resolved 1`] = `
+#### \`omit-lockfile-registry-resolved\`
+
+* Default: false
+* Type: Boolean
+
+Set to true to omit 'resolved' key from registry dependencies in lock files.
+
+This setting is useful in projects that may install dependencies from
+different registries but would use a lockfile to lock package versions. This
+option makes installing slower because npm must fetch package manifest to
+resolve the package version's tarball. See 'record-default-registry' for an
+alternative.
+`
+
 exports[`test/lib/utils/config/definitions.js TAP > config description for only 1`] = `
 #### \`only\`
 
@@ -1412,6 +1429,21 @@ exports[`test/lib/utils/config/definitions.js TAP > config description for rebui
 * Type: Boolean
 
 Rebuild bundled dependencies after installation.
+`
+
+exports[`test/lib/utils/config/definitions.js TAP > config description for record-default-registry 1`] = `
+#### \`record-default-registry\`
+
+* Default: false
+* Type: Boolean
+
+Set to true to replace the actual registry in urls resolved from registires
+with the default registry when recording lock files.
+
+This setting is useful in projects that may install dependencies from
+different registries but would use a lockfile to lock package versions. This
+option supports registries that host tarballs at the same path. If even the
+path may change see 'omit-lockfile-registry-resolved'.
 `
 
 exports[`test/lib/utils/config/definitions.js TAP > config description for registry 1`] = `

--- a/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
@@ -1035,6 +1035,22 @@ variable will be set to \`'production'\` for all lifecycle scripts.
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->
 
+#### \`omit-lockfile-registry-resolved\`
+
+* Default: false
+* Type: Boolean
+
+Set to true to omit 'resolved' key from registry dependencies in lock files.
+
+This setting is useful in projects that may install dependencies from
+different registries but would use a lockfile to lock package versions. This
+option makes installing slower because npm must fetch package manifest to
+resolve the package version's tarball. See 'record-default-registry' for an
+alternative.
+
+<!-- automatically generated, do not edit manually -->
+<!-- see lib/utils/config/definitions.js -->
+
 #### \`otp\`
 
 * Default: null
@@ -1203,6 +1219,22 @@ access tokens with the \`npm token create\` command.
 * Type: Boolean
 
 Rebuild bundled dependencies after installation.
+
+<!-- automatically generated, do not edit manually -->
+<!-- see lib/utils/config/definitions.js -->
+
+#### \`record-default-registry\`
+
+* Default: false
+* Type: Boolean
+
+Set to true to replace the actual registry in urls resolved from registires
+with the default registry when recording lock files.
+
+This setting is useful in projects that may install dependencies from
+different registries but would use a lockfile to lock package versions. This
+option supports registries that host tarballs at the same path. If even the
+path may change see 'omit-lockfile-registry-resolved'.
 
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->

--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -327,6 +327,7 @@ Try using the package name instead, e.g:
         ? Shrinkwrap.reset({
           path: this.path,
           lockfileVersion: this.options.lockfileVersion,
+          resolveOptions: this.options,
         }).then(meta => Object.assign(root, { meta }))
         : this.loadVirtual({ root }))
 
@@ -386,6 +387,7 @@ Try using the package name instead, e.g:
     const meta = new Shrinkwrap({
       path: this.path,
       lockfileVersion: this.options.lockfileVersion,
+      resolveOptions: this.options,
     })
     meta.reset()
     root.meta = meta

--- a/workspaces/arborist/lib/arborist/load-actual.js
+++ b/workspaces/arborist/lib/arborist/load-actual.js
@@ -147,6 +147,7 @@ module.exports = cls => class ActualLoader extends cls {
     const meta = await Shrinkwrap.load({
       path: this[_actualTree].path,
       hiddenLockfile: true,
+      resolveOptions: this.options,
     })
     if (meta.loadedFromDisk) {
       this[_actualTree].meta = meta
@@ -155,6 +156,7 @@ module.exports = cls => class ActualLoader extends cls {
       const meta = await Shrinkwrap.load({
         path: this[_actualTree].path,
         lockfileVersion: this.options.lockfileVersion,
+        resolveOptions: this.options,
       })
       this[_actualTree].meta = meta
       return this[_loadActualActually]({ root, ignoreMissing })

--- a/workspaces/arborist/lib/arborist/load-virtual.js
+++ b/workspaces/arborist/lib/arborist/load-virtual.js
@@ -57,6 +57,7 @@ module.exports = cls => class VirtualLoader extends cls {
     const s = await Shrinkwrap.load({
       path: this.path,
       lockfileVersion: this.options.lockfileVersion,
+      resolveOptions: this.options,
     })
     if (!s.loadedFromDisk && !options.root) {
       const er = new Error('loadVirtual requires existing shrinkwrap file')

--- a/workspaces/arborist/lib/node.js
+++ b/workspaces/arborist/lib/node.js
@@ -522,6 +522,18 @@ class Node {
     return this === this.root || this === this.root.target
   }
 
+  get isRegistryDependency () {
+    if (this.edgesIn.size === 0) {
+      return false
+    }
+    for (const edge of this.edgesIn) {
+      if (!npa(edge.spec).registry) {
+        return false
+      }
+    }
+    return true
+  }
+
   * ancestry () {
     for (let anc = this; anc; anc = anc.resolveParent) {
       yield anc

--- a/workspaces/arborist/lib/override-resolves.js
+++ b/workspaces/arborist/lib/override-resolves.js
@@ -1,0 +1,11 @@
+function overrideResolves (resolved, opts = {}) {
+  const { omitLockfileRegistryResolved = false } = opts
+
+  if (omitLockfileRegistryResolved) {
+    return undefined
+  }
+
+  return resolved
+}
+
+module.exports = { overrideResolves }

--- a/workspaces/arborist/lib/override-resolves.js
+++ b/workspaces/arborist/lib/override-resolves.js
@@ -1,8 +1,49 @@
-function overrideResolves (resolved, opts = {}) {
-  const { omitLockfileRegistryResolved = false } = opts
+const npa = require('npm-package-arg')
 
-  if (omitLockfileRegistryResolved) {
+function overrideResolves (node, resolved, opts = {}) {
+  const {
+    omitLockfileRegistryResolved = false,
+    recordDefaultRegistry = false,
+  } = opts
+
+  const isRegistryDependency = node.isRegistryDependency
+
+  // omit the resolved url of registry dependencies. this makes installs slower
+  // because npm must resolve the url for each package version but it allows
+  // users to use a lockfile across registries that host tarballs at different
+  // paths.
+  if (isRegistryDependency && omitLockfileRegistryResolved) {
     return undefined
+  }
+
+  // replace the configured registry with the default registry. the default
+  // registry is a magic value meaning the current registry, so recording
+  // resolved with the default registry allows users to switch to a
+  // different registry without removing their lockfile. The path portion
+  // of the resolved url is preserved so this trick only works when the
+  // different registries host tarballs at the same relative paths.
+  if (isRegistryDependency && recordDefaultRegistry) {
+    const scope = npa(node.packageName).scope
+    const registry = scope && opts[`${scope}:registry`]
+      ? opts[`${scope}:registry`]
+      : opts.registry
+
+    // normalize registry url - strip trailing slash.
+    // TODO improve normalization for both the configured registry and resolved
+    // url. consider port, protocol, more path normalization.
+    const normalized = registry.endsWith('/')
+      ? registry.slice(0, -1)
+      : registry
+
+    // only replace the host if the resolved url is for the configured
+    // registry. registries may host tarballs on another server. return
+    // undefined so npm will re-resolve the url from the current registry when
+    // it reads the lockfile.
+    if (resolved.startsWith(normalized)) {
+      return 'https://registry.npmjs.org' + resolved.slice(normalized.length)
+    } else {
+      return undefined
+    }
   }
 
   return resolved

--- a/workspaces/arborist/lib/shrinkwrap.js
+++ b/workspaces/arborist/lib/shrinkwrap.js
@@ -300,13 +300,8 @@ class Shrinkwrap {
     })
 
     const resolved = consistentResolve(node.resolved, node.path, path, true)
-    // hide resolved from registry dependencies.
-    if (!resolved) {
-      // no-op
-    } else if (node.isRegistryDependency) {
-      meta.resolved = overrideResolves(resolved, options)
-    } else {
-      meta.resolved = resolved
+    if (resolved) {
+      meta.resolved = overrideResolves(node, resolved, options)
     }
 
     if (node.extraneous) {
@@ -1030,7 +1025,7 @@ class Shrinkwrap {
         spec.type !== 'git' &&
         spec.type !== 'file' &&
         spec.type !== 'remote') {
-      lock.resolved = overrideResolves(node.resolved, this.resolveOptions)
+      lock.resolved = overrideResolves(node, node.resolved, this.resolveOptions)
     }
 
     if (node.integrity) {

--- a/workspaces/arborist/test/node.js
+++ b/workspaces/arborist/test/node.js
@@ -2842,3 +2842,26 @@ t.test('overrides', (t) => {
 
   t.end()
 })
+
+t.test('node with no edges in is not a registry dep', async t => {
+  const node = new Node({ path: '/foo' })
+  t.equal(node.isRegistryDependency, false)
+})
+
+t.test('node with non registry edge in is not a registry dep', async t => {
+  const root = new Node({ path: '/some/path', pkg: { dependencies: { registry: '', tar: '' } } })
+  const node = new Node({ pkg: { name: 'node', version: '1.0.0' }, parent: root })
+
+  new Node({ pkg: { name: 'registry', dependencies: { node: '^1.0.0' } }, parent: root })
+  new Node({ pkg: { name: 'tar', dependencies: { node: 'file:node' } }, parent: root })
+
+  t.equal(node.isRegistryDependency, false)
+})
+
+t.test('node with only registry edges in a registry dep', async t => {
+  const root = new Node({ path: '/some/path', pkg: { dependencies: { registry: '', tar: '' } } })
+  const node = new Node({ pkg: { name: 'node', version: '1.0.0' }, parent: root })
+  new Node({ pkg: { name: 'registry', dependencies: { node: '^1.0.0' } }, parent: root })
+
+  t.equal(node.isRegistryDependency, true)
+})


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
This PR implements two options that affect t he `resolved` value in lock files described in npm/rfcs#486. There are more details in the RFC but the gist is that the lock file records information from the registry used when packages were added to the lock file. This can cause undesired behaviors including install failures when changing the configured registry.

This is very much a work in progress and I'm eager for any feedback, especially  the names of the options, alternate solutions to these problems, and how I've plumbed 'options' thru the Shrinkwrap class.

### `omit-lockfile-registry-resolved`

This option omits the resolved value from the registry. On subsequent installs npm will resolve the tarball url from the registry. This supports any kind of registry, and guarantees the registry is the authority on the location of tarballs, but makes installs slower.

### `record-default-registry`
This option uses the magic properties of the default registry `https://registry.npmjs.com`. When the lockfile is read npm replaces the default registry with the currently configured registry. This magic behavior allows users to switch from the default registry to a custom registry - but you can't switch from a custom registry to another registry once a custom registry is recorded in a lock file.

This option does the opposite transform of the magic default, replacing the custom registry with the default registry when recording the lock file.

There were other proposals to record lock files with a sigil that explicitly means 'the current registry'

> "resolved": "${registry}/npm/-/npm-8.3.1.tgz"

But this isn't cross compatible with other npm versions or clients. This option effectively uses `https://registry.npmjs.com` as that sigil, which is compatible with earlier versions of npm.

The main downside with this option is that the lockfile records the path portion of the resolved url which can change between registries. This option only supports switching between registries that host tarballs at the same relative path. This downside is already present in npm's magic handling of the default registry.

The other downside is that it hangs more weight on the magic behavior of the default registry.

## References

Related to npm/rfcs#486
