### PR TITLE
docs: recommend prepare over prepublish

### DIFF
--- a/docs/content/using-npm/scripts.md
+++ b/docs/content/using-npm/scripts.md
@@ -339,7 +339,7 @@ file.
 * Don't prefix your script commands with "sudo".  If root permissions
   are required for some reason, then it'll fail with that error, and
   the user will sudo the npm command in question.
-* Don't use `install`. Use a `.gyp` file for compilation, and `prepublish`
+* Don't use `install`. Use a `.gyp` file for compilation, and `prepare`
   for anything else. You should almost never have to explicitly set a
   preinstall or install script. If you are doing this, please consider if
   there is another option. The only valid use of `install` or `preinstall`


### PR DESCRIPTION
Earlier in the docs it says `prepublish` is deprecated and that a new `prepare` event that "preserves this existing behavior" was added, so I assume this section should say to use it as well.