### PR TITLE
feat: add --replace-registry-host=<npmjs|always|never>

### DIFF
--- a/docs/content/using-npm/config.md
+++ b/docs/content/using-npm/config.md
@@ -1393,6 +1393,24 @@ The base URL of the npm registry.
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->
 
+#### `replace-registry-host`
+
+* Default: "npmjs"
+* Type: "npmjs", "never", "always", or String
+
+Defines behavior for replacing the registry host in a lockfile with the
+configured registry.
+
+The default behavior is to replace package dist URLs from the default
+registry (https://registry.npmjs.org) to the configured registry. If set to
+"never", then use the registry value. If set to "always", then replace the
+registry host with the configured host every time.
+
+You may also specify a bare hostname (e.g., "registry.npmjs.org").
+
+<!-- automatically generated, do not edit manually -->
+<!-- see lib/utils/config/definitions.js -->
+
 #### `save`
 
 * Default: `true` unless when using `npm update` where it defaults to `false`

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -1649,6 +1649,24 @@ define('registry', {
   flatten,
 })
 
+define('replace-registry-host', {
+  default: 'npmjs',
+  hint: '<npmjs|never|always> | hostname',
+  type: ['npmjs', 'never', 'always', String],
+  description: `
+    Defines behavior for replacing the registry host in a lockfile with the
+    configured registry.
+
+    The default behavior is to replace package dist URLs from the default
+    registry (https://registry.npmjs.org) to the configured registry. If set to
+    "never", then use the registry value. If set to "always", then replace the
+    registry host with the configured host every time.
+
+    You may also specify a bare hostname (e.g., "registry.npmjs.org").
+  `,
+  flatten,
+})
+
 define('save', {
   default: true,
   defaultDescription: `\`true\` unless when using \`npm update\` where it

--- a/tap-snapshots/test/lib/commands/config.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/config.js.test.cjs
@@ -121,6 +121,7 @@ exports[`test/lib/commands/config.js TAP config list --json > output matches sna
   "read-only": false,
   "rebuild-bundle": true,
   "registry": "https://registry.npmjs.org/",
+  "replace-registry-host": "npmjs",
   "save": true,
   "save-bundle": false,
   "save-dev": false,
@@ -277,6 +278,7 @@ proxy = null
 read-only = false 
 rebuild-bundle = true 
 registry = "https://registry.npmjs.org/" 
+replace-registry-host = "npmjs" 
 save = true 
 save-bundle = false 
 save-dev = false 

--- a/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
@@ -116,6 +116,7 @@ Array [
   "read-only",
   "rebuild-bundle",
   "registry",
+  "replace-registry-host",
   "save",
   "save-bundle",
   "save-dev",
@@ -1458,6 +1459,23 @@ exports[`test/lib/utils/config/definitions.js TAP > config description for regis
 * Type: URL
 
 The base URL of the npm registry.
+`
+
+exports[`test/lib/utils/config/definitions.js TAP > config description for replace-registry-host 1`] = `
+#### \`replace-registry-host\`
+
+* Default: "npmjs"
+* Type: "npmjs", "never", "always", or String
+
+Defines behavior for replacing the registry host in a lockfile with the
+configured registry.
+
+The default behavior is to replace package dist URLs from the default
+registry (https://registry.npmjs.org) to the configured registry. If set to
+"never", then use the registry value. If set to "always", then replace the
+registry host with the configured host every time.
+
+You may also specify a bare hostname (e.g., "registry.npmjs.org").
 `
 
 exports[`test/lib/utils/config/definitions.js TAP > config description for save 1`] = `

--- a/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
@@ -1266,6 +1266,24 @@ The base URL of the npm registry.
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->
 
+#### \`replace-registry-host\`
+
+* Default: "npmjs"
+* Type: "npmjs", "never", "always", or String
+
+Defines behavior for replacing the registry host in a lockfile with the
+configured registry.
+
+The default behavior is to replace package dist URLs from the default
+registry (https://registry.npmjs.org) to the configured registry. If set to
+"never", then use the registry value. If set to "always", then replace the
+registry host with the configured host every time.
+
+You may also specify a bare hostname (e.g., "registry.npmjs.org").
+
+<!-- automatically generated, do not edit manually -->
+<!-- see lib/utils/config/definitions.js -->
+
 #### \`save\`
 
 * Default: \`true\` unless when using \`npm update\` where it defaults to \`false\`

--- a/workspaces/arborist/lib/arborist/index.js
+++ b/workspaces/arborist/lib/arborist/index.js
@@ -74,8 +74,12 @@ class Arborist extends Base {
       cache: options.cache || `${homedir()}/.npm/_cacache`,
       packumentCache: options.packumentCache || new Map(),
       workspacesEnabled: options.workspacesEnabled !== false,
+      replaceRegistryHost: options.replaceRegistryHost,
       lockfileVersion: lockfileVersion(options.lockfileVersion),
     }
+    this.replaceRegistryHost = this.options.replaceRegistryHost =
+      (!this.options.replaceRegistryHost || this.options.replaceRegistryHost === 'npmjs') ?
+        'registry.npmjs.org' : this.options.replaceRegistryHost
 
     this[_workspacesEnabled] = this.options.workspacesEnabled
 

--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -712,13 +712,19 @@ module.exports = cls => class Reifier extends cls {
   [_registryResolved] (resolved) {
     // the default registry url is a magic value meaning "the currently
     // configured registry".
+    // `resolved` must never be falsey.
     //
     // XXX: use a magic string that isn't also a valid value, like
     // ${REGISTRY} or something.  This has to be threaded through the
     // Shrinkwrap and Node classes carefully, so for now, just treat
     // the default reg as the magical animal that it has been.
-    return resolved && resolved
-      .replace(/^https?:\/\/registry\.npmjs\.org\//, this.registry)
+    const resolvedURL = new URL(resolved)
+    if ((this.options.replaceRegistryHost === resolvedURL.hostname)
+      || this.options.replaceRegistryHost === 'always') {
+      // this.registry always has a trailing slash
+      resolved = `${this.registry.slice(0, -1)}${resolvedURL.pathname}${resolvedURL.searchParams}`
+    }
+    return resolved
   }
 
   // bundles are *sort of* like shrinkwraps, in that the branch is defined

--- a/workspaces/arborist/test/arborist/index.js
+++ b/workspaces/arborist/test/arborist/index.js
@@ -236,3 +236,12 @@ t.test('lockfileVersion config validation', async t => {
     message: 'Invalid lockfileVersion config: banana',
   })
 })
+
+t.test('valid replaceRegistryHost values', t => {
+  t.equal(new Arborist({ replaceRegistryHost: 'registry.garbage.com' }).options.replaceRegistryHost, 'registry.garbage.com')
+  t.equal(new Arborist({ replaceRegistryHost: 'npmjs' }).options.replaceRegistryHost, 'registry.npmjs.org')
+  t.equal(new Arborist({ replaceRegistryHost: undefined }).options.replaceRegistryHost, 'registry.npmjs.org')
+  t.equal(new Arborist({ replaceRegistryHost: 'always' }).options.replaceRegistryHost, 'always')
+  t.equal(new Arborist({ replaceRegistryHost: 'never' }).options.replaceRegistryHost, 'never')
+  t.end()
+})

--- a/workspaces/arborist/test/fixtures/tnock.js
+++ b/workspaces/arborist/test/fixtures/tnock.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const nock = require('nock')
+
+module.exports = tnock
+function tnock (t, host) {
+  const server = nock(host)
+  nock.disableNetConnect()
+  t.teardown(function () {
+    nock.enableNetConnect()
+    server.done()
+  })
+  return server
+}


### PR DESCRIPTION
Dist references in a lockfile currently have their host replaced with the configured registry when it is https://registry.npmjs.org, but not otherwise. Between this PR and a pacote PR, we added the options or `never` replacing the host or `always` replacing the host, in addition to the current behavior of `npmjs`.
