### PR TITLE
fix: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/commands/cache.js
+++ b/lib/commands/cache.js
@@ -177,7 +177,7 @@ class Cache extends BaseCommand {
   async verify () {
     const cache = path.join(this.npm.cache, '_cacache')
     const prefix = cache.indexOf(process.env.HOME) === 0
-      ? `~${cache.substr(process.env.HOME.length)}`
+      ? `~${cache.slice(process.env.HOME.length)}`
       : cache
     const stats = await cacache.verify(cache)
     this.npm.output(`Cache verified and compressed (${prefix})`)

--- a/lib/commands/completion.js
+++ b/lib/commands/completion.js
@@ -97,17 +97,17 @@ class Completion extends BaseCommand {
     const word = words[w]
     const line = COMP_LINE
     const point = +COMP_POINT
-    const partialLine = line.substr(0, point)
+    const partialLine = line.slice(0, point)
     const partialWords = words.slice(0, w)
 
     // figure out where in that last word the point is.
     const partialWordRaw = args[w]
     let i = partialWordRaw.length
-    while (partialWordRaw.substr(0, i) !== partialLine.substr(-1 * i) && i > 0) {
+    while (partialWordRaw.slice(0, i) !== partialLine.slice(-1 * i) && i > 0) {
       i--
     }
 
-    const partialWord = unescape(partialWordRaw.substr(0, i))
+    const partialWord = unescape(partialWordRaw.slice(0, i))
     partialWords.push(partialWord)
 
     const opts = {

--- a/lib/commands/doctor.js
+++ b/lib/commands/doctor.js
@@ -145,7 +145,7 @@ class Doctor extends BaseCommand {
       return ''
     } catch (er) {
       if (/^E\d{3}$/.test(er.code || '')) {
-        throw er.code.substr(1) + ' ' + er.message
+        throw er.code.slice(1) + ' ' + er.message
       } else {
         throw er.message
       }
@@ -211,7 +211,7 @@ class Doctor extends BaseCommand {
       const gid = process.getgid()
       const files = new Set([root])
       for (const f of files) {
-        tracker.silly('checkFilesPermission', f.substr(root.length + 1))
+        tracker.silly('checkFilesPermission', f.slice(root.length + 1))
         const st = await lstat(f).catch(er => {
           // if it can't be missing, or if it can and the error wasn't that it was missing
           if (!missingOk || er.code !== 'ENOENT') {

--- a/lib/commands/help-search.js
+++ b/lib/commands/help-search.js
@@ -171,8 +171,8 @@ class HelpSearch extends BaseCommand {
           const finder = line.toLowerCase().split(arg.toLowerCase())
           let p = 0
           for (const f of finder) {
-            hilitLine.push(line.substr(p, f.length))
-            const word = line.substr(p + f.length, arg.length)
+            hilitLine.push(line.slice(p, p + f.length))
+            const word = line.slice(p + f.length, p + f.length + arg.length)
             const hilit = color.bgBlack(color.red(word))
             hilitLine.push(hilit)
             p += f.length + arg.length

--- a/lib/search/format-package-stream.js
+++ b/lib/search/format-package-stream.js
@@ -111,7 +111,7 @@ function addColorMarker (str, arg, i) {
 
   if (arg.charAt(0) === '/') {
     return str.replace(
-      new RegExp(arg.substr(1, arg.length - 2), 'gi'),
+      new RegExp(arg.slice(1, -1), 'gi'),
       bit => markStart + bit + markEnd
     )
   }
@@ -121,9 +121,9 @@ function addColorMarker (str, arg, i) {
   var p = 0
 
   return pieces.map(function (piece) {
-    piece = str.substr(p, piece.length)
+    piece = str.slice(p, p + piece.length)
     var mark = markStart +
-               str.substr(p + piece.length, arg.length) +
+               str.slice(p + piece.length, p + piece.length + arg.length) +
                markEnd
     p += piece.length + arg.length
     return piece + mark

--- a/lib/search/package-filter.js
+++ b/lib/search/package-filter.js
@@ -36,7 +36,7 @@ function filterWords (data, include, exclude, opts) {
 function match (words, pattern) {
   if (pattern.charAt(0) === '/') {
     pattern = pattern.replace(/\/$/, '')
-    pattern = new RegExp(pattern.substr(1, pattern.length - 1))
+    pattern = new RegExp(pattern.slice(1))
     return words.match(pattern)
   }
   return words.indexOf(pattern) !== -1

--- a/lib/utils/config/definition.js
+++ b/lib/utils/config/definition.js
@@ -233,7 +233,7 @@ const wrapAll = s => {
         return (
           '* ' +
           block
-            .substr(1)
+            .slice(1)
             .trim()
             .split('\n* ')
             .map(li => {

--- a/lib/utils/npm-usage.js
+++ b/lib/utils/npm-usage.js
@@ -53,7 +53,7 @@ const wrap = (arr) => {
       out[l] = c
     }
   }
-  return out.join('\n    ').substr(2)
+  return out.join('\n    ').slice(2)
 }
 
 const usages = async (npm) => {

--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -48,9 +48,9 @@ const logTar = (tarball, opts = {}) => {
         {
           name: 'integrity:',
           value:
-            tarball.integrity.toString().substr(0, 20) +
+            tarball.integrity.toString().slice(0, 20) +
             '[...]' +
-            tarball.integrity.toString().substr(80),
+            tarball.integrity.toString().slice(80),
         },
         tarball.bundled.length && { name: 'bundled deps:', value: tarball.bundled.length },
         tarball.bundled.length && {

--- a/workspaces/arborist/lib/retire-path.js
+++ b/workspaces/arborist/lib/retire-path.js
@@ -7,7 +7,7 @@ const pathSafeHash = s =>
     .update(s)
     .digest('base64')
     .replace(/[^a-zA-Z0-9]+/g, '')
-    .substr(0, 8)
+    .slice(0, 8)
 
 const retirePath = from => {
   const d = dirname(from)

--- a/workspaces/arborist/lib/shrinkwrap.js
+++ b/workspaces/arborist/lib/shrinkwrap.js
@@ -807,7 +807,7 @@ class Shrinkwrap {
       const pathFixed = !resolved ? null
         : !/^file:/.test(resolved) ? resolved
         // resolve onto the metadata path
-        : `file:${resolve(this.path, resolved.substr(5))}`
+        : `file:${resolve(this.path, resolved.slice(5))}`
 
       // if we have one, only set the other if it matches
       // otherwise it could be for a completely different thing.
@@ -1056,7 +1056,7 @@ class Shrinkwrap {
             // turn absolute file: paths into relative paths from the node
             // this especially shows up with workspace edges when the root
             // node is also a workspace in the set.
-            const p = resolve(node.realpath, spec.substr('file:'.length))
+            const p = resolve(node.realpath, spec.slice('file:'.length))
             set[k] = `file:${relpath(node.realpath, p)}`
           } else {
             set[k] = spec

--- a/workspaces/arborist/lib/version-from-tgz.js
+++ b/workspaces/arborist/lib/version-from-tgz.js
@@ -16,7 +16,7 @@ module.exports = (name, tgz) => {
     // basename checking.  Note that registries can
     // be mounted below the root url, so /a/b/-/x/y/foo/-/foo-1.2.3.tgz
     // is a potential option.
-    const tfsplit = u.path.substr(1).split('/-/')
+    const tfsplit = u.path.slice(1).split('/-/')
     if (tfsplit.length > 1) {
       const afterTF = tfsplit.pop()
       if (afterTF === base) {

--- a/workspaces/arborist/scripts/benchmark.js
+++ b/workspaces/arborist/scripts/benchmark.js
@@ -63,13 +63,13 @@ Options:
 for (let i = 2; i < process.argv.length; i++) {
   const arg = process.argv[i]
   if (/^--previous=/.test(arg)) {
-    options.previous = arg.substr('--previous='.length)
+    options.previous = arg.slice('--previous='.length)
   } else if (/^--warn-range=[0-9]+/.test(arg)) {
-    options.warnRange = +arg.substr('--warn-range='.length)
+    options.warnRange = +arg.slice('--warn-range='.length)
   } else if (/^--cache=/.test(arg)) {
-    options.cache = resolve(arg.substr('--cache='.length))
+    options.cache = resolve(arg.slice('--cache='.length))
   } else if (/^--save=/.test(arg)) {
-    const save = arg.substr('--save='.length)
+    const save = arg.slice('--save='.length)
     if (/[/\\]|^\.\.?$/.test(save)) {
       throw new Error('save cannot have slashes or be . or ..')
     }

--- a/workspaces/arborist/test/arborist/load-actual.js
+++ b/workspaces/arborist/test/arborist/load-actual.js
@@ -14,7 +14,7 @@ const {
 
 // strip the fixtures path off of the trees in snapshots
 const pp = path => path &&
-  normalizePath(path).substr(normalizePath(fixtures).length + 1)
+  normalizePath(path).slice(normalizePath(fixtures).length + 1)
 const defixture = obj => {
   if (obj instanceof Set) {
     return new Set([...obj].map(defixture))

--- a/workspaces/libnpmdiff/lib/should-print-patch.js
+++ b/workspaces/libnpmdiff/lib/should-print-patch.js
@@ -14,7 +14,7 @@ const shouldPrintPatch = (path, opts = {}) => {
     filename.startsWith('.')
       ? filename
       : extname(filename)
-  ).substr(1)
+  ).slice(1)
 
   return !binaryExtensions.includes(extension)
 }

--- a/workspaces/libnpmhook/lib/index.js
+++ b/workspaces/libnpmhook/lib/index.js
@@ -13,7 +13,7 @@ cmd.add = (name, endpoint, secret, opts = {}) => {
   }
   if (name[0] === '~') {
     type = 'owner'
-    name = name.substr(1)
+    name = name.slice(1)
   }
   return fetch.json('/-/npm/v1/hooks/hook', {
     ...opts,

--- a/workspaces/libnpmpublish/lib/unpublish.js
+++ b/workspaces/libnpmpublish/lib/unpublish.js
@@ -82,7 +82,7 @@ const unpublish = async (spec, opts) => {
         ...opts,
         query: { write: true },
       })
-      const tarballUrl = new URL(dist.tarball).pathname.substr(1)
+      const tarballUrl = new URL(dist.tarball).pathname.slice(1)
       await npmFetch(`${tarballUrl}/-rev/${_rev}`, {
         ...opts,
         method: 'DELETE',


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.