### PR TITLE
fix: publish of tarballs includes README in packument

### DIFF
--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -195,7 +195,11 @@ class Publish extends BaseCommand {
     if (spec.type === 'directory') {
       return readJson(`${spec.fetchSpec}/package.json`)
     }
-    return pacote.manifest(spec, { ...opts, fullMetadata: true })
+    return pacote.manifest(spec, {
+      ...opts,
+      fullMetadata: true,
+      fullReadJson: true,
+    })
   }
 }
 module.exports = Publish

--- a/test/lib/commands/publish.js
+++ b/test/lib/commands/publish.js
@@ -290,6 +290,7 @@ t.test('can publish a tarball', async t => {
         name: 'my-cool-tarball',
         version: '1.2.3',
       }),
+      'README.md': 'This is my readme',
     },
   })
   const tar = require('tar')
@@ -311,6 +312,9 @@ t.test('can publish a tarball', async t => {
           {
             name: 'my-cool-tarball',
             version: '1.2.3',
+            readme: 'This is my readme',
+            description: 'This is my readme',
+            readmeFilename: 'README.md',
           },
           'sent manifest to lib pub'
         )


### PR DESCRIPTION
When pacote is used for prepping a tarball for publish (non directory publishes), invoke with `fullReadJSON: true` so that the README is included in the tarball.

Closes #3548