### PR TITLE
fix: ignore implict workspace for some commands

### DIFF
--- a/lib/arborist-cmd.js
+++ b/lib/arborist-cmd.js
@@ -14,6 +14,8 @@ class ArboristCmd extends BaseCommand {
     'include-workspace-root',
   ]
 
+  static ignoreImplicitWorkspace = false
+
   async execWorkspaces (args, filters) {
     await this.setWorkspaces(filters)
     return this.exec(args)

--- a/lib/base-command.js
+++ b/lib/base-command.js
@@ -21,7 +21,7 @@ class BaseCommand {
   }
 
   get ignoreImplicitWorkspace () {
-    return !!this.constructor.ignoreImplicitWorkspace
+    return this.constructor.ignoreImplicitWorkspace
   }
 
   get usage () {

--- a/lib/base-command.js
+++ b/lib/base-command.js
@@ -20,6 +20,10 @@ class BaseCommand {
     return this.constructor.description
   }
 
+  get ignoreImplicitWorkspace () {
+    return !!this.constructor.ignoreImplicitWorkspace
+  }
+
   get usage () {
     let usage = `npm ${this.constructor.name}\n\n`
     if (this.constructor.description) {

--- a/lib/commands/access.js
+++ b/lib/commands/access.js
@@ -27,6 +27,8 @@ class Access extends BaseCommand {
     'otp',
   ]
 
+  static ignoreImplicitWorkspace = true
+
   static usage = [
     'public [<package>]',
     'restricted [<package>]',

--- a/lib/commands/adduser.js
+++ b/lib/commands/adduser.js
@@ -16,6 +16,8 @@ class AddUser extends BaseCommand {
     'scope',
   ]
 
+  static ignoreImplicitWorkspace = true
+
   async exec (args) {
     const { scope } = this.npm.flatOptions
     const registry = this.getRegistry(this.npm.flatOptions)

--- a/lib/commands/bin.js
+++ b/lib/commands/bin.js
@@ -5,6 +5,7 @@ class Bin extends BaseCommand {
   static description = 'Display npm bin folder'
   static name = 'bin'
   static params = ['global']
+  static ignoreImplicitWorkspace = true
 
   async exec (args) {
     const b = this.npm.bin

--- a/lib/commands/birthday.js
+++ b/lib/commands/birthday.js
@@ -2,6 +2,8 @@ const BaseCommand = require('../base-command.js')
 
 class Birthday extends BaseCommand {
   static name = 'birthday'
+  static ignoreImplicitWorkspace = true
+
   async exec () {
     this.npm.config.set('yes', true)
     return this.npm.exec('exec', ['@npmcli/npm-birthday'])

--- a/lib/commands/bugs.js
+++ b/lib/commands/bugs.js
@@ -9,6 +9,7 @@ class Bugs extends BaseCommand {
   static name = 'bugs'
   static usage = ['[<pkgname>]']
   static params = ['browser', 'registry']
+  static ignoreImplicitWorkspace = true
 
   async exec (args) {
     if (!args || !args.length) {

--- a/lib/commands/cache.js
+++ b/lib/commands/cache.js
@@ -81,6 +81,8 @@ class Cache extends BaseCommand {
     'verify',
   ]
 
+  static ignoreImplicitWorkspace = true
+
   async completion (opts) {
     const argv = opts.conf.argv.remain
     if (argv.length === 2) {

--- a/lib/commands/completion.js
+++ b/lib/commands/completion.js
@@ -47,6 +47,7 @@ const BaseCommand = require('../base-command.js')
 class Completion extends BaseCommand {
   static description = 'Tab Completion for npm'
   static name = 'completion'
+  static ignoreImplicitWorkspace = false
 
   // completion for the completion command
   async completion (opts) {

--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -61,6 +61,8 @@ class Config extends BaseCommand {
     'long',
   ]
 
+  static ignoreImplicitWorkspace = false
+
   async completion (opts) {
     const argv = opts.conf.argv.remain
     if (argv[1] !== 'config') {

--- a/lib/commands/deprecate.js
+++ b/lib/commands/deprecate.js
@@ -15,6 +15,8 @@ class Deprecate extends BaseCommand {
     'otp',
   ]
 
+  static ignoreImplicitWorkspace = false
+
   async completion (opts) {
     if (opts.conf.argv.remain.length > 1) {
       return []

--- a/lib/commands/diff.js
+++ b/lib/commands/diff.js
@@ -32,6 +32,8 @@ class Diff extends BaseCommand {
     'include-workspace-root',
   ]
 
+  static ignoreImplicitWorkspace = false
+
   async exec (args) {
     const specs = this.npm.config.get('diff').filter(d => d)
     if (specs.length > 2) {

--- a/lib/commands/dist-tag.js
+++ b/lib/commands/dist-tag.js
@@ -16,6 +16,8 @@ class DistTag extends BaseCommand {
     'ls [<pkg>]',
   ]
 
+  static ignoreImplicitWorkspace = false
+
   async completion (opts) {
     const argv = opts.conf.argv.remain
     if (argv.length === 2) {

--- a/lib/commands/docs.js
+++ b/lib/commands/docs.js
@@ -15,6 +15,7 @@ class Docs extends BaseCommand {
   ]
 
   static usage = ['[<pkgname> [<pkgname> ...]]']
+  static ignoreImplicitWorkspace = false
 
   async exec (args) {
     if (!args || !args.length) {

--- a/lib/commands/doctor.js
+++ b/lib/commands/doctor.js
@@ -41,6 +41,7 @@ class Doctor extends BaseCommand {
   static description = 'Check your npm environment'
   static name = 'doctor'
   static params = ['registry']
+  static ignoreImplicitWorkspace = false
 
   async exec (args) {
     log.info('Running checkup')

--- a/lib/commands/edit.js
+++ b/lib/commands/edit.js
@@ -13,6 +13,7 @@ class Edit extends BaseCommand {
   static name = 'edit'
   static usage = ['<pkg>[/<subpkg>...]']
   static params = ['editor']
+  static ignoreImplicitWorkspace = false
 
   // TODO
   /* istanbul ignore next */

--- a/lib/commands/exec.js
+++ b/lib/commands/exec.js
@@ -45,6 +45,8 @@ class Exec extends BaseCommand {
     '--package=foo -c \'<cmd> [args...]\'',
   ]
 
+  static ignoreImplicitWorkspace = false
+
   async exec (_args, { locationMsg, path, runPath } = {}) {
     if (!path) {
       path = this.npm.localPrefix

--- a/lib/commands/explain.js
+++ b/lib/commands/explain.js
@@ -16,6 +16,8 @@ class Explain extends ArboristWorkspaceCmd {
     'workspace',
   ]
 
+  static ignoreImplicitWorkspace = false
+
   // TODO
   /* istanbul ignore next */
   async completion (opts) {

--- a/lib/commands/explore.js
+++ b/lib/commands/explore.js
@@ -13,6 +13,7 @@ class Explore extends BaseCommand {
   static name = 'explore'
   static usage = ['<pkg> [ -- <command>]']
   static params = ['shell']
+  static ignoreImplicitWorkspace = false
 
   // TODO
   /* istanbul ignore next */

--- a/lib/commands/get.js
+++ b/lib/commands/get.js
@@ -4,6 +4,7 @@ class Get extends BaseCommand {
   static description = 'Get a value from the npm configuration'
   static name = 'get'
   static usage = ['[<key> ...] (See `npm config`)']
+  static ignoreImplicitWorkspace = false
 
   // TODO
   /* istanbul ignore next */

--- a/lib/commands/help-search.js
+++ b/lib/commands/help-search.js
@@ -11,6 +11,7 @@ class HelpSearch extends BaseCommand {
   static name = 'help-search'
   static usage = ['<text>']
   static params = ['long']
+  static ignoreImplicitWorkspace = true
 
   async exec (args) {
     if (!args.length) {

--- a/lib/commands/help.js
+++ b/lib/commands/help.js
@@ -17,6 +17,7 @@ class Help extends BaseCommand {
   static name = 'help'
   static usage = ['<term> [<terms..>]']
   static params = ['viewer']
+  static ignoreImplicitWorkspace = true
 
   async completion (opts) {
     if (opts.conf.argv.remain.length > 2) {

--- a/lib/commands/hook.js
+++ b/lib/commands/hook.js
@@ -19,6 +19,8 @@ class Hook extends BaseCommand {
     'update <id> <url> <secret>',
   ]
 
+  static ignoreImplicitWorkspace = true
+
   async exec (args) {
     return otplease({
       ...this.npm.flatOptions,

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -22,6 +22,8 @@ class Init extends BaseCommand {
     '[<@scope>/]<name> (same as `npx [<@scope>/]create-<name>`)',
   ]
 
+  static ignoreImplicitWorkspace = false
+
   async exec (args) {
     // npm exec style
     if (args.length) {

--- a/lib/commands/logout.js
+++ b/lib/commands/logout.js
@@ -11,6 +11,8 @@ class Logout extends BaseCommand {
     'scope',
   ]
 
+  static ignoreImplicitWorkspace = true
+
   async exec (args) {
     const registry = this.npm.config.get('registry')
     const scope = this.npm.config.get('scope')

--- a/lib/commands/org.js
+++ b/lib/commands/org.js
@@ -13,6 +13,7 @@ class Org extends BaseCommand {
   ]
 
   static params = ['registry', 'otp', 'json', 'parseable']
+  static ignoreImplicitWorkspace = true
 
   async completion (opts) {
     const argv = opts.conf.argv.remain

--- a/lib/commands/owner.js
+++ b/lib/commands/owner.js
@@ -20,6 +20,8 @@ class Owner extends BaseCommand {
     'ls [<@scope>/]<pkg>',
   ]
 
+  static ignoreImplicitWorkspace = false
+
   async completion (opts) {
     const argv = opts.conf.argv.remain
     if (argv.length > 3) {

--- a/lib/commands/pack.js
+++ b/lib/commands/pack.js
@@ -18,6 +18,7 @@ class Pack extends BaseCommand {
   ]
 
   static usage = ['[[<@scope>/]<pkg>...]']
+  static ignoreImplicitWorkspace = false
 
   async exec (args) {
     if (args.length === 0) {

--- a/lib/commands/ping.js
+++ b/lib/commands/ping.js
@@ -6,6 +6,7 @@ class Ping extends BaseCommand {
   static description = 'Ping npm registry'
   static params = ['registry']
   static name = 'ping'
+  static ignoreImplicitWorkspace = true
 
   async exec (args) {
     log.notice('PING', this.npm.config.get('registry'))

--- a/lib/commands/pkg.js
+++ b/lib/commands/pkg.js
@@ -20,6 +20,8 @@ class Pkg extends BaseCommand {
     'workspaces',
   ]
 
+  static ignoreImplicitWorkspace = false
+
   async exec (args, { prefix } = {}) {
     if (!prefix) {
       this.prefix = this.npm.localPrefix

--- a/lib/commands/prefix.js
+++ b/lib/commands/prefix.js
@@ -5,6 +5,7 @@ class Prefix extends BaseCommand {
   static name = 'prefix'
   static params = ['global']
   static usage = ['[-g]']
+  static ignoreImplicitWorkspace = true
 
   async exec (args) {
     return this.npm.output(this.npm.prefix)

--- a/lib/commands/profile.js
+++ b/lib/commands/profile.js
@@ -54,6 +54,8 @@ class Profile extends BaseCommand {
     'otp',
   ]
 
+  static ignoreImplicitWorkspace = true
+
   async completion (opts) {
     var argv = opts.conf.argv.remain
 

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -39,6 +39,7 @@ class Publish extends BaseCommand {
   ]
 
   static usage = ['[<folder>]']
+  static ignoreImplicitWorkspace = false
 
   async exec (args) {
     if (args.length === 0) {

--- a/lib/commands/repo.js
+++ b/lib/commands/repo.js
@@ -10,6 +10,7 @@ class Repo extends BaseCommand {
   static name = 'repo'
   static params = ['browser', 'workspace', 'workspaces', 'include-workspace-root']
   static usage = ['[<pkgname> [<pkgname> ...]]']
+  static ignoreImplicitWorkspace = false
 
   async exec (args) {
     if (!args || !args.length) {

--- a/lib/commands/restart.js
+++ b/lib/commands/restart.js
@@ -8,5 +8,7 @@ class Restart extends LifecycleCmd {
     'ignore-scripts',
     'script-shell',
   ]
+
+  static ignoreImplicitWorkspace = false
 }
 module.exports = Restart

--- a/lib/commands/root.js
+++ b/lib/commands/root.js
@@ -3,6 +3,7 @@ class Root extends BaseCommand {
   static description = 'Display npm root'
   static name = 'root'
   static params = ['global']
+  static ignoreImplicitWorkspace = true
 
   async exec () {
     this.npm.output(this.npm.dir)

--- a/lib/commands/run-script.js
+++ b/lib/commands/run-script.js
@@ -40,6 +40,7 @@ class RunScript extends BaseCommand {
 
   static name = 'run-script'
   static usage = ['<command> [-- <args>]']
+  static ignoreImplicitWorkspace = false
 
   async completion (opts) {
     const argv = opts.conf.argv.remain

--- a/lib/commands/search.js
+++ b/lib/commands/search.js
@@ -44,6 +44,7 @@ class Search extends BaseCommand {
   ]
 
   static usage = ['[search terms ...]']
+  static ignoreImplicitWorkspace = true
 
   async exec (args) {
     const opts = {

--- a/lib/commands/set-script.js
+++ b/lib/commands/set-script.js
@@ -9,6 +9,7 @@ class SetScript extends BaseCommand {
   static params = ['workspace', 'workspaces', 'include-workspace-root']
   static name = 'set-script'
   static usage = ['[<script>] [<command>]']
+  static ignoreImplicitWorkspace = false
 
   async completion (opts) {
     const argv = opts.conf.argv.remain

--- a/lib/commands/set.js
+++ b/lib/commands/set.js
@@ -4,6 +4,7 @@ class Set extends BaseCommand {
   static description = 'Set a value in the npm configuration'
   static name = 'set'
   static usage = ['<key>=<value> [<key>=<value> ...] (See `npm config`)']
+  static ignoreImplicitWorkspace = false
 
   // TODO
   /* istanbul ignore next */

--- a/lib/commands/shrinkwrap.js
+++ b/lib/commands/shrinkwrap.js
@@ -6,6 +6,7 @@ const BaseCommand = require('../base-command.js')
 class Shrinkwrap extends BaseCommand {
   static description = 'Lock down dependency versions for publication'
   static name = 'shrinkwrap'
+  static ignoreImplicitWorkspace = false
 
   async exec () {
     // if has a npm-shrinkwrap.json, nothing to do

--- a/lib/commands/star.js
+++ b/lib/commands/star.js
@@ -13,6 +13,8 @@ class Star extends BaseCommand {
     'unicode',
   ]
 
+  static ignoreImplicitWorkspace = false
+
   async exec (args) {
     if (!args.length) {
       throw this.usageError()

--- a/lib/commands/stars.js
+++ b/lib/commands/stars.js
@@ -8,6 +8,7 @@ class Stars extends BaseCommand {
   static name = 'stars'
   static usage = ['[<user>]']
   static params = ['registry']
+  static ignoreImplicitWorkspace = false
 
   async exec ([user]) {
     try {

--- a/lib/commands/start.js
+++ b/lib/commands/start.js
@@ -8,5 +8,7 @@ class Start extends LifecycleCmd {
     'ignore-scripts',
     'script-shell',
   ]
+
+  static ignoreImplicitWorkspace = false
 }
 module.exports = Start

--- a/lib/commands/stop.js
+++ b/lib/commands/stop.js
@@ -8,5 +8,7 @@ class Stop extends LifecycleCmd {
     'ignore-scripts',
     'script-shell',
   ]
+
+  static ignoreImplicitWorkspace = false
 }
 module.exports = Stop

--- a/lib/commands/team.js
+++ b/lib/commands/team.js
@@ -22,6 +22,8 @@ class Team extends BaseCommand {
     'json',
   ]
 
+  static ignoreImplicitWorkspace = false
+
   async completion (opts) {
     const { conf: { argv: { remain: argv } } } = opts
     const subcommands = ['create', 'destroy', 'add', 'rm', 'ls']

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -8,5 +8,7 @@ class Test extends LifecycleCmd {
     'ignore-scripts',
     'script-shell',
   ]
+
+  static ignoreImplicitWorkspace = false
 }
 module.exports = Test

--- a/lib/commands/token.js
+++ b/lib/commands/token.js
@@ -14,6 +14,7 @@ class Token extends BaseCommand {
   static name = 'token'
   static usage = ['list', 'revoke <id|token>', 'create [--read-only] [--cidr=list]']
   static params = ['read-only', 'cidr', 'registry', 'otp']
+  static ignoreImplicitWorkspace = true
 
   async completion (opts) {
     const argv = opts.conf.argv.remain

--- a/lib/commands/uninstall.js
+++ b/lib/commands/uninstall.js
@@ -11,6 +11,7 @@ class Uninstall extends ArboristWorkspaceCmd {
   static name = 'uninstall'
   static params = ['save', ...super.params]
   static usage = ['[<@scope>/]<pkg>...']
+  static ignoreImplicitWorkspace = false
 
   // TODO
   /* istanbul ignore next */

--- a/lib/commands/unpublish.js
+++ b/lib/commands/unpublish.js
@@ -19,6 +19,7 @@ class Unpublish extends BaseCommand {
   static name = 'unpublish'
   static params = ['dry-run', 'force', 'workspace', 'workspaces']
   static usage = ['[<@scope>/]<pkg>[@<version>]']
+  static ignoreImplicitWorkspace = false
 
   async getKeysOfVersions (name, opts) {
     const json = await npmFetch.json(npa(name).escapedName, opts)

--- a/lib/commands/version.js
+++ b/lib/commands/version.js
@@ -20,6 +20,8 @@ class Version extends BaseCommand {
     'include-workspace-root',
   ]
 
+  static ignoreImplicitWorkspace = false
+
   /* eslint-disable-next-line max-len */
   static usage = ['[<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease | from-git]']
 

--- a/lib/commands/view.js
+++ b/lib/commands/view.js
@@ -29,6 +29,8 @@ class View extends BaseCommand {
     'include-workspace-root',
   ]
 
+  static ignoreImplicitWorkspace = false
+
   static usage = ['[<@scope>/]<pkg>[@<version>] [<field>[.subfield]...]']
 
   async completion (opts) {

--- a/lib/commands/whoami.js
+++ b/lib/commands/whoami.js
@@ -5,6 +5,7 @@ class Whoami extends BaseCommand {
   static description = 'Display npm username'
   static name = 'whoami'
   static params = ['registry']
+  static ignoreImplicitWorkspace = false
 
   async exec (args) {
     const username = await getIdentity(this.npm, { ...this.npm.flatOptions })

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -24,28 +24,6 @@ const _tmpFolder = Symbol('_tmpFolder')
 const _title = Symbol('_title')
 const pkg = require('../package.json')
 
-const ignoreWorkspacesCommands = new Set([
-  'adduser',
-  'access',
-  'login',
-  'bin',
-  'birthday',
-  'bugs',
-  'cache',
-  'help-search',
-  'help',
-  'hook',
-  'logout',
-  'org',
-  // 'owner', // TODO, this may need some workspace support
-  'ping',
-  'prefix',
-  'profile',
-  // 'restart', // TODO add workspace support
-  'root',
-  'search',
-])
-
 class Npm extends EventEmitter {
   static get version () {
     return pkg.version
@@ -146,7 +124,7 @@ class Npm extends EventEmitter {
     // or when it is implicit and not in our ignore list
     const filterByWorkspaces =
       (workspacesEnabled || workspacesFilters.length > 0)
-      && (!implicitWorkspace || !ignoreWorkspacesCommands.has(cmd))
+      && (!implicitWorkspace || !command.ignoreImplicitWorkspace)
     // normally this would go in the constructor, but our tests don't
     // actually use a real npm object so this.npm.config isn't always
     // populated.  this is the compromise until we can make that a reality

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -24,6 +24,28 @@ const _tmpFolder = Symbol('_tmpFolder')
 const _title = Symbol('_title')
 const pkg = require('../package.json')
 
+const ignoreWorkspacesCommands = new Set([
+  'adduser',
+  'access',
+  'login',
+  'bin',
+  'birthday',
+  'bugs',
+  'cache',
+  'help-search',
+  'help',
+  'hook',
+  'logout',
+  'org',
+  // 'owner', // TODO, this may need some workspace support
+  'ping',
+  'prefix',
+  'profile',
+  // 'restart', // TODO add workspace support
+  'root',
+  'search',
+])
+
 class Npm extends EventEmitter {
   static get version () {
     return pkg.version
@@ -113,12 +135,18 @@ class Npm extends EventEmitter {
     }
 
     const workspacesEnabled = this.config.get('workspaces')
+    /* istanbul ignore next */
+    const implicitWorkspace = (this.config.get('workspace', 'default') || []).length > 0
     const workspacesFilters = this.config.get('workspace')
     if (workspacesEnabled === false && workspacesFilters.length > 0) {
       throw new Error('Can not use --no-workspaces and --workspace at the same time')
     }
 
-    const filterByWorkspaces = workspacesEnabled || workspacesFilters.length > 0
+    // only call execWorkspaces when we have workspaces explicitly set
+    // or when it is implicit and not in our ignore list
+    const filterByWorkspaces =
+      (workspacesEnabled || workspacesFilters.length > 0)
+      && (!implicitWorkspace || !ignoreWorkspacesCommands.has(cmd))
     // normally this would go in the constructor, but our tests don't
     // actually use a real npm object so this.npm.config isn't always
     // populated.  this is the compromise until we can make that a reality

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -113,8 +113,7 @@ class Npm extends EventEmitter {
     }
 
     const workspacesEnabled = this.config.get('workspaces')
-    /* istanbul ignore next */
-    const implicitWorkspace = (this.config.get('workspace', 'default') || []).length > 0
+    const implicitWorkspace = this.config.get('workspace', 'default').length > 0
     const workspacesFilters = this.config.get('workspace')
     if (workspacesEnabled === false && workspacesFilters.length > 0) {
       throw new Error('Can not use --no-workspaces and --workspace at the same time')

--- a/test/lib/load-all-commands.js
+++ b/test/lib/load-all-commands.js
@@ -28,6 +28,7 @@ t.test('load each command', async t => {
       )
       t.ok(impl.description, 'implementation has a description')
       t.ok(impl.name, 'implementation has a name')
+      t.ok(impl.ignoreImplicitWorkspace !== undefined, 'implementation has ignoreImplictWorkspace')
       t.match(impl.usage, cmd, 'usage contains the command')
       await npm.exec(cmd, [])
       t.match(outputs[0][0], impl.usage, 'usage is what is output')

--- a/test/lib/npm.js
+++ b/test/lib/npm.js
@@ -575,7 +575,6 @@ t.test('implicit workspace rejection', async t => {
   })
   const cwd = join(mock.npm.config.localPrefix, 'packages', 'a')
   mock.npm.config.set('workspace', [cwd], 'default')
-  console.log(mock.npm.config.get('workspace', 'default'))
   mockGlobals(t, {
     'process.argv': [
       process.execPath,

--- a/test/lib/npm.js
+++ b/test/lib/npm.js
@@ -1,5 +1,5 @@
 const t = require('tap')
-const { resolve, dirname } = require('path')
+const { resolve, dirname, join } = require('path')
 
 const { load: loadMockNpm } = require('../fixtures/mock-npm.js')
 const mockGlobals = require('../fixtures/mock-globals')
@@ -518,5 +518,108 @@ t.test('unknown command', async t => {
   await t.rejects(
     npm.cmd('thisisnotacommand'),
     { code: 'EUNKNOWNCOMMAND' }
+  )
+})
+
+t.test('explicit workspace rejection', async t => {
+  mockGlobals(t, {
+    'process.argv': [
+      process.execPath,
+      process.argv[1],
+      '--color', 'false',
+      '--workspace', './packages/a',
+    ],
+  })
+  const mock = await loadMockNpm(t, {
+    testdir: {
+      packages: {
+        a: {
+          'package.json': JSON.stringify({
+            name: 'a',
+            version: '1.0.0',
+            scripts: { test: 'echo test a' },
+          }),
+        },
+      },
+      'package.json': JSON.stringify({
+        name: 'root',
+        version: '1.0.0',
+        workspaces: ['./packages/a'],
+      }),
+    },
+  })
+  await t.rejects(
+    mock.npm.exec('ping', []),
+    /This command does not support workspaces/
+  )
+})
+
+t.test('implicit workspace rejection', async t => {
+  const mock = await loadMockNpm(t, {
+    testdir: {
+      packages: {
+        a: {
+          'package.json': JSON.stringify({
+            name: 'a',
+            version: '1.0.0',
+            scripts: { test: 'echo test a' },
+          }),
+        },
+      },
+      'package.json': JSON.stringify({
+        name: 'root',
+        version: '1.0.0',
+        workspaces: ['./packages/a'],
+      }),
+    },
+  })
+  const cwd = join(mock.npm.config.localPrefix, 'packages', 'a')
+  mock.npm.config.set('workspace', [cwd], 'default')
+  console.log(mock.npm.config.get('workspace', 'default'))
+  mockGlobals(t, {
+    'process.argv': [
+      process.execPath,
+      process.argv[1],
+      '--color', 'false',
+    ],
+  })
+  await t.rejects(
+    mock.npm.exec('owner', []),
+    /This command does not support workspaces/
+  )
+})
+
+t.test('implicit workspace accept', async t => {
+  const mock = await loadMockNpm(t, {
+    testdir: {
+      packages: {
+        a: {
+          'package.json': JSON.stringify({
+            name: 'a',
+            version: '1.0.0',
+            scripts: { test: 'echo test a' },
+          }),
+        },
+      },
+      'package.json': JSON.stringify({
+        name: 'root',
+        version: '1.0.0',
+        workspaces: ['./packages/a'],
+      }),
+    },
+  })
+  const cwd = join(mock.npm.config.localPrefix, 'packages', 'a')
+  mock.npm.config.set('workspace', [cwd], 'default')
+  mockGlobals(t, {
+    'process.cwd': () => mock.npm.config.cwd,
+    'process.argv': [
+      process.execPath,
+      process.argv[1],
+      '--color', 'false',
+    ],
+  })
+  await t.rejects(
+    mock.npm.exec('org', []),
+    /.*Usage/
   )
 })


### PR DESCRIPTION
For some commands, ignore implicit cwd workspace config and run as if no workspace filter is set.

'adduser', 'access', 'login', 'bin', 'birthday', 'bugs', 'cache', 'help-search', 'help', 'hook', 'logout', 'org', 'ping', 'prefix', 'profile', 'root', 'search', 'token'

closes #4404

Special thanks to @mshima for submitting a similar PR #4439