### PR TITLE
fix(install): do not install invalid package name

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -139,6 +139,12 @@ class Install extends ArboristWorkspaceCmd {
       args = ['.']
     }
 
+    // throw usage error if trying to install empty package
+    // name to global space, e.g: `npm i -g ""`
+    if (where === globalTop && !args.every(Boolean)) {
+      throw this.usageError()
+    }
+
     const opts = {
       ...this.npm.flatOptions,
       auditLevel: null,

--- a/test/lib/commands/install.js
+++ b/test/lib/commands/install.js
@@ -139,6 +139,23 @@ t.test('should install globally using Arborist', async t => {
   t.strictSame(SCRIPTS, [], 'no scripts when installing globally')
 })
 
+t.test('should not install invalid global package name', async t => {
+  const { npm } = await loadMockNpm(t, {
+    '@npmcli/run-script': () => {},
+    '../../lib/utils/reify-finish.js': async () => {},
+    '@npmcli/arborist': function (args) {
+      throw new Error('should not reify')
+    },
+  })
+  npm.config.set('global', true)
+  npm.globalPrefix = path.resolve(t.testdir({}))
+  await t.rejects(
+    npm.exec('install', ['']),
+    /Usage:/,
+    'should not install invalid package name'
+  )
+})
+
 t.test('npm i -g npm engines check success', async t => {
   const { npm } = await loadMockNpm(t, {
     '../../lib/utils/reify-finish.js': async () => {},


### PR DESCRIPTION
Throws an usage error if finding an invalid argument in global install.

## References
Fixes: https://github.com/npm/cli/issues/3029

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
