### PR TITLE
chore(fix): replace with exact comparison function

### DIFF
--- a/test/lib/commands/exec.js
+++ b/test/lib/commands/exec.js
@@ -473,7 +473,7 @@ t.test('npm exec foo, not present locally but in central loc', async t => {
   await exec.exec(['foo', 'one arg', 'two arg'])
   t.strictSame(MKDIRPS, [installDir], 'need to make install dir')
   t.match(ARB_CTOR, [{ path }])
-  t.match(ARB_REIFY, [], 'no need to install again, already there')
+  t.strictSame(ARB_REIFY, [], 'no need to install again, already there')
   t.equal(PROGRESS_ENABLED, true, 'progress re-enabled')
   const PATH = `${resolve(installDir, 'node_modules', '.bin')}${delimiter}${process.env.PATH}`
   t.match(RUN_SCRIPTS, [


### PR DESCRIPTION
`t.match()` never throws an error for empty array.


## References
No issue related
