### PR TITLE
fix(libnpmexec): fix bug not install latest pkg

### DIFF
--- a/workspaces/libnpmexec/lib/index.js
+++ b/workspaces/libnpmexec/lib/index.js
@@ -166,7 +166,7 @@ const exec = async (opts) => {
     const add = manis
       .filter(mani => !mani[_localManifest])
       .filter(filterMissingPackagesFromInstallDir)
-      .map(mani => mani._from)
+      .map(mani => mani._id ? mani._id : mani._from)
       .sort((a, b) => a.localeCompare(b, 'en'))
 
     // no need to install if already present

--- a/workspaces/libnpmexec/lib/index.js
+++ b/workspaces/libnpmexec/lib/index.js
@@ -166,7 +166,7 @@ const exec = async (opts) => {
     const add = manis
       .filter(mani => !mani[_localManifest])
       .filter(filterMissingPackagesFromInstallDir)
-      .map(mani => mani._id ? mani._id : mani._from)
+      .map(mani => mani._id || mani._from)
       .sort((a, b) => a.localeCompare(b, 'en'))
 
     // no need to install if already present

--- a/workspaces/libnpmexec/test/index.js
+++ b/workspaces/libnpmexec/test/index.js
@@ -657,7 +657,7 @@ t.test('no prompt if CI, multiple packages', async t => {
       warn (title, msg) {
         t.equal(title, 'exec', 'should warn exec title')
         const expected = 'The following packages were not found and will be ' +
-          'installed: @ruyadorno/create-index, @ruyadorno/create-test'
+          'installed: @ruyadorno/create-index@1.0.0, @ruyadorno/create-test@1.0.0'
         t.equal(msg, expected, 'should warn installing pkg')
       },
     },


### PR DESCRIPTION
After the major version of the package is changed (e.g. 0.9 > 1.0 > 2.0)
npx just asks if you want to install it every time 
It doesn't actually install.

## References
Fixes #4871
Fixes #4619
