### PR TITLE
chore: run make docs in postsnap script instead of make mandocs

### DIFF
--- a/package.json
+++ b/package.json
@@ -213,7 +213,7 @@
     "test": "tap",
     "test-all": "npm run test --if-present --workspaces --include-workspace-root",
     "snap": "tap",
-    "postsnap": "make -s mandocs",
+    "postsnap": "make -s docs",
     "test:nocleanup": "NO_TEST_CLEANUP=1 npm run test --",
     "sudotest": "sudo npm run test --",
     "sudotest:nocleanup": "sudo NO_TEST_CLEANUP=1 npm run test --",


### PR DESCRIPTION
this ensures that _all_ docs are rebuilt every time we run `npm run snap` rather than just the man files
