### PR TITLE
docs: update reference to deprecated spdx package

### DIFF
--- a/docs/content/configuring-npm/package-json.md
+++ b/docs/content/configuring-npm/package-json.md
@@ -124,7 +124,7 @@ IDs](https://spdx.org/licenses/).  Ideally you should pick one that is
 
 If your package is licensed under multiple common licenses, use an [SPDX
 license expression syntax version 2.0
-string](https://www.npmjs.com/package/spdx), like this:
+string](https://spdx.dev/specifications/), [parser](https://www.npmjs.com/package/spdx-expression-parse) and [test helper](https://www.npmjs.com/package/spdx-satisfies) are hosted on npm. like this:
 
 ```json
 {

--- a/docs/content/configuring-npm/package-json.md
+++ b/docs/content/configuring-npm/package-json.md
@@ -124,7 +124,7 @@ IDs](https://spdx.org/licenses/).  Ideally you should pick one that is
 
 If your package is licensed under multiple common licenses, use an [SPDX
 license expression syntax version 2.0
-string](https://spdx.dev/specifications/), [parser](https://www.npmjs.com/package/spdx-expression-parse) and [test helper](https://www.npmjs.com/package/spdx-satisfies) are hosted on npm. like this:
+string](https://spdx.dev/specifications/), like this:
 
 ```json
 {


### PR DESCRIPTION
Author describes the reason here:

https://github.com/kemitchell/spdx.js/commit/616ce611bb8ba4271cc31cbec7d11468af852808

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

<img width="860" alt="deprecated-on-npm" src="https://user-images.githubusercontent.com/1180335/175608822-4fdcf7ac-0167-4082-9e38-a272d994f0f6.png">

