### PR TITLE
Fixes typo in npm update command doc

### DIFF
--- a/docs/content/commands/npm-update.md
+++ b/docs/content/commands/npm-update.md
@@ -13,7 +13,7 @@ description: Update packages
 ```bash
 npm update [<pkg>...]
 
-aliases: up, upgrade, udpate
+aliases: up, upgrade, update
 ```
 
 <!-- automatically generated, do not edit manually -->


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

The `d` and `p` were flipped in the `update` command doc.  Simply fixes the spelling error.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
