### PR TITLE
Add `loglevel` to commands of `install` and `update` and to the relevant documentation pages 

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -31,6 +31,7 @@ class Install extends ArboristWorkspaceCmd {
     'bin-links',
     'fund',
     'dry-run',
+    'loglevel',
     ...super.params,
   ]
 

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -25,6 +25,7 @@ class Update extends ArboristWorkspaceCmd {
     'bin-links',
     'fund',
     'dry-run',
+    'loglevel',
     ...super.params,
   ]
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

The aim of this PR is to add [loglevel](https://docs.npmjs.com/cli/v8/using-npm/config#loglevel) to the commands of [install](https://docs.npmjs.com/cli/v8/commands/npm-install) and [update](https://docs.npmjs.com/cli/v8/commands/npm-update) and the relevant documentation pages, following https://github.com/npm/cli/issues/4690#issuecomment-1090510309 .

I simply added `'loglevel'` to install.js and update.js following the info in https://github.com/npm/cli/issues/4690#issuecomment-1090600926.

`npm run test` results in the following errors (see below).

~Note to reviewers: 
Unfortunately I am completely unfamiliar with the codebase. If someone could guide me in fixing the errors I'm getting (=how to fix them) that would be awesome. Otherwise please feel free to close this PR.~

<details>
<summary>The summary results of <code>npm run test</code> is as follows:</summary>

> npm run test

(...)

  🌈 SUMMARY RESULTS 🌈

​ SKIP ​ test/bin/windows-shims.js 2 skip of 6 9s
 ~ wsl bash not installed
 ~ Cygwin does not play nicely with NYC, run without coverage

​ FAIL ​ test/lib/commands/install.js 8 failed of 15 1s
 ✖ ENOTEMPTY: directory not empty, rmdir
   '\\?\C:\Users\Kostas\Documents\GitHub\cli\test\lib\commands\tap-testdir-install-with-args-dev-true\cache\_logs'
 ✖ ENOTEMPTY: directory not empty, rmdir
   '\\?\C:\Users\Kostas\Documents\GitHub\cli\test\lib\commands\tap-testdir-install-without-args\cache\_logs'
 ✖ENOTEMPTY: directory not empty, rmdir '\\?\C:\Users\Kostas\Documents\GitHub\cli\test\lib\commands\tap-testdir-install-
  should-ignore-scripts-with---ignore-scripts\cache\_logs'
 ✖ENOTEMPTY: directory not empty, rmdir '\\?\C:\Users\Kostas\Documents\GitHub\cli\test\lib\commands\tap-testdir-install-
  should-install-globally-using-Arborist\cache\_logs'
 ✖ENOTEMPTY: directory not empty, rmdir '\\?\C:\Users\Kostas\Documents\GitHub\cli\test\lib\commands\tap-testdir-install-
  npm-i--g-npm-engines-check-success\cache\_logs'
 ✖ENOTEMPTY: directory not empty, rmdir '\\?\C:\Users\Kostas\Documents\GitHub\cli\test\lib\commands\tap-testdir-install-
  npm-i--g-npm-engines-check-failure\cache\_logs'
 ✖ENOTEMPTY: directory not empty, rmdir '\\?\C:\Users\Kostas\Documents\GitHub\cli\test\lib\commands\tap-testdir-install-
  npm-i--g-npm-engines-check-failure-forced-override\cache\_logs'
 ✖ENOTEMPTY: directory not empty, rmdir '\\?\C:\Users\Kostas\Documents\GitHub\cli\test\lib\commands\tap-testdir-install-
  npm-i--g-npm-version-engines-check-failure\cache\_logs'

​ SKIP ​ test/lib/commands/set.js 1 skip of 3 124.764ms
 ~ npm set

​ FAIL ​ test/lib/load-all-commands.js 3 failed of 712 5s
 ✖ must match snapshot
 ✖ must match snapshot
 ✖ must match snapshot

​ FAIL ​ test/lib/npm.js 1 failed of 64 2s
 ✖ ENOTEMPTY: directory not empty, rmdir
   '\\?\C:\Users\Kostas\Documents\GitHub\cli\test\lib\tap-testdir-npm-npm.load-basic-loading\cache\_logs'

​ FAIL ​ test/lib/utils/npm-usage.js 1 failed of 5 703.061ms
 ✖ must match snapshot

​
Suites:   ​4 failed​, ​115 passed​, ​119 of 119 completed​
Asserts:  ​​​13 failed​, ​4045 passed​, ​3 skip​, ​of 4061​
​Time:​   ​1m​ERROR: Coverage for lines (99.27%) does not meet global threshold (100%)
ERROR: Coverage for functions (98.43%) does not meet global threshold (100%)
ERROR: Coverage for branches (98.94%) does not meet global threshold (100%)
ERROR: Coverage for statements (99.25%) does not meet global threshold (100%)
-----------------------------------|---------|----------|---------|---------|-------------------------
File                               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-----------------------------------|---------|----------|---------|---------|-------------------------
All files                          |   99.25 |    98.94 |   98.43 |   99.27 |
 cli                               |     100 |      100 |     100 |     100 |
  index.js                         |     100 |      100 |     100 |     100 |
 cli/bin                           |     100 |      100 |     100 |     100 |
  npm-cli.js                       |     100 |      100 |     100 |     100 |
  npx-cli.js                       |     100 |      100 |     100 |     100 |
 cli/lib                           |   95.33 |    88.11 |   87.01 |   95.23 |
  arborist-cmd.js                  |     100 |      100 |     100 |     100 |
  base-command.js                  |     100 |      100 |     100 |     100 |
  cli.js                           |     100 |      100 |     100 |     100 |
  lifecycle-cmd.js                 |     100 |      100 |     100 |     100 |
  npm.js                           |   92.34 |    81.81 |    83.6 |   92.13 | 334,375,391-418,432-436
 cli/lib/auth                      |     100 |      100 |     100 |     100 |
  legacy.js                        |     100 |      100 |     100 |     100 |
  oauth.js                         |     100 |      100 |     100 |     100 |
  saml.js                          |     100 |      100 |     100 |     100 |
  sso.js                           |     100 |      100 |     100 |     100 |
 cli/lib/commands                  |    99.2 |    98.93 |   99.35 |   99.24 |
  access.js                        |     100 |      100 |     100 |     100 |
  adduser.js                       |     100 |      100 |     100 |     100 |
  audit.js                         |     100 |      100 |     100 |     100 |
  bin.js                           |     100 |      100 |     100 |     100 |
  birthday.js                      |     100 |      100 |     100 |     100 |
  bugs.js                          |     100 |      100 |     100 |     100 |
  cache.js                         |     100 |      100 |     100 |     100 |
  ci.js                            |     100 |      100 |     100 |     100 |
  completion.js                    |     100 |      100 |     100 |     100 |
  config.js                        |     100 |      100 |     100 |     100 |
  dedupe.js                        |     100 |      100 |     100 |     100 |
  deprecate.js                     |     100 |      100 |     100 |     100 |
  diff.js                          |     100 |      100 |     100 |     100 |
  dist-tag.js                      |     100 |      100 |     100 |     100 |
  docs.js                          |     100 |      100 |     100 |     100 |
  doctor.js                        |     100 |      100 |     100 |     100 |
  edit.js                          |     100 |      100 |     100 |     100 |
  exec.js                          |     100 |      100 |     100 |     100 |
  explain.js                       |     100 |      100 |     100 |     100 |
  explore.js                       |     100 |      100 |     100 |     100 |
  find-dupes.js                    |     100 |      100 |     100 |     100 |
  fund.js                          |     100 |      100 |     100 |     100 |
  get.js                           |     100 |      100 |     100 |     100 |
  help-search.js                   |     100 |      100 |     100 |     100 |
  help.js                          |     100 |      100 |     100 |     100 |
  hook.js                          |     100 |      100 |     100 |     100 |
  init.js                          |     100 |      100 |     100 |     100 |
  install.js                       |   56.94 |    34.28 |      40 |   58.57 | 108-184
  link.js                          |     100 |      100 |     100 |     100 |
  ll.js                            |     100 |      100 |     100 |     100 |
  logout.js                        |     100 |      100 |     100 |     100 |
  ls.js                            |     100 |      100 |     100 |     100 |
  org.js                           |     100 |      100 |     100 |     100 |
  outdated.js                      |     100 |      100 |     100 |     100 |
  owner.js                         |     100 |      100 |     100 |     100 |
  pack.js                          |     100 |      100 |     100 |     100 |
  ping.js                          |     100 |      100 |     100 |     100 |
  pkg.js                           |     100 |      100 |     100 |     100 |
  prefix.js                        |     100 |      100 |     100 |     100 |
  profile.js                       |     100 |      100 |     100 |     100 |
  prune.js                         |     100 |      100 |     100 |     100 |
  publish.js                       |     100 |      100 |     100 |     100 |
  rebuild.js                       |     100 |      100 |     100 |     100 |
  repo.js                          |     100 |      100 |     100 |     100 |
  restart.js                       |     100 |      100 |     100 |     100 |
  root.js                          |     100 |      100 |     100 |     100 |
  run-script.js                    |     100 |      100 |     100 |     100 |
  search.js                        |     100 |      100 |     100 |     100 |
  set-script.js                    |     100 |      100 |     100 |     100 |
  set.js                           |     100 |      100 |     100 |     100 |
  shrinkwrap.js                    |     100 |      100 |     100 |     100 |
  star.js                          |     100 |      100 |     100 |     100 |
  stars.js                         |     100 |      100 |     100 |     100 |
  start.js                         |     100 |      100 |     100 |     100 |
  stop.js                          |     100 |      100 |     100 |     100 |
  team.js                          |     100 |      100 |     100 |     100 |
  test.js                          |     100 |      100 |     100 |     100 |
  token.js                         |     100 |      100 |     100 |     100 |
  uninstall.js                     |     100 |      100 |     100 |     100 |
  unpublish.js                     |     100 |      100 |     100 |     100 |
  unstar.js                        |     100 |      100 |     100 |     100 |
  update.js                        |     100 |      100 |     100 |     100 |
  version.js                       |     100 |      100 |     100 |     100 |
  view.js                          |     100 |      100 |     100 |     100 |
  whoami.js                        |     100 |      100 |     100 |     100 |
 cli/lib/exec                      |     100 |      100 |     100 |     100 |
  get-workspace-location-msg.js    |     100 |      100 |     100 |     100 |
 cli/lib/utils                     |     100 |      100 |     100 |     100 |
  ansi-trim.js                     |     100 |      100 |     100 |     100 |
  audit-error.js                   |     100 |      100 |     100 |     100 |
  cmd-list.js                      |     100 |      100 |     100 |     100 |
  did-you-mean.js                  |     100 |      100 |     100 |     100 |
  display.js                       |     100 |      100 |     100 |     100 |
  error-message.js                 |     100 |      100 |     100 |     100 |
  exit-handler.js                  |     100 |      100 |     100 |     100 |
  explain-dep.js                   |     100 |      100 |     100 |     100 |
  explain-eresolve.js              |     100 |      100 |     100 |     100 |
  file-exists.js                   |     100 |      100 |     100 |     100 |
  get-identity.js                  |     100 |      100 |     100 |     100 |
  hosted-git-info-from-manifest.js |     100 |      100 |     100 |     100 |
  is-windows.js                    |     100 |      100 |     100 |     100 |
  log-file.js                      |     100 |      100 |     100 |     100 |
  log-shim.js                      |     100 |      100 |     100 |     100 |
  npm-usage.js                     |     100 |      100 |     100 |     100 |
  open-url.js                      |     100 |      100 |     100 |     100 |
  otplease.js                      |     100 |      100 |     100 |     100 |
  ping.js                          |     100 |      100 |     100 |     100 |
  pulse-till-done.js               |     100 |      100 |     100 |     100 |
  queryable.js                     |     100 |      100 |     100 |     100 |
  read-package-name.js             |     100 |      100 |     100 |     100 |
  read-user-info.js                |     100 |      100 |     100 |     100 |
  reify-finish.js                  |     100 |      100 |     100 |     100 |
  reify-output.js                  |     100 |      100 |     100 |     100 |
  replace-info.js                  |     100 |      100 |     100 |     100 |
  tar.js                           |     100 |      100 |     100 |     100 |
  timers.js                        |     100 |      100 |     100 |     100 |
  update-notifier.js               |     100 |      100 |     100 |     100 |
  validate-lockfile.js             |     100 |      100 |     100 |     100 |
 cli/lib/utils/completion          |     100 |      100 |     100 |     100 |
  installed-deep.js                |     100 |      100 |     100 |     100 |
  installed-shallow.js             |     100 |      100 |     100 |     100 |
 cli/lib/utils/config              |     100 |      100 |     100 |     100 |
  definition.js                    |     100 |      100 |     100 |     100 |
  definitions.js                   |     100 |      100 |     100 |     100 |
  describe-all.js                  |     100 |      100 |     100 |     100 |
  flatten.js                       |     100 |      100 |     100 |     100 |
  index.js                         |     100 |      100 |     100 |     100 |
 cli/lib/workspaces                |     100 |      100 |     100 |     100 |
  get-workspaces.js                |     100 |      100 |     100 |     100 |
-----------------------------------|---------|----------|---------|---------|-------------------------

</details>

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->


Related to https://github.com/npm/cli/issues/4690#issuecomment-1090510309

~cc @lukekarrys~ 