### PR TITLE
fix: remove html comments from man entries

### DIFF
--- a/scripts/docs-build.js
+++ b/scripts/docs-build.js
@@ -30,6 +30,7 @@ fs.readFile(src, 'utf8', function (err, data) {
   }
 
   var result = data.replace(/@VERSION@/g, npm.version)
+    .replace(/^<!--.*-->$/gm, '')
     .replace(/^---\n([\s\S]+\n)---/, frontmatter)
     .replace(/\[([^\]]+)\]\(\/commands\/([^)]+)\)/g, replacer)
     .replace(/\[([^\]]+)\]\(\/configuring-npm\/([^)]+)\)/g, replacer)


### PR DESCRIPTION
Before:

```man
   Configuration
       <!-- AUTOGENERATED CONFIG DESCRIPTIONS START --> <!-- automatically generated, do not edit manually -->
       <!-- see lib/utils/config/definitions.js -->

   json
```

After:


```man
   Configuration
   json
```


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
