### PR TITLE
chore: gitignore __pycache__ directories in node_modules

### DIFF
--- a/node_modules/.gitignore
+++ b/node_modules/.gitignore
@@ -5,6 +5,7 @@ CHANGELOG*
 changelog*
 README*
 readme*
+__pycache__
 .editorconfig
 .idea/
 .npmignore

--- a/scripts/bundle-and-gitignore-deps.js
+++ b/scripts/bundle-and-gitignore-deps.js
@@ -33,6 +33,7 @@ CHANGELOG*
 changelog*
 README*
 readme*
+__pycache__
 .editorconfig
 .idea/
 .npmignore


### PR DESCRIPTION
the `__pycache__` directories inside `node_modules` showing up as untracked files were bugging me, so i made them go away
