### PR TITLE
feat: deprecate some access subcommands

### DIFF
--- a/docs/content/commands/npm-access.md
+++ b/docs/content/commands/npm-access.md
@@ -35,28 +35,28 @@ For all of the subcommands, `npm access` will perform actions on the packages
 in the current working directory if no package name is passed to the
 subcommand.
 
-* public / restricted:
+* public / restricted (deprecated):
   Set a package to be either publicly accessible or restricted.
 
 * grant / revoke:
   Add or remove the ability of users and teams to have read-only or read-write
   access to a package.
 
-* 2fa-required / 2fa-not-required:
+* 2fa-required / 2fa-not-required (deprecated):
   Configure whether a package requires that anyone publishing it have two-factor
   authentication enabled on their account.
 
-* ls-packages:
+* ls-packages (deprecated):
   Show all of the packages a user or a team is able to access, along with the
   access level, except for read-only public packages (it won't print the whole
   registry listing)
 
-* ls-collaborators:
+* ls-collaborators (deprecated):
   Show all of the access privileges for a package. Will only show permissions
   for packages to which you have at least read access. If `<user>` is passed in,
   the list is filtered only to teams _that_ user happens to belong to.
 
-* edit:
+* edit (deprecated):
   Set the access privileges for a package at once using `$EDITOR`.
 
 ### Details

--- a/lib/commands/access.js
+++ b/lib/commands/access.js
@@ -3,6 +3,7 @@ const path = require('path')
 const libaccess = require('libnpmaccess')
 const readPackageJson = require('read-package-json-fast')
 
+const log = require('../utils/log-shim.js')
 const otplease = require('../utils/otplease.js')
 const getIdentity = require('../utils/get-identity.js')
 const BaseCommand = require('../base-command.js')
@@ -18,6 +19,16 @@ const subcommands = [
   '2fa-required',
   '2fa-not-required',
 ]
+
+const deprecatedSubcommands = new Set([
+  '2fa-required',
+  '2fa-not-required',
+  'public',
+  'restricted',
+  'edit',
+  'ls-packages',
+  'ls-collaborators',
+])
 
 class Access extends BaseCommand {
   static description = 'Set access level on published packages'
@@ -72,6 +83,9 @@ class Access extends BaseCommand {
   async exec ([cmd, ...args]) {
     if (!cmd) {
       throw this.usageError('Subcommand is required.')
+    }
+    if (deprecatedSubcommands.has(cmd)) {
+      log.warn('access', `${cmd} is deprecated and will be removed in a future version.`)
     }
 
     if (!subcommands.includes(cmd) || !this[cmd]) {


### PR DESCRIPTION
Added warning logs for `npm access <subcommand>` for the following subcommands:
 - 2fa-required
 - 2fa-not-required
 - public
 - restricted
 - edit
 - ls-packages
 - ls-collaborators