### PR TITLE
fix: set proper workspace repo urls in package.json

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -9,7 +9,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/npm/cli"
+    "url": "https://github.com/npm/cli",
+    "directory": "workspaces/docs"
   },
   "devDependencies": {
     "@mdx-js/mdx": "^1.6.22",

--- a/workspaces/arborist/package.json
+++ b/workspaces/arborist/package.json
@@ -66,7 +66,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/npm/arborist"
+    "url": "https://github.com/npm/cli",
+    "directory": "workspaces/arborist"
   },
   "author": "GitHub Inc.",
   "license": "ISC",

--- a/workspaces/libnpmaccess/package.json
+++ b/workspaces/libnpmaccess/package.json
@@ -24,7 +24,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/npm/libnpmaccess.git"
+    "url": "https://github.com/npm/cli",
+    "directory": "workspaces/libnpmaccess"
   },
   "bugs": "https://github.com/npm/libnpmaccess/issues",
   "homepage": "https://npmjs.com/package/libnpmaccess",

--- a/workspaces/libnpmdiff/package.json
+++ b/workspaces/libnpmdiff/package.json
@@ -2,7 +2,11 @@
   "name": "libnpmdiff",
   "version": "4.0.0",
   "description": "The registry diff",
-  "repository": "https://github.com/npm/libnpmdiff",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/npm/cli",
+    "directory": "workspaces/libnpmdiff"
+  },
   "main": "lib/index.js",
   "files": [
     "bin",

--- a/workspaces/libnpmexec/package.json
+++ b/workspaces/libnpmexec/package.json
@@ -10,7 +10,11 @@
     "node": "^12.13.0 || ^14.15.0 || >=16"
   },
   "description": "npm exec (npx) programmatic API",
-  "repository": "https://github.com/npm/libnpmexec",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/npm/cli",
+    "directory": "workspaces/libnpmexec"
+  },
   "keywords": [
     "npm",
     "npmcli",

--- a/workspaces/libnpmfund/package.json
+++ b/workspaces/libnpmfund/package.json
@@ -7,7 +7,11 @@
     "lib"
   ],
   "description": "Programmatic API for npm fund",
-  "repository": "https://github.com/npm/libnpmfund",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/npm/cli",
+    "directory": "workspaces/libnpmfund"
+  },
   "keywords": [
     "npm",
     "npmcli",

--- a/workspaces/libnpmhook/package.json
+++ b/workspaces/libnpmhook/package.json
@@ -23,7 +23,11 @@
   "tap": {
     "check-coverage": true
   },
-  "repository": "https://github.com/npm/libnpmhook",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/npm/cli",
+    "directory": "workspaces/libnpmhook"
+  },
   "keywords": [
     "npm",
     "hooks",

--- a/workspaces/libnpmorg/package.json
+++ b/workspaces/libnpmorg/package.json
@@ -39,7 +39,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/npm/libnpmorg.git"
+    "url": "https://github.com/npm/cli",
+    "directory": "workspaces/libnpmorg"
   },
   "bugs": "https://github.com/npm/libnpmorg/issues",
   "homepage": "https://npmjs.com/package/libnpmorg",

--- a/workspaces/libnpmpack/package.json
+++ b/workspaces/libnpmpack/package.json
@@ -33,7 +33,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/npm/libnpmpack.git"
+    "url": "https://github.com/npm/cli",
+    "directory": "workspaces/libnpmpack"
   },
   "bugs": "https://github.com/npm/libnpmpack/issues",
   "homepage": "https://npmjs.com/package/libnpmpack",

--- a/workspaces/libnpmpublish/package.json
+++ b/workspaces/libnpmpublish/package.json
@@ -37,7 +37,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/npm/cli.git"
+    "url": "https://github.com/npm/cli",
+    "directory": "workspaces/libnpmpublish"
   },
   "bugs": "https://github.com/npm/cli/issues",
   "homepage": "https://npmjs.com/package/libnpmpublish",

--- a/workspaces/libnpmsearch/package.json
+++ b/workspaces/libnpmsearch/package.json
@@ -36,7 +36,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/npm/libnpmsearch.git"
+    "url": "https://github.com/npm/cli",
+    "directory": "workspaces/libnpmsearch"
   },
   "bugs": "https://github.com/npm/libnpmsearch/issues",
   "homepage": "https://npmjs.com/package/libnpmsearch",

--- a/workspaces/libnpmteam/package.json
+++ b/workspaces/libnpmteam/package.json
@@ -23,7 +23,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/npm/libnpmteam.git"
+    "url": "https://github.com/npm/cli",
+    "directory": "workspaces/libnpmteam"
   },
   "files": [
     "bin",

--- a/workspaces/libnpmversion/package.json
+++ b/workspaces/libnpmversion/package.json
@@ -9,7 +9,8 @@
   "description": "library to do the things that 'npm version' does",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/npm/libnpmversion"
+    "url": "https://github.com/npm/cli",
+    "directory": "workspaces/libnpmversion"
   },
   "author": "GitHub Inc.",
   "license": "ISC",


### PR DESCRIPTION
v5 was published 2 days ago but still points to the archived repo.