### PR TITLE
chore(publish): add test for _auth with configured registry

### DIFF
--- a/tap-snapshots/test/lib/commands/publish.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/publish.js.test.cjs
@@ -9,6 +9,10 @@ exports[`test/lib/commands/publish.js TAP _auth config default registry > new pa
 + test-package@1.0.0
 `
 
+exports[`test/lib/commands/publish.js TAP bare _auth and registry config > new package version 1`] = `
++ @npm/test-package@1.0.0
+`
+
 exports[`test/lib/commands/publish.js TAP dry-run > must match snapshot 1`] = `
 Array [
   Array [

--- a/test/lib/commands/publish.js
+++ b/test/lib/commands/publish.js
@@ -626,6 +626,33 @@ t.test('_auth config default registry', async t => {
   t.matchSnapshot(joinedOutput(), 'new package version')
 })
 
+t.test('bare _auth and registry config', async t => {
+  const spec = npa('@npm/test-package')
+  const { npm, joinedOutput } = await loadMockNpm(t, {
+    config: {
+      registry: alternateRegistry,
+      _auth: basic,
+    },
+    prefixDir: {
+      'package.json': JSON.stringify({
+        name: '@npm/test-package',
+        version: '1.0.0',
+      }, null, 2),
+    },
+    globals: ({ prefix }) => ({
+      'process.cwd': () => prefix,
+    }),
+  })
+  const registry = new MockRegistry({
+    tap: t,
+    registry: alternateRegistry,
+    basic,
+  })
+  registry.nock.put(`/${spec.escapedName}`).reply(200, {})
+  await npm.exec('publish', [])
+  t.matchSnapshot(joinedOutput(), 'new package version')
+})
+
 t.test('bare _auth config scoped registry', async t => {
   const { npm } = await loadMockNpm(t, {
     config: {


### PR DESCRIPTION
During https://github.com/npm/cli/issues/4763 it became apparent there was a test missing to show how `_auth` works with a configured `registry` (not a scope-configured registry)