### PR TITLE
fix: remove unnecessary logging for webauthn auth

### DIFF
--- a/lib/auth/legacy.js
+++ b/lib/auth/legacy.js
@@ -2,6 +2,7 @@ const profile = require('npm-profile')
 const log = require('../utils/log-shim')
 const openUrlPrompt = require('../utils/open-url-prompt.js')
 const read = require('../utils/read-user-info.js')
+const replaceInfo = require('../utils/replace-info.js')
 
 const loginPrompter = async (creds) => {
   creds.username = await read.username('Username:', creds.username)
@@ -13,6 +14,10 @@ const loginPrompter = async (creds) => {
 
 const login = async (npm, opts) => {
   let res
+
+  if (opts.authType === 'legacy') {
+    log.notice('', `Log in on ${replaceInfo(opts.registry)}`)
+  }
 
   const requestOTP = async () => {
     const otp = await read.otp(

--- a/lib/auth/sso.js
+++ b/lib/auth/sso.js
@@ -12,6 +12,7 @@ const npmFetch = require('npm-registry-fetch')
 const log = require('../utils/log-shim')
 const openUrl = require('../utils/open-url.js')
 const otplease = require('../utils/otplease.js')
+const replaceInfo = require('../utils/replace-info.js')
 
 const pollForSession = ({ registry, token, opts }) => {
   log.info('adduser', 'Polling for validated SSO session')
@@ -38,6 +39,8 @@ function sleep (time) {
 const login = async (npm, { creds, registry, scope }) => {
   const opts = { ...npm.flatOptions, creds, registry, scope }
   const { ssoType } = opts
+
+  log.notice('', `Log in on ${replaceInfo(registry)}`)
 
   if (!ssoType) {
     throw new Error('Missing option: sso-type')

--- a/lib/commands/adduser.js
+++ b/lib/commands/adduser.js
@@ -1,5 +1,4 @@
 const log = require('../utils/log-shim.js')
-const replaceInfo = require('../utils/replace-info.js')
 const BaseCommand = require('../base-command.js')
 const authTypes = {
   legacy: require('../auth/legacy.js'),
@@ -27,8 +26,6 @@ class AddUser extends BaseCommand {
     const creds = this.npm.config.getCredentialsByURI(registry)
 
     log.disableProgress()
-
-    log.notice('', `Log in on ${replaceInfo(registry)}`)
 
     const { message, newCreds } = await auth(this.npm, {
       ...this.npm.flatOptions,

--- a/test/lib/auth/sso.js
+++ b/test/lib/auth/sso.js
@@ -8,10 +8,15 @@ const _flatOptions = {
 const token = '24528a24f240'
 const SSO_URL = 'https://registry.npmjs.org/{SSO_URL}'
 const profile = {}
-const npmFetch = {}
+const npmFetch = {
+  cleanUrl: (s) => s,
+}
 const sso = t.mock('../../../lib/auth/sso.js', {
   'proc-log': {
     info: (...msgs) => {
+      log += msgs.join(' ') + '\n'
+    },
+    notice: (...msgs) => {
       log += msgs.join(' ') + '\n'
     },
   },
@@ -82,6 +87,7 @@ t.test('simple login', async (t) => {
 
   t.equal(
     log,
+    ' Log in on https://registry.npmjs.org/\n' +
     'adduser Polling for validated SSO session\nadduser Authorized user foo\n',
     'should have correct logged info msg'
   )
@@ -220,6 +226,7 @@ t.test('scoped login', async (t) => {
 
   t.equal(
     log,
+    ' Log in on https://diff-registry.npmjs.org/\n' +
     'adduser Polling for validated SSO session\nadduser Authorized user foo\n',
     'should have correct logged info msg'
   )


### PR DESCRIPTION
## Description

When authenticating using `Webauthn` it is unnecessary to log `Log in on...`.  This PR hides that logging in that case.

Prior to this PR the output looks like:

![image](https://user-images.githubusercontent.com/645812/175899431-6a034013-f1f1-4746-bde8-2b29a924bb93.png)

An alternative approach would be to use the existing auth handler polymorphism, rather than adding branching into `lib/auth/legacy.js`. If we introduce a new `lib/auth/webauthn.js` handler and move our `legacy.js` logic there, then `legacy.js` can log the notice and then call `webauthn.js`. This would avoid the branching introduced by this PR and the unfortunate confusion of `legacy.js` checking if `authType == 'legacy'`. The downside of that approach is the merge conflicts it will create with ongoing work to these files, and the naming confusion around `legacy` and `webauthn`.

## References
- Closes https://github.com/github/npm/issues/5497