### PR TITLE
fix(libnpmpublish): unpublish from custom reg

### DIFF
--- a/workspaces/libnpmpublish/lib/unpublish.js
+++ b/workspaces/libnpmpublish/lib/unpublish.js
@@ -1,9 +1,26 @@
 'use strict'
 
+const { URL } = require('url')
 const npa = require('npm-package-arg')
 const npmFetch = require('npm-registry-fetch')
 const semver = require('semver')
-const { URL } = require('url')
+
+// given a tarball url and a registry url, returns just the
+// relevant pathname portion of it, so that it can be handled
+// elegantly by npm-registry-fetch which only expects pathnames
+// and handles the registry hostname via opts
+const getPathname = (tarball, registry) => {
+  const registryUrl = new URL(registry).pathname.slice(1)
+  let tarballUrl = new URL(tarball).pathname.slice(1)
+
+  // test the tarball url to see if it starts with a possible
+  // pathname from the registry url, in that case strips that portion
+  // of it so that we only return the post-registry-url pathname
+  if (registryUrl) {
+    tarballUrl = tarballUrl.slice(registryUrl.length)
+  }
+  return tarballUrl
+}
 
 const unpublish = async (spec, opts) => {
   spec = npa(spec)
@@ -82,7 +99,7 @@ const unpublish = async (spec, opts) => {
         ...opts,
         query: { write: true },
       })
-      const tarballUrl = new URL(dist.tarball).pathname.slice(1)
+      const tarballUrl = getPathname(dist.tarball, opts.registry)
       await npmFetch(`${tarballUrl}/-rev/${_rev}`, {
         ...opts,
         method: 'DELETE',


### PR DESCRIPTION
Fixes unpublishing a package from a registry url that has pathnames after its hostname.

## References
Fixes: https://github.com/npm/cli/issues/4253

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
