### PR TITLE
npm.cmd, npx.cmd - replace deprecated switch -g with --location=global

### DIFF
--- a/bin/npm.cmd
+++ b/bin/npm.cmd
@@ -9,7 +9,7 @@ IF NOT EXIST "%NODE_EXE%" (
 )
 
 SET "NPM_CLI_JS=%~dp0\node_modules\npm\bin\npm-cli.js"
-FOR /F "delims=" %%F IN ('CALL "%NODE_EXE%" "%NPM_CLI_JS%" prefix -g') DO (
+FOR /F "delims=" %%F IN ('CALL "%NODE_EXE%" "%NPM_CLI_JS%" prefix --location=global') DO (
   SET "NPM_PREFIX_NPM_CLI_JS=%%F\node_modules\npm\bin\npm-cli.js"
 )
 IF EXIST "%NPM_PREFIX_NPM_CLI_JS%" (

--- a/bin/npx.cmd
+++ b/bin/npx.cmd
@@ -10,7 +10,7 @@ IF NOT EXIST "%NODE_EXE%" (
 
 SET "NPM_CLI_JS=%~dp0\node_modules\npm\bin\npm-cli.js"
 SET "NPX_CLI_JS=%~dp0\node_modules\npm\bin\npx-cli.js"
-FOR /F "delims=" %%F IN ('CALL "%NODE_EXE%" "%NPM_CLI_JS%" prefix -g') DO (
+FOR /F "delims=" %%F IN ('CALL "%NODE_EXE%" "%NPM_CLI_JS%" prefix --location=global') DO (
   SET "NPM_PREFIX_NPX_CLI_JS=%%F\node_modules\npm\bin\npx-cli.js"
 )
 IF EXIST "%NPM_PREFIX_NPX_CLI_JS%" (


### PR DESCRIPTION
The commandline switch `-g` is deprecated and should be replaced with `--location=global`.

Fixes #4980 
