### PR TITLE
Use node in  and fallback to PATH if not found

### DIFF
--- a/bin/npx
+++ b/bin/npx
@@ -13,6 +13,9 @@ esac
 
 NODE_EXE="$basedir/node.exe"
 if ! [ -x "$NODE_EXE" ]; then
+  NODE_EXE="$basedir/node"
+fi
+if ! [ -x "$NODE_EXE" ]; then
   NODE_EXE=node
 fi
 


### PR DESCRIPTION
Contrary to `npm`, `npx` does not check `$basedir/node` and fallbacks to `node` if `$basedir/node` is not found. 

This pull request align the behaviour of `npx` with `npm`.

