### PR TITLE
docs: update roadmap link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ npm <command>
 * [**Documentation**](https://docs.npmjs.com/) - Official docs & how-tos for all things **npm**
     * Note: you can also search docs locally with `npm help-search <query>`
 * [**Bug Tracker**](https://github.com/npm/cli/issues) - Search or submit bugs against the CLI
-* [**Roadmap**](https://github.com/npm/roadmap) - Track & follow along with our public roadmap
+* [**Roadmap**](https://github.com/orgs/github/projects/4247/views/1?filterQuery=npm) - Track & follow along with our public roadmap
 * [**Feedback**](https://github.com/npm/feedback) - Contribute ideas & discussion around the npm registry, website & CLI
 * [**RFCs**](https://github.com/npm/rfcs) - Contribute ideas & specifications for the API/design of the npm CLI
 * [**Service Status**](https://status.npmjs.org/) - Monitor the current status & see incident reports for the website & registry


### PR DESCRIPTION
<!-- What / Why -->
Updated the roadmap link in README.md

## References
[Old Raodmap](https://github.com/npm/roadmap)
[New Raodmap](https://github.com/orgs/github/projects/4247/views/1?filterQuery=npm)
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
