### PR TITLE
fix: some commands should ignore workspaces

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -120,7 +120,7 @@ class Npm extends EventEmitter {
     }
 
     const filterByWorkspaces =
-      !['prefix', 'whoami'].includes(this.command) &&
+      !['bin', 'cache', 'completion', 'doctor', 'get', 'help', 'owner', 'prefix', 'whoami'].includes(this.command) &&
       (workspacesEnabled || workspacesFilters.length > 0)
     // normally this would go in the constructor, but our tests don't
     // actually use a real npm object so this.npm.config isn't always

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -119,7 +119,9 @@ class Npm extends EventEmitter {
       throw new Error('Can not use --no-workspaces and --workspace at the same time')
     }
 
-    const filterByWorkspaces = workspacesEnabled || workspacesFilters.length > 0
+    const filterByWorkspaces =
+      !['prefix', 'whoami'].includes(this.command) &&
+      (workspacesEnabled || workspacesFilters.length > 0)
     // normally this would go in the constructor, but our tests don't
     // actually use a real npm object so this.npm.config isn't always
     // populated.  this is the compromise until we can make that a reality


### PR DESCRIPTION
Add condition so commands like `npm prefix` and `npm whoami` succeed inside a workspace.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
