### PR TITLE
fix(ci): should not use package-lock config

### DIFF
--- a/docs/content/using-npm/config.md
+++ b/docs/content/using-npm/config.md
@@ -1190,6 +1190,8 @@ When package package-locks are disabled, automatic pruning of extraneous
 modules will also be disabled. To remove extraneous modules with
 package-locks disabled use `npm prune`.
 
+This configuration does not affect `npm ci`.
+
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->
 

--- a/lib/commands/ci.js
+++ b/lib/commands/ci.js
@@ -37,6 +37,7 @@ class CI extends ArboristWorkspaceCmd {
     const where = this.npm.prefix
     const opts = {
       ...this.npm.flatOptions,
+      packageLock: true, // npm ci should never skip lock files
       path: where,
       log,
       save: false, // npm ci should never modify the lockfile or package.json

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -1417,6 +1417,8 @@ define('package-lock', {
     When package package-locks are disabled, automatic pruning of extraneous
     modules will also be disabled.  To remove extraneous modules with
     package-locks disabled use \`npm prune\`.
+
+    This configuration does not affect \`npm ci\`.
   `,
   flatten: (key, obj, flatOptions) => {
     flatten(key, obj, flatOptions)

--- a/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
@@ -1271,6 +1271,8 @@ will also prevent _writing_ \`package-lock.json\` if \`save\` is true.
 When package package-locks are disabled, automatic pruning of extraneous
 modules will also be disabled. To remove extraneous modules with
 package-locks disabled use \`npm prune\`.
+
+This configuration does not affect \`npm ci\`.
 `
 
 exports[`test/lib/utils/config/definitions.js TAP > config description for package-lock-only 1`] = `

--- a/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
@@ -1064,6 +1064,8 @@ When package package-locks are disabled, automatic pruning of extraneous
 modules will also be disabled. To remove extraneous modules with
 package-locks disabled use \`npm prune\`.
 
+This configuration does not affect \`npm ci\`.
+
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->
 

--- a/test/lib/commands/ci.js
+++ b/test/lib/commands/ci.js
@@ -199,7 +199,7 @@ t.test('should throw ECIGLOBAL', async t => {
 })
 
 t.test('should remove existing node_modules before installing', async t => {
-  t.plan(2)
+  t.plan(3)
   const testDir = t.testdir({
     node_modules: {
       'some-file': 'some contents',
@@ -212,6 +212,7 @@ t.test('should remove existing node_modules before installing', async t => {
     '@npmcli/arborist': function () {
       this.loadVirtual = () => Promise.resolve(true)
       this.reify = async (options) => {
+        t.equal(options.packageLock, true, 'npm ci should never ignore lock')
         t.equal(options.save, false, 'npm ci should never save')
         // check if node_modules was removed before reifying
         const contents = await readdir(testDir)


### PR DESCRIPTION
`npm ci` should never be affected by the `package-lock` config.

## References
Fixes: https://github.com/npm/cli/issues/4185

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
