### PR TITLE
Pin actions to a full length commit SHA

### DIFF
--- a/.github/workflows/benchmark-comment.yml
+++ b/.github/workflows/benchmark-comment.yml
@@ -5,8 +5,13 @@ on:
   issue_comment:
     types: [created, edited]
 
+permissions:
+  contents: read
+
 jobs:
   comment-handler:
+    permissions:
+      contents: none
     name: Trigger Benchmarks
 
     runs-on: ubuntu-latest

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,8 +6,13 @@ on:
     branches:
       - "**"
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: none
     name: Trigger Benchmarks
 
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -14,14 +14,17 @@ on:
       - latest
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       # Checkout the npm/cli repo
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
       - name: Use Node.js 14.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
         with:
           node-version: 14.x
           cache: npm
@@ -37,9 +40,9 @@ jobs:
   check_docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
       - name: Use Node.js 14.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
         with:
           node-version: 14.x
           cache: npm

--- a/.github/workflows/ci-libnpmaccess.yml
+++ b/.github/workflows/ci-libnpmaccess.yml
@@ -12,13 +12,16 @@ on:
       - latest
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       # Checkout the npm/cli repo
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+      - uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
         with:
           node-version: '16'
       - run: npm i --prefer-online -g npm@latest
@@ -42,8 +45,8 @@ jobs:
       run:
         shell: ${{ matrix.platform.shell }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+      - uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
         with:
           node-version: ${{ matrix.node-version }}
         # node 12 and 14 ship with npm@6, which is known to fail when updating itself in windows

--- a/.github/workflows/ci-libnpmdiff.yml
+++ b/.github/workflows/ci-libnpmdiff.yml
@@ -12,13 +12,16 @@ on:
       - latest
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       # Checkout the npm/cli repo
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+      - uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
         with:
           node-version: '16'
       - run: npm i --prefer-online -g npm@latest
@@ -42,8 +45,8 @@ jobs:
       run:
         shell: ${{ matrix.platform.shell }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+      - uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
         with:
           node-version: ${{ matrix.node-version }}
         # node 12 and 14 ship with npm@6, which is known to fail when updating itself in windows

--- a/.github/workflows/ci-libnpmexec.yml
+++ b/.github/workflows/ci-libnpmexec.yml
@@ -12,13 +12,16 @@ on:
       - latest
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       # Checkout the npm/cli repo
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+      - uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
         with:
           node-version: '16'
       - run: npm i --prefer-online -g npm@latest
@@ -42,8 +45,8 @@ jobs:
       run:
         shell: ${{ matrix.platform.shell }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+      - uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
         with:
           node-version: ${{ matrix.node-version }}
         # node 12 and 14 ship with npm@6, which is known to fail when updating itself in windows

--- a/.github/workflows/ci-libnpmfund.yml
+++ b/.github/workflows/ci-libnpmfund.yml
@@ -12,13 +12,16 @@ on:
       - latest
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       # Checkout the npm/cli repo
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+      - uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
         with:
           node-version: '16'
       - run: npm i --prefer-online -g npm@latest
@@ -42,8 +45,8 @@ jobs:
       run:
         shell: ${{ matrix.platform.shell }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+      - uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
         with:
           node-version: ${{ matrix.node-version }}
         # node 12 and 14 ship with npm@6, which is known to fail when updating itself in windows

--- a/.github/workflows/ci-libnpmhook.yml
+++ b/.github/workflows/ci-libnpmhook.yml
@@ -12,13 +12,16 @@ on:
       - latest
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       # Checkout the npm/cli repo
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+      - uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
         with:
           node-version: '16'
       - run: npm i --prefer-online -g npm@latest
@@ -42,8 +45,8 @@ jobs:
       run:
         shell: ${{ matrix.platform.shell }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+      - uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
         with:
           node-version: ${{ matrix.node-version }}
         # node 12 and 14 ship with npm@6, which is known to fail when updating itself in windows

--- a/.github/workflows/ci-libnpmorg.yml
+++ b/.github/workflows/ci-libnpmorg.yml
@@ -12,13 +12,16 @@ on:
       - latest
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       # Checkout the npm/cli repo
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+      - uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
         with:
           node-version: '16'
       - run: npm i --prefer-online -g npm@latest
@@ -42,8 +45,8 @@ jobs:
       run:
         shell: ${{ matrix.platform.shell }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+      - uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
         with:
           node-version: ${{ matrix.node-version }}
         # node 12 and 14 ship with npm@6, which is known to fail when updating itself in windows

--- a/.github/workflows/ci-libnpmpack.yml
+++ b/.github/workflows/ci-libnpmpack.yml
@@ -12,13 +12,16 @@ on:
       - latest
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       # Checkout the npm/cli repo
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+      - uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
         with:
           node-version: '16'
       - run: npm i --prefer-online -g npm@latest
@@ -42,8 +45,8 @@ jobs:
       run:
         shell: ${{ matrix.platform.shell }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+      - uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
         with:
           node-version: ${{ matrix.node-version }}
         # node 12 and 14 ship with npm@6, which is known to fail when updating itself in windows

--- a/.github/workflows/ci-libnpmpublish.yml
+++ b/.github/workflows/ci-libnpmpublish.yml
@@ -12,13 +12,16 @@ on:
       - latest
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       # Checkout the npm/cli repo
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+      - uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
         with:
           node-version: '16'
       - run: npm i --prefer-online -g npm@latest
@@ -42,8 +45,8 @@ jobs:
       run:
         shell: ${{ matrix.platform.shell }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+      - uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
         with:
           node-version: ${{ matrix.node-version }}
         # node 12 and 14 ship with npm@6, which is known to fail when updating itself in windows

--- a/.github/workflows/ci-libnpmsearch.yml
+++ b/.github/workflows/ci-libnpmsearch.yml
@@ -12,13 +12,16 @@ on:
       - latest
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       # Checkout the npm/cli repo
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+      - uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
         with:
           node-version: '16'
       - run: npm i --prefer-online -g npm@latest
@@ -42,8 +45,8 @@ jobs:
       run:
         shell: ${{ matrix.platform.shell }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+      - uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
         with:
           node-version: ${{ matrix.node-version }}
         # node 12 and 14 ship with npm@6, which is known to fail when updating itself in windows

--- a/.github/workflows/ci-libnpmteam.yml
+++ b/.github/workflows/ci-libnpmteam.yml
@@ -12,13 +12,16 @@ on:
       - latest
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       # Checkout the npm/cli repo
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+      - uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
         with:
           node-version: '16'
       - run: npm i --prefer-online -g npm@latest
@@ -42,8 +45,8 @@ jobs:
       run:
         shell: ${{ matrix.platform.shell }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+      - uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
         with:
           node-version: ${{ matrix.node-version }}
         # node 12 and 14 ship with npm@6, which is known to fail when updating itself in windows

--- a/.github/workflows/ci-libnpmversion.yml
+++ b/.github/workflows/ci-libnpmversion.yml
@@ -12,13 +12,16 @@ on:
       - latest
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       # Checkout the npm/cli repo
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+      - uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
         with:
           node-version: '16'
       - run: npm i --prefer-online -g npm@latest
@@ -42,8 +45,8 @@ jobs:
       run:
         shell: ${{ matrix.platform.shell }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+      - uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
         with:
           node-version: ${{ matrix.node-version }}
         # node 12 and 14 ship with npm@6, which is known to fail when updating itself in windows

--- a/.github/workflows/ci-npmcli-arborist.yml
+++ b/.github/workflows/ci-npmcli-arborist.yml
@@ -12,13 +12,16 @@ on:
       - latest
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       # Checkout the npm/cli repo
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+      - uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
         with:
           node-version: '16'
       - run: npm i --prefer-online -g npm@latest
@@ -42,8 +45,8 @@ jobs:
       run:
         shell: ${{ matrix.platform.shell }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
+      - uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
         with:
           node-version: ${{ matrix.node-version }}
         # node 12 and 14 ship with npm@6, which is known to fail when updating itself in windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,17 @@ on:
       - latest
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       # Checkout the npm/cli repo
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
       - name: Use Node.js 14.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
         with:
           node-version: 14.x
           cache: npm
@@ -33,9 +36,9 @@ jobs:
   check_docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
       - name: Use Node.js 14.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
         with:
           node-version: 14.x
           cache: npm
@@ -52,9 +55,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checkout the npm/cli repo
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
       - name: Use Node.js 14.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
         with:
           node-version: 14.x
           cache: npm
@@ -87,11 +90,11 @@ jobs:
 
     steps:
       # Checkout the npm/cli repo
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
 
       # Installs the specific version of Node.js
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
       with:
         node-version: ${{ matrix.node-version }}
         cache: npm
@@ -130,11 +133,11 @@ jobs:
 
     steps:
       # Checkout the npm/cli repo
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
 
       # Installs the specific version of Node.js
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561 # v2
       with:
         node-version: ${{ matrix.node-version }}
         cache: npm

--- a/.github/workflows/create-cli-deps-pr.yml
+++ b/.github/workflows/create-cli-deps-pr.yml
@@ -24,7 +24,7 @@ jobs:
           sudo apt-get install -y jq
           sudo apt install gh
       - name: Checkout npm/node
-        uses: actions/checkout@v2
+        uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2
         with:
           fetch-depth: 0
           ref: master
@@ -32,7 +32,7 @@ jobs:
           token: ${{ secrets.NPM_ROBOT_USER_PAT }}
       - name: Pull (Fast-Forward) upstream
         id: sync
-        uses: aormsby/Fork-Sync-With-Upstream-action@v2.1
+        uses: aormsby/Fork-Sync-With-Upstream-action@3911125c30210b7f1ea2b46ac84722aff061d257 # v2.1
         with:
           upstream_repository: nodejs/node
           upstream_branch: master

--- a/.github/workflows/release-please-libnpmaccess.yml
+++ b/.github/workflows/release-please-libnpmaccess.yml
@@ -10,11 +10,16 @@ on:
       - release-next
       - latest
 
+permissions:
+  contents: read
+
 jobs:
   release-please:
+    permissions:
+      contents: write  # for google-github-actions/release-please-action to create release PR's and commit message
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v2
+      - uses: google-github-actions/release-please-action@0bf3158b7041ea3e07a46031da6bb5467dbea087 # v2
         id: release
         with:
           release-type: node

--- a/.github/workflows/release-please-libnpmdiff.yml
+++ b/.github/workflows/release-please-libnpmdiff.yml
@@ -10,11 +10,16 @@ on:
       - release-next
       - latest
 
+permissions:
+  contents: read
+
 jobs:
   release-please:
+    permissions:
+      contents: write  # for google-github-actions/release-please-action to create release PR's and commit message
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v2
+      - uses: google-github-actions/release-please-action@0bf3158b7041ea3e07a46031da6bb5467dbea087 # v2
         id: release
         with:
           release-type: node

--- a/.github/workflows/release-please-libnpmexec.yml
+++ b/.github/workflows/release-please-libnpmexec.yml
@@ -10,11 +10,16 @@ on:
       - release-next
       - latest
 
+permissions:
+  contents: read
+
 jobs:
   release-please:
+    permissions:
+      contents: write  # for google-github-actions/release-please-action to create release PR's and commit message
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v2
+      - uses: google-github-actions/release-please-action@0bf3158b7041ea3e07a46031da6bb5467dbea087 # v2
         id: release
         with:
           release-type: node

--- a/.github/workflows/release-please-libnpmfund.yml
+++ b/.github/workflows/release-please-libnpmfund.yml
@@ -10,11 +10,16 @@ on:
       - release-next
       - latest
 
+permissions:
+  contents: read
+
 jobs:
   release-please:
+    permissions:
+      contents: write  # for google-github-actions/release-please-action to create release PR's and commit message
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v2
+      - uses: google-github-actions/release-please-action@0bf3158b7041ea3e07a46031da6bb5467dbea087 # v2
         id: release
         with:
           release-type: node

--- a/.github/workflows/release-please-libnpmhook.yml
+++ b/.github/workflows/release-please-libnpmhook.yml
@@ -10,11 +10,16 @@ on:
       - release-next
       - latest
 
+permissions:
+  contents: read
+
 jobs:
   release-please:
+    permissions:
+      contents: write  # for google-github-actions/release-please-action to create release PR's and commit message
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v2
+      - uses: google-github-actions/release-please-action@0bf3158b7041ea3e07a46031da6bb5467dbea087 # v2
         id: release
         with:
           release-type: node

--- a/.github/workflows/release-please-libnpmorg.yml
+++ b/.github/workflows/release-please-libnpmorg.yml
@@ -10,11 +10,16 @@ on:
       - release-next
       - latest
 
+permissions:
+  contents: read
+
 jobs:
   release-please:
+    permissions:
+      contents: write  # for google-github-actions/release-please-action to create release PR's and commit message
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v2
+      - uses: google-github-actions/release-please-action@0bf3158b7041ea3e07a46031da6bb5467dbea087 # v2
         id: release
         with:
           release-type: node

--- a/.github/workflows/release-please-libnpmpack.yml
+++ b/.github/workflows/release-please-libnpmpack.yml
@@ -10,11 +10,16 @@ on:
       - release-next
       - latest
 
+permissions:
+  contents: read
+
 jobs:
   release-please:
+    permissions:
+      contents: write  # for google-github-actions/release-please-action to create release PR's and commit message
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v2
+      - uses: google-github-actions/release-please-action@0bf3158b7041ea3e07a46031da6bb5467dbea087 # v2
         id: release
         with:
           release-type: node

--- a/.github/workflows/release-please-libnpmpublish.yml
+++ b/.github/workflows/release-please-libnpmpublish.yml
@@ -10,11 +10,16 @@ on:
       - release-next
       - latest
 
+permissions:
+  contents: read
+
 jobs:
   release-please:
+    permissions:
+      contents: write  # for google-github-actions/release-please-action to create release PR's and commit message
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v2
+      - uses: google-github-actions/release-please-action@0bf3158b7041ea3e07a46031da6bb5467dbea087 # v2
         id: release
         with:
           release-type: node

--- a/.github/workflows/release-please-libnpmsearch.yml
+++ b/.github/workflows/release-please-libnpmsearch.yml
@@ -10,11 +10,16 @@ on:
       - release-next
       - latest
 
+permissions:
+  contents: read
+
 jobs:
   release-please:
+    permissions:
+      contents: write  # for google-github-actions/release-please-action to create release PR's and commit message
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v2
+      - uses: google-github-actions/release-please-action@0bf3158b7041ea3e07a46031da6bb5467dbea087 # v2
         id: release
         with:
           release-type: node

--- a/.github/workflows/release-please-libnpmteam.yml
+++ b/.github/workflows/release-please-libnpmteam.yml
@@ -10,11 +10,16 @@ on:
       - release-next
       - latest
 
+permissions:
+  contents: read
+
 jobs:
   release-please:
+    permissions:
+      contents: write  # for google-github-actions/release-please-action to create release PR's and commit message
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v2
+      - uses: google-github-actions/release-please-action@0bf3158b7041ea3e07a46031da6bb5467dbea087 # v2
         id: release
         with:
           release-type: node

--- a/.github/workflows/release-please-libnpmversion.yml
+++ b/.github/workflows/release-please-libnpmversion.yml
@@ -10,11 +10,16 @@ on:
       - release-next
       - latest
 
+permissions:
+  contents: read
+
 jobs:
   release-please:
+    permissions:
+      contents: write  # for google-github-actions/release-please-action to create release PR's and commit message
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v2
+      - uses: google-github-actions/release-please-action@0bf3158b7041ea3e07a46031da6bb5467dbea087 # v2
         id: release
         with:
           release-type: node

--- a/.github/workflows/release-please-npmcli-arborist.yml
+++ b/.github/workflows/release-please-npmcli-arborist.yml
@@ -10,11 +10,16 @@ on:
       - release-next
       - latest
 
+permissions:
+  contents: read
+
 jobs:
   release-please:
+    permissions:
+      contents: write  # for google-github-actions/release-please-action to create release PR's and commit message
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v2
+      - uses: google-github-actions/release-please-action@0bf3158b7041ea3e07a46031da6bb5467dbea087 # v2
         id: release
         with:
           release-type: node


### PR DESCRIPTION
- Pinned actions by SHA https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

>Pin actions to a full length commit SHA

>Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload.

https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

Also, dependabot supports upgrading based on SHA.

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
