### PR TITLE
package unpublished and 404 cleanup

### DIFF
--- a/lib/commands/view.js
+++ b/lib/commands/view.js
@@ -208,7 +208,7 @@ class View extends BaseCommand {
 
     if (pckmnt.time && pckmnt.time.unpublished) {
       const u = pckmnt.time.unpublished
-      const er = new Error('Unpublished by ' + u.name + ' on ' + u.time)
+      const er = new Error(`Unpublished on ${u.time}`)
       er.statusCode = 404
       er.code = 'E404'
       er.pkgid = pckmnt._id

--- a/lib/utils/error-message.js
+++ b/lib/utils/error-message.js
@@ -199,12 +199,7 @@ module.exports = (er, npm) => {
 
         const valResult = nameValidator(pkg)
 
-        if (valResult.validForNewPackages) {
-          detail.push([
-            '404',
-            'You should bug the author to publish it (or use the name yourself!)',
-          ])
-        } else {
+        if (!valResult.validForNewPackages) {
           detail.push(['404', 'This package name is not valid, because', ''])
 
           const errorsArray = [...(valResult.errors || []), ...(valResult.warnings || [])]

--- a/tap-snapshots/test/lib/utils/error-message.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/error-message.js.test.cjs
@@ -157,10 +157,6 @@ Object {
     ],
     Array [
       "404",
-      "You should bug the author to publish it (or use the name yourself!)",
-    ],
-    Array [
-      "404",
       String(
         
         Note that you can also install from a

--- a/test/lib/commands/view.js
+++ b/test/lib/commands/view.js
@@ -32,12 +32,15 @@ const packument = (nv, opts) => {
 
   const mocks = {
     red: {
+      _id: 'red@1.0.1',
       name: 'red',
       'dist-tags': {
         '1.0.1': {},
       },
       time: {
-        unpublished: new Date(),
+        unpublished: {
+          time: '2012-12-20T00:00:00.000Z',
+        },
       },
     },
     blue: {
@@ -533,7 +536,7 @@ t.test('throws when unpublished', async t => {
   const view = new View(npm)
   await t.rejects(
     view.exec(['red']),
-    { code: 'E404' }
+    { code: 'E404', pkgid: 'red@1.0.1', message: 'Unpublished on 2012-12-20T00:00:00.000Z' }
   )
 })
 


### PR DESCRIPTION
Two commits here, one removes the user name from the unpublished message, as that's no longer returned by the npm registry.  The second one removes the "bug the author" message from the package 404, [that copy is outdated and from a different era](https://github.com/npm/cli/pull/3834#issuecomment-934493290).