### PR TITLE
fix(arborist): use string-locale-compare

### DIFF
--- a/workspaces/arborist/bin/license.js
+++ b/workspaces/arborist/bin/license.js
@@ -1,4 +1,5 @@
 const Arborist = require('../')
+const localeCompare = require('@isaacs/string-locale-compare')('en')
 const options = require('./lib/options.js')
 require('./lib/logging.js')
 require('./lib/timers.js')
@@ -24,7 +25,7 @@ a.loadVirtual().then(tree => {
     }
 
     for (const [count, license] of set.sort((a, b) =>
-      a[1] && b[1] ? b[0] - a[0] || a[1].localeCompare(b[1], 'en')
+      a[1] && b[1] ? b[0] - a[0] || localeCompare(a[1], b[1])
       : a[1] ? -1
       : b[1] ? 1
       : 0)) {

--- a/workspaces/arborist/test/arborist/rebuild.js
+++ b/workspaces/arborist/test/arborist/rebuild.js
@@ -5,6 +5,7 @@ const { resolve, dirname } = require('path')
 const fs = require('fs')
 const fixtures = resolve(__dirname, '../fixtures')
 const relpath = require('../../lib/relpath.js')
+const localeCompare = require('@isaacs/string-locale-compare')('en')
 
 const fixture = (t, p) => require(`${fixtures}/reify-cases/${p}`)(t)
 
@@ -181,7 +182,7 @@ t.test('verify dep flags in script environments', async t => {
   // don't include path or env, because that's going to be platform-specific
   const saved = [...arb.scriptsRun]
     .sort(({ path: patha, event: eventa }, { path: pathb, event: eventb }) =>
-      patha.localeCompare(pathb, 'en') || eventa.localeCompare(eventb, 'en'))
+      localeCompare(patha, pathb) || localeCompare(eventa, eventb))
     .map(({ pkg, event, cmd, code, signal, stdout, stderr }) =>
       ({ pkg, event, cmd, code, signal, stdout, stderr }))
   t.matchSnapshot(saved, 'saved script results')
@@ -191,7 +192,7 @@ t.test('verify dep flags in script environments', async t => {
     t.strictSame(flags, fs.readFileSync(file, 'utf8').split('\n'), pkg)
   }
   t.strictSame(checkLogs().sort((a, b) =>
-    a[2].localeCompare(b[2], 'en') || (typeof a[4] === 'string' ? -1 : 1)), [
+    localeCompare(a[2], b[2]) || (typeof a[4] === 'string' ? -1 : 1)), [
     ['info', 'run', 'devdep@1.0.0', 'postinstall', 'node_modules/devdep', 'node ../../env.js'],
     ['info', 'run', 'devdep@1.0.0', 'postinstall', { code: 0, signal: null }],
     ['info', 'run', 'devopt@1.0.0', 'postinstall', 'node_modules/devopt', 'node ../../env.js'],

--- a/workspaces/arborist/test/arborist/reify.js
+++ b/workspaces/arborist/test/arborist/reify.js
@@ -1,6 +1,7 @@
 const { resolve, basename } = require('path')
 const t = require('tap')
 const runScript = require('@npmcli/run-script')
+const localeCompare = require('@isaacs/string-locale-compare')('en')
 
 // mock rimraf so we can make it fail in rollback tests
 const realRimraf = require('rimraf')
@@ -241,7 +242,7 @@ t.test('omit peer deps', t => {
     .then(() => {
       process.removeListener('time', onTime)
       process.removeListener('timeEnd', onTimeEnd)
-      finishedTimers.sort((a, b) => a.localeCompare(b, 'en'))
+      finishedTimers.sort(localeCompare)
       t.matchSnapshot(finishedTimers, 'finished timers')
       t.strictSame(timers, {}, 'should have no timers in progress now')
     })

--- a/workspaces/arborist/test/audit-report.js
+++ b/workspaces/arborist/test/audit-report.js
@@ -1,4 +1,5 @@
 const t = require('tap')
+const localeCompare = require('@isaacs/string-locale-compare')('en')
 const AuditReport = require('../lib/audit-report.js')
 const { auditToBulk } = AuditReport
 const Node = require('../lib/node.js')
@@ -24,14 +25,14 @@ const newArb = (path, opts = {}) =>
 
 const sortReport = report => {
   const entries = Object.entries(report.vulnerabilities)
-  const vulns = entries.sort(([a], [b]) => a.localeCompare(b, 'en'))
+  const vulns = entries.sort(([a], [b]) => localeCompare(a, b))
     .map(([name, vuln]) => [
       name,
       {
         ...vuln,
         via: (vuln.via || []).sort((a, b) =>
-          String(a.source || a).localeCompare(String(b.source || b), 'en')),
-        effects: (vuln.effects || []).sort((a, b) => a.localeCompare(b, 'en')),
+          localeCompare(String(a.source || a), String(b.source || b))),
+        effects: (vuln.effects || []).sort(localeCompare),
       },
     ])
   report.vulnerabilities = vulns.reduce((set, [k, v]) => {

--- a/workspaces/arborist/test/diff.js
+++ b/workspaces/arborist/test/diff.js
@@ -1,3 +1,4 @@
+const localeCompare = require('@isaacs/string-locale-compare')('en')
 const Diff = require('../lib/diff.js')
 const t = require('tap')
 const Node = require('../lib/node.js')
@@ -31,7 +32,7 @@ const formatDiff = obj =>
     removed: obj.removed.map(d => normalizePath(d.path).split(normalizedCWD).join('{CWD}')),
     children: [...obj.children]
       .map(formatDiff)
-      .sort((a, b) => path(a).localeCompare(path(b), 'en')),
+      .sort((a, b) => localeCompare(path(a), path(b))),
   })
 
 t.formatSnapshot = obj => format(formatDiff(obj), { sort: false })

--- a/workspaces/arborist/test/fixtures/index.js
+++ b/workspaces/arborist/test/fixtures/index.js
@@ -1,4 +1,5 @@
 const mkdirp = require('mkdirp').sync
+const localeCompare = require('@isaacs/string-locale-compare')('en')
 const { unlinkSync, symlinkSync, readFileSync, writeFileSync } = require('fs')
 const { relative, resolve, dirname } = require('path')
 
@@ -167,7 +168,7 @@ const setup = () => {
       `### BEGIN IGNORED SYMLINKS ###
 ### this list is generated automatically, do not edit directly
 ### update it by running \`node test/fixtures/index.js\`
-${links.sort((a,b) => a.localeCompare(b, 'en')).join('\n')}
+${links.sort(localeCompare).join('\n')}
 ### END IGNORED SYMLINKS ###`)
     writeFileSync(gifile, gitignore)
   }

--- a/workspaces/arborist/test/gather-dep-set.js
+++ b/workspaces/arborist/test/gather-dep-set.js
@@ -1,4 +1,5 @@
 const t = require('tap')
+const localeCompare = require('@isaacs/string-locale-compare')('en')
 const gatherDepSet = require('../lib/gather-dep-set.js')
 
 const Node = require('../lib/node.js')
@@ -81,7 +82,7 @@ const tree = new Node({
 const normalizePath = path => path.replace(/[A-Z]:/, '').replace(/\\/g, '/')
 
 const printSet = set => [...set]
-  .sort((a, b) => a.name.localeCompare(b.name, 'en'))
+  .sort((a, b) => localeCompare(a.name, b.name))
   .map(n => n.location)
 
 const cwd = normalizePath(process.cwd())

--- a/workspaces/arborist/test/inventory.js
+++ b/workspaces/arborist/test/inventory.js
@@ -2,6 +2,8 @@
 // does not enable it.
 process.env.ARBORIST_DEBUG = '1'
 const Inventory = require('../lib/inventory.js')
+const localeCompare = require('@isaacs/string-locale-compare')('en')
+
 const t = require('tap')
 
 t.test('basic operations', t => {
@@ -21,7 +23,7 @@ t.test('basic operations', t => {
     i.get('y'),
   ], 'filter returns an iterable of all matching nodes')
 
-  t.same([...i.query('license')].sort((a, b) => String(a).localeCompare(String(b), 'en')),
+  t.same([...i.query('license')].sort((a, b) => localeCompare(String(a), String(b))),
     ['ISC', 'MIT', undefined])
   t.same([...i.query('license', 'MIT')], [
     { location: 'x', name: 'x', package: { licence: 'MIT', funding: 'foo' } },
@@ -33,7 +35,7 @@ t.test('basic operations', t => {
     { location: 'x', name: 'x', package: { licence: 'MIT', funding: 'foo' } },
     { location: 'y', name: 'x', package: { licenses: [{ type: 'ISC' }], funding: { url: 'foo' } } },
   ], 'can query by name')
-  t.same([...i.query('funding')].sort((a, b) => String(a).localeCompare(String(b), 'en')),
+  t.same([...i.query('funding')].sort((a, b) => localeCompare(String(a), String(b))),
     ['bar', 'foo', undefined])
   t.same([...i.query('funding', 'foo')], [
     { location: 'x', name: 'x', package: { licence: 'MIT', funding: 'foo' } },


### PR DESCRIPTION
I noticed this when reviewing #4464. We use `@isaacs/string-locale-compare` everywhere else, so I converted any relevant scripts/tests to use it as well. This should prevent future bugs like #4464 fixed.