### PR TITLE
fix: `npm ls` now respects `--include-workspace-root`

### DIFF
--- a/lib/commands/ls.js
+++ b/lib/commands/ls.js
@@ -95,12 +95,15 @@ class LS extends ArboristWorkspaceCmd {
         return true
       }
 
+      if (this.npm.flatOptions.includeWorkspaceRoot
+          && !edge.to.isWorkspace) {
+        return true
+      }
+
       if (edge.from.isProjectRoot) {
         return (edge.to
           && edge.to.isWorkspace
           && wsNodes.includes(edge.to.target))
-          || (this.npm.flatOptions.includeWorkspaceRoot
-          && !edge.to.isWorkspace)
       }
 
       return true

--- a/lib/commands/ls.js
+++ b/lib/commands/ls.js
@@ -96,9 +96,11 @@ class LS extends ArboristWorkspaceCmd {
       }
 
       if (edge.from.isProjectRoot) {
-        return edge.to &&
-          edge.to.isWorkspace &&
-          wsNodes.includes(edge.to.target)
+        return (edge.to
+          && edge.to.isWorkspace
+          && wsNodes.includes(edge.to.target))
+          || (this.npm.flatOptions.includeWorkspaceRoot
+          && !edge.to.isWorkspace)
       }
 
       return true

--- a/tap-snapshots/test/lib/commands/ls.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/ls.js.test.cjs
@@ -504,6 +504,15 @@ workspaces-tree@1.0.0 {CWD}/tap-testdir-ls-ls-loading-a-tree-containing-workspac
 
 `
 
+exports[`test/lib/commands/ls.js TAP ls loading a tree containing workspaces > should inlude root and specified workspace 1`] = `
+workspaces-tree@1.0.0 {CWD}/tap-testdir-ls-ls-loading-a-tree-containing-workspaces
++-- d@1.0.0 -> ./d
+| \`-- foo@1.1.1
+|   \`-- bar@1.0.0
+\`-- pacote@1.0.0
+
+`
+
 exports[`test/lib/commands/ls.js TAP ls loading a tree containing workspaces > should list --all workspaces properly 1`] = `
 workspaces-tree@1.0.0 {CWD}/tap-testdir-ls-ls-loading-a-tree-containing-workspaces
 +-- a@1.0.0 -> ./a
@@ -515,7 +524,8 @@ workspaces-tree@1.0.0 {CWD}/tap-testdir-ls-ls-loading-a-tree-containing-workspac
 | \`-- foo@1.1.1
 |   \`-- bar@1.0.0
 +-- e@1.0.0 -> ./group/e
-\`-- f@1.0.0 -> ./group/f
++-- f@1.0.0 -> ./group/f
+\`-- pacote@1.0.0
 
 `
 
@@ -529,7 +539,8 @@ workspaces-tree@1.0.0 {CWD}/tap-testdir-ls-ls-loading-a-tree-containing-workspac
 | \`-- foo@1.1.1
 |   \`-- bar@1.0.0
 +-- e@1.0.0 -> ./group/e
-\`-- f@1.0.0 -> ./group/f
++-- f@1.0.0 -> ./group/f
+\`-- pacote@1.0.0
 
 `
 
@@ -543,13 +554,14 @@ exports[`test/lib/commands/ls.js TAP ls loading a tree containing workspaces > s
 [0m+-- [32md@1.0.0[39m -> ./d[0m
 [0m| \`-- foo@1.1.1[0m
 [0m+-- [32me@1.0.0[39m -> ./group/e[0m
-[0m\`-- [32mf@1.0.0[39m -> ./group/f[0m
+[0m+-- [32mf@1.0.0[39m -> ./group/f[0m
+[0m\`-- pacote@1.0.0[0m
 [0m[0m
 `
 
 exports[`test/lib/commands/ls.js TAP ls loading a tree containing workspaces > should not list workspaces with --no-workspaces 1`] = `
 [0mworkspaces-tree@1.0.0 {CWD}/tap-testdir-ls-ls-loading-a-tree-containing-workspaces[0m
-[0m\`-- (empty)[0m
+[0m\`-- pacote@1.0.0[0m
 [0m[0m
 `
 

--- a/test/lib/commands/ls.js
+++ b/test/lib/commands/ls.js
@@ -1384,6 +1384,7 @@ t.test('ls', t => {
         name: 'workspaces-tree',
         version: '1.0.0',
         workspaces: ['./a', './b', './d', './group/*'],
+        dependencies: { pacote: '1.0.0' },
       }),
       node_modules: {
         a: t.fixture('symlink', '../a'),
@@ -1411,6 +1412,9 @@ t.test('ls', t => {
         },
         baz: {
           'package.json': JSON.stringify({ name: 'baz', version: '1.0.0' }),
+        },
+        pacote: {
+          'package.json': JSON.stringify({ name: 'pacote', version: '1.0.0' }),
         },
       },
       a: {
@@ -1469,6 +1473,7 @@ t.test('ls', t => {
     npm.flatOptions.workspacesEnabled = false
     await ls.exec([])
     t.matchSnapshot(redactCwd(result), 'should not list workspaces with --no-workspaces')
+
     config.all = true
     config.depth = Infinity
     npm.color = false
@@ -1494,6 +1499,12 @@ t.test('ls', t => {
     await ls.execWorkspaces([], ['a'])
 
     t.matchSnapshot(redactCwd(result), 'should filter using workspace config')
+
+    // filter out a single workspace and include root
+    npm.flatOptions.includeWorkspaceRoot = true
+    await ls.execWorkspaces([], ['d'])
+    t.matchSnapshot(redactCwd(result), 'should inlude root and specified workspace')
+    npm.flatOptions.includeWorkspaceRoot = false
 
     // filter out a workspace by parent path
     await ls.execWorkspaces([], ['./group'])


### PR DESCRIPTION
`npm ls` with a workspace specified used to ignore `--include-workspace-root`, but now includes the root when set.

Closes #3945
