### PR TITLE
docs: remove incorrect v6 auto prune info

### DIFF
--- a/docs/content/commands/npm-dedupe.md
+++ b/docs/content/commands/npm-dedupe.md
@@ -147,10 +147,6 @@ this warning is treated as a failure.
 If set to false, then ignore `package-lock.json` files when installing. This
 will also prevent _writing_ `package-lock.json` if `save` is true.
 
-When package package-locks are disabled, automatic pruning of extraneous
-modules will also be disabled. To remove extraneous modules with
-package-locks disabled use `npm prune`.
-
 This configuration does not affect `npm ci`.
 
 <!-- automatically generated, do not edit manually -->

--- a/docs/content/commands/npm-find-dupes.md
+++ b/docs/content/commands/npm-find-dupes.md
@@ -87,10 +87,6 @@ this warning is treated as a failure.
 If set to false, then ignore `package-lock.json` files when installing. This
 will also prevent _writing_ `package-lock.json` if `save` is true.
 
-When package package-locks are disabled, automatic pruning of extraneous
-modules will also be disabled. To remove extraneous modules with
-package-locks disabled use `npm prune`.
-
 This configuration does not affect `npm ci`.
 
 <!-- automatically generated, do not edit manually -->

--- a/docs/content/commands/npm-install-test.md
+++ b/docs/content/commands/npm-install-test.md
@@ -162,10 +162,6 @@ this warning is treated as a failure.
 If set to false, then ignore `package-lock.json` files when installing. This
 will also prevent _writing_ `package-lock.json` if `save` is true.
 
-When package package-locks are disabled, automatic pruning of extraneous
-modules will also be disabled. To remove extraneous modules with
-package-locks disabled use `npm prune`.
-
 This configuration does not affect `npm ci`.
 
 <!-- automatically generated, do not edit manually -->

--- a/docs/content/commands/npm-install.md
+++ b/docs/content/commands/npm-install.md
@@ -552,10 +552,6 @@ this warning is treated as a failure.
 If set to false, then ignore `package-lock.json` files when installing. This
 will also prevent _writing_ `package-lock.json` if `save` is true.
 
-When package package-locks are disabled, automatic pruning of extraneous
-modules will also be disabled. To remove extraneous modules with
-package-locks disabled use `npm prune`.
-
 This configuration does not affect `npm ci`.
 
 <!-- automatically generated, do not edit manually -->

--- a/docs/content/commands/npm-link.md
+++ b/docs/content/commands/npm-link.md
@@ -224,10 +224,6 @@ this warning is treated as a failure.
 If set to false, then ignore `package-lock.json` files when installing. This
 will also prevent _writing_ `package-lock.json` if `save` is true.
 
-When package package-locks are disabled, automatic pruning of extraneous
-modules will also be disabled. To remove extraneous modules with
-package-locks disabled use `npm prune`.
-
 This configuration does not affect `npm ci`.
 
 <!-- automatically generated, do not edit manually -->

--- a/docs/content/commands/npm-update.md
+++ b/docs/content/commands/npm-update.md
@@ -280,10 +280,6 @@ this warning is treated as a failure.
 If set to false, then ignore `package-lock.json` files when installing. This
 will also prevent _writing_ `package-lock.json` if `save` is true.
 
-When package package-locks are disabled, automatic pruning of extraneous
-modules will also be disabled. To remove extraneous modules with
-package-locks disabled use `npm prune`.
-
 This configuration does not affect `npm ci`.
 
 <!-- automatically generated, do not edit manually -->

--- a/docs/content/using-npm/config.md
+++ b/docs/content/using-npm/config.md
@@ -1219,10 +1219,6 @@ The package to install for [`npm exec`](/commands/npm-exec)
 If set to false, then ignore `package-lock.json` files when installing. This
 will also prevent _writing_ `package-lock.json` if `save` is true.
 
-When package package-locks are disabled, automatic pruning of extraneous
-modules will also be disabled. To remove extraneous modules with
-package-locks disabled use `npm prune`.
-
 This configuration does not affect `npm ci`.
 
 <!-- automatically generated, do not edit manually -->

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -1448,10 +1448,6 @@ define('package-lock', {
     This will also prevent _writing_ \`package-lock.json\` if \`save\` is
     true.
 
-    When package package-locks are disabled, automatic pruning of extraneous
-    modules will also be disabled.  To remove extraneous modules with
-    package-locks disabled use \`npm prune\`.
-
     This configuration does not affect \`npm ci\`.
   `,
   flatten: (key, obj, flatOptions) => {

--- a/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
@@ -1302,10 +1302,6 @@ exports[`test/lib/utils/config/definitions.js TAP > config description for packa
 If set to false, then ignore \`package-lock.json\` files when installing. This
 will also prevent _writing_ \`package-lock.json\` if \`save\` is true.
 
-When package package-locks are disabled, automatic pruning of extraneous
-modules will also be disabled. To remove extraneous modules with
-package-locks disabled use \`npm prune\`.
-
 This configuration does not affect \`npm ci\`.
 `
 

--- a/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
@@ -1093,10 +1093,6 @@ The package to install for [\`npm exec\`](/commands/npm-exec)
 If set to false, then ignore \`package-lock.json\` files when installing. This
 will also prevent _writing_ \`package-lock.json\` if \`save\` is true.
 
-When package package-locks are disabled, automatic pruning of extraneous
-modules will also be disabled. To remove extraneous modules with
-package-locks disabled use \`npm prune\`.
-
 This configuration does not affect \`npm ci\`.
 
 <!-- automatically generated, do not edit manually -->


### PR DESCRIPTION
As of npm@7, extraneous modules are always auto pruned
