### PR TITLE
fix(arborist): handle link nodes in old lockfiles correctly

### DIFF
--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -743,6 +743,12 @@ This is a one-time fix-up, please be patient...
         continue
       }
 
+      // if the node's location isn't within node_modules then this is actually
+      // a link target, so skip it. the link node itself will be queued later.
+      if (!node.location.startsWith('node_modules')) {
+        continue
+      }
+
       queue.push(async () => {
         log.silly('inflate', node.location)
         const { resolved, version, path, name, location, integrity } = node
@@ -750,8 +756,7 @@ This is a one-time fix-up, please be patient...
         const useResolved = resolved && (
           !version || resolved.startsWith('file:')
         )
-        const id = useResolved ? resolved
-          : version || `file:${node.path}`
+        const id = useResolved ? resolved : version
         const spec = npa.resolve(name, id, dirname(path))
         const t = `idealTree:inflate:${location}`
         this.addTracker(t)

--- a/workspaces/arborist/test/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/test/arborist/build-ideal-tree.js
@@ -1163,6 +1163,26 @@ This is a one-time fix-up, please be patient...
   ])
 })
 
+t.test('inflating a link node in an old lockfile skips registry', async t => {
+  const checkLogs = warningTracker()
+  const path = resolve(fixtures, 'old-lock-with-link')
+  const arb = new Arborist({ path, ...OPT, registry: 'http://invalid.host' })
+  const tree = await arb.buildIdealTree()
+  t.matchSnapshot(printTree(tree))
+  t.strictSame(checkLogs(), [
+    [
+      'warn',
+      'old lockfile',
+      `
+The package-lock.json file was created with an old version of npm,
+so supplemental metadata must be fetched from the registry.
+
+This is a one-time fix-up, please be patient...
+`,
+    ],
+  ])
+})
+
 t.test('warn for ancient lockfile, even if we use v1', async t => {
   const checkLogs = warningTracker()
   const path = resolve(fixtures, 'sax')

--- a/workspaces/arborist/test/fixtures/old-lock-with-link/link-dep/package.json
+++ b/workspaces/arborist/test/fixtures/old-lock-with-link/link-dep/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "link-dep",
+  "version": "1.0.0"
+}

--- a/workspaces/arborist/test/fixtures/old-lock-with-link/package-lock.json
+++ b/workspaces/arborist/test/fixtures/old-lock-with-link/package-lock.json
@@ -1,0 +1,11 @@
+{
+  "name": "old-lock-with-link",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "link-dep": {
+      "version": "file:link-dep"
+    }
+  }
+}

--- a/workspaces/arborist/test/fixtures/old-lock-with-link/package.json
+++ b/workspaces/arborist/test/fixtures/old-lock-with-link/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "old-lock-with-link",
+  "version": "1.0.0",
+  "dependencies": {
+    "link-dep": "file:./link-dep"
+  }
+}


### PR DESCRIPTION
we were previously assuming that a node with no version property is a link, however in old lockfiles a link _target_ is also in the inventory and has a version so this check does not catch all edge cases

closes #3628
