### PR TITLE
docs: typo in npm command

### DIFF
--- a/docs/content/commands/npm.md
+++ b/docs/content/commands/npm.md
@@ -102,7 +102,7 @@ following help topics:
   done via [`npm install`](/commands/npm-install)
 * adduser:
   Create an account or log in.  When you do this, npm will store
-  credentials in the user config file config file.
+  credentials in the user config file.
 * publish:
   Use the [`npm publish`](/commands/npm-publish) command to upload your
   code to the registry.


### PR DESCRIPTION
Change `config file config file` -> `config file`
