### PR TITLE
fix: Add space to SemVer log message

### DIFF
--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -673,7 +673,7 @@ Try using the package name instead, e.g:
           const breakingMessage = isSemVerMajor
             ? 'a SemVer major change'
             : 'outside your stated dependency range'
-          log.warn('audit', `Updating ${name} to ${version},` +
+          log.warn('audit', `Updating ${name} to ${version}, ` +
             `which is ${breakingMessage}.`)
 
           await this[_add](node, { add: [`${name}@${version}`] })


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
This pull request adds a space after the comma for the `npm audit` SemVer message, currently it can look like this:
`npm WARN audit Updating react-scripts to 2.1.3,which is a SemVer major change.`

