### PR TITLE
doc: include org instructions in scoped publish

### DIFF
--- a/docs/content/using-npm/scope.md
+++ b/docs/content/using-npm/scope.md
@@ -91,10 +91,11 @@ with the appropriate permisssions. For example, if you'd like to
 publish to `@org`, you would  need to create the `org` organization 
 on npmjs.com prior to trying to publish.
 
-Once you will need to 
-specify `--access public` with the initial `npm publish` command.
-This will publish the package and set access to `public` as if 
-you had run `npm access public` after publishing.
+Scoped packages are not public by default.  You will need to specify
+`--access public` with the initial `npm publish` command.  This will publish
+the package and set access to `public` as if you had run `npm access public`
+after publishing.  You do not need to do this when publishing new versions of
+an existing scoped package.
 
 #### Publishing private scoped packages to the npm registry
 

--- a/docs/content/using-npm/scope.md
+++ b/docs/content/using-npm/scope.md
@@ -79,9 +79,14 @@ If you wish, you may associate a scope with a registry; see below.
 
 #### Publishing public scoped packages to the primary npm registry
 
-To publish a public scoped package, you must specify `--access public` with
-the initial publication. This will publish the package and set access
-to `public` as if you had run `npm access public` after publishing.
+To publish a public scoped package, you must first create an
+organization with the name of the scope that you'd like to publish to.
+For example, if you'd like to publish to `@myscope`, you'd need to
+create the `myscope` organization on npmjs.com prior to trying to
+publish. Once you've created, the organization, you will need to 
+specify `--access public` with the initial `npm publish` command.
+This will publish the package and set access to `public` as if 
+you had run `npm access public` after publishing.
 
 #### Publishing private scoped packages to the npm registry
 

--- a/docs/content/using-npm/scope.md
+++ b/docs/content/using-npm/scope.md
@@ -79,11 +79,19 @@ If you wish, you may associate a scope with a registry; see below.
 
 #### Publishing public scoped packages to the primary npm registry
 
-To publish a public scoped package, you must first create an
-organization with the name of the scope that you'd like to publish to.
-For example, if you'd like to publish to `@myscope`, you'd need to
-create the `myscope` organization on npmjs.com prior to trying to
-publish. Once you've created, the organization, you will need to 
+Publishing to a scope, you have two options:
+
+- Publishing to your user scope (example: `@username/module`)
+- Publishing to an organization scope (example: `@org/module`)
+
+If publishing a public module to an organization scope, you must
+first either create an organization with the name of the scope
+that you'd like to publish to or be added to an existing organization
+with the appropriate permisssions. For example, if you'd like to 
+publish to `@org`, you would  need to create the `org` organization 
+on npmjs.com prior to trying to publish.
+
+Once you will need to 
 specify `--access public` with the initial `npm publish` command.
 This will publish the package and set access to `public` as if 
 you had run `npm access public` after publishing.


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

If you've not created an organization but try to publish to a scope, you'll get a "helpful" message telling you to publish the module... that you're trying to publish. Upon reading the documentation, there's no indication that you need to actually create an organization prior to trying to publish, making it... annoying to try to publish to a net new scope.

This PR adds some documentation telling people to create an org first. There's probably more context that could be added, but wanted to get this up while it's top of mind for me so I don't continue hitting this wall without doing anything to help alleviate it.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
