### PR TITLE
feat(config): add more npm/node information to config ls

### DIFF
--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -266,6 +266,9 @@ ${defData}
     if (!long) {
       msg.push(
         `; node bin location = ${process.execPath}`,
+        `; node version = ${process.version}`,
+        `; npm bin location = ${dirname(dirname(__dirname))}`,
+        `; npm version = ${this.npm.version}`,
         `; cwd = ${process.cwd()}`,
         `; HOME = ${process.env.HOME}`,
         '; Run `npm config ls -l` to show all defaults.'

--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -267,7 +267,7 @@ ${defData}
       msg.push(
         `; node bin location = ${process.execPath}`,
         `; node version = ${process.version}`,
-        `; npm bin location = ${dirname(dirname(__dirname))}`,
+        `; npm local prefix = ${this.npm.localPrefix}`,
         `; npm version = ${this.npm.version}`,
         `; cwd = ${process.cwd()}`,
         `; HOME = ${process.env.HOME}`,

--- a/tap-snapshots/test/lib/commands/config.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/config.js.test.cjs
@@ -342,6 +342,9 @@ prefix = "{LOCALPREFIX}"
 userconfig = "{HOME}/.npmrc" 
 
 ; node bin location = {EXECPATH}
+; node version = {NODE-VERSION}
+; npm bin location = {NPMDIR}
+; npm version = {NPM-VERSION}
 ; cwd = {NPMDIR}
 ; HOME = {HOME}
 ; Run \`npm config ls -l\` to show all defaults.
@@ -355,6 +358,9 @@ prefix = "{LOCALPREFIX}"
 userconfig = "{HOME}/.npmrc" 
 
 ; node bin location = {EXECPATH}
+; node version = {NODE-VERSION}
+; npm bin location = {NPMDIR}
+; npm version = {NPM-VERSION}
 ; cwd = {NPMDIR}
 ; HOME = {HOME}
 ; Run \`npm config ls -l\` to show all defaults.
@@ -383,6 +389,9 @@ prefix = "{LOCALPREFIX}"
 userconfig = "{HOME}/.npmrc" 
 
 ; node bin location = {EXECPATH}
+; node version = {NODE-VERSION}
+; npm bin location = {NPMDIR}
+; npm version = {NPM-VERSION}
 ; cwd = {NPMDIR}
 ; HOME = {HOME}
 ; Run \`npm config ls -l\` to show all defaults.

--- a/tap-snapshots/test/lib/commands/config.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/config.js.test.cjs
@@ -343,7 +343,7 @@ userconfig = "{HOME}/.npmrc"
 
 ; node bin location = {EXECPATH}
 ; node version = {NODE-VERSION}
-; npm bin location = {NPMDIR}
+; npm local prefix = {LOCALPREFIX}
 ; npm version = {NPM-VERSION}
 ; cwd = {NPMDIR}
 ; HOME = {HOME}
@@ -359,7 +359,7 @@ userconfig = "{HOME}/.npmrc"
 
 ; node bin location = {EXECPATH}
 ; node version = {NODE-VERSION}
-; npm bin location = {NPMDIR}
+; npm local prefix = {LOCALPREFIX}
 ; npm version = {NPM-VERSION}
 ; cwd = {NPMDIR}
 ; HOME = {HOME}
@@ -390,7 +390,7 @@ userconfig = "{HOME}/.npmrc"
 
 ; node bin location = {EXECPATH}
 ; node version = {NODE-VERSION}
-; npm bin location = {NPMDIR}
+; npm local prefix = {LOCALPREFIX}
 ; npm version = {NPM-VERSION}
 ; cwd = {NPMDIR}
 ; HOME = {HOME}


### PR DESCRIPTION
`npm config ls` has become helpful to ask users to post the output of in bug reports. This adds the npm __dirname, npm version, and node version. These aren't really "config" items but we already have `process.execPath` in there and I think these are as important as that.

I want to be mindful of making this have too much output, but these additions feel like a positive tradeoff to me.