### PR TITLE
fix(arborist): identify and repair invalid nodes in the virtual tree

### DIFF
--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -355,6 +355,21 @@ Try using the package name instead, e.g:
       })
 
       .then(tree => {
+        // search the virtual tree for invalid edges, if any are found add their source to
+        // the depsQueue so that we'll fix it later
+        depth({
+          tree,
+          getChildren: (node) => [...node.edgesOut.values()].map(edge => edge.to),
+          filter: node => node,
+          visit: node => {
+            for (const edge of node.edgesOut.values()) {
+              if (!edge.valid) {
+                this[_depsQueue].push(node)
+                break // no need to continue the loop after the first hit
+              }
+            }
+          },
+        })
         // null the virtual tree, because we're about to hack away at it
         // if you want another one, load another copy.
         this.idealTree = tree

--- a/workspaces/arborist/lib/arborist/load-virtual.js
+++ b/workspaces/arborist/lib/arborist/load-virtual.js
@@ -79,7 +79,7 @@ module.exports = cls => class VirtualLoader extends cls {
   async [loadRoot] (s) {
     const pj = this.path + '/package.json'
     const pkg = await rpj(pj).catch(() => s.data.packages['']) || {}
-    return this[loadWorkspaces](this[loadNode]('', pkg))
+    return this[loadWorkspaces](this[loadNode]('', pkg, true))
   }
 
   async [loadFromShrinkwrap] (s, root) {
@@ -264,7 +264,7 @@ module.exports = cls => class VirtualLoader extends cls {
     }
   }
 
-  [loadNode] (location, sw) {
+  [loadNode] (location, sw, loadOverrides) {
     const p = this.virtualTree ? this.virtualTree.realpath : this.path
     const path = resolve(p, location)
     // shrinkwrap doesn't include package name unless necessary
@@ -290,6 +290,7 @@ module.exports = cls => class VirtualLoader extends cls {
       optional,
       devOptional,
       peer,
+      loadOverrides,
     })
     // cast to boolean because they're undefined in the lock file when false
     node.extraneous = !!sw.extraneous

--- a/workspaces/arborist/test/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/test/arborist/build-ideal-tree.js
@@ -2193,10 +2193,10 @@ t.test('update global', async t => {
   })
 
   t.matchSnapshot(await printIdeal(path, { global: true, update: ['abbrev'] }),
-    'updating missing dep should have no effect')
+    'updating missing dep should have no effect, but fix the invalid node')
 
   t.matchSnapshot(await printIdeal(path, { global: true, update: ['wrappy'] }),
-    'updating sub-dep has no effect')
+    'updating sub-dep has no effect, but fixes the invalid node')
 
   const invalidArgs = [
     'once@1.4.0',
@@ -2214,7 +2214,7 @@ t.test('update global', async t => {
   }
 
   t.matchSnapshot(await printIdeal(path, { global: true, update: ['once'] }),
-    'update a single dep')
+    'update a single dep, also fixes the invalid node')
   t.matchSnapshot(await printIdeal(path, { global: true, update: true }),
     'update all the deps')
 })


### PR DESCRIPTION
the effect after this change is that a pre-existing tree (either virtual from a package-lock, or actual from node_modules) will have any invalid edges repaired.

these invalid edges could be due to:

- a missing meta dependency
- a no-longer-valid override
- other drift between package.json and package-lock.json

closes #4422
closes #4232
