### PR TITLE
chore: fix adduser tests

### DIFF
--- a/test/fixtures/mock-npm.js
+++ b/test/fixtures/mock-npm.js
@@ -61,6 +61,7 @@ const LoadMockNpm = async (t, {
   init = true,
   load = init,
   prefixDir = {},
+  homeDir = {},
   cacheDir = {},
   globalPrefixDir = {},
   config = {},
@@ -70,6 +71,12 @@ const LoadMockNpm = async (t, {
   // Mock some globals with their original values so they get torn down
   // back to the original at the end of the test since they are manipulated
   // by npm itself
+  const npmConfigEnv = {}
+  for (const key in process.env) {
+    if (key.startsWith('npm_config_')) {
+      npmConfigEnv[key] = undefined
+    }
+  }
   mockGlobals(t, {
     process: {
       title: process.title,
@@ -77,6 +84,7 @@ const LoadMockNpm = async (t, {
       env: {
         npm_command: process.env.npm_command,
         COLOR: process.env.COLOR,
+        ...npmConfigEnv,
       },
     },
   })
@@ -94,14 +102,21 @@ const LoadMockNpm = async (t, {
   // Set log level as early as possible since
   setLoglevel(t, config.loglevel)
 
-  const dir = t.testdir({ prefix: prefixDir, cache: cacheDir, global: globalPrefixDir })
+  const dir = t.testdir({
+    home: homeDir,
+    prefix: prefixDir,
+    cache: cacheDir,
+    global: globalPrefixDir,
+  })
   const prefix = path.join(dir, 'prefix')
   const cache = path.join(dir, 'cache')
   const globalPrefix = path.join(dir, 'global')
+  const home = path.join(dir, 'home')
 
   // Set cache to testdir via env var so it is available when load is run
   // XXX: remove this for a solution where cache argv is passed in
   mockGlobals(t, {
+    'process.env.HOME': home,
     'process.env.npm_config_cache': cache,
     ...(globals ? result(globals, { prefix, cache }) : {}),
     // Some configs don't work because they can't be set via npm.config.set until
@@ -140,6 +155,7 @@ const LoadMockNpm = async (t, {
     ...rest,
     Npm,
     npm,
+    home,
     prefix,
     globalPrefix,
     testdir: dir,

--- a/test/lib/commands/adduser.js
+++ b/test/lib/commands/adduser.js
@@ -1,190 +1,176 @@
 const t = require('tap')
-const { getCredentialsByURI, setCredentialsByURI } =
-  require('@npmcli/config').prototype
+const path = require('path')
+const fs = require('fs')
+const os = require('os')
 
-let result = ''
-
-const _flatOptions = {
-  authType: 'legacy',
-  registry: 'https://registry.npmjs.org/',
-  scope: '',
-  fromFlatOptions: true,
-}
-
-let failSave = false
-let deletedConfig = {}
-let registryOutput = ''
-let setConfig = {}
-const authDummy = (npm, options) => {
-  if (!options.fromFlatOptions) {
-    throw new Error('did not pass full flatOptions to auth function')
-  }
-
-  return Promise.resolve({
-    message: 'success',
-    newCreds: {
-      username: 'u',
-      password: 'p',
-      email: 'u@npmjs.org',
-    },
-  })
-}
-
-const deleteMock = (key, where) => {
-  deletedConfig = {
-    ...deletedConfig,
-    [key]: where,
-  }
-}
-const npm = {
-  flatOptions: _flatOptions,
-  config: {
-    delete: deleteMock,
-    get (key, where) {
-      if (!where || where === 'user') {
-        return _flatOptions[key]
-      }
-    },
-    getCredentialsByURI,
-    async save () {
-      if (failSave) {
-        throw new Error('error saving user config')
-      }
-    },
-    set (key, value, where) {
-      setConfig = {
-        ...setConfig,
-        [key]: {
-          value,
-          where,
-        },
-      }
-    },
-    setCredentialsByURI,
-  },
-  output: msg => {
-    result = msg
-  },
-}
-
-const AddUser = t.mock('../../../lib/commands/adduser.js', {
-  npmlog: {
-    clearProgress: () => null,
-    disableProgress: () => null,
-  },
-  'proc-log': {
-    notice: (_, msg) => {
-      registryOutput = msg
-    },
-  },
-  '../../../lib/auth/legacy.js': authDummy,
-})
-
-const adduser = new AddUser(npm)
-
-t.afterEach(() => {
-  _flatOptions.authType = 'legacy'
-  _flatOptions.scope = ''
-  registryOutput = ''
-  deletedConfig = {}
-  setConfig = {}
-  result = ''
-  failSave = false
-})
+const { load: loadMockNpm } = require('../../fixtures/mock-npm.js')
+const mockGlobals = require('../../fixtures/mock-globals.js')
+const MockRegistry = require('../../fixtures/mock-registry.js')
+const stream = require('stream')
 
 t.test('usage', async t => {
+  const { npm } = await loadMockNpm(t)
+  const adduser = await npm.cmd('adduser')
   t.match(adduser.usage, 'adduser', 'usage has command name in it')
 })
 
 t.test('simple login', async t => {
-  await adduser.exec([])
-  t.equal(
-    registryOutput,
-    'Log in on https://registry.npmjs.org/',
-    'should have correct message result'
-  )
-
-  t.same(
-    deletedConfig,
-    {
-      _token: 'user',
-      _password: 'user',
-      username: 'user',
-      _auth: 'user',
-      _authtoken: 'user',
-      '-authtoken': 'user',
-      _authToken: 'user',
-      '//registry.npmjs.org/:-authtoken': 'user',
-      '//registry.npmjs.org/:_authToken': 'user',
-      '//registry.npmjs.org/:_authtoken': 'user',
-      '//registry.npmjs.org/:always-auth': 'user',
-      '//registry.npmjs.org/:email': 'user',
+  const stdin = new stream.PassThrough()
+  stdin.write('test-user\n')
+  stdin.write('test-password\n')
+  stdin.write('test-email@npmjs.org\n')
+  mockGlobals(t, {
+    'process.stdin': stdin,
+    'process.stdout': new stream.PassThrough(), // to quiet readline
+  }, { replace: true })
+  const { npm, home } = await loadMockNpm(t, {
+    homeDir: {
+      // These all get cleaned up by config.setCredentialsByURI
+      '.npmrc': [
+        '_token=user',
+        '_password=user',
+        'username=user',
+        '_auth=user',
+        '_authtoken=user',
+        '-authtoken=user',
+        '_authToken=user',
+        '//registry.npmjs.org/:-authtoken=user',
+        '//registry.npmjs.org/:_authToken=user',
+        '//registry.npmjs.org/:_authtoken=user',
+        '//registry.npmjs.org/:always-auth=user',
+        '//registry.npmjs.org/:email=test-email-old@npmjs.org',
+      ].join('\n'),
     },
-    'should delete token in user config'
-  )
-
+  })
+  const registry = new MockRegistry({
+    tap: t,
+    registry: npm.config.get('registry'),
+  })
+  registry.couchlogin({
+    username: 'test-user',
+    password: 'test-password',
+    email: 'test-email@npmjs.org',
+    token: 'npm_test-token',
+  })
+  await npm.exec('adduser', [])
+  t.same(npm.config.get('email'), 'test-email-old@npmjs.org')
+  t.same(npm.config.get('//registry.npmjs.org/:_authToken'), 'npm_test-token')
+  const rc = fs.readFileSync(path.join(home, '.npmrc'), 'utf8')
   t.same(
-    setConfig,
-    {
-      '//registry.npmjs.org/:_password': { value: 'cA==', where: 'user' },
-      '//registry.npmjs.org/:username': { value: 'u', where: 'user' },
-      email: { value: 'u@npmjs.org', where: 'user' },
-    },
-    'should set expected user configs'
-  )
-
-  t.equal(
-    result,
-    'success',
-    'should output auth success msg'
+    rc.trim().split(os.EOL), [
+      '//registry.npmjs.org/:_authToken=npm_test-token',
+      'email=test-email-old@npmjs.org',
+    ], 'should only have token and un-nerfed old email'
   )
 })
 
 t.test('bad auth type', async t => {
-  _flatOptions.authType = 'foo'
-
-  await t.rejects(
-    adduser.exec([]),
-    /no such auth module/,
-    'should throw bad auth type error'
-  )
+  const { npm } = await loadMockNpm(t, {
+    config: {
+      'auth-type': 'foo',
+    },
+  })
+  await t.rejects(npm.exec('adduser', []), {
+    message: 'no such auth module',
+  })
 })
 
 t.test('scoped login', async t => {
-  _flatOptions.scope = '@myscope'
-
-  await adduser.exec([])
-
+  const stdin = new stream.PassThrough()
+  stdin.write('test-user\n')
+  stdin.write('test-password\n')
+  stdin.write('test-email@npmjs.org\n')
+  mockGlobals(t, {
+    'process.stdin': stdin,
+    'process.stdout': new stream.PassThrough(), // to quiet readline
+  }, { replace: true })
+  const { npm, home } = await loadMockNpm(t, {
+    config: {
+      scope: '@myscope',
+    },
+  })
+  const registry = new MockRegistry({
+    tap: t,
+    registry: npm.config.get('registry'),
+  })
+  registry.couchlogin({
+    username: 'test-user',
+    password: 'test-password',
+    email: 'test-email@npmjs.org',
+    token: 'npm_test-token',
+  })
+  await npm.exec('adduser', [])
+  t.same(npm.config.get('//registry.npmjs.org/:_authToken'), 'npm_test-token')
+  t.same(npm.config.get('@myscope:registry'), 'https://registry.npmjs.org/')
+  const rc = fs.readFileSync(path.join(home, '.npmrc'), 'utf8')
   t.same(
-    setConfig['@myscope:registry'],
-    { value: 'https://registry.npmjs.org/', where: 'user' },
-    'should set scoped registry config'
-  )
+    rc.trim().split(os.EOL), [
+      '//registry.npmjs.org/:_authToken=npm_test-token',
+      '@myscope:registry=https://registry.npmjs.org/',
+    ], 'should only have token and scope:registry')
 })
 
 t.test('scoped login with valid scoped registry config', async t => {
-  _flatOptions['@myscope:registry'] = 'https://diff-registry.npmjs.com/'
-  _flatOptions.scope = '@myscope'
-
-  t.teardown(() => {
-    delete _flatOptions['@myscope:registry']
+  const stdin = new stream.PassThrough()
+  stdin.write('test-user\n')
+  stdin.write('test-password\n')
+  stdin.write('test-email@npmjs.org\n')
+  mockGlobals(t, {
+    'process.stdin': stdin,
+    'process.stdout': new stream.PassThrough(), // to quiet readline
+  }, { replace: true })
+  const { npm, home } = await loadMockNpm(t, {
+    homeDir: {
+      '.npmrc': '@myscope:registry=https://diff-registry.npmjs.org',
+    },
+    config: {
+      scope: '@myscope',
+    },
   })
-
-  await adduser.exec([])
-
-  t.same(
-    setConfig['@myscope:registry'],
-    { value: 'https://diff-registry.npmjs.com/', where: 'user' },
-    'should keep scoped registry config'
-  )
+  const registry = new MockRegistry({
+    tap: t,
+    registry: 'https://diff-registry.npmjs.org',
+  })
+  registry.couchlogin({
+    username: 'test-user',
+    password: 'test-password',
+    email: 'test-email@npmjs.org',
+    token: 'npm_test-token',
+  })
+  await npm.exec('adduser', [])
+  t.same(npm.config.get('//diff-registry.npmjs.org/:_authToken'), 'npm_test-token')
+  t.same(npm.config.get('@myscope:registry'), 'https://diff-registry.npmjs.org')
+  const rc = fs.readFileSync(path.join(home, '.npmrc'), 'utf8')
+  t.same(rc.trim().split(os.EOL),
+    [
+      '@myscope:registry=https://diff-registry.npmjs.org',
+      '//diff-registry.npmjs.org/:_authToken=npm_test-token',
+    ], 'should only have token and scope:registry')
 })
 
 t.test('save config failure', async t => {
-  failSave = true
-
-  await t.rejects(
-    adduser.exec([]),
-    /error saving user config/,
-    'should throw config.save error'
-  )
+  const stdin = new stream.PassThrough()
+  stdin.write('test-user\n')
+  stdin.write('test-password\n')
+  stdin.write('test-email@npmjs.org\n')
+  mockGlobals(t, {
+    'process.stdin': stdin,
+    'process.stdout': new stream.PassThrough(), // to quiet readline
+  }, { replace: true })
+  const { npm } = await loadMockNpm(t, {
+    homeDir: {
+      '.npmrc': {},
+    },
+  })
+  const registry = new MockRegistry({
+    tap: t,
+    registry: npm.config.get('registry'),
+  })
+  registry.couchlogin({
+    username: 'test-user',
+    password: 'test-password',
+    email: 'test-email@npmjs.org',
+    token: 'npm_test-token',
+  })
+  await t.rejects(npm.exec('adduser', []))
 })


### PR DESCRIPTION
They mock real registry calls now

## NOTE:

This asserts the existing behavior, even if that existing behavior is incorrect.  The "unnerfing" of the email in `@npmcli/config` leaves an `email` entry in your `.npmrc` that is ignored, except for when you log in it is used to inform readline of the default.  `email` is not in the config definitions, is not validated or flattened and is thus not passed to any submodules.