### PR TITLE
chore: add docs issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs-enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/docs-enhancement.yml
@@ -1,4 +1,4 @@
-name: 📄 Docs Enhancement
+name: 📄 CLI Docs Enhancement
 description: File a potential enhancement for the npm documentation 
 title: "[DOCS] <title>"
 labels: [Documentation, Needs Triage]
@@ -9,6 +9,13 @@ body:
     description: Please [search here](https://github.com/npm/cli/issues) to see if an issue already exists for your problem.
     options:
     - label: I have searched the existing issues
+      required: true
+- type: checkboxes
+  attributes:
+    label: This is a CLI Docs Enhancement, not another kind of Docs Enhancement.
+    description: These issue templates are only for CLI documentation enhancements. If you are looking to submit another kind of documentation enhancement, please submit it to the [documentation](https://github.com/npm/documentation) repo.
+    options:
+    - label: This is a CLI Docs Enhancement.
       required: true
 - type: textarea
   attributes:

--- a/.github/ISSUE_TEMPLATE/docs-enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/docs-enhancement.yml
@@ -1,0 +1,30 @@
+name: 📄 Docs Enhancement
+description: File a potential enhancement for the npm documentation 
+title: "[DOCS] <title>"
+labels: [Documentation, Needs Triage]
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please [search here](https://github.com/npm/cli/issues) to see if an issue already exists for your problem.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: textarea
+  attributes:
+    label: Description of Problem
+    description: A clear & concise description of the current state of the docs.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Potential Solution
+    description: A clear & concise description of the potential enhancement, if there is one.
+  validations:
+    required: false
+- type: input
+  attributes:
+    label: Docs URL
+    description: Please provide the URL of the page you'd like to see an enhancement to.
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/docs-problem.yml
+++ b/.github/ISSUE_TEMPLATE/docs-problem.yml
@@ -1,4 +1,4 @@
-name: 📄 Docs Problem
+name: 📄 CLI Docs Problem
 description: File a problem with the npm documentation
 title: "[DOCS] <title>"
 labels: [Documentation, Needs Triage]
@@ -9,6 +9,13 @@ body:
     description: Please [search here](https://github.com/npm/cli/issues) to see if an issue already exists for your problem.
     options:
     - label: I have searched the existing issues
+      required: true
+- type: checkboxes
+  attributes:
+    label: This is a CLI Docs Problem, not another kind of Docs Problem.
+    description: These issue templates are only for CLI documentation problems. If you are looking to submit another kind of documentation problem, please submit it to the [documentation](https://github.com/npm/documentation) repo.
+    options:
+    - label: This is a CLI Docs Problem.
       required: true
 - type: textarea
   attributes:

--- a/.github/ISSUE_TEMPLATE/docs-problem.yml
+++ b/.github/ISSUE_TEMPLATE/docs-problem.yml
@@ -1,0 +1,30 @@
+name: 📄 Docs Problem
+description: File a problem with the npm documentation
+title: "[DOCS] <title>"
+labels: [Documentation, Needs Triage]
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please [search here](https://github.com/npm/cli/issues) to see if an issue already exists for your problem.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: textarea
+  attributes:
+    label: Description of Problem
+    description: A clear & concise description of what is wrong with the docs.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Potential Solution
+    description: A clear & concise description of a potential solution or fix to the problem, if there is one.
+  validations:
+    required: false
+- type: input
+  attributes:
+    label: Affected URL
+    description: Please provide the affected URL.
+  validations:
+    required: false


### PR DESCRIPTION
adds documentation issue templates, since docs now (?) live in npm/cli. ideally this will help provide an avenue to capture feedback about documentation and provide a path to good enhancements <3 