### PR TITLE
docs: bundledDependencies can be a boolean

### DIFF
--- a/docs/content/configuring-npm/package-json.md
+++ b/docs/content/configuring-npm/package-json.md
@@ -838,6 +838,10 @@ include any versions, as that information is specified in `dependencies`.
 
 If this is spelled `"bundleDependencies"`, then that is also honored.
 
+Alternatively, `"bundledDependencies"` can be defined as a boolean value. A
+value of `true` will bundle all dependencies, a value of `false` will bundle
+none.
+
 ### optionalDependencies
 
 If a dependency can be used, but you would like npm to proceed if it cannot


### PR DESCRIPTION
I discovered when reading the code of npm-bundled [1] that bundledDependencies could be a boolean and that this has the same effect as bundling all dependencies. This seems convenient, as this is probably the main use case for that property, and it already works perfectly :)

Also, as a very meta change, it turn out npm itself seems to bundle all its dependencies, which mean it can take advantage of this to be a bit terser in the package.json, and avoiding the risk of forgetting to add a future new dependency.

[1] https://github.com/npm/npm-bundled/blob/main/index.js#L112