### PR TITLE
fix(arborist): load actual tree on named updates

### DIFF
--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -320,7 +320,7 @@ module.exports = cls => class IdealTreeBuilder extends cls {
       // Load on a new Arborist object, so the Nodes aren't the same,
       // or else it'll get super confusing when we change them!
       .then(async root => {
-        if (!this[_updateAll] && !this[_global] && !root.meta.loadedFromDisk) {
+        if ((!this[_updateAll] && !this[_global] && !root.meta.loadedFromDisk) || (this[_global] && this[_updateNames].length)) {
           await new this.constructor(this.options).loadActual({ root })
           const tree = root.target
           // even though we didn't load it from a package-lock.json FILE,

--- a/workspaces/arborist/test/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/test/arborist/build-ideal-tree.js
@@ -2092,6 +2092,10 @@ t.test('update global', async t => {
       },
     },
   })
+
+  t.matchSnapshot(await printIdeal(path, { global: true, update: ['abbrev'] }),
+    'updating missing dep should have no effect')
+
   t.matchSnapshot(await printIdeal(path, { global: true, update: ['wrappy'] }),
     'updating sub-dep has no effect')
   t.matchSnapshot(await printIdeal(path, { global: true, update: ['once'] }),


### PR DESCRIPTION
Arborist was not loading the actual tree when using named updates for
global updates, that would result in removing all previously installed
deps from a global install anytime the user would try to run
`npm update <pkgname>`.

This changeset fixes the problem by allowing the load of the actual tree
if the `global` and `update.names` options are defined.

Added a few more tests to illustrate but some of the snapshots already
included were actually demonstrating the problem by having empty trees
as result, these are now also updated with the expected tree result.

## References
Fixes: https://github.com/npm/cli/issues/3175

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
