### PR TITLE
chore: update action secrets + bot info

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           # gh cli uses these env vars for owner/repo/token
           GH_REPO: "npm/benchmarks"
-          GITHUB_TOKEN: ${{ secrets.NPM_BENCHMARKS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BENCHMARKS_DISPATCH_TOKEN }}
         run: |
           if [[ "$GITHUB_TOKEN" == "" ]]; then
             echo "No auth - from fork pull request, exiting"
@@ -68,7 +68,7 @@ jobs:
           github.event_name == 'issue_comment' &&
           github.event.issue.pull_request &&
           github.event.issue.state == 'open' &&
-          startsWith(github.event.comment.body, '@npm-robot benchmark this')
+          startsWith(github.event.comment.body, '@npm-cli-bot benchmark this')
         env:
           # gh cli uses this env var as the token
           GITHUB_TOKEN: ${{ secrets.NPM_BENCHMARKS_TOKEN }}

--- a/.github/workflows/create-cli-deps-pr.yml
+++ b/.github/workflows/create-cli-deps-pr.yml
@@ -21,22 +21,22 @@ jobs:
           fetch-depth: 0
           ref: master
           repository: npm/node
-          token: ${{ secrets.NPM_ROBOT_USER_PAT }}
+          token: ${{ secrets.NODE_PULL_REQUEST_TOKEN }}
       - name: Setup git user
         run: |
-          git config --global user.email "npm team"
-          git config --global user.name "ops+robot@npmjs.com"
+          git config --global user.email "npm CLI robot"
+          git config --global user.name "npm-cli+bot@github.com"
       - name: Sync upstream changes
         uses: aormsby/Fork-Sync-With-Upstream-action@v3.2
         with:
           target_sync_branch: master
-          target_repo_token: ${{ secrets.NPM_ROBOT_USER_PAT }}
+          target_repo_token: ${{ secrets.NODE_PULL_REQUEST_TOKEN }}
           upstream_sync_branch: master
           upstream_sync_repo: nodejs/node
           upstream_pull_args: --ff-only
       - name: Run dependency updates and create PR
         env:
-          GITHUB_TOKEN: ${{ secrets.NPM_ROBOT_USER_PAT }}
+          GITHUB_TOKEN: ${{ secrets.NODE_PULL_REQUEST_TOKEN }}
         run: |
           base_dir="$( pwd )"/ 
           dry_run="${{ github.event.inputs.dryRun }}"

--- a/.mailmap
+++ b/.mailmap
@@ -56,6 +56,7 @@ Michael Hayes <michael@hayes.io> <mhayes@newrelic.com>
 Misha Kaletsky <misha.kaletsky@gmail.com>
 Nicolas Morel <marsup@gmail.com>
 npm team <ops+robot@npmjs.com> <ops+npm-cli@npmjs.com>
+npm CLI robot <npm-cli+bot@github.com>
 Olivier Melcher <olivier.melcher@gmail.com>
 Ra'Shaun Stovall <rashaunstovall@gmail.com>
 Rebecca Turner <me@re-becca.org> <rebecca@npmjs.com>

--- a/scripts/update-authors.sh
+++ b/scripts/update-authors.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-git log --use-mailmap --reverse --format='%aN <%aE>' | grep -v "\[bot\]" | grep -v "^npm team" | perl -wnE '
+git log --use-mailmap --reverse --format='%aN <%aE>' | grep -v -e "\[bot\]" -e "^npm team" -e "^npm CLI robot" | perl -wnE '
 BEGIN {
   say "# Authors sorted by whether or not they\x27re me";
 }


### PR DESCRIPTION
the `ci` and `release-please` workflows will have the bot account updated through a patch to `@npmcli/template-oss`
