### PR TITLE
fix(owner): bypass cache when fetching packument

### DIFF
--- a/lib/commands/owner.js
+++ b/lib/commands/owner.js
@@ -78,7 +78,7 @@ class Owner extends BaseCommand {
     const spec = npa(pkg)
 
     try {
-      const packumentOpts = { ...this.npm.flatOptions, fullMetadata: true }
+      const packumentOpts = { ...this.npm.flatOptions, fullMetadata: true, preferOnline: true }
       const { maintainers } = await pacote.packument(spec, packumentOpts)
       if (!maintainers || !maintainers.length) {
         this.npm.output('no admin found')
@@ -137,7 +137,11 @@ class Owner extends BaseCommand {
     // normalize user data
     u = { name: u.name, email: u.email }
 
-    const data = await pacote.packument(spec, { ...this.npm.flatOptions, fullMetadata: true })
+    const data = await pacote.packument(spec, {
+      ...this.npm.flatOptions,
+      fullMetadata: true,
+      preferOnline: true,
+    })
 
     const owners = data.maintainers || []
     let maintainers


### PR DESCRIPTION
If folks are doing multiple `owner` commands in succession this can cause the second run to overwrite the first.