### PR TITLE
fix: undeprecate and remove warnings for --global, -g, --local

### DIFF
--- a/docs/content/commands/npm-bin.md
+++ b/docs/content/commands/npm-bin.md
@@ -34,8 +34,6 @@ Print the folder where npm will install executables.
 
 * Default: false
 * Type: Boolean
-* DEPRECATED: `--global`, `--local` are deprecated. Use `--location=global`
-  instead.
 
 Operates in "global" mode, so that packages are installed into the `prefix`
 folder instead of the current working directory. See

--- a/docs/content/commands/npm-config.md
+++ b/docs/content/commands/npm-config.md
@@ -124,8 +124,6 @@ Not supported by all npm commands.
 
 * Default: false
 * Type: Boolean
-* DEPRECATED: `--global`, `--local` are deprecated. Use `--location=global`
-  instead.
 
 Operates in "global" mode, so that packages are installed into the `prefix`
 folder instead of the current working directory. See

--- a/docs/content/commands/npm-diff.md
+++ b/docs/content/commands/npm-diff.md
@@ -248,8 +248,6 @@ Treat all files as text in `npm diff`.
 
 * Default: false
 * Type: Boolean
-* DEPRECATED: `--global`, `--local` are deprecated. Use `--location=global`
-  instead.
 
 Operates in "global" mode, so that packages are installed into the `prefix`
 folder instead of the current working directory. See

--- a/docs/content/commands/npm-install-test.md
+++ b/docs/content/commands/npm-install-test.md
@@ -70,8 +70,6 @@ rather than using npm's default semver range operator.
 
 * Default: false
 * Type: Boolean
-* DEPRECATED: `--global`, `--local` are deprecated. Use `--location=global`
-  instead.
 
 Operates in "global" mode, so that packages are installed into the `prefix`
 folder instead of the current working directory. See

--- a/docs/content/commands/npm-install.md
+++ b/docs/content/commands/npm-install.md
@@ -460,8 +460,6 @@ rather than using npm's default semver range operator.
 
 * Default: false
 * Type: Boolean
-* DEPRECATED: `--global`, `--local` are deprecated. Use `--location=global`
-  instead.
 
 Operates in "global" mode, so that packages are installed into the `prefix`
 folder instead of the current working directory. See

--- a/docs/content/commands/npm-link.md
+++ b/docs/content/commands/npm-link.md
@@ -153,8 +153,6 @@ rather than using npm's default semver range operator.
 
 * Default: false
 * Type: Boolean
-* DEPRECATED: `--global`, `--local` are deprecated. Use `--location=global`
-  instead.
 
 Operates in "global" mode, so that packages are installed into the `prefix`
 folder instead of the current working directory. See

--- a/docs/content/commands/npm-ls.md
+++ b/docs/content/commands/npm-ls.md
@@ -137,8 +137,6 @@ Output parseable results from commands that write to standard output. For
 
 * Default: false
 * Type: Boolean
-* DEPRECATED: `--global`, `--local` are deprecated. Use `--location=global`
-  instead.
 
 Operates in "global" mode, so that packages are installed into the `prefix`
 folder instead of the current working directory. See

--- a/docs/content/commands/npm-outdated.md
+++ b/docs/content/commands/npm-outdated.md
@@ -150,8 +150,6 @@ Output parseable results from commands that write to standard output. For
 
 * Default: false
 * Type: Boolean
-* DEPRECATED: `--global`, `--local` are deprecated. Use `--location=global`
-  instead.
 
 Operates in "global" mode, so that packages are installed into the `prefix`
 folder instead of the current working directory. See

--- a/docs/content/commands/npm-prefix.md
+++ b/docs/content/commands/npm-prefix.md
@@ -51,8 +51,6 @@ npm prefix -g
 
 * Default: false
 * Type: Boolean
-* DEPRECATED: `--global`, `--local` are deprecated. Use `--location=global`
-  instead.
 
 Operates in "global" mode, so that packages are installed into the `prefix`
 folder instead of the current working directory. See

--- a/docs/content/commands/npm-rebuild.md
+++ b/docs/content/commands/npm-rebuild.md
@@ -42,8 +42,6 @@ will be rebuilt.
 
 * Default: false
 * Type: Boolean
-* DEPRECATED: `--global`, `--local` are deprecated. Use `--location=global`
-  instead.
 
 Operates in "global" mode, so that packages are installed into the `prefix`
 folder instead of the current working directory. See

--- a/docs/content/commands/npm-root.md
+++ b/docs/content/commands/npm-root.md
@@ -41,8 +41,6 @@ echo "Global packages installed in: ${global_node_modules}"
 
 * Default: false
 * Type: Boolean
-* DEPRECATED: `--global`, `--local` are deprecated. Use `--location=global`
-  instead.
 
 Operates in "global" mode, so that packages are installed into the `prefix`
 folder instead of the current working directory. See

