### PR TITLE
fix(arborist): use full location as tracker key when inflating

### DIFF
--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -737,8 +737,7 @@ This is a one-time fix-up, please be patient...
         const id = useResolved ? resolved
           : version || `file:${node.path}`
         const spec = npa.resolve(name, id, dirname(path))
-        const sloc = location.substr('node_modules/'.length)
-        const t = `idealTree:inflate:${sloc}`
+        const t = `idealTree:inflate:${location}`
         this.addTracker(t)
         await pacote.manifest(spec, {
           ...this.options,


### PR DESCRIPTION
Fixes: https://github.com/npm/cli/issues/4273
Ref: https://github.com/npm/cli/pull/4298

I ran into this issue in #4427 while making tracker events run by default on all tests. [This test](https://github.com/npm/cli/blob/dd63e21a0e192f5a7e797d6c89595fd09dbfd7b9/workspaces/arborist/test/arborist/build-ideal-tree.js#L512-L516) was failing because the two packages being inflated are `file:` so they don't start with `node_modules/` resulting in the location portion of the tracker key being empty. I don't see a reason why the key shouldn't be the full path, except that we show it to the user as part of the logs. But if that's a concern it can be fixed elsewhere.