### PR TITLE
fix: pass prefix and workspaces to libnpmpack

### DIFF
--- a/lib/commands/pack.js
+++ b/lib/commands/pack.js
@@ -44,7 +44,11 @@ class Pack extends BaseCommand {
     // noise generated during packing
     const tarballs = []
     for (const { arg, manifest } of manifests) {
-      const tarballData = await libpack(arg, this.npm.flatOptions)
+      const tarballData = await libpack(arg, {
+        ...this.npm.flatOptions,
+        prefix: this.npm.localPrefix,
+        workspaces: this.workspacePaths,
+      })
       const pkgContents = await getContents(manifest, tarballData)
       tarballs.push(pkgContents)
     }

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -80,7 +80,12 @@ class Publish extends BaseCommand {
     }
 
     // we pass dryRun: true to libnpmpack so it doesn't write the file to disk
-    const tarballData = await pack(spec, { ...opts, dryRun: true })
+    const tarballData = await pack(spec, {
+      ...opts,
+      dryRun: true,
+      prefix: this.npm.localPrefix,
+      workspaces: this.workspacePaths,
+    })
     const pkgContents = await getContents(manifest, tarballData)
 
     // The purpose of re-reading the manifest is in case it changed,


### PR DESCRIPTION
this change will have no effect until https://github.com/npm/npm-packlist/pull/102 lands here, but allows us to fix the bugs where we a) miss gitignore files in a workspace root when packing a workspace, and b) pack workspaces as part of the workspace root when that's what we're packing
