### PR TITLE
chore: remove bot from authors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -55,6 +55,7 @@ Maximilian Antoni <mail@maxantoni.de> <maximilian.antoni@juliusbaer.com>
 Michael Hayes <michael@hayes.io> <mhayes@newrelic.com>
 Misha Kaletsky <misha.kaletsky@gmail.com>
 Nicolas Morel <marsup@gmail.com>
+npm team <ops+robot@npmjs.com> <ops+npm-cli@npmjs.com>
 Olivier Melcher <olivier.melcher@gmail.com>
 Ra'Shaun Stovall <rashaunstovall@gmail.com>
 Rebecca Turner <me@re-becca.org> <rebecca@npmjs.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -829,6 +829,4 @@ David Walker <d0sboots@gmail.com>
 Boris Verkhovskiy <boris.verk@gmail.com>
 JSKitty <jskitty@protonmail.com>
 CommanderRoot <CommanderRoot@users.noreply.github.com>
-npm cli ops bot <ops+npm-cli@npmjs.com>
 Marco Tizzoni <marco.tizzoni@gmail.com>
-npm team <ops+robot@npmjs.com>

--- a/scripts/update-authors.sh
+++ b/scripts/update-authors.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-git log --use-mailmap --reverse --format='%aN <%aE>' | grep -v "\[bot\]" | perl -wnE '
+git log --use-mailmap --reverse --format='%aN <%aE>' | grep -v "\[bot\]" | grep -v "^npm team" | perl -wnE '
 BEGIN {
   say "# Authors sorted by whether or not they\x27re me";
 }


### PR DESCRIPTION
Uses `.mailmap` to map all bot accounts to a single name (npm team) and skip adding it to `AUTHORS` file in the `update-authors.sh` script.

## References
Follow up from: https://github.com/npm/cli/pull/4814
