### PR TITLE
Release/v8.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v8.12.1 (2022-06-02)
+
+### Bug Fixes
+
+  * [`40c823c`](https://github.com/npm/cli/commit/40c823cc7d33d22f659a1ccceed440baacaaff1d) [#4982](https://github.com/npm/cli/pull/4982) fix: undeprecate and remove warnings for --global, -g, --local ([@fritzy](https://github.com/fritzy))
+
 ## v8.12.0 (2022-06-01)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "npm",
-  "version": "8.12.0",
+  "version": "8.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "npm",
-      "version": "8.12.0",
+      "version": "8.12.1",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "8.12.0",
+  "version": "8.12.1",
   "name": "npm",
   "description": "a package manager for JavaScript",
   "workspaces": [


### PR DESCRIPTION
## v8.12.1 (2022-06-02)

### Bug Fixes

  * [`40c823c`](https://github.com/npm/cli/commit/40c823cc7d33d22f659a1ccceed440baacaaff1d) [#4982](https://github.com/npm/cli/pull/4982) fix: undeprecate and remove warnings for --global, -g, --local (@fritzy)
