### PR TITLE
docs: update workspaces guide for consistency

### DIFF
--- a/docs/content/using-npm/workspaces.md
+++ b/docs/content/using-npm/workspaces.md
@@ -30,24 +30,25 @@ Workspaces are usually defined via the `workspaces` property of the
 {
   "name": "my-workspaces-powered-project",
   "workspaces": [
-    "workspace-a"
+    "packages/a"
   ]
 }
 ```
 
 Given the above `package.json` example living at a current working
-directory `.` that contains a folder named `workspace-a` that itself contains
+directory `.` that contains a folder named `packages/a` that itself contains
 a `package.json` inside it, defining a Node.js package, e.g:
 
 ```
 .
 +-- package.json
-`-- workspace-a
-   `-- package.json
+`-- packages
+   +-- a
+   |   `-- package.json
 ```
 
 The expected result once running `npm install` in this current working
-directory `.` is that the folder `workspace-a` will get symlinked to the
+directory `.` is that the folder `packages/a` will get symlinked to the
 `node_modules` folder of the current working dir.
 
 Below is a post `npm install` example, given that same previous example
@@ -56,11 +57,12 @@ structure of files and folders:
 ```
 .
 +-- node_modules
-|  `-- workspace-a -> ../workspace-a
+|  `-- packages/a -> ../packages/a
 +-- package-lock.json
 +-- package.json
-`-- workspace-a
-   `-- package.json
+`-- packages
+   +-- a
+   |   `-- package.json
 ```
 
 ### Getting started with workspaces


### PR DESCRIPTION
This PR normalizes the workspaces documentation in the `Using npm` directory to only use one example structure, rather than two distinct structures. Ideally, this helps make following this document from top to bottom easier for folks who are trying to get up and running.