### PR TITLE
docs: fix broken link in changelog

### DIFF
--- a/changelogs/CHANGELOG-7.md
+++ b/changelogs/CHANGELOG-7.md
@@ -1069,7 +1069,7 @@
 
 ### DOCUMENTATION
 
-* [`efdd7dd44`](https://github.com/npm/cli/commit/efdd7dd4427a0ee856c18aab1df2d3d30a307997)
+* [`72a7eeb49`](https://github.com/npm/cli/commit/72a7eeb493e0e71cba3af36490cb245030ed31a3)
   Remove unused and incorrectly documented `--always-auth` config definition
   ([@isaacs](https://github.com/isaacs))
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
The old link for the `--always-auth` flag (https://github.com/npm/cli/commit/efdd7dd4427a0ee856c18aab1df2d3d30a307997) was broken. I found the correct sha in `git log v7.11.0..v7.11.1`.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
