### PR TITLE
fix(outdated): parse aliased modules

### DIFF
--- a/lib/commands/outdated.js
+++ b/lib/commands/outdated.js
@@ -193,7 +193,12 @@ class Outdated extends ArboristWorkspaceCmd {
   }
 
   async getOutdatedInfo (edge) {
-    const spec = npa(edge.name)
+    let alias = false
+    try {
+      alias = npa(edge.spec).subSpec
+    } catch (err) {
+    }
+    const spec = npa(alias ? alias.name : edge.name)
     const node = edge.to || edge
     const { path, location } = node
     const { version: current } = node.package || {}
@@ -217,7 +222,7 @@ class Outdated extends ArboristWorkspaceCmd {
 
     try {
       const packument = await this.getPackument(spec)
-      const expected = edge.spec
+      const expected = alias ? alias.fetchSpec : edge.spec
       // if it's not a range, version, or tag, skip it
       try {
         if (!npa(`${edge.name}@${edge.spec}`).registry) {
@@ -239,7 +244,7 @@ class Outdated extends ArboristWorkspaceCmd {
           : 'global'
 
         this.list.push({
-          name: edge.name,
+          name: alias ? edge.spec.replace('npm', edge.name) : edge.name,
           path,
           type,
           current,

--- a/tap-snapshots/test/lib/commands/outdated.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/outdated.js.test.cjs
@@ -5,6 +5,12 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/lib/commands/outdated.js TAP aliases > should display aliased outdated dep output 1`] = `
+
+Package         Current  Wanted  Latest  Location          Depended by
+cat:dog@latest    1.0.0   2.0.0   2.0.0  node_modules/cat  tap-testdir-outdated-aliases
+`
+
 exports[`test/lib/commands/outdated.js TAP should display outdated deps outdated --all > must match snapshot 1`] = `
 
 Package  Current  Wanted  Latest  Location           Depended by

--- a/test/lib/commands/outdated.js
+++ b/test/lib/commands/outdated.js
@@ -609,3 +609,28 @@ t.test('workspaces', async t => {
   t.matchSnapshot(logs,
     'should display missing deps when filtering by ws')
 })
+
+t.test('aliases', async t => {
+  const testDir = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'display-aliases',
+      version: '1.0.0',
+      dependencies: {
+        cat: 'npm:dog@latest',
+      },
+    }),
+    node_modules: {
+      cat: {
+        'package.json': JSON.stringify({
+          name: 'dog',
+          version: '1.0.0',
+        }),
+      },
+    },
+  })
+
+  await outdated(testDir, {}).exec([])
+
+  t.matchSnapshot(logs, 'should display aliased outdated dep output')
+  t.equal(process.exitCode, 1)
+})


### PR DESCRIPTION
Fixes `npm outdated` to properly parse and display info on aliased
packages.

## References
Fixes: https://github.com/npm/cli/issues/2800

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
