### PR TITLE
docs: add foreground-scripts to run-script page

### DIFF
--- a/docs/content/commands/npm-run-script.md
+++ b/docs/content/commands/npm-run-script.md
@@ -240,6 +240,21 @@ will *not* run any pre- or post-scripts.
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->
 
+#### `foreground-scripts`
+
+* Default: false
+* Type: Boolean
+
+Run all build scripts (ie, `preinstall`, `install`, and `postinstall`)
+scripts for installed packages in the foreground process, sharing standard
+input, output, and error with the main npm process.
+
+Note that this will generally make installs run slower, and be much noisier,
+but can be useful for debugging.
+
+<!-- automatically generated, do not edit manually -->
+<!-- see lib/utils/config/definitions.js -->
+
 #### `script-shell`
 
 * Default: '/bin/sh' on POSIX systems, 'cmd.exe' on Windows

--- a/lib/commands/run-script.js
+++ b/lib/commands/run-script.js
@@ -35,6 +35,7 @@ class RunScript extends BaseCommand {
     'include-workspace-root',
     'if-present',
     'ignore-scripts',
+    'foreground-scripts',
     'script-shell',
   ]
 

--- a/tap-snapshots/test/lib/load-all-commands.js.test.cjs
+++ b/tap-snapshots/test/lib/load-all-commands.js.test.cjs
@@ -771,7 +771,7 @@ npm run-script <command> [-- <args>]
 Options:
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [-ws|--workspaces] [--include-workspace-root] [--if-present] [--ignore-scripts]
-[--script-shell <script-shell>]
+[--foreground-scripts] [--script-shell <script-shell>]
 
 aliases: run, rum, urn
 

--- a/tap-snapshots/test/lib/npm.js.test.cjs
+++ b/tap-snapshots/test/lib/npm.js.test.cjs
@@ -815,7 +815,7 @@ All commands:
                     Options:
                     [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
                     [-ws|--workspaces] [--include-workspace-root] [--if-present] [--ignore-scripts]
-                    [--script-shell <script-shell>]
+                    [--foreground-scripts] [--script-shell <script-shell>]
                     
                     aliases: run, rum, urn
                     


### PR DESCRIPTION
I was trying to find that option in the docs for `npm run` and could not find it there. This option should probably be documented in its page.