### PR TITLE
fix(arborist): update save exact

### DIFF
--- a/workspaces/arborist/test/arborist/reify.js
+++ b/workspaces/arborist/test/arborist/reify.js
@@ -2572,5 +2572,34 @@ t.test('save package.json on update', t => {
     )
   })
 
+  t.test('should preserve exact ranges', async t => {
+    const path = fixture(t, 'update-exact-version')
+
+    await reify(path, { update: true, save: true })
+
+    t.equal(
+      require(resolve(path, 'package.json')).dependencies.abbrev,
+      '1.0.4',
+      'should save no top level dep update to root package.json'
+    )
+  })
+
+  t.test('should preserve exact ranges, missing actual tree', async t => {
+    const path = t.testdir({
+      'package.json': JSON.stringify({
+        dependencies: {
+          abbrev: '1.0.4',
+        },
+      }),
+    })
+
+    await reify(path, { update: true, save: true })
+
+    t.equal(
+      require(resolve(path, 'package.json')).dependencies.abbrev,
+      '1.0.4',
+      'should save no top level dep update to root package.json'
+    )
+  })
   t.end()
 })

--- a/workspaces/arborist/test/fixtures/reify-cases/update-exact-version.js
+++ b/workspaces/arborist/test/fixtures/reify-cases/update-exact-version.js
@@ -1,0 +1,54 @@
+// generated from test/fixtures/update-exact-version
+module.exports = t => {
+  const path = t.testdir({
+  "node_modules": {
+    "abbrev": {
+      "package.json": JSON.stringify({
+        "name": "abbrev",
+        "version": "1.0.4",
+        "description": "Like ruby's abbrev module, but in js",
+        "author": "Isaac Z. Schlueter <i@izs.me>",
+        "main": "./lib/abbrev.js",
+        "scripts": {
+          "test": "node lib/abbrev.js"
+        },
+        "repository": "http://github.com/isaacs/abbrev-js",
+        "license": {
+          "type": "MIT",
+          "url": "https://github.com/isaacs/abbrev-js/raw/master/LICENSE"
+        }
+      })
+    }
+  },
+  "package-lock.json": JSON.stringify({
+    "name": "update-exact-version",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+      "": {
+        "dependencies": {
+          "abbrev": "1.0.4"
+        }
+      },
+      "node_modules/abbrev": {
+        "version": "1.0.4",
+        "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.4.tgz",
+        "integrity": "sha1-vVWuXkE7oXIu5Mq6H26hBBSlns0="
+      }
+    },
+    "dependencies": {
+      "abbrev": {
+        "version": "1.0.4",
+        "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.4.tgz",
+        "integrity": "sha1-vVWuXkE7oXIu5Mq6H26hBBSlns0="
+      }
+    }
+  }),
+  "package.json": JSON.stringify({
+    "dependencies": {
+      "abbrev": "1.0.4"
+    }
+  })
+})
+  return path
+}

--- a/workspaces/arborist/test/fixtures/update-exact-version/node_modules/abbrev/package.json
+++ b/workspaces/arborist/test/fixtures/update-exact-version/node_modules/abbrev/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "abbrev",
+  "version": "1.0.4",
+  "description": "Like ruby's abbrev module, but in js",
+  "author": "Isaac Z. Schlueter <i@izs.me>",
+  "main": "./lib/abbrev.js",
+  "scripts": {
+    "test": "node lib/abbrev.js"
+  },
+  "repository": "http://github.com/isaacs/abbrev-js",
+  "license": {
+    "type": "MIT",
+    "url": "https://github.com/isaacs/abbrev-js/raw/master/LICENSE"
+  }
+}

--- a/workspaces/arborist/test/fixtures/update-exact-version/package-lock.json
+++ b/workspaces/arborist/test/fixtures/update-exact-version/package-lock.json
@@ -1,0 +1,24 @@
+{
+  "name": "update-exact-version",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "abbrev": "1.0.4"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.4.tgz",
+      "integrity": "sha1-vVWuXkE7oXIu5Mq6H26hBBSlns0="
+    }
+  },
+  "dependencies": {
+    "abbrev": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.4.tgz",
+      "integrity": "sha1-vVWuXkE7oXIu5Mq6H26hBBSlns0="
+    }
+  }
+}

--- a/workspaces/arborist/test/fixtures/update-exact-version/package.json
+++ b/workspaces/arborist/test/fixtures/update-exact-version/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "abbrev": "1.0.4"
+  }
+}


### PR DESCRIPTION
When updating dependencies we need an extra check when filtering nodes
to be updated that ensures we do not override semver ranges that are
pointing to an exact version. e.g: =1.0.0, 1.0.0


## References
Fixes: https://github.com/npm/cli/issues/4329

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
