### PR TITLE
chore: remove hard set tap colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,13 +210,11 @@
     "dumpconf": "env | grep npm | sort | uniq",
     "preversion": "bash scripts/update-authors.sh && git add AUTHORS && git commit -m \"chore: update AUTHORS\" || true",
     "licenses": "licensee --production --errors-only",
-    "test": "tap",
+    "test": "FORCE_COLOR=true NO_COLOR='' tap -Rclassic",
     "test-all": "npm run test --if-present --workspaces --include-workspace-root",
-    "snap": "tap",
+    "snap": "FORCE_COLOR=true NO_COLOR='' tap -Rclassic",
     "postsnap": "make -s docs",
     "test:nocleanup": "NO_TEST_CLEANUP=1 npm run test --",
-    "sudotest": "sudo npm run test --",
-    "sudotest:nocleanup": "sudo NO_TEST_CLEANUP=1 npm run test --",
     "posttest": "npm run lint",
     "lint": "eslint \"**/*.js\"",
     "lintfix": "npm run lint -- --fix",
@@ -228,7 +226,6 @@
     "test-env": [
       "LC_ALL=sk"
     ],
-    "color": 1,
     "files": "test/{lib,bin,index.js}",
     "coverage-map": "test/coverage-map.js",
     "timeout": 600

--- a/test/lib/utils/config/definitions.js
+++ b/test/lib/utils/config/definitions.js
@@ -379,18 +379,18 @@ t.test('color', t => {
 
   obj.color = true
   definitions.color.flatten('color', obj, flat)
-  t.strictSame(flat, { color: false, logColor: false }, 'no color when stdout not tty')
+  t.match(flat, { color: false }, 'no color when stdout not tty')
   setTTY('stdout', true)
   definitions.color.flatten('color', obj, flat)
-  t.strictSame(flat, { color: true, logColor: false }, '--color turns on color when stdout is tty')
+  t.match(flat, { color: true }, '--color turns on color when stdout is tty')
   setTTY('stdout', false)
 
   obj.color = true
   definitions.color.flatten('color', obj, flat)
-  t.strictSame(flat, { color: false, logColor: false }, 'no color when stderr not tty')
+  t.match(flat, { logColor: false }, 'no logColor when stderr not tty')
   setTTY('stderr', true)
   definitions.color.flatten('color', obj, flat)
-  t.strictSame(flat, { color: false, logColor: true }, '--color turns on color when stderr is tty')
+  t.match(flat, { logColor: true }, '--color turns on logColor when stderr is tty')
   setTTY('stderr', false)
 
   const setColor = (value) => mockGlobals(t, { 'process.env.NO_COLOR': value })

--- a/test/lib/utils/error-message.js
+++ b/test/lib/utils/error-message.js
@@ -438,9 +438,6 @@ t.test('explain ERESOLVE errors', async t => {
       },
     },
   }))
-  t.match(EXPLAIN_CALLED, [[
-    er,
-    false,
-    path.resolve(npm.cache, 'eresolve-report.txt'),
-  ]])
+  t.equal(EXPLAIN_CALLED[0][0], er)
+  t.equal(EXPLAIN_CALLED[0][2], path.resolve(npm.cache, 'eresolve-report.txt'))
 })


### PR DESCRIPTION
The original PR https://github.com/npm/cli/pull/2225 indicated that this
would prevent snapshot failures in CI with no color, but I hard set this
to "0" and ran tests and they passed.  This will make debugging tests in
CI environments like the Node.js CITGM much easier.
