### PR TITLE
fix(arborist): when reloading an edge, also refresh overrides

### DIFF
--- a/workspaces/arborist/lib/edge.js
+++ b/workspaces/arborist/lib/edge.js
@@ -215,6 +215,11 @@ class Edge {
 
   reload (hard = false) {
     this[_explanation] = null
+    if (this[_from].overrides) {
+      this.overrides = this[_from].overrides.getEdgeRule(this)
+    } else {
+      delete this.overrides
+    }
     const newTo = this[_from].resolve(this.name)
     if (newTo !== this[_to]) {
       if (this[_to]) {

--- a/workspaces/arborist/lib/node.js
+++ b/workspaces/arborist/lib/node.js
@@ -792,6 +792,9 @@ class Node {
       target.root = root
     }
 
+    if (!this.overrides && this.parent && this.parent.overrides) {
+      this.overrides = this.parent.overrides.getNodeRule(this)
+    }
     // tree should always be valid upon root setter completion.
     treeCheck(this)
     treeCheck(root)

--- a/workspaces/arborist/tap-snapshots/test/printable.js.test.cjs
+++ b/workspaces/arborist/tap-snapshots/test/printable.js.test.cjs
@@ -564,24 +564,24 @@ version:'1.0.0',
 location:'',
 path:'/some/path',
 isProjectRoot:true,
-overrides:Map{'foo@1' => '2.0.0', 'bar' => '2.0.0'},
-edgesOut:Map{
-'bar' =>{prod bar@^1.0.0 overridden:2.0.0 -> node_modules/bar},
-'foo' =>{prod foo@^1.0.0 overridden:2.0.0 -> node_modules/foo}},
+overrides:Map{'bar' => '2.0.0'},
+edgesOut:Map{'foo' =>{prod foo@^1.0.0 -> node_modules/foo}},
 children:Map{
 'bar' =>{
 name:'bar',
 version:'2.0.0',
 location:'node_modules/bar',
 path:'/some/path/node_modules/bar',
-overrides:Map{'bar' => '2.0.0', 'foo@1' => '2.0.0'},
-edgesIn:Set{{"" prod bar@^1.0.0}}},
+overrides:Map{'bar' => '2.0.0'},
+edgesIn:Set{{node_modules/foo prod bar@^1.0.0}}},
 'foo' =>{
 name:'foo',
-version:'2.0.0',
+version:'1.0.0',
 location:'node_modules/foo',
 path:'/some/path/node_modules/foo',
-overrides:Map{'foo@1' => '2.0.0', 'bar' => '2.0.0'},
+overrides:Map{'bar' => '2.0.0'},
+edgesOut:Map{
+'bar' =>{prod bar@^1.0.0 overridden:2.0.0 -> node_modules/bar}},
 edgesIn:Set{{"" prod foo@^1.0.0}}}}}
 `
 

--- a/workspaces/arborist/test/edge.js
+++ b/workspaces/arborist/test/edge.js
@@ -244,16 +244,19 @@ t.not(new Edge({
 }).satisfiedBy(b), 'b does not satisfy edge for c')
 reset(a)
 
+const overrideSet = new OverrideSet({
+  overrides: {
+    c: '2.x',
+  },
+})
+
+a.overrides = overrideSet
 t.matchSnapshot(new Edge({
   from: a,
   type: 'prod',
   name: 'c',
   spec: '1.x',
-  overrides: new OverrideSet({
-    overrides: {
-      c: '2.x',
-    },
-  }).getEdgeRule({ name: 'c', spec: '1.x' }),
+  overrides: overrideSet.getEdgeRule({ name: 'c', spec: '1.x' }),
 }).toJSON(), 'printableEdge shows overrides')
 reset(a)
 
@@ -262,11 +265,7 @@ const overriddenExplanation = new Edge({
   type: 'prod',
   name: 'c',
   spec: '1.x',
-  overrides: new OverrideSet({
-    overrides: {
-      c: '2.x',
-    },
-  }).getEdgeRule({ name: 'c', spec: '1.x' }),
+  overrides: overrideSet.getEdgeRule({ name: 'c', spec: '1.x' }),
 }).explain()
 t.equal(overriddenExplanation.rawSpec, '1.x', 'rawSpec has original spec')
 t.equal(overriddenExplanation.spec, '2.x', 'spec has override spec')
@@ -278,24 +277,22 @@ t.ok(new Edge({
   type: 'prod',
   name: 'c',
   spec: '1.x',
-  overrides: new OverrideSet({
-    overrides: {
-      c: '2.x',
-    },
-  }).getEdgeRule({ name: 'c', spec: '1.x' }),
+  overrides: overrideSet.getEdgeRule({ name: 'c', spec: '1.x' }),
 }).satisfiedBy(c), 'c@2 satisfies spec:1.x, override:2.x')
 reset(a)
 
+const overrideSetB = new OverrideSet({
+  overrides: {
+    b: '1.x',
+  },
+})
+a.overrides = overrideSetB
 t.matchSnapshot(new Edge({
   from: a,
   type: 'prod',
   name: 'c',
   spec: '2.x',
-  overrides: new OverrideSet({
-    overrides: {
-      b: '1.x',
-    },
-  }).getEdgeRule({ name: 'c', spec: '2.x' }),
+  overrides: overrideSetB.getEdgeRule({ name: 'c', spec: '2.x' }),
 }).toJSON(), 'printableEdge does not show non-applicable override')
 
 t.ok(new Edge({
@@ -303,12 +300,25 @@ t.ok(new Edge({
   type: 'prod',
   name: 'c',
   spec: '2.x',
-  overrides: new OverrideSet({
-    overrides: {
-      b: '1.x',
-    },
-  }).getEdgeRule({ name: 'c', spec: '2.x' }),
+  overrides: overrideSetB.getEdgeRule({ name: 'c', spec: '2.x' }),
 }).satisfiedBy(c), 'c@2 satisfies spec:1.x, no matching override')
+reset(a)
+delete a.overrides
+
+const overrideEdge = new Edge({
+  from: a,
+  type: 'prod',
+  name: 'c',
+  spec: '2.x',
+})
+t.notOk(overrideEdge.overrides, 'edge has no overrides')
+a.overrides = new OverrideSet({ overrides: { b: '1.x' } })
+t.notOk(overrideEdge.overrides, 'edge has no overrides')
+overrideEdge.reload()
+t.ok(overrideEdge.overrides, 'edge has overrides after reload')
+delete a.overrides
+overrideEdge.reload()
+t.notOk(overrideEdge.overrides, 'edge has no overrides after reload')
 reset(a)
 
 const referenceTop = {
@@ -494,6 +504,7 @@ const overrides = new OverrideSet({
     c: '1.x',
   },
 })
+a.overrides = overrides
 const overriddenEdge = new Edge({
   from: a,
   type: 'prod',
@@ -504,6 +515,7 @@ const overriddenEdge = new Edge({
 t.equal(overriddenEdge.spec, '1.x', 'override spec takes priority')
 t.equal(overriddenEdge.rawSpec, '2.x', 'rawSpec holds original spec')
 reset(a)
+delete a.overrides
 
 const old = new Edge({
   from: a,

--- a/workspaces/arborist/test/printable.js
+++ b/workspaces/arborist/test/printable.js
@@ -421,15 +421,13 @@ t.test('show overrides', (t) => {
       version: '1.0.0',
       dependencies: {
         foo: '^1.0.0',
-        bar: '^1.0.0',
       },
       overrides: {
-        'foo@1': '2.0.0',
         bar: '2.0.0',
       },
     },
     children: [
-      { pkg: { name: 'foo', version: '2.0.0' }, ...flags },
+      { pkg: { name: 'foo', version: '1.0.0', dependencies: { bar: '^1.0.0' } }, ...flags },
       { pkg: { name: 'bar', version: '2.0.0' }, ...flags },
     ],
     ...flags,


### PR DESCRIPTION
when we load a virtual tree, we do it based on the package-lock structure setting only the root node in each constructor (_not_ the parent, since we may not even have it yet). these changes ensure that even in this out-of-order scenario we still pick up the overrides on the child node, which means we more consistently apply overrides and identify when they are mismatched.
