### PR TITLE
fix(exec): ignore packageLockOnly flag

### DIFF
--- a/lib/commands/exec.js
+++ b/lib/commands/exec.js
@@ -73,6 +73,9 @@ class Exec extends BaseCommand {
 
     return libexec({
       ...flatOptions,
+      // we explicitly set packageLockOnly to false because if it's true
+      // when we try to install a missing package, we won't actually install it
+      packageLockOnly: false,
       args,
       call,
       localBin,


### PR DESCRIPTION
this flag can cause npx/npm exec to fail to install missing packages correctly, so we forcibly turn it off

replaces #4649
closes #4595
