### PR TITLE
fix: run postpack after tarball is written

### DIFF
--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -83,7 +83,8 @@ class Publish extends BaseCommand {
       })
     }
 
-    const tarballData = await pack(spec, opts)
+    // we pass dryRun: true to libnpmpack so it doesn't write the file to disk
+    const tarballData = await pack(spec, { ...opts, dryRun: true })
     const pkgContents = await getContents(manifest, tarballData)
 
     // The purpose of re-reading the manifest is in case it changed,

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -1455,6 +1455,7 @@ define('pack-destination', {
   description: `
     Directory in which \`npm pack\` will save tarballs.
   `,
+  flatten,
 })
 
 define('parseable', {

--- a/workspaces/libnpmpack/lib/index.js
+++ b/workspaces/libnpmpack/lib/index.js
@@ -3,6 +3,9 @@
 const pacote = require('pacote')
 const npa = require('npm-package-arg')
 const runScript = require('@npmcli/run-script')
+const path = require('path')
+const util = require('util')
+const writeFile = util.promisify(require('fs').writeFile)
 
 module.exports = pack
 async function pack (spec = 'file:.', opts = {}) {
@@ -32,6 +35,14 @@ async function pack (spec = 'file:.', opts = {}) {
     ...opts,
     integrity: manifest._integrity,
   })
+
+  // check for explicit `false` so the default behavior is to skip writing to disk
+  if (opts.dryRun === false) {
+    const filename = `${manifest.name}-${manifest.version}.tgz`
+      .replace(/^@/, '').replace(/\//, '-')
+    const destination = path.resolve(opts.packDestination, filename)
+    await writeFile(destination, tarball)
+  }
 
   if (spec.type === 'directory') {
     // postpack


### PR DESCRIPTION
The version bump commit for `libnpmpack` still needs to take place, but it felt appropriate to make all of these changes as part of this pull request so as to not break things while it's in flight.

Closes #2220
