### PR TITLE
chore: remove workspaces prepublishOnly scripts

### DIFF
--- a/workspaces/arborist/package.json
+++ b/workspaces/arborist/package.json
@@ -56,7 +56,6 @@
     "test-proxy": "ARBORIST_TEST_PROXY=1 tap --snapshot",
     "preversion": "npm test",
     "postversion": "npm publish",
-    "prepublishOnly": "git push origin --follow-tags",
     "eslint": "eslint",
     "lint": "eslint \"**/*.js\"",
     "lintfix": "npm run lint -- --fix",

--- a/workspaces/libnpmaccess/package.json
+++ b/workspaces/libnpmaccess/package.json
@@ -13,7 +13,6 @@
     "test": "tap",
     "postlint": "template-oss-check",
     "lintfix": "npm run lint -- --fix",
-    "prepublishOnly": "git push origin --follow-tags",
     "snap": "tap",
     "posttest": "npm run lint",
     "template-oss-apply": "template-oss-apply --force"

--- a/workspaces/libnpmdiff/package.json
+++ b/workspaces/libnpmdiff/package.json
@@ -40,7 +40,6 @@
     "snap": "tap",
     "preversion": "npm test",
     "postversion": "npm publish",
-    "prepublishOnly": "git push origin --follow-tags",
     "postlint": "template-oss-check",
     "template-oss-apply": "template-oss-apply --force"
   },

--- a/workspaces/libnpmexec/package.json
+++ b/workspaces/libnpmexec/package.json
@@ -39,7 +39,6 @@
     "snap": "tap",
     "preversion": "npm test",
     "postversion": "npm publish",
-    "prepublishOnly": "git push origin --follow-tags",
     "postlint": "template-oss-check",
     "lintfix": "npm run lint -- --fix",
     "template-oss-apply": "template-oss-apply --force"

--- a/workspaces/libnpmfund/package.json
+++ b/workspaces/libnpmfund/package.json
@@ -39,7 +39,6 @@
     "snap": "tap",
     "preversion": "npm test",
     "postversion": "npm publish",
-    "prepublishOnly": "git push origin --follow-tags",
     "postlint": "template-oss-check",
     "template-oss-apply": "template-oss-apply --force"
   },

--- a/workspaces/libnpmhook/package.json
+++ b/workspaces/libnpmhook/package.json
@@ -16,7 +16,6 @@
     "lintfix": "npm run lint -- --fix",
     "preversion": "npm test",
     "postversion": "npm publish",
-    "prepublishOnly": "git push origin --follow-tags",
     "snap": "tap",
     "posttest": "npm run lint",
     "template-oss-apply": "template-oss-apply --force"

--- a/workspaces/libnpmorg/package.json
+++ b/workspaces/libnpmorg/package.json
@@ -16,7 +16,6 @@
   "scripts": {
     "preversion": "npm test",
     "postversion": "npm publish",
-    "prepublishOnly": "git push origin --follow-tags",
     "lint": "eslint \"**/*.js\"",
     "test": "tap",
     "posttest": "npm run lint",

--- a/workspaces/libnpmpack/package.json
+++ b/workspaces/libnpmpack/package.json
@@ -15,7 +15,6 @@
   "scripts": {
     "preversion": "npm test",
     "postversion": "npm publish",
-    "prepublishOnly": "git push origin --follow-tags",
     "lint": "eslint \"**/*.js\"",
     "test": "tap",
     "posttest": "npm run lint",

--- a/workspaces/libnpmpublish/package.json
+++ b/workspaces/libnpmpublish/package.json
@@ -19,7 +19,6 @@
     "lintfix": "npm run lint -- --fix",
     "preversion": "npm test",
     "postversion": "npm publish",
-    "prepublishOnly": "git push origin --follow-tags",
     "test": "tap",
     "posttest": "npm run lint",
     "postlint": "template-oss-check",

--- a/workspaces/libnpmsearch/package.json
+++ b/workspaces/libnpmsearch/package.json
@@ -18,7 +18,6 @@
   "scripts": {
     "preversion": "npm test",
     "postversion": "npm publish",
-    "prepublishOnly": "git push origin --follow-tags",
     "posttest": "npm run lint",
     "test": "tap",
     "lint": "eslint \"**/*.js\"",

--- a/workspaces/libnpmteam/package.json
+++ b/workspaces/libnpmteam/package.json
@@ -8,7 +8,6 @@
   "scripts": {
     "preversion": "npm test",
     "postversion": "npm publish",
-    "prepublishOnly": "git push origin --follow-tags",
     "lint": "eslint \"**/*.js\"",
     "test": "tap",
     "posttest": "npm run lint",

--- a/workspaces/libnpmversion/package.json
+++ b/workspaces/libnpmversion/package.json
@@ -21,7 +21,6 @@
     "snap": "tap",
     "preversion": "npm test",
     "postversion": "npm publish",
-    "prepublishOnly": "git push origin --follow-tags",
     "postlint": "template-oss-check",
     "lintfix": "npm run lint -- --fix",
     "template-oss-apply": "template-oss-apply --force"


### PR DESCRIPTION
They're no longer necessary and are actually very annoying, one of these landed the actual **cli** ongoing PR/release while I was trying to simply publish a workspace.