### PR TITLE
fix: ignore packageLockOnly in npx/exec

### DIFF
--- a/workspaces/libnpmexec/lib/index.js
+++ b/workspaces/libnpmexec/lib/index.js
@@ -40,6 +40,8 @@ const exec = async (opts) => {
     yes = undefined,
     ...flatOptions
   } = opts
+  delete flatOptions.packageLock
+  delete flatOptions.packageLockOnly
 
   // dereferences values because we manipulate it later
   const packages = [..._packages]


### PR DESCRIPTION
When npx/exec is ran as a script, packageLock and packageLockOnly config items can be passed to npx, which may prevent the bin packages from being installed.

This updated libnpmexec to clear those config items.

Closes #4595
