### PR TITLE
Make 'npm install --loglevel warn' Output Quieter

### DIFF
--- a/lib/utils/reify-output.js
+++ b/lib/utils/reify-output.js
@@ -25,9 +25,9 @@ const reifyOutput = (npm, arb) => {
   // stuff in that case!
   const auditReport = auditError(npm, arb.auditReport) ? null : arb.auditReport
 
-  // don't print any info in --silent mode, but we still need to
+  // don't print any info if loglevel is 'warn' or higher, but we still need to
   // set the exitCode properly from the audit report, if we have one.
-  if (log.levels[log.level] > log.levels.error) {
+  if (log.levels[log.level] >= log.levels.warn) {
     getAuditReport(npm, auditReport)
     return
   }
@@ -88,7 +88,7 @@ const reifyOutput = (npm, arb) => {
 // at the end if there's still stuff, because it's silly for `npm audit`
 // to tell you to run `npm audit` for details.  otherwise, use the summary
 // report.  if we get here, we know it's not quiet or json.
-// If the loglevel is set higher than 'error', then we just run the report
+// If the loglevel is set to 'warn' or higher, then we just run the report
 // to get the exitCode set appropriately.
 const printAuditReport = (npm, report) => {
   const res = getAuditReport(npm, report)
@@ -103,9 +103,9 @@ const getAuditReport = (npm, report) => {
     return
   }
 
-  // when in silent mode, we print nothing.  the JSON output is
+  // when loglevel is 'warn' or higher, we print nothing.  the JSON output is
   // going to just JSON.stringify() the report object.
-  const reporter = log.levels[log.level] > log.levels.error ? 'quiet'
+  const reporter = log.levels[log.level] >= log.levels.warn ? 'quiet'
     : npm.flatOptions.json ? 'quiet'
     : npm.command !== 'audit' ? 'install'
     : 'detail'

--- a/test/lib/utils/reify-output.js
+++ b/test/lib/utils/reify-output.js
@@ -2,7 +2,7 @@ const t = require('tap')
 const log = require('../../../lib/utils/log-shim')
 
 const _level = log.level
-t.beforeEach(() => log.level = 'warn')
+t.beforeEach(() => log.level = 'notice')
 t.teardown(() => log.level = _level)
 
 t.cleanSnapshot = str => str.replace(/in [0-9]+m?s/g, 'in {TIME}')
@@ -267,6 +267,40 @@ t.test('showing and not showing audit report', async t => {
       },
     })
     t.match(OUT.join('\n'), /Run `npm audit` for details\.$/, 'got audit report')
+    t.end()
+  })
+
+  t.test('no output when loglevel = error', t => {
+    npm.output = out => {
+      t.fail('should not get output when loglevel = error', { actual: out })
+    }
+    log.level = 'error'
+    reifyOutput(npm, {
+      actualTree: { inventory: { size: 999 }, children: [] },
+      auditReport,
+      diff: {
+        children: [
+          { action: 'ADD', ideal: { location: 'loc' } },
+        ],
+      },
+    })
+    t.end()
+  })
+
+  t.test('no output when loglevel = warn', t => {
+    npm.output = out => {
+      t.fail('should not get output when loglevel = warn', { actual: out })
+    }
+    log.level = 'warn'
+    reifyOutput(npm, {
+      actualTree: { inventory: { size: 999 }, children: [] },
+      auditReport,
+      diff: {
+        children: [
+          { action: 'ADD', ideal: { location: 'loc' } },
+        ],
+      },
+    })
     t.end()
   })
 


### PR DESCRIPTION
## What / Why

I know this is kind of trivial, but I was trying to turn off the `up to date in 420ms` and `14 packages are looking for funding`-type messages in my CI/CD pipeline, and was surprised/disappointed to discover that `npm install --loglevel error` wasn't good enough.

Having to reach for `--silent` seems a little *too* heavy-handed, IMHO...  "changed", "audit", and "funding" messages aren't **errors**, *per se* — or even ***warnings***, for that matter — they don't alert me to imminent breakage — and `--silent` is a foot-gun waiting to happen; I'm infinitely more likely to miss something important.  But I understand wanting to keep them in the default output.

## Describe the request in detail. What it does and why it's being changed.

This PR simply makes it so `--loglevel warn` is sufficient to turn them off, without impacting other, ***actual*** `npm install` errors...

Instead of:
```
if (log.levels[log.level] > log.levels.error)
```
it simply does:
```
if (log.levels[log.level] >= log.levels.warn)
```

[Note: That also meant setting the fixture from *warn* to *notice* in `test/lib/utils/reify-output.js:beforeEach`]

## References
  Related to #3311