### PR TITLE
feat(arborist): add named updates validation

### DIFF
--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -272,11 +272,15 @@ module.exports = cls => class IdealTreeBuilder extends cls {
 
     // validates list of update names, they must
     // be dep names only, no semver ranges are supported
-    const validationError =
-      new TypeError('Update arguments must not contain semver ranges')
-    validationError.code = 'EUPDATEARGS'
     for (const name of update.names) {
       const spec = npa(name)
+      const validationError =
+        new TypeError(`Update arguments must not contain package version specifiers
+
+Try using the package name instead, e.g:
+    npm update ${spec.name}`)
+      validationError.code = 'EUPDATEARGS'
+
       if (spec.fetchSpec !== 'latest') {
         throw validationError
       }

--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -269,6 +269,18 @@ module.exports = cls => class IdealTreeBuilder extends cls {
     this[_complete] = !!options.complete
     this[_preferDedupe] = !!options.preferDedupe
     this[_legacyBundling] = !!options.legacyBundling
+
+    // validates list of update names, they must
+    // be dep names only, no semver ranges are supported
+    const validationError =
+      new TypeError('Update arguments must not contain semver ranges')
+    validationError.code = 'EUPDATEARGS'
+    for (const name of update.names) {
+      const spec = npa(name)
+      if (spec.fetchSpec !== 'latest') {
+        throw validationError
+      }
+    }
     this[_updateNames] = update.names
 
     this[_updateAll] = update.all

--- a/workspaces/arborist/test/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/test/arborist/build-ideal-tree.js
@@ -2094,6 +2094,22 @@ t.test('update global', async t => {
   })
   t.matchSnapshot(await printIdeal(path, { global: true, update: ['wrappy'] }),
     'updating sub-dep has no effect')
+
+  const invalidArgs = [
+    'once@1.4.0',
+    'once@next',
+    'once@^1.0.0',
+    'once@>=2.0.0',
+    'once@2',
+  ]
+  for (const updateName of invalidArgs) {
+    t.rejects(
+      printIdeal(path, { global: true, update: [updateName] }),
+      { code: 'EUPDATEARGS' },
+      'should throw an error when using semver ranges'
+    )
+  }
+
   t.matchSnapshot(await printIdeal(path, { global: true, update: ['once'] }),
     'update a single dep')
   t.matchSnapshot(await printIdeal(path, { global: true, update: true }),


### PR DESCRIPTION
Arborist update does not support anything other than dependency names,
that is confusing to some users that are used to provide semver ranges
when using `npm install` and other commands.

This changeset adds validation to the values provided as arguments in
`npm update` and will throw a `EUPDATEARGS` error in case the user tries
to use semver ranges, e.g: `npm update abbrev@1.0.0`

## References
Relates to: https://github.com/npm/cli/issues/4240

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
