### PR TITLE
chore(arborist): update readme link

### DIFF
--- a/workspaces/arborist/README.md
+++ b/workspaces/arborist/README.md
@@ -9,7 +9,7 @@ Inspect and manage `node_modules` trees.
 ![a tree with the word ARBORIST superimposed on it](https://raw.githubusercontent.com/npm/arborist/main/docs/logo.svg?sanitize=true)
 
 There's more documentation [in the docs
-folder](https://github.com/npm/arborist/tree/main/docs).
+folder](https://github.com/npm/cli/tree/latest/workspaces/arborist/docs).
 
 ## USAGE
 


### PR DESCRIPTION
Update the link in the arborist README, which used to point to the previous repository, now archived.