### PR TITLE
fix: typo in npm-version.md

### DIFF
--- a/docs/content/commands/npm-version.md
+++ b/docs/content/commands/npm-version.md
@@ -13,7 +13,7 @@ description: Bump a package version
 ```bash
 npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease | from-git]
 
-alias: verison
+alias: version
 ```
 
 <!-- automatically generated, do not edit manually -->


### PR DESCRIPTION
Fix for a typo in `npm-version.md`: from `verison` to `version`.