### PR TITLE
[WIP] chore: Deprecate singular `auth-type` config values

### DIFF
--- a/docs/content/using-npm/config.md
+++ b/docs/content/using-npm/config.md
@@ -1909,8 +1909,8 @@ When set to `dev` or `development`, this is an alias for `--include=dev`.
 
 * Default: "legacy"
 * Type: "legacy", "webauthn", "sso", "saml", or "oauth"
-* DEPRECATED: The SSO/SAML/OAuth methods are deprecated and will be removed in
-  a future version of npm in favor of web-based login.
+* DEPRECATED: The SSO/SAML/OAuth/Webauthn methods are deprecated and will be
+  removed in a future version of npm in favor of web-based login.
 
 What authentication strategy to use with `adduser`/`login`.
 

--- a/lib/utils/config/definition.js
+++ b/lib/utils/config/definition.js
@@ -12,6 +12,7 @@ const allowed = [
   'default',
   'defaultDescription',
   'deprecated',
+  'deprecatedValues',
   'description',
   'flatten',
   'hint',

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -240,9 +240,10 @@ define('auth-type', {
   default: 'legacy',
   type: ['legacy', 'webauthn', 'sso', 'saml', 'oauth'],
   deprecated: `
-    The SSO/SAML/OAuth methods are deprecated and will be removed in
+    The SSO/SAML/OAuth/Webauthn methods are deprecated and will be removed in
     a future version of npm in favor of web-based login.
   `,
+  deprecatedValues: ['webauthn', 'sso', 'saml', 'oauth'],
   description: `
     What authentication strategy to use with \`adduser\`/\`login\`.
 

--- a/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
@@ -254,8 +254,8 @@ exports[`test/lib/utils/config/definitions.js TAP > config description for auth-
 
 * Default: "legacy"
 * Type: "legacy", "webauthn", "sso", "saml", or "oauth"
-* DEPRECATED: The SSO/SAML/OAuth methods are deprecated and will be removed in
-  a future version of npm in favor of web-based login.
+* DEPRECATED: The SSO/SAML/OAuth/Webauthn methods are deprecated and will be
+  removed in a future version of npm in favor of web-based login.
 
 What authentication strategy to use with \`adduser\`/\`login\`.
 


### PR DESCRIPTION
## What
Add the ability to deprecate single values for options, instead of just whole options.

## Why
Allows for instance the `--auth-type` configuration option to have non-deprecated as well as deprecated values.

## References
- https://github.com/github/npm/issues/5542
- https://github.com/npm/config/pull/68