--- a/docs/content/commands/npm-update.md
+++ b/docs/content/commands/npm-update.md
@@ -188,8 +188,6 @@ Will also prevent writing to `package-lock.json` if set to `false`.
 
 * Default: false
 * Type: Boolean
-* DEPRECATED: `--global`, `--local` are deprecated. Use `--location=global`
-  instead.
 
 Operates in "global" mode, so that packages are installed into the `prefix`
 folder instead of the current working directory. See

--- a/docs/content/using-npm/config.md
+++ b/docs/content/using-npm/config.md
@@ -687,6 +687,23 @@ results in no commit being made at all.
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->
 
+#### `global`
+
+* Default: false
+* Type: Boolean
+
+Operates in "global" mode, so that packages are installed into the `prefix`
+folder instead of the current working directory. See
+[folders](/configuring-npm/folders) for more on the differences in behavior.
+
+* packages are installed into the `{prefix}/lib/node_modules` folder, instead
+  of the current working directory.
+* bin files are linked to `{prefix}/bin`
+* man pages are linked to `{prefix}/share/man`
+
+<!-- automatically generated, do not edit manually -->
+<!-- see lib/utils/config/definitions.js -->
+
 #### `global-style`
 
 * Default: false
@@ -1931,25 +1948,6 @@ Pass `webauthn` to use a web-based login.
 * DEPRECATED: Please use --include=dev instead.
 
 Alias for `--include=dev`.
-
-<!-- automatically generated, do not edit manually -->
-<!-- see lib/utils/config/definitions.js -->
-
-#### `global`
-
-* Default: false
-* Type: Boolean
-* DEPRECATED: `--global`, `--local` are deprecated. Use `--location=global`
-  instead.
-
-Operates in "global" mode, so that packages are installed into the `prefix`
-folder instead of the current working directory. See
-[folders](/configuring-npm/folders) for more on the differences in behavior.
-
-* packages are installed into the `{prefix}/lib/node_modules` folder, instead
-  of the current working directory.
-* bin files are linked to `{prefix}/bin`
-* man pages are linked to `{prefix}/share/man`
 
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -813,9 +813,6 @@ define('global', {
   default: false,
   type: Boolean,
   short: 'g',
-  deprecated: `
-    \`--global\`, \`--local\` are deprecated. Use \`--location=global\` instead.
-  `,
   description: `
     Operates in "global" mode, so that packages are installed into the
     \`prefix\` folder instead of the current working directory.  See

--- a/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
@@ -733,8 +733,6 @@ exports[`test/lib/utils/config/definitions.js TAP > config description for globa
 
 * Default: false
 * Type: Boolean
-* DEPRECATED: \`--global\`, \`--local\` are deprecated. Use \`--location=global\`
-  instead.
 
 Operates in "global" mode, so that packages are installed into the \`prefix\`
 folder instead of the current working directory. See

--- a/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
@@ -560,6 +560,23 @@ results in no commit being made at all.
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->
 
+#### \`global\`
+
+* Default: false
+* Type: Boolean
+
+Operates in "global" mode, so that packages are installed into the \`prefix\`
+folder instead of the current working directory. See
+[folders](/configuring-npm/folders) for more on the differences in behavior.
+
+* packages are installed into the \`{prefix}/lib/node_modules\` folder, instead
+  of the current working directory.
+* bin files are linked to \`{prefix}/bin\`
+* man pages are linked to \`{prefix}/share/man\`
+
+<!-- automatically generated, do not edit manually -->
+<!-- see lib/utils/config/definitions.js -->
+
 #### \`global-style\`
 
 * Default: false
@@ -1804,25 +1821,6 @@ Pass \`webauthn\` to use a web-based login.
 * DEPRECATED: Please use --include=dev instead.
 
 Alias for \`--include=dev\`.
-
-<!-- automatically generated, do not edit manually -->
-<!-- see lib/utils/config/definitions.js -->
-
-#### \`global\`
-
-* Default: false
-* Type: Boolean
-* DEPRECATED: \`--global\`, \`--local\` are deprecated. Use \`--location=global\`
-  instead.
-
-Operates in "global" mode, so that packages are installed into the \`prefix\`
-folder instead of the current working directory. See
-[folders](/configuring-npm/folders) for more on the differences in behavior.
-
-* packages are installed into the \`{prefix}/lib/node_modules\` folder, instead
-  of the current working directory.
-* bin files are linked to \`{prefix}/bin\`
-* man pages are linked to \`{prefix}/share/man\`
 
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->


### PR DESCRIPTION
Internally, we made a mistake in deprecating `--global`, and are correcting that with this PR. 

The original PR is here. https://github.com/npm/cli/pull/4879

This removes deprecation warnings and updates documentation.