### PR TITLE
fix: add global getter to npm class

### DIFF
--- a/lib/commands/bin.js
+++ b/lib/commands/bin.js
@@ -15,7 +15,7 @@ class Bin extends BaseCommand {
   async exec (args) {
     const b = this.npm.bin
     this.npm.output(b)
-    if (this.npm.config.get('global') && !path.split(delimiter).includes(b)) {
+    if (this.npm.global && !path.split(delimiter).includes(b)) {
       log.error('bin', '(not in PATH env variable)')
     }
   }

--- a/lib/commands/ci.js
+++ b/lib/commands/ci.js
@@ -21,7 +21,7 @@ class CI extends ArboristWorkspaceCmd {
   ]
 
   async exec () {
-    if (this.npm.config.get('global')) {
+    if (this.npm.global) {
       throw Object.assign(new Error('`npm ci` does not work for global packages'), {
         code: 'ECIGLOBAL',
       })

--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -276,7 +276,7 @@ ${defData}
       msg.push('')
     }
 
-    if (!this.npm.config.get('global')) {
+    if (!this.npm.global) {
       const pkgPath = resolve(this.npm.prefix, 'package.json')
       const pkg = await rpj(pkgPath).catch(() => ({}))
 

--- a/lib/commands/dedupe.js
+++ b/lib/commands/dedupe.js
@@ -22,7 +22,7 @@ class Dedupe extends ArboristWorkspaceCmd {
   ]
 
   async exec (args) {
-    if (this.npm.config.get('global')) {
+    if (this.npm.global) {
       const er = new Error('`npm dedupe` does not work in global mode.')
       er.code = 'EDEDUPEGLOBAL'
       throw er

--- a/lib/commands/diff.js
+++ b/lib/commands/diff.js
@@ -50,7 +50,7 @@ class Diff extends BaseCommand {
     // node_modules is sometimes under ./lib, and in global mode we're only ever
     // walking through node_modules (because we will have been given a package
     // name already)
-    if (this.npm.config.get('global')) {
+    if (this.npm.global) {
       this.top = resolve(this.npm.globalDir, '..')
     } else {
       this.top = this.prefix

--- a/lib/commands/dist-tag.js
+++ b/lib/commands/dist-tag.js
@@ -148,7 +148,7 @@ class DistTag extends BaseCommand {
 
   async list (spec, opts) {
     if (!spec) {
-      if (this.npm.config.get('global')) {
+      if (this.npm.global) {
         throw this.usageError()
       }
       const { name } = await readPackage(path.resolve(this.npm.prefix, 'package.json'))

--- a/lib/commands/fund.js
+++ b/lib/commands/fund.js
@@ -45,7 +45,7 @@ class Fund extends ArboristWorkspaceCmd {
       throw err
     }
 
-    if (this.npm.config.get('global')) {
+    if (this.npm.global) {
       const err = new Error('`npm fund` does not support global packages')
       err.code = 'EFUNDGLOBAL'
       throw err

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -106,7 +106,7 @@ class Install extends ArboristWorkspaceCmd {
     // the /path/to/node_modules/..
     const globalTop = resolve(this.npm.globalDir, '..')
     const ignoreScripts = this.npm.config.get('ignore-scripts')
-    const isGlobalInstall = this.npm.config.get('global')
+    const isGlobalInstall = this.npm.global
     const where = isGlobalInstall ? globalTop : this.npm.prefix
     const forced = this.npm.config.get('force')
     const scriptShell = this.npm.config.get('script-shell') || undefined

--- a/lib/commands/link.js
+++ b/lib/commands/link.js
@@ -43,7 +43,7 @@ class Link extends ArboristWorkspaceCmd {
   }
 
   async exec (args) {
-    if (this.npm.config.get('global')) {
+    if (this.npm.global) {
       throw Object.assign(
         new Error(
           'link should never be --global.\n' +

--- a/lib/commands/ls.js
+++ b/lib/commands/ls.js
@@ -52,7 +52,7 @@ class LS extends ArboristWorkspaceCmd {
     const all = this.npm.config.get('all')
     const color = this.npm.color
     const depth = this.npm.config.get('depth')
-    const global = this.npm.config.get('global')
+    const global = this.npm.global
     const json = this.npm.config.get('json')
     const link = this.npm.config.get('link')
     const long = this.npm.config.get('long')

--- a/lib/commands/outdated.js
+++ b/lib/commands/outdated.js
@@ -27,7 +27,7 @@ class Outdated extends ArboristWorkspaceCmd {
 
   async exec (args) {
     const global = path.resolve(this.npm.globalDir, '..')
-    const where = this.npm.config.get('global')
+    const where = this.npm.global
       ? global
       : this.npm.prefix
 
@@ -140,7 +140,7 @@ class Outdated extends ArboristWorkspaceCmd {
 
   getEdgesOut (node) {
     // TODO: normalize usage of edges and avoid looping through nodes here
-    if (this.npm.config.get('global')) {
+    if (this.npm.global) {
       for (const child of node.children.values()) {
         this.trackEdge(child)
       }
@@ -166,7 +166,7 @@ class Outdated extends ArboristWorkspaceCmd {
   }
 
   getWorkspacesEdges (node) {
-    if (this.npm.config.get('global')) {
+    if (this.npm.global) {
       return
     }
 

--- a/lib/commands/owner.js
+++ b/lib/commands/owner.js
@@ -50,7 +50,7 @@ class Owner extends BaseCommand {
 
     // reaches registry in order to autocomplete rm
     if (argv[2] === 'rm') {
-      if (this.npm.config.get('global')) {
+      if (this.npm.global) {
         return []
       }
       const { name } = await readJson(resolve(this.npm.prefix, 'package.json'))
@@ -126,7 +126,7 @@ class Owner extends BaseCommand {
 
   async getPkg (prefix, pkg) {
     if (!pkg) {
-      if (this.npm.config.get('global')) {
+      if (this.npm.global) {
         throw this.usageError()
       }
       const { name } = await readJson(resolve(prefix, 'package.json'))

--- a/lib/commands/pkg.js
+++ b/lib/commands/pkg.js
@@ -29,7 +29,7 @@ class Pkg extends BaseCommand {
       this.prefix = prefix
     }
 
-    if (this.npm.config.get('global')) {
+    if (this.npm.global) {
       throw Object.assign(
         new Error(`There's no package.json file to manage on global mode`),
         { code: 'EPKGGLOBAL' }

--- a/lib/commands/rebuild.js
+++ b/lib/commands/rebuild.js
@@ -26,7 +26,7 @@ class Rebuild extends ArboristWorkspaceCmd {
 
   async exec (args) {
     const globalTop = resolve(this.npm.globalDir, '..')
-    const where = this.npm.config.get('global') ? globalTop : this.npm.prefix
+    const where = this.npm.global ? globalTop : this.npm.prefix
     const arb = new Arborist({
       ...this.npm.flatOptions,
       path: where,

--- a/lib/commands/shrinkwrap.js
+++ b/lib/commands/shrinkwrap.js
@@ -15,7 +15,7 @@ class Shrinkwrap extends BaseCommand {
     //
     // loadVirtual, fall back to loadActual
     // rename shrinkwrap file type, and tree.meta.save()
-    if (this.npm.config.get('global')) {
+    if (this.npm.global) {
       const er = new Error('`npm shrinkwrap` does not work for global packages')
       er.code = 'ESHRINKWRAPGLOBAL'
       throw er

--- a/lib/commands/uninstall.js
+++ b/lib/commands/uninstall.js
@@ -21,13 +21,12 @@ class Uninstall extends ArboristWorkspaceCmd {
 
   async exec (args) {
     // the /path/to/node_modules/..
-    const global = this.npm.config.get('global')
-    const path = global
+    const path = this.npm.global
       ? resolve(this.npm.globalDir, '..')
       : this.npm.localPrefix
 
     if (!args.length) {
-      if (!global) {
+      if (!this.npm.global) {
         throw new Error('Must provide a package name to remove')
       } else {
         let pkg

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -39,7 +39,7 @@ class Update extends ArboristWorkspaceCmd {
   async exec (args) {
     const update = args.length === 0 ? true : args
     const global = path.resolve(this.npm.globalDir, '..')
-    const where = this.npm.config.get('global')
+    const where = this.npm.global
       ? global
       : this.npm.prefix
 

--- a/lib/commands/view.js
+++ b/lib/commands/view.js
@@ -91,7 +91,7 @@ class View extends BaseCommand {
     const local = /^\.@/.test(pkg) || pkg === '.'
 
     if (local) {
-      if (this.npm.config.get('global')) {
+      if (this.npm.global) {
         throw new Error('Cannot use view command in global mode.')
       }
       const dir = this.npm.prefix

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -129,7 +129,6 @@ class Npm extends EventEmitter {
         })
     }
 
-    const isGlobal = this.config.get('global')
     const workspacesEnabled = this.config.get('workspaces')
     // if cwd is a workspace, the default is set to [that workspace]
     const implicitWorkspace = this.config.get('workspace', 'default').length > 0
@@ -160,7 +159,7 @@ class Npm extends EventEmitter {
       execPromise = Promise.reject(
         new Error('Can not use --no-workspaces and --workspace at the same time'))
     } else if (filterByWorkspaces) {
-      if (isGlobal) {
+      if (this.global) {
         execPromise = Promise.reject(new Error('Workspaces not supported for global packages'))
       } else {
         execPromise = command.execWorkspaces(args, workspacesFilters)
@@ -333,6 +332,10 @@ class Npm extends EventEmitter {
     return this.#chalk
   }
 
+  get global () {
+    return this.config.get('global') || this.config.get('location') === 'global'
+  }
+
   get logColor () {
     return this.flatOptions.logColor
   }
@@ -409,7 +412,7 @@ class Npm extends EventEmitter {
   }
 
   get dir () {
-    return this.config.get('global') ? this.globalDir : this.localDir
+    return this.global ? this.globalDir : this.localDir
   }
 
   get globalBin () {
@@ -422,15 +425,15 @@ class Npm extends EventEmitter {
   }
 
   get bin () {
-    return this.config.get('global') ? this.globalBin : this.localBin
+    return this.global ? this.globalBin : this.localBin
   }
 
   get prefix () {
-    return this.config.get('global') ? this.globalPrefix : this.localPrefix
+    return this.global ? this.globalPrefix : this.localPrefix
   }
 
   set prefix (r) {
-    const k = this.config.get('global') ? 'globalPrefix' : 'localPrefix'
+    const k = this.global ? 'globalPrefix' : 'localPrefix'
     this[k] = r
   }
 

--- a/test/fixtures/mock-npm.js
+++ b/test/fixtures/mock-npm.js
@@ -224,6 +224,10 @@ class MockNpm {
     }
   }
 
+  get global () {
+    return this.config.get('global') || this.config.get('location') === 'global'
+  }
+
   output (...msg) {
     if (this.base.output) {
       return this.base.output(msg)

--- a/test/lib/commands/outdated.js
+++ b/test/lib/commands/outdated.js
@@ -343,7 +343,9 @@ t.test('should return if no outdated deps', async t => {
   })
 
   await outdated(testDir, {
-    global: false,
+    config: {
+      global: false,
+    },
   }).exec([])
   t.equal(logs.length, 0, 'no logs')
 })
@@ -369,7 +371,9 @@ t.test('throws if error with a dep', async t => {
 
   await t.rejects(
     outdated(testDir, {
-      global: false,
+      config: {
+        global: false,
+      },
     }).exec([]),
     'There is an error with this package.'
   )
@@ -388,7 +392,9 @@ t.test('should skip missing non-prod deps', async t => {
   })
 
   await outdated(testDir, {
-    global: false,
+    config: {
+      global: false,
+    },
   }).exec([])
   t.equal(logs.length, 0, 'no logs')
 })


### PR DESCRIPTION
currently everywhere we were doing `this.npm.config.get('global')` was not accounting for the `location` flag, so keeping in tradition with our other "derived" configs i 
attached it as a getter to the npm class and changed all the references to use the getter
