### PR TITLE
chore(benchmarks): fix secret name in benchmark workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           # gh cli uses these env vars for owner/repo/token
           GH_REPO: "npm/benchmarks"
-          GITHUB_TOKEN: ${{ secrets.BENCHMARKS_DISPATCH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BENCHMARK_DISPATCH_TOKEN }}
         run: |
           if [[ "$GITHUB_TOKEN" == "" ]]; then
             echo "No auth - from fork pull request, exiting"
@@ -71,7 +71,7 @@ jobs:
           startsWith(github.event.comment.body, '@npm-cli-bot benchmark this')
         env:
           # gh cli uses this env var as the token
-          GITHUB_TOKEN: ${{ secrets.NPM_BENCHMARKS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BENCHMARK_DISPATCH_TOKEN }}
         run: |
           OWNER="${{ github.event.repository.owner.login }}"
           REPO="${{ github.event.repository.name }}"


### PR DESCRIPTION
this was my fault, typoed the first instance and didn't even update the second one. this should get our benchmarks working again, i hope!
