### PR TITLE
fix(run-script): don't cascade if-present config

### DIFF
--- a/docs/content/commands/npm-run-script.md
+++ b/docs/content/commands/npm-run-script.md
@@ -220,6 +220,8 @@ it's present and fail if the script fails. This is useful, for example, when
 running scripts that may only apply for some builds in an otherwise generic
 CI setup.
 
+This value is not exported to the environment for child processes.
+
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->
 

--- a/docs/content/using-npm/config.md
+++ b/docs/content/using-npm/config.md
@@ -762,6 +762,8 @@ it's present and fail if the script fails. This is useful, for example, when
 running scripts that may only apply for some builds in an otherwise generic
 CI setup.
 
+This value is not exported to the environment for child processes.
+
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->
 

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -880,6 +880,7 @@ define('https-proxy', {
 define('if-present', {
   default: false,
   type: Boolean,
+  envExport: false,
   description: `
     If true, npm will not exit with an error code when \`run-script\` is
     invoked for a script that isn't defined in the \`scripts\` section of

--- a/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
@@ -795,6 +795,8 @@ This option can be used when it's desirable to optionally run a script when
 it's present and fail if the script fails. This is useful, for example, when
 running scripts that may only apply for some builds in an otherwise generic
 CI setup.
+
+This value is not exported to the environment for child processes.
 `
 
 exports[`test/lib/utils/config/definitions.js TAP > config description for ignore-scripts 1`] = `

--- a/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
@@ -636,6 +636,8 @@ it's present and fail if the script fails. This is useful, for example, when
 running scripts that may only apply for some builds in an otherwise generic
 CI setup.
 
+This value is not exported to the environment for child processes.
+
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->
 


### PR DESCRIPTION
Do not pass the `if-present` env config value to spawned processes.

## References
Fixes: https://github.com/npm/cli/issues/3352
Close: https://github.com/npm/cli/pull/3589

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

cc @wraithgar 

<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
