### PR TITLE
fix(ci): lock file validation

### DIFF
--- a/lib/commands/ci.js
+++ b/lib/commands/ci.js
@@ -6,6 +6,7 @@ const runScript = require('@npmcli/run-script')
 const fs = require('fs')
 const readdir = util.promisify(fs.readdir)
 const log = require('../utils/log-shim.js')
+const validateLockfile = require('../utils/validate-lockfile.js')
 
 const removeNodeModules = async where => {
   const rimrafOpts = { glob: false }
@@ -55,6 +56,28 @@ class CI extends ArboristWorkspaceCmd {
       }),
       removeNodeModules(where),
     ])
+
+    // retrieves inventory of packages from loaded virtual tree (lock file)
+    const virtualInventory = new Map(arb.virtualTree.inventory)
+
+    // build ideal tree step needs to come right after retrieving the virtual
+    // inventory since it's going to erase the previous ref to virtualTree
+    await arb.buildIdealTree()
+
+    // verifies that the packages from the ideal tree will match
+    // the same versions that are present in the virtual tree (lock file)
+    // throws a validation error in case of mismatches
+    const errors = validateLockfile(virtualInventory, arb.idealTree.inventory)
+    if (errors.length) {
+      throw new Error(
+        '`npm ci` can only install packages when your package.json and ' +
+        'package-lock.json or npm-shrinkwrap.json are in sync. Please ' +
+        'update your lock file with `npm install` ' +
+        'before continuing.\n\n' +
+        errors.join('\n') + '\n'
+      )
+    }
+
     await arb.reify(opts)
 
     const ignoreScripts = this.npm.config.get('ignore-scripts')

--- a/lib/utils/validate-lockfile.js
+++ b/lib/utils/validate-lockfile.js
@@ -1,0 +1,29 @@
+// compares the inventory of package items in the tree
+// that is about to be installed (idealTree) with the inventory
+// of items stored in the package-lock file (virtualTree)
+//
+// Returns empty array if no errors found or an array populated
+// with an entry for each validation error found.
+function validateLockfile (virtualTree, idealTree) {
+  const errors = []
+
+  // loops through the inventory of packages resulted by ideal tree,
+  // for each package compares the versions with the version stored in the
+  // package-lock and adds an error to the list in case of mismatches
+  for (const [key, entry] of idealTree.entries()) {
+    const lock = virtualTree.get(key)
+
+    if (!lock) {
+      errors.push(`Missing: ${entry.name}@${entry.version} from lock file`)
+      continue
+    }
+
+    if (entry.version !== lock.version) {
+      errors.push(`Invalid: lock file's ${lock.name}@${lock.version} does ` +
+      `not satisfy ${entry.name}@${entry.version}`)
+    }
+  }
+  return errors
+}
+
+module.exports = validateLockfile

--- a/tap-snapshots/smoke-tests/index.js.test.cjs
+++ b/tap-snapshots/smoke-tests/index.js.test.cjs
@@ -42,6 +42,17 @@ npm {CWD}
 
 `
 
+exports[`smoke-tests/index.js TAP npm ci > should throw mismatch deps in lock file error 1`] = `
+npm ERR! \`npm ci\` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with \`npm install\` before continuing.
+npm ERR! 
+npm ERR! Invalid: lock file's abbrev@1.0.4 does not satisfy abbrev@1.1.1
+npm ERR! 
+
+npm ERR! A complete log of this run can be found in:
+
+
+`
+
 exports[`smoke-tests/index.js TAP npm diff > should have expected diff output 1`] = `
 diff --git a/package.json b/package.json
 index v1.0.4..v1.1.1 100644

--- a/tap-snapshots/test/lib/commands/ci.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/ci.js.test.cjs
@@ -1,0 +1,13 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/lib/commands/ci.js TAP should throw error when ideal inventory mismatches virtual > must match snapshot 1`] = `
+\`npm ci\` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with \`npm install\` before continuing.
+
+Invalid: lock file's foo@1.0.0 does not satisfy foo@2.0.0
+
+`

--- a/tap-snapshots/test/lib/utils/validate-lockfile.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/validate-lockfile.js.test.cjs
@@ -1,0 +1,35 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/lib/utils/validate-lockfile.js TAP extra inventory items on idealTree > should have missing entries error 1`] = `
+Array [
+  "Missing: baz@3.0.0 from lock file",
+]
+`
+
+exports[`test/lib/utils/validate-lockfile.js TAP extra inventory items on virtualTree > should have no errors if finding virtualTree extra items 1`] = `
+Array []
+`
+
+exports[`test/lib/utils/validate-lockfile.js TAP identical inventory for both idealTree and virtualTree > should have no errors on identical inventories 1`] = `
+Array []
+`
+
+exports[`test/lib/utils/validate-lockfile.js TAP mismatching versions on inventory > should have errors for each mismatching version 1`] = `
+Array [
+  "Invalid: lock file's foo@1.0.0 does not satisfy foo@2.0.0",
+  "Invalid: lock file's bar@2.0.0 does not satisfy bar@3.0.0",
+]
+`
+
+exports[`test/lib/utils/validate-lockfile.js TAP missing virtualTree inventory > should have errors for each mismatching version 1`] = `
+Array [
+  "Missing: foo@1.0.0 from lock file",
+  "Missing: bar@2.0.0 from lock file",
+  "Missing: baz@3.0.0 from lock file",
+]
+`

--- a/test/lib/commands/ci.js
+++ b/test/lib/commands/ci.js
@@ -19,6 +19,17 @@ t.test('should ignore scripts with --ignore-scripts', async t => {
       this.reify = () => {
         REIFY_CALLED = true
       }
+      this.buildIdealTree = () => {}
+      this.virtualTree = {
+        inventory: new Map([
+          ['foo', { name: 'foo', version: '1.0.0' }],
+        ]),
+      }
+      this.idealTree = {
+        inventory: new Map([
+          ['foo', { name: 'foo', version: '1.0.0' }],
+        ]),
+      }
     },
   })
 
@@ -99,6 +110,17 @@ t.test('should use Arborist and run-script', async t => {
       this.reify = () => {
         t.ok(true, 'reify is called')
       }
+      this.buildIdealTree = () => {}
+      this.virtualTree = {
+        inventory: new Map([
+          ['foo', { name: 'foo', version: '1.0.0' }],
+        ]),
+      }
+      this.idealTree = {
+        inventory: new Map([
+          ['foo', { name: 'foo', version: '1.0.0' }],
+        ]),
+      }
     },
     rimraf: (path, ...args) => {
       actualRimrafs++
@@ -137,6 +159,17 @@ t.test('should pass flatOptions to Arborist.reify', async t => {
       this.loadVirtual = () => Promise.resolve(true)
       this.reify = async (options) => {
         t.equal(options.production, true, 'should pass flatOptions to Arborist.reify')
+      }
+      this.buildIdealTree = () => {}
+      this.virtualTree = {
+        inventory: new Map([
+          ['foo', { name: 'foo', version: '1.0.0' }],
+        ]),
+      }
+      this.idealTree = {
+        inventory: new Map([
+          ['foo', { name: 'foo', version: '1.0.0' }],
+        ]),
       }
     },
   })
@@ -218,6 +251,17 @@ t.test('should remove existing node_modules before installing', async t => {
         const nodeModules = contents.filter((path) => path.startsWith('node_modules'))
         t.same(nodeModules, ['node_modules'], 'should only have the node_modules directory')
       }
+      this.buildIdealTree = () => {}
+      this.virtualTree = {
+        inventory: new Map([
+          ['foo', { name: 'foo', version: '1.0.0' }],
+        ]),
+      }
+      this.idealTree = {
+        inventory: new Map([
+          ['foo', { name: 'foo', version: '1.0.0' }],
+        ]),
+      }
     },
   })
 
@@ -230,4 +274,42 @@ t.test('should remove existing node_modules before installing', async t => {
   const ci = new CI(npm)
 
   await ci.exec(null)
+})
+
+t.test('should throw error when ideal inventory mismatches virtual', async t => {
+  const CI = t.mock('../../../lib/commands/ci.js', {
+    '../../../lib/utils/reify-finish.js': async () => {},
+    '@npmcli/run-script': ({ event }) => {},
+    '@npmcli/arborist': function () {
+      this.loadVirtual = async () => {}
+      this.reify = () => {}
+      this.buildIdealTree = () => {}
+      this.virtualTree = {
+        inventory: new Map([
+          ['foo', { name: 'foo', version: '1.0.0' }],
+        ]),
+      }
+      this.idealTree = {
+        inventory: new Map([
+          ['foo', { name: 'foo', version: '2.0.0' }],
+        ]),
+      }
+    },
+  })
+
+  const npm = mockNpm({
+    globalDir: 'path/to/node_modules/',
+    prefix: 'foo',
+    config: {
+      global: false,
+      'ignore-scripts': true,
+    },
+  })
+  const ci = new CI(npm)
+
+  try {
+    await ci.exec([])
+  } catch (err) {
+    t.matchSnapshot(err.message)
+  }
 })

--- a/test/lib/utils/validate-lockfile.js
+++ b/test/lib/utils/validate-lockfile.js
@@ -1,0 +1,82 @@
+const t = require('tap')
+const validateLockfile = require('../../../lib/utils/validate-lockfile.js')
+
+t.test('identical inventory for both idealTree and virtualTree', async t => {
+  t.matchSnapshot(
+    validateLockfile(
+      new Map([
+        ['foo', { name: 'foo', version: '1.0.0' }],
+        ['bar', { name: 'bar', version: '2.0.0' }],
+      ]),
+      new Map([
+        ['foo', { name: 'foo', version: '1.0.0' }],
+        ['bar', { name: 'bar', version: '2.0.0' }],
+      ])
+    ),
+    'should have no errors on identical inventories'
+  )
+})
+
+t.test('extra inventory items on idealTree', async t => {
+  t.matchSnapshot(
+    validateLockfile(
+      new Map([
+        ['foo', { name: 'foo', version: '1.0.0' }],
+        ['bar', { name: 'bar', version: '2.0.0' }],
+      ]),
+      new Map([
+        ['foo', { name: 'foo', version: '1.0.0' }],
+        ['bar', { name: 'bar', version: '2.0.0' }],
+        ['baz', { name: 'baz', version: '3.0.0' }],
+      ])
+    ),
+    'should have missing entries error'
+  )
+})
+
+t.test('extra inventory items on virtualTree', async t => {
+  t.matchSnapshot(
+    validateLockfile(
+      new Map([
+        ['foo', { name: 'foo', version: '1.0.0' }],
+        ['bar', { name: 'bar', version: '2.0.0' }],
+        ['baz', { name: 'baz', version: '3.0.0' }],
+      ]),
+      new Map([
+        ['foo', { name: 'foo', version: '1.0.0' }],
+        ['bar', { name: 'bar', version: '2.0.0' }],
+      ])
+    ),
+    'should have no errors if finding virtualTree extra items'
+  )
+})
+
+t.test('mismatching versions on inventory', async t => {
+  t.matchSnapshot(
+    validateLockfile(
+      new Map([
+        ['foo', { name: 'foo', version: '1.0.0' }],
+        ['bar', { name: 'bar', version: '2.0.0' }],
+      ]),
+      new Map([
+        ['foo', { name: 'foo', version: '2.0.0' }],
+        ['bar', { name: 'bar', version: '3.0.0' }],
+      ])
+    ),
+    'should have errors for each mismatching version'
+  )
+})
+
+t.test('missing virtualTree inventory', async t => {
+  t.matchSnapshot(
+    validateLockfile(
+      new Map([]),
+      new Map([
+        ['foo', { name: 'foo', version: '1.0.0' }],
+        ['bar', { name: 'bar', version: '2.0.0' }],
+        ['baz', { name: 'baz', version: '3.0.0' }],
+      ])
+    ),
+    'should have errors for each mismatching version'
+  )
+})


### PR DESCRIPTION
Make sure to validate any lock file (either `package-lock.json` or
`npm-shrinkwrap.json`) against the current install. This will properly
throw an error in case any of the dependencies being installed don't
match the dependencies that are currently listed in the lock file.

## References
Fixes: https://github.com/npm/cli/issues/2701
Fixes: https://github.com/npm/cli/issues/3947

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
