### PR TITLE
fix: ignore implicit workspace for whoami

### DIFF
--- a/lib/commands/whoami.js
+++ b/lib/commands/whoami.js
@@ -5,7 +5,7 @@ class Whoami extends BaseCommand {
   static description = 'Display npm username'
   static name = 'whoami'
   static params = ['registry']
-  static ignoreImplicitWorkspace = false
+  static ignoreImplicitWorkspace = true
 
   async exec (args) {
     const username = await getIdentity(this.npm, { ...this.npm.flatOptions })


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
this was left respecting the workspace due to concerns about configs in the workspaces affecting the command, but configs in workspaces are explicitly ignored unless you disable workspaces entirely so that concern should have no impact here.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
