### PR TITLE
fix(ls): make `--omit` filter `npm ls`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ test-all: deps
 	node bin/npm-cli.js run test-all
 
 ls-ok:
-	node bin/npm-cli.js ls --production >/dev/null
+	node bin/npm-cli.js ls --omit=dev >/dev/null
 
 gitclean:
 	git clean -fd
@@ -97,7 +97,7 @@ link: uninstall
 	node bin/npm-cli.js link -f --ignore-scripts
 
 prune: deps
-	node bin/npm-cli.js prune --production --no-save --no-audit --no-fund
+	node bin/npm-cli.js prune --omit=dev --no-save --no-audit --no-fund
 	node scripts/git-dirty.js
 
 publish: gitclean ls-ok link test-all docs prune

--- a/lib/commands/ls.js
+++ b/lib/commands/ls.js
@@ -52,16 +52,12 @@ class LS extends ArboristWorkspaceCmd {
     const all = this.npm.config.get('all')
     const color = this.npm.color
     const depth = this.npm.config.get('depth')
-    const dev = this.npm.config.get('dev')
-    const development = this.npm.config.get('development')
     const global = this.npm.config.get('global')
     const json = this.npm.config.get('json')
     const link = this.npm.config.get('link')
     const long = this.npm.config.get('long')
-    const only = this.npm.config.get('only')
+    const omit = this.npm.flatOptions.omit
     const parseable = this.npm.config.get('parseable')
-    const prod = this.npm.config.get('prod')
-    const production = this.npm.config.get('production')
     const unicode = this.npm.config.get('unicode')
     const packageLockOnly = this.npm.config.get('package-lock-only')
     const workspacesEnabled = this.npm.flatOptions.workspacesEnabled
@@ -138,15 +134,10 @@ class LS extends ArboristWorkspaceCmd {
           ? []
           : [...(node.target).edgesOut.values()]
             .filter(filterBySelectedWorkspaces)
-            .filter(filterByEdgesTypes({
-              currentDepth,
-              dev,
-              development,
+            .filter(currentDepth === 0 ? filterByEdgesTypes({
               link,
-              prod,
-              production,
-              only,
-            }))
+              omit,
+            }) : () => true)
             .map(mapEdgesToNodes({ seenPaths }))
             .concat(appendExtraneousChildren({ node, seenPaths }))
             .sort(sortAlphabetically)
@@ -399,27 +390,13 @@ const getJsonOutputItem = (node, { global, long }) => {
   return augmentItemWithIncludeMetadata(node, item)
 }
 
-const filterByEdgesTypes = ({
-  currentDepth,
-  dev,
-  development,
-  link,
-  prod,
-  production,
-  only,
-}) => {
-  // filter deps by type, allows for: `npm ls --dev`, `npm ls --prod`,
-  // `npm ls --link`, `npm ls --only=dev`, etc
-  const filterDev = currentDepth === 0 &&
-    (dev || development || /^dev(elopment)?$/.test(only))
-  const filterProd = currentDepth === 0 &&
-    (prod || production || /^prod(uction)?$/.test(only))
-  const filterLink = currentDepth === 0 && link
-
-  return (edge) =>
-    (filterDev ? edge.dev : true) &&
-    (filterProd ? (!edge.dev && !edge.peer && !edge.peerOptional) : true) &&
-    (filterLink ? (edge.to && edge.to.isLink) : true)
+const filterByEdgesTypes = ({ link, omit = [] }) => (edge) => {
+  for (const omitType of omit) {
+    if (edge[omitType]) {
+      return false
+    }
+  }
+  return link ? edge.to && edge.to.isLink : true
 }
 
 const appendExtraneousChildren = ({ node, seenPaths }) =>

--- a/lib/commands/outdated.js
+++ b/lib/commands/outdated.js
@@ -208,7 +208,7 @@ class Outdated extends ArboristWorkspaceCmd {
       : edge.dev ? 'devDependencies'
       : 'dependencies'
 
-    for (const omitType of this.npm.config.get('omit')) {
+    for (const omitType of this.npm.flatOptions.omit) {
       if (node[omitType]) {
         return
       }

--- a/test/lib/commands/ls.js
+++ b/test/lib/commands/ls.js
@@ -99,14 +99,12 @@ const LS = t.mock('../../../lib/commands/ls.js', {
 const config = {
   all: true,
   color: false,
-  dev: false,
   depth: Infinity,
   global: false,
   json: false,
   link: false,
-  only: null,
+  omit: [],
   parseable: false,
-  production: false,
   'package-lock-only': false,
 }
 const flatOptions = {
@@ -456,7 +454,7 @@ t.test('ls', t => {
   })
 
   t.test('--dev', async t => {
-    config.dev = true
+    flatOptions.omit = ['peer', 'prod', 'optional']
     npm.prefix = t.testdir({
       'package.json': JSON.stringify({
         name: 'test-npm-ls',
@@ -479,34 +477,7 @@ t.test('ls', t => {
     })
     await ls.exec([])
     t.matchSnapshot(redactCwd(result), 'should output tree containing dev deps')
-    config.dev = false
-  })
-
-  t.test('--only=development', async t => {
-    config.only = 'development'
-    npm.prefix = t.testdir({
-      'package.json': JSON.stringify({
-        name: 'test-npm-ls',
-        version: '1.0.0',
-        dependencies: {
-          'prod-dep': '^1.0.0',
-          chai: '^1.0.0',
-        },
-        devDependencies: {
-          'dev-dep': '^1.0.0',
-        },
-        optionalDependencies: {
-          'optional-dep': '^1.0.0',
-        },
-        peerDependencies: {
-          'peer-dep': '^1.0.0',
-        },
-      }),
-      ...diffDepTypesNmFixture,
-    })
-    await ls.exec([])
-    t.matchSnapshot(redactCwd(result), 'should output tree containing only development deps')
-    config.only = null
+    flatOptions.omit = []
   })
 
   t.test('--link', async t => {
@@ -581,7 +552,7 @@ t.test('ls', t => {
   })
 
   t.test('--production', async t => {
-    config.production = true
+    flatOptions.omit = ['dev', 'peer']
     npm.prefix = t.testdir({
       'package.json': JSON.stringify({
         name: 'test-npm-ls',
@@ -604,34 +575,7 @@ t.test('ls', t => {
     })
     await ls.exec([])
     t.matchSnapshot(redactCwd(result), 'should output tree containing production deps')
-    config.production = false
-  })
-
-  t.test('--only=prod', async t => {
-    config.only = 'prod'
-    npm.prefix = t.testdir({
-      'package.json': JSON.stringify({
-        name: 'test-npm-ls',
-        version: '1.0.0',
-        dependencies: {
-          'prod-dep': '^1.0.0',
-          chai: '^1.0.0',
-        },
-        devDependencies: {
-          'dev-dep': '^1.0.0',
-        },
-        optionalDependencies: {
-          'optional-dep': '^1.0.0',
-        },
-        peerDependencies: {
-          'peer-dep': '^1.0.0',
-        },
-      }),
-      ...diffDepTypesNmFixture,
-    })
-    await ls.exec([])
-    t.matchSnapshot(redactCwd(result), 'should output tree containing only prod deps')
-    config.only = null
+    flatOptions.omit = []
   })
 
   t.test('--long', async t => {
@@ -1484,12 +1428,12 @@ t.test('ls', t => {
     t.matchSnapshot(redactCwd(result), 'should list --all workspaces properly')
 
     // --production
-    config.production = true
+    flatOptions.omit = ['dev', 'peer', 'optional']
     await ls.exec([])
 
     t.matchSnapshot(redactCwd(result), 'should list only prod deps of workspaces')
 
-    config.production = false
+    flatOptions.omit = []
 
     // filter out a single workspace using args
     await ls.exec(['d'])
@@ -1811,7 +1755,7 @@ t.test('ls --parseable', t => {
   })
 
   t.test('--dev', async t => {
-    config.dev = true
+    flatOptions.omit = ['peer', 'prod', 'optional']
     npm.prefix = t.testdir({
       'package.json': JSON.stringify({
         name: 'test-npm-ls',
@@ -1834,34 +1778,7 @@ t.test('ls --parseable', t => {
     })
     await ls.exec([])
     t.matchSnapshot(redactCwd(result), 'should output tree containing dev deps')
-    config.dev = false
-  })
-
-  t.test('--only=development', async t => {
-    config.only = 'development'
-    npm.prefix = t.testdir({
-      'package.json': JSON.stringify({
-        name: 'test-npm-ls',
-        version: '1.0.0',
-        dependencies: {
-          'prod-dep': '^1.0.0',
-          chai: '^1.0.0',
-        },
-        devDependencies: {
-          'dev-dep': '^1.0.0',
-        },
-        optionalDependencies: {
-          'optional-dep': '^1.0.0',
-        },
-        peerDependencies: {
-          'peer-dep': '^1.0.0',
-        },
-      }),
-      ...diffDepTypesNmFixture,
-    })
-    await ls.exec([])
-    t.matchSnapshot(redactCwd(result), 'should output tree containing only development deps')
-    config.only = null
+    flatOptions.omit = []
   })
 
   t.test('--link', async t => {
@@ -1902,7 +1819,7 @@ t.test('ls --parseable', t => {
   })
 
   t.test('--production', async t => {
-    config.production = true
+    flatOptions.omit = ['dev', 'peer']
     npm.prefix = t.testdir({
       'package.json': JSON.stringify({
         name: 'test-npm-ls',
@@ -1925,34 +1842,7 @@ t.test('ls --parseable', t => {
     })
     await ls.exec([])
     t.matchSnapshot(redactCwd(result), 'should output tree containing production deps')
-    config.production = false
-  })
-
-  t.test('--only=prod', async t => {
-    config.only = 'prod'
-    npm.prefix = t.testdir({
-      'package.json': JSON.stringify({
-        name: 'test-npm-ls',
-        version: '1.0.0',
-        dependencies: {
-          'prod-dep': '^1.0.0',
-          chai: '^1.0.0',
-        },
-        devDependencies: {
-          'dev-dep': '^1.0.0',
-        },
-        optionalDependencies: {
-          'optional-dep': '^1.0.0',
-        },
-        peerDependencies: {
-          'peer-dep': '^1.0.0',
-        },
-      }),
-      ...diffDepTypesNmFixture,
-    })
-    await ls.exec([])
-    t.matchSnapshot(redactCwd(result), 'should output tree containing only prod deps')
-    config.only = null
+    flatOptions.omit = []
   })
 
   t.test('--long', async t => {
@@ -2935,7 +2825,7 @@ t.test('ls --json', t => {
   })
 
   t.test('--dev', async t => {
-    config.dev = true
+    flatOptions.omit = ['prod', 'optional', 'peer']
     npm.prefix = t.testdir({
       'package.json': JSON.stringify({
         name: 'test-npm-ls',
@@ -2976,52 +2866,7 @@ t.test('ls --json', t => {
       },
       'should output json containing dev deps'
     )
-    config.dev = false
-  })
-
-  t.test('--only=development', async t => {
-    config.only = 'development'
-    npm.prefix = t.testdir({
-      'package.json': JSON.stringify({
-        name: 'test-npm-ls',
-        version: '1.0.0',
-        dependencies: {
-          'prod-dep': '^1.0.0',
-          chai: '^1.0.0',
-        },
-        devDependencies: {
-          'dev-dep': '^1.0.0',
-        },
-        optionalDependencies: {
-          'optional-dep': '^1.0.0',
-        },
-        peerDependencies: {
-          'peer-dep': '^1.0.0',
-        },
-      }),
-      ...diffDepTypesNmFixture,
-    })
-    await ls.exec([])
-    t.same(
-      jsonParse(result),
-      {
-        name: 'test-npm-ls',
-        version: '1.0.0',
-        dependencies: {
-          'dev-dep': {
-            version: '1.0.0',
-            dependencies: {
-              foo: {
-                version: '1.0.0',
-                dependencies: { dog: { version: '1.0.0' } },
-              },
-            },
-          },
-        },
-      },
-      'should output json containing only development deps'
-    )
-    config.only = null
+    flatOptions.omit = []
   })
 
   t.test('--link', async t => {
@@ -3075,7 +2920,7 @@ t.test('ls --json', t => {
   })
 
   t.test('--production', async t => {
-    config.production = true
+    flatOptions.omit = ['dev', 'peer']
     npm.prefix = t.testdir({
       'package.json': JSON.stringify({
         name: 'test-npm-ls',
@@ -3110,46 +2955,7 @@ t.test('ls --json', t => {
       },
       'should output json containing production deps'
     )
-    config.production = false
-  })
-
-  t.test('--only=prod', async t => {
-    config.only = 'prod'
-    npm.prefix = t.testdir({
-      'package.json': JSON.stringify({
-        name: 'test-npm-ls',
-        version: '1.0.0',
-        dependencies: {
-          'prod-dep': '^1.0.0',
-          chai: '^1.0.0',
-        },
-        devDependencies: {
-          'dev-dep': '^1.0.0',
-        },
-        optionalDependencies: {
-          'optional-dep': '^1.0.0',
-        },
-        peerDependencies: {
-          'peer-dep': '^1.0.0',
-        },
-      }),
-      ...diffDepTypesNmFixture,
-    })
-    await ls.exec([])
-    t.same(
-      jsonParse(result),
-      {
-        name: 'test-npm-ls',
-        version: '1.0.0',
-        dependencies: {
-          chai: { version: '1.0.0' },
-          'optional-dep': { version: '1.0.0' },
-          'prod-dep': { version: '1.0.0', dependencies: { dog: { version: '2.0.0' } } },
-        },
-      },
-      'should output json containing only prod deps'
-    )
-    config.only = null
+    flatOptions.omit = []
   })
 
   t.test('from lockfile', async t => {


### PR DESCRIPTION
This makes `npm ls` use the same logic as other commands (eg `outdated`)
when parsing config items that filter the output based on package type.

Previously `--development` and `--production` has special semantics when
used with `npm ls` that were inconsistent with the rest of the CLI. To
achieve the same behavior as these deprecated flags use:

- in place of `--development` use `--omit peer --omit prod --omit optional`
- in place of `--production` use `--omit dev --omit peer`

Fixes #4739
