### PR TITLE
fix: resolve workspace paths from cwd when possible

### DIFF
--- a/lib/base-command.js
+++ b/lib/base-command.js
@@ -1,4 +1,7 @@
 // Base class for npm commands
+
+const { relative } = require('path')
+
 const usageUtil = require('./utils/usage.js')
 const ConfigDefinitions = require('./utils/config/definitions.js')
 const getWorkspaces = require('./workspaces/get-workspaces.js')
@@ -78,9 +81,14 @@ class BaseCommand {
       this.includeWorkspaceRoot = false
     }
 
+    const relativeFrom = relative(this.npm.localPrefix, process.cwd()).startsWith('..')
+      ? this.npm.localPrefix
+      : process.cwd()
+
     const ws = await getWorkspaces(filters, {
       path: this.npm.localPrefix,
       includeWorkspaceRoot: this.includeWorkspaceRoot,
+      relativeFrom,
     })
     this.workspaces = ws
     this.workspaceNames = [...ws.keys()]

--- a/lib/workspaces/get-workspaces.js
+++ b/lib/workspaces/get-workspaces.js
@@ -5,7 +5,7 @@ const rpj = require('read-package-json-fast')
 
 // Returns an Map of paths to workspaces indexed by workspace name
 // { foo => '/path/to/foo' }
-const getWorkspaces = async (filters, { path, includeWorkspaceRoot }) => {
+const getWorkspaces = async (filters, { path, includeWorkspaceRoot, relativeFrom }) => {
   // TODO we need a better error to be bubbled up here if this rpj call fails
   const pkg = await rpj(resolve(path, 'package.json'))
   const workspaces = await mapWorkspaces({ cwd: path, pkg })
@@ -21,8 +21,8 @@ const getWorkspaces = async (filters, { path, includeWorkspaceRoot }) => {
   for (const filterArg of filters) {
     for (const [workspaceName, workspacePath] of workspaces.entries()) {
       if (filterArg === workspaceName
-        || resolve(path, filterArg) === workspacePath
-        || minimatch(workspacePath, `${resolve(path, filterArg)}/*`)) {
+        || resolve(relativeFrom || path, filterArg) === workspacePath
+        || minimatch(workspacePath, `${resolve(relativeFrom || path, filterArg)}/*`)) {
         res.set(workspaceName, workspacePath)
       }
     }

--- a/test/lib/arborist-cmd.js
+++ b/test/lib/arborist-cmd.js
@@ -98,7 +98,7 @@ t.test('handle getWorkspaces raising an error', async t => {
   })
   class TestCmd extends ArboristCmd {}
   const cmd = new TestCmd()
-  cmd.npm = {}
+  cmd.npm = { localPrefix: t.testdir() }
 
   await t.rejects(
     cmd.execWorkspaces(['foo'], ['a']),


### PR DESCRIPTION
these are changes that are required along with landing and publishing npm/config#28 (and updating it here) to enable automatic detection of a workspace root.

this fix stands on its own, however. if a user had the structure

```
/package.json
/workspaces/a/package.json
```

and they ran `npm test -w ./a` from within `/workspaces/`, they would currently get an error. this corrects that behavior so we resolve the path for `a` based on `process.cwd()` instead of the workspace root.

> to disable this feature currently a user must run ~`npm --prefix=./`~ `npm --no-workspaces` to skip the prefix auto detection. the workspaces flag _must_ be part of the environment or command line flags and not in a file to work.

the above comment is not directly related to this pull request, but i wanted to keep it here for posterity