### PR TITLE
docs: naming of files in example code should be consistent

### DIFF
--- a/docs/content/using-npm/workspaces.md
+++ b/docs/content/using-npm/workspaces.md
@@ -57,7 +57,7 @@ structure of files and folders:
 ```
 .
 +-- node_modules
-|  `-- packages/a -> ../packages/a
+|  `-- a -> ../packages/a
 +-- package-lock.json
 +-- package.json
 `-- packages
@@ -112,15 +112,15 @@ respect the provided `workspace` configuration.
 
 Given the [specifities of how Node.js handles module resolution](https://nodejs.org/dist/latest-v14.x/docs/api/modules.html#modules_all_together) it's possible to consume any defined workspace
 by its declared `package.json` `name`. Continuing from the example defined
-above, let's also create a Node.js script that will require the `workspace-a`
+above, let's also create a Node.js script that will require the workspace `a`
 example module, e.g:
 
 ```
-// ./workspace-a/index.js
+// ./packages/a/index.js
 module.exports = 'a'
 
 // ./lib/index.js
-const moduleA = require('workspace-a')
+const moduleA = require('a')
 console.log(moduleA) // -> a
 ```
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
The use of `a` workspace have some inconsistency in terms of naming, making the doc not easy to follow.

<!-- Examples:
## References

  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
