### PR TITLE
feat: prompt before opening web-login URL when performing `login`/`adduser`

### DIFF
--- a/lib/auth/legacy.js
+++ b/lib/auth/legacy.js
@@ -59,13 +59,11 @@ const login = async (npm, opts) => {
   try {
     res = await profile.login(openerPromise, loginPrompter, opts)
   } catch (err) {
-    const needsMoreInfo = !(
-      opts &&
+    const needsMoreInfo = !(opts &&
       opts.creds &&
       opts.creds.username &&
       opts.creds.password &&
-      opts.creds.email
-    )
+      opts.creds.email)
     if (err.code === 'EOTP') {
       res = await requestOTP()
     } else if (needsMoreInfo) {

--- a/lib/auth/legacy.js
+++ b/lib/auth/legacy.js
@@ -3,7 +3,7 @@ const log = require('../utils/log-shim')
 const openUrlPrompt = require('../utils/open-url-prompt.js')
 const read = require('../utils/read-user-info.js')
 
-const loginPrompter = async creds => {
+const loginPrompter = async (creds) => {
   creds.username = await read.username('Username:', creds.username)
   creds.password = await read.password('Password:', creds.password)
   creds.email = await read.email('Email: (this IS public) ', creds.email)
@@ -15,9 +15,15 @@ const login = async (npm, opts) => {
   let res
 
   const requestOTP = async () => {
-    const otp = await read.otp('Enter one-time password: ')
+    const otp = await read.otp(
+      'Enter one-time password: '
+    )
 
-    return profile.loginCouch(opts.creds.username, opts.creds.password, { ...opts, otp })
+    return profile.loginCouch(
+      opts.creds.username,
+      opts.creds.password,
+      { ...opts, otp }
+    )
   }
 
   const addNewUser = async () => {

--- a/lib/auth/legacy.js
+++ b/lib/auth/legacy.js
@@ -1,9 +1,9 @@
 const profile = require('npm-profile')
 const log = require('../utils/log-shim')
-const openUrl = require('../utils/open-url.js')
+const openUrlPrompt = require('../utils/open-url-prompt.js')
 const read = require('../utils/read-user-info.js')
 
-const loginPrompter = async (creds) => {
+const loginPrompter = async creds => {
   creds.username = await read.username('Username:', creds.username)
   creds.password = await read.password('Password:', creds.password)
   creds.email = await read.email('Email: (this IS public) ', creds.email)
@@ -15,15 +15,9 @@ const login = async (npm, opts) => {
   let res
 
   const requestOTP = async () => {
-    const otp = await read.otp(
-      'Enter one-time password: '
-    )
+    const otp = await read.otp('Enter one-time password: ')
 
-    return profile.loginCouch(
-      opts.creds.username,
-      opts.creds.password,
-      { ...opts, otp }
-    )
+    return profile.loginCouch(opts.creds.username, opts.creds.password, { ...opts, otp })
   }
 
   const addNewUser = async () => {
@@ -47,15 +41,19 @@ const login = async (npm, opts) => {
     return newUser
   }
 
-  const openerPromise = (url) => openUrl(npm, url, 'to complete your login please visit')
+  const openerPromise = (url, emitter) =>
+    openUrlPrompt(npm, 'Authenticate your account at', url, emitter)
+
   try {
     res = await profile.login(openerPromise, loginPrompter, opts)
   } catch (err) {
-    const needsMoreInfo = !(opts &&
+    const needsMoreInfo = !(
+      opts &&
       opts.creds &&
       opts.creds.username &&
       opts.creds.password &&
-      opts.creds.email)
+      opts.creds.email
+    )
     if (err.code === 'EOTP') {
       res = await requestOTP()
     } else if (needsMoreInfo) {

--- a/lib/auth/legacy.js
+++ b/lib/auth/legacy.js
@@ -42,7 +42,13 @@ const login = async (npm, opts) => {
   }
 
   const openerPromise = (url, emitter) =>
-    openUrlPrompt(npm, 'Authenticate your account at', url, emitter)
+    openUrlPrompt(
+      npm,
+      url,
+      'Authenticate your account at',
+      'Press ENTER to open in the browser...',
+      emitter
+    )
 
   try {
     res = await profile.login(openerPromise, loginPrompter, opts)

--- a/lib/utils/open-url-prompt.js
+++ b/lib/utils/open-url-prompt.js
@@ -28,12 +28,12 @@ const promptOpen = async (npm, url, title, prompt, emitter) => {
     return
   }
 
-  const tryOpen = await new Promise(resolve => {
-    const rl = readline.createInterface({
-      input: process.stdin,
-      output: process.stdout,
-    })
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  })
 
+  const tryOpen = await new Promise(resolve => {
     rl.question(prompt, () => {
       resolve(true)
     })

--- a/lib/utils/open-url-prompt.js
+++ b/lib/utils/open-url-prompt.js
@@ -3,31 +3,38 @@ const opener = require('opener')
 
 const rl = readline.createInterface({
   input: process.stdin,
-  output: process.stdout,
+  output: process.stdout
 })
 
-const interactive = process.stdin.isTTY && process.stdout.isTTY
+function print(npm, title, url) {
+  const json = npm.config.get('json')
+
+  const message = json ? JSON.stringify({title, url}) : `${title}:\n${url}`
+
+  npm.output(message)
+}
 
 // Prompt to open URL in browser if possible
-const promptOpen = async (npm, prompt, url, emitter) => {
+const promptOpen = async (npm, url, title, prompt, emitter) => {
   const browser = npm.config.get('browser')
+  const isInteractive = process.stdin.isTTY === true && process.stdout.isTTY === true
 
-  function printPrompt (title, url) {
-    const json = npm.config.get('json')
-
-    const message = json ? JSON.stringify({ title, url }) : `${title}:\n${url}`
-
-    npm.output(message)
+  try {
+    if (!/^https?:$/.test(new URL(url).protocol)) {
+      throw new Error()
+    }
+  } catch (_) {
+    throw new Error('Invalid URL: ' + url)
   }
 
-  printPrompt(npm, prompt, url)
+  print(npm, title, url)
 
-  if (browser === false || !interactive) {
+  if (browser === false || !isInteractive) {
     return
   }
 
   const tryOpen = await new Promise(resolve => {
-    rl.question('Press ENTER to open in the browser...', () => {
+    rl.question(prompt, () => {
       resolve(true)
     })
 
@@ -49,7 +56,7 @@ const promptOpen = async (npm, prompt, url, emitter) => {
 
   const command = browser === true ? null : browser
   await new Promise((resolve, reject) => {
-    opener(url, { command }, err => {
+    opener(url, {command}, err => {
       if (err) {
         return reject(err)
       }

--- a/lib/utils/open-url-prompt.js
+++ b/lib/utils/open-url-prompt.js
@@ -1,11 +1,6 @@
 const readline = require('readline')
 const opener = require('opener')
 
-const rl = readline.createInterface({
-  input: process.stdin,
-  output: process.stdout,
-})
-
 function print (npm, title, url) {
   const json = npm.config.get('json')
 
@@ -34,6 +29,11 @@ const promptOpen = async (npm, url, title, prompt, emitter) => {
   }
 
   const tryOpen = await new Promise(resolve => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    })
+
     rl.question(prompt, () => {
       resolve(true)
     })

--- a/lib/utils/open-url-prompt.js
+++ b/lib/utils/open-url-prompt.js
@@ -3,13 +3,13 @@ const opener = require('opener')
 
 const rl = readline.createInterface({
   input: process.stdin,
-  output: process.stdout
+  output: process.stdout,
 })
 
-function print(npm, title, url) {
+function print (npm, title, url) {
   const json = npm.config.get('json')
 
-  const message = json ? JSON.stringify({title, url}) : `${title}:\n${url}`
+  const message = json ? JSON.stringify({ title, url }) : `${title}:\n${url}`
 
   npm.output(message)
 }
@@ -56,7 +56,7 @@ const promptOpen = async (npm, url, title, prompt, emitter) => {
 
   const command = browser === true ? null : browser
   await new Promise((resolve, reject) => {
-    opener(url, {command}, err => {
+    opener(url, { command }, err => {
       if (err) {
         return reject(err)
       }

--- a/lib/utils/open-url-prompt.js
+++ b/lib/utils/open-url-prompt.js
@@ -1,0 +1,60 @@
+const readline = require('readline')
+const opener = require('opener')
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+})
+
+const interactive = process.stdin.isTTY && process.stdout.isTTY
+
+function printPrompt (npm, title, url) {
+  const json = npm.config.get('json')
+
+  const message = json ? JSON.stringify({ title, url }) : `${title}: ${url}`
+
+  npm.output(message)
+}
+
+// Prompt to open URL in browser if possible
+const promptOpen = async (npm, prompt, url, emitter) => {
+  const browser = npm.config.get('browser')
+
+  printPrompt(npm, prompt, url)
+
+  if (browser === false || !interactive) {
+    return
+  }
+
+  const tryOpen = await new Promise(resolve => {
+    rl.question('Press ENTER to open in the browser...', () => {
+      resolve(true)
+    })
+
+    emitter?.addListener('abort', () => {
+      rl.close()
+
+      // clear the prompt line
+      npm.output('')
+
+      resolve(false)
+    })
+  })
+
+  if (!tryOpen) {
+    return
+  }
+
+  const command = browser === true ? null : browser
+  await new Promise((resolve, reject) => {
+    opener(url, { command }, err => {
+      if (err) {
+        return reject(err)
+      }
+
+      return resolve()
+    })
+  })
+}
+
+module.exports = promptOpen

--- a/lib/utils/open-url-prompt.js
+++ b/lib/utils/open-url-prompt.js
@@ -14,14 +14,15 @@ const promptOpen = async (npm, prompt, url, emitter) => {
 
   function printPrompt (title, url) {
     const json = npm.config.get('json')
-    const message = json ? JSON.stringify({ title, url }) : `${title}: ${url}`
+
+    const message = json ? JSON.stringify({ title, url }) : `${title}:\n${url}`
 
     npm.output(message)
   }
 
   printPrompt(npm, prompt, url)
 
-  if (browser === false) {
+  if (browser === false || !interactive) {
     return
   }
 

--- a/lib/utils/open-url-prompt.js
+++ b/lib/utils/open-url-prompt.js
@@ -8,21 +8,20 @@ const rl = readline.createInterface({
 
 const interactive = process.stdin.isTTY && process.stdout.isTTY
 
-function printPrompt (npm, title, url) {
-  const json = npm.config.get('json')
-
-  const message = json ? JSON.stringify({ title, url }) : `${title}: ${url}`
-
-  npm.output(message)
-}
-
 // Prompt to open URL in browser if possible
 const promptOpen = async (npm, prompt, url, emitter) => {
   const browser = npm.config.get('browser')
 
+  function printPrompt (title, url) {
+    const json = npm.config.get('json')
+    const message = json ? JSON.stringify({ title, url }) : `${title}: ${url}`
+
+    npm.output(message)
+  }
+
   printPrompt(npm, prompt, url)
 
-  if (browser === false || !interactive) {
+  if (browser === false) {
     return
   }
 
@@ -31,14 +30,16 @@ const promptOpen = async (npm, prompt, url, emitter) => {
       resolve(true)
     })
 
-    emitter?.addListener('abort', () => {
-      rl.close()
+    if (emitter && emitter.addListener) {
+      emitter.addListener('abort', () => {
+        rl.close()
 
-      // clear the prompt line
-      npm.output('')
+        // clear the prompt line
+        npm.output('')
 
-      resolve(false)
-    })
+        resolve(false)
+      })
+    }
   })
 
   if (!tryOpen) {

--- a/tap-snapshots/test/lib/utils/open-url-prompt.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/open-url-prompt.js.test.cjs
@@ -1,0 +1,25 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/lib/utils/open-url-prompt.js TAP opens a url > must match snapshot 1`] = `
+Array [
+  Array [
+    String(
+      npm home:
+      https://www.npmjs.com
+    ),
+  ],
+]
+`
+
+exports[`test/lib/utils/open-url-prompt.js TAP prints json output > must match snapshot 1`] = `
+Array [
+  Array [
+    "{\\"title\\":\\"npm home\\",\\"url\\":\\"https://www.npmjs.com\\"}",
+  ],
+]
+`

--- a/test/lib/auth/legacy.js
+++ b/test/lib/auth/legacy.js
@@ -12,7 +12,7 @@ const legacy = t.mock('../../../lib/auth/legacy.js', {
     },
   },
   'npm-profile': profile,
-  '../../../lib/utils/open-url.js': (npm, url, msg) => {
+  '../../../lib/utils/open-url-prompt.js': (_npm, url) => {
     if (!url) {
       throw Object.assign(new Error('failed open url'), { code: 'ERROR' })
     }

--- a/test/lib/utils/open-url-prompt.js
+++ b/test/lib/utils/open-url-prompt.js
@@ -7,15 +7,15 @@ const output = (...args) => OUTPUT.push(args)
 const npm = {
   _config: {
     json: false,
-    browser: true
+    browser: true,
   },
   config: {
     get: k => npm._config[k],
     set: (k, v) => {
       npm._config[k] = v
-    }
+    },
   },
-  output
+  output,
 }
 
 let openerUrl = null
@@ -35,18 +35,18 @@ const readline = {
         cb()
       }
     },
-    close: () => {}
-  })
+    close: () => {},
+  }),
 }
 
 const openUrlPrompt = t.mock('../../../lib/utils/open-url-prompt.js', {
   opener,
-  readline
+  readline,
 })
 
 mockGlobals(t, {
   'process.stdin.isTTY': true,
-  'process.stdout.isTTY': true
+  'process.stdout.isTTY': true,
 })
 
 t.test('does not open a url in non-interactive environments', async t => {
@@ -58,7 +58,7 @@ t.test('does not open a url in non-interactive environments', async t => {
 
   mockGlobals(t, {
     'process.stdin.isTTY': false,
-    'process.stdout.isTTY': false
+    'process.stdout.isTTY': false,
   })
 
   await openUrlPrompt(npm, 'https://www.npmjs.com', 'npm home', 'prompt')
@@ -77,20 +77,20 @@ t.test('opens a url', async t => {
   npm._config.browser = 'browser'
   await openUrlPrompt(npm, 'https://www.npmjs.com', 'npm home', 'prompt')
   t.equal(openerUrl, 'https://www.npmjs.com', 'opened the given url')
-  t.same(openerOpts, {command: 'browser'}, 'passed command as null (the default)')
+  t.same(openerOpts, { command: 'browser' }, 'passed command as null (the default)')
   t.matchSnapshot(OUTPUT)
 })
 
 t.test('prints json output', async t => {
-	t.teardown(() => {
+  t.teardown(() => {
     openerUrl = null
     openerOpts = null
     OUTPUT.length = 0
     npm._config.json = false
   })
 
-	npm._config.json = true
-	await openUrlPrompt(npm, 'https://www.npmjs.com', 'npm home', 'prompt')
+  npm._config.json = true
+  await openUrlPrompt(npm, 'https://www.npmjs.com', 'npm home', 'prompt')
   t.matchSnapshot(OUTPUT)
 })
 

--- a/test/lib/utils/open-url-prompt.js
+++ b/test/lib/utils/open-url-prompt.js
@@ -1,0 +1,150 @@
+const t = require('tap')
+const mockGlobals = require('../../fixtures/mock-globals.js')
+const EventEmitter = require('events')
+
+const OUTPUT = []
+const output = (...args) => OUTPUT.push(args)
+const npm = {
+  _config: {
+    json: false,
+    browser: true
+  },
+  config: {
+    get: k => npm._config[k],
+    set: (k, v) => {
+      npm._config[k] = v
+    }
+  },
+  output
+}
+
+let openerUrl = null
+let openerOpts = null
+let openerResult = null
+const opener = (url, opts, cb) => {
+  openerUrl = url
+  openerOpts = opts
+  return cb(openerResult)
+}
+
+let questionShouldResolve = true
+const readline = {
+  createInterface: () => ({
+    question: (_q, cb) => {
+      if (questionShouldResolve === true) {
+        cb()
+      }
+    },
+    close: () => {}
+  })
+}
+
+const openUrlPrompt = t.mock('../../../lib/utils/open-url-prompt.js', {
+  opener,
+  readline
+})
+
+mockGlobals(t, {
+  'process.stdin.isTTY': true,
+  'process.stdout.isTTY': true
+})
+
+t.test('does not open a url in non-interactive environments', async t => {
+  t.teardown(() => {
+    openerUrl = null
+    openerOpts = null
+    OUTPUT.length = 0
+  })
+
+  mockGlobals(t, {
+    'process.stdin.isTTY': false,
+    'process.stdout.isTTY': false
+  })
+
+  await openUrlPrompt(npm, 'https://www.npmjs.com', 'npm home', 'prompt')
+  t.equal(openerUrl, null, 'did not open')
+  t.same(openerOpts, null, 'did not open')
+})
+
+t.test('opens a url', async t => {
+  t.teardown(() => {
+    openerUrl = null
+    openerOpts = null
+    OUTPUT.length = 0
+    npm._config.browser = true
+  })
+
+  npm._config.browser = 'browser'
+  await openUrlPrompt(npm, 'https://www.npmjs.com', 'npm home', 'prompt')
+  t.equal(openerUrl, 'https://www.npmjs.com', 'opened the given url')
+  t.same(openerOpts, {command: 'browser'}, 'passed command as null (the default)')
+  t.matchSnapshot(OUTPUT)
+})
+
+t.test('prints json output', async t => {
+	t.teardown(() => {
+    openerUrl = null
+    openerOpts = null
+    OUTPUT.length = 0
+    npm._config.json = false
+  })
+
+	npm._config.json = true
+	await openUrlPrompt(npm, 'https://www.npmjs.com', 'npm home', 'prompt')
+  t.matchSnapshot(OUTPUT)
+})
+
+t.test('returns error for non-https url', async t => {
+  t.teardown(() => {
+    openerUrl = null
+    openerOpts = null
+    OUTPUT.length = 0
+  })
+  await t.rejects(
+    openUrlPrompt(npm, 'ftp://www.npmjs.com', 'npm home', 'prompt'),
+    /Invalid URL/,
+    'got the correct error'
+  )
+  t.equal(openerUrl, null, 'did not open')
+  t.same(openerOpts, null, 'did not open')
+  t.same(OUTPUT, [], 'printed no output')
+})
+
+t.test('does not open url if canceled', async t => {
+  t.teardown(() => {
+    openerUrl = null
+    openerOpts = null
+    OUTPUT.length = 0
+    questionShouldResolve = true
+  })
+
+  questionShouldResolve = false
+  const emitter = new EventEmitter()
+
+  const open = openUrlPrompt(npm, 'https://www.npmjs.com', 'npm home', 'prompt', emitter)
+
+  emitter.emit('abort')
+
+  await open
+
+  t.equal(openerUrl, null, 'did not open')
+  t.same(openerOpts, null, 'did not open')
+})
+
+t.test('returns error when opener errors', async t => {
+  t.teardown(() => {
+    openerUrl = null
+    openerOpts = null
+    openerResult = null
+    OUTPUT.length = 0
+  })
+
+  openerResult = new Error('Opener failed')
+
+  await t.rejects(
+    openUrlPrompt(npm, 'https://www.npmjs.com', 'npm home', 'prompt'),
+    /Opener failed/,
+    'got the correct error'
+  )
+  t.equal(openerUrl, 'https://www.npmjs.com', 'did not open')
+})


### PR DESCRIPTION
## Why
We want the npm CLI to prompt and wait before opening a URL.
The flow should be dependent on the authorization result and should continue without user input if the authorization is completed.

## What
- Add a utility that opens an URL after a prompt
- The prompt is cancellable by an `EventEmitter`
- Switch `login`/`adduser` to use the new prompt when applicable

The new `openerPromise` API is backwards compatible with the old one (it only adds new parameters), so it will work even without the changes from `npm-profile`.

Without the changes from `npm-profile`, the user will always have to press `Enter` to continue the flow.

## References
- Parent Issue: github/npm#4897
- Closes: github/npm#5312
- Dependent on: npm/npm-profile#50
- Dependent on: npm/cli#5034