### PR TITLE
feat: Add `web` auth type

### DIFF
--- a/docs/content/commands/npm-adduser.md
+++ b/docs/content/commands/npm-adduser.md
@@ -93,14 +93,12 @@ npm init --scope=@foo --yes
 #### `auth-type`
 
 * Default: "legacy"
-* Type: "legacy", "webauthn", "sso", "saml", or "oauth"
+* Type: "legacy", "web", "sso", "saml", "oauth", or "webauthn"
 
-NOTE: auth-type values "sso", "saml", and "oauth" will be removed in a
-future version.
+NOTE: auth-type values "sso", "saml", "oauth", and "webauthn" will be
+removed in a future version.
 
 What authentication strategy to use with `login`.
-
-Pass `webauthn` to use a web-based login.
 
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->

--- a/docs/content/using-npm/config.md
+++ b/docs/content/using-npm/config.md
@@ -218,14 +218,12 @@ exit code.
 #### `auth-type`
 
 * Default: "legacy"
-* Type: "legacy", "webauthn", "sso", "saml", or "oauth"
+* Type: "legacy", "web", "sso", "saml", "oauth", or "webauthn"
 
-NOTE: auth-type values "sso", "saml", and "oauth" will be removed in a
-future version.
+NOTE: auth-type values "sso", "saml", "oauth", and "webauthn" will be
+removed in a future version.
 
 What authentication strategy to use with `login`.
-
-Pass `webauthn` to use a web-based login.
 
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->

--- a/lib/commands/adduser.js
+++ b/lib/commands/adduser.js
@@ -3,6 +3,7 @@ const replaceInfo = require('../utils/replace-info.js')
 const BaseCommand = require('../base-command.js')
 const authTypes = {
   legacy: require('../auth/legacy.js'),
+  web: require('../auth/legacy.js'),
   webauthn: require('../auth/legacy.js'),
   oauth: require('../auth/oauth.js'),
   saml: require('../auth/saml.js'),

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -239,15 +239,14 @@ define('audit-level', {
 
 define('auth-type', {
   default: 'legacy',
-  type: ['legacy', 'webauthn', 'sso', 'saml', 'oauth'],
+  type: ['legacy', 'web', 'sso', 'saml', 'oauth', 'webauthn'],
   // deprecation in description rather than field, because not every value
   // is deprecated
   description: `
-    NOTE: auth-type values "sso", "saml", and "oauth" will be removed in a future version.
-    
-    What authentication strategy to use with \`login\`.
+    NOTE: auth-type values "sso", "saml", "oauth", and "webauthn" will be
+    removed in a future version.
 
-    Pass \`webauthn\` to use a web-based login.
+    What authentication strategy to use with \`login\`.
   `,
   flatten (key, obj, flatOptions) {
     flatOptions.authType = obj[key]

--- a/tap-snapshots/test/lib/load-all-commands.js.test.cjs
+++ b/tap-snapshots/test/lib/load-all-commands.js.test.cjs
@@ -33,7 +33,7 @@ npm adduser
 
 Options:
 [--registry <registry>] [--scope <@scope>]
-[--auth-type <legacy|webauthn|sso|saml|oauth>]
+[--auth-type <legacy|web|sso|saml|oauth|webauthn>]
 
 aliases: login, add-user
 
@@ -499,7 +499,7 @@ npm adduser
 
 Options:
 [--registry <registry>] [--scope <@scope>]
-[--auth-type <legacy|webauthn|sso|saml|oauth>]
+[--auth-type <legacy|web|sso|saml|oauth|webauthn>]
 
 aliases: login, add-user
 

--- a/tap-snapshots/test/lib/npm.js.test.cjs
+++ b/tap-snapshots/test/lib/npm.js.test.cjs
@@ -190,7 +190,7 @@ All commands:
                     
                     Options:
                     [--registry <registry>] [--scope <@scope>]
-                    [--auth-type <legacy|webauthn|sso|saml|oauth>]
+                    [--auth-type <legacy|web|sso|saml|oauth|webauthn>]
                     
                     aliases: login, add-user
                     
@@ -577,7 +577,7 @@ All commands:
                     
                     Options:
                     [--registry <registry>] [--scope <@scope>]
-                    [--auth-type <legacy|webauthn|sso|saml|oauth>]
+                    [--auth-type <legacy|web|sso|saml|oauth|webauthn>]
                     
                     aliases: login, add-user
                     

--- a/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
@@ -253,14 +253,12 @@ exports[`test/lib/utils/config/definitions.js TAP > config description for auth-
 #### \`auth-type\`
 
 * Default: "legacy"
-* Type: "legacy", "webauthn", "sso", "saml", or "oauth"
+* Type: "legacy", "web", "sso", "saml", "oauth", or "webauthn"
 
-NOTE: auth-type values "sso", "saml", and "oauth" will be removed in a
-future version.
+NOTE: auth-type values "sso", "saml", "oauth", and "webauthn" will be
+removed in a future version.
 
 What authentication strategy to use with \`login\`.
-
-Pass \`webauthn\` to use a web-based login.
 `
 
 exports[`test/lib/utils/config/definitions.js TAP > config description for before 1`] = `

--- a/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
@@ -91,14 +91,12 @@ exit code.
 #### \`auth-type\`
 
 * Default: "legacy"
-* Type: "legacy", "webauthn", "sso", "saml", or "oauth"
+* Type: "legacy", "web", "sso", "saml", "oauth", or "webauthn"
 
-NOTE: auth-type values "sso", "saml", and "oauth" will be removed in a
-future version.
+NOTE: auth-type values "sso", "saml", "oauth", and "webauthn" will be
+removed in a future version.
 
 What authentication strategy to use with \`login\`.
-
-Pass \`webauthn\` to use a web-based login.
 
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->


### PR DESCRIPTION
## What
Add the more generic `web` for the registry to use, instead of the implementation-specific `webauthn` authentication type.

## Why
It's more generic and sounds better.

## References
- Closes https://github.com/github/npm/issues/5499