### PR TITLE
Update repository and bugs URLs

### DIFF
--- a/workspaces/libnpmpublish/package.json
+++ b/workspaces/libnpmpublish/package.json
@@ -37,9 +37,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/npm/libnpmpublish.git"
+    "url": "https://github.com/npm/cli.git"
   },
-  "bugs": "https://github.com/npm/libnpmpublish/issues",
+  "bugs": "https://github.com/npm/cli/issues",
   "homepage": "https://npmjs.com/package/libnpmpublish",
   "dependencies": {
     "normalize-package-data": "^3.0.2",


### PR DESCRIPTION
#### What I Did

Update the repository and bugs URL in the package.json (since `libnpmpublish moved from https://github.com/npm/libnpmpublish to https://github.com/npm/cli)
