### PR TITLE
feat: accept registry-scoped certfile and keyfile as credentials

### DIFF
--- a/docs/content/using-npm/config.md
+++ b/docs/content/using-npm/config.md
@@ -357,8 +357,9 @@ newlines replaced by the string "\n". For example:
 cert="-----BEGIN CERTIFICATE-----\nXXXX\nXXXX\n-----END CERTIFICATE-----"
 ```
 
-It is _not_ the path to a certificate file (and there is no "certfile"
-option).
+It is _not_ the path to a certificate file, though you can set a
+registry-scoped "certfile" path like
+"//other-registry.tld/:certfile=/path/to/cert.pem".
 
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->
@@ -946,7 +947,8 @@ format with newlines replaced by the string "\n". For example:
 key="-----BEGIN PRIVATE KEY-----\nXXXX\nXXXX\n-----END PRIVATE KEY-----"
 ```
 
-It is _not_ the path to a key file (and there is no "keyfile" option).
+It is _not_ the path to a key file, though you can set a registry-scoped
+"keyfile" path like "//other-registry.tld/:keyfile=/path/to/key.pem".
 
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -101,7 +101,7 @@ class Publish extends BaseCommand {
     const resolved = npa.resolve(manifest.name, manifest.version)
     const registry = npmFetch.pickRegistry(resolved, opts)
     const creds = this.npm.config.getCredentialsByURI(registry)
-    const noCreds = !creds.token && !creds.username
+    const noCreds = !(creds.token || creds.username || creds.certfile && creds.keyfile)
     const outputRegistry = replaceInfo(registry)
 
     if (noCreds) {

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -436,8 +436,8 @@ define('cert', {
     cert="-----BEGIN CERTIFICATE-----\\nXXXX\\nXXXX\\n-----END CERTIFICATE-----"
     \`\`\`
 
-    It is _not_ the path to a certificate file (and there is no "certfile"
-    option).
+    It is _not_ the path to a certificate file, though you can set a registry-scoped
+    "certfile" path like "//other-registry.tld/:certfile=/path/to/cert.pem".
   `,
   flatten,
 })
@@ -1118,7 +1118,8 @@ define('key', {
     key="-----BEGIN PRIVATE KEY-----\\nXXXX\\nXXXX\\n-----END PRIVATE KEY-----"
     \`\`\`
 
-    It is _not_ the path to a key file (and there is no "keyfile" option).
+    It is _not_ the path to a key file, though you can set a registry-scoped
+    "keyfile" path like "//other-registry.tld/:keyfile=/path/to/key.pem".
   `,
   flatten,
 })

--- a/lib/utils/get-identity.js
+++ b/lib/utils/get-identity.js
@@ -9,8 +9,8 @@ module.exports = async (npm, opts) => {
     return creds.username
   }
 
-  // No username, but we have a token; fetch the username from registry
-  if (creds.token) {
+  // No username, but we have other credentials; fetch the username from registry
+  if (creds.token || creds.certfile && creds.keyfile) {
     const registryData = await npmFetch.json('/-/whoami', { ...opts })
     return registryData.username
   }

--- a/tap-snapshots/test/lib/commands/publish.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/publish.js.test.cjs
@@ -56,7 +56,11 @@ Array [
 ]
 `
 
-exports[`test/lib/commands/publish.js TAP has auth for scope configured registry > new package version 1`] = `
+exports[`test/lib/commands/publish.js TAP has mTLS auth for scope configured registry > new package version 1`] = `
++ @npm/test-package@1.0.0
+`
+
+exports[`test/lib/commands/publish.js TAP has token auth for scope configured registry > new package version 1`] = `
 + @npm/test-package@1.0.0
 `
 

--- a/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
@@ -404,8 +404,9 @@ newlines replaced by the string "\\n". For example:
 cert="-----BEGIN CERTIFICATE-----\\nXXXX\\nXXXX\\n-----END CERTIFICATE-----"
 \`\`\`
 
-It is _not_ the path to a certificate file (and there is no "certfile"
-option).
+It is _not_ the path to a certificate file, though you can set a
+registry-scoped "certfile" path like
+"//other-registry.tld/:certfile=/path/to/cert.pem".
 `
 
 exports[`test/lib/utils/config/definitions.js TAP > config description for ci-name 1`] = `
@@ -1016,7 +1017,8 @@ format with newlines replaced by the string "\\n". For example:
 key="-----BEGIN PRIVATE KEY-----\\nXXXX\\nXXXX\\n-----END PRIVATE KEY-----"
 \`\`\`
 
-It is _not_ the path to a key file (and there is no "keyfile" option).
+It is _not_ the path to a key file, though you can set a registry-scoped
+"keyfile" path like "//other-registry.tld/:keyfile=/path/to/key.pem".
 `
 
 exports[`test/lib/utils/config/definitions.js TAP > config description for legacy-bundling 1`] = `

--- a/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
@@ -230,8 +230,9 @@ newlines replaced by the string "\\n". For example:
 cert="-----BEGIN CERTIFICATE-----\\nXXXX\\nXXXX\\n-----END CERTIFICATE-----"
 \`\`\`
 
-It is _not_ the path to a certificate file (and there is no "certfile"
-option).
+It is _not_ the path to a certificate file, though you can set a
+registry-scoped "certfile" path like
+"//other-registry.tld/:certfile=/path/to/cert.pem".
 
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->
@@ -819,7 +820,8 @@ format with newlines replaced by the string "\\n". For example:
 key="-----BEGIN PRIVATE KEY-----\\nXXXX\\nXXXX\\n-----END PRIVATE KEY-----"
 \`\`\`
 
-It is _not_ the path to a key file (and there is no "keyfile" option).
+It is _not_ the path to a key file, though you can set a registry-scoped
+"keyfile" path like "//other-registry.tld/:keyfile=/path/to/key.pem".
 
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->

--- a/test/lib/commands/whoami.js
+++ b/test/lib/commands/whoami.js
@@ -34,6 +34,20 @@ t.test('npm whoami --json', async t => {
   t.equal(JSON.parse(joinedOutput()), username, 'should print username')
 })
 
+t.test('npm whoami using mTLS', async t => {
+  const { npm, joinedOutput } = await loadMockNpm(t, { config: {
+    '//registry.npmjs.org/:certfile': '/some.cert',
+    '//registry.npmjs.org/:keyfile': '/some.key',
+  } })
+  const registry = new MockRegistry({
+    tap: t,
+    registry: npm.config.get('registry'),
+  })
+  registry.whoami({ username })
+  await npm.exec('whoami', [])
+  t.equal(joinedOutput(), username, 'should print username')
+})
+
 t.test('credentials from token', async t => {
   const { npm, joinedOutput } = await loadMockNpm(t, {
     config: {


### PR DESCRIPTION
While this doesn't directly allow top-level cert/key as credentials (per the [original issue](https://github.com/npm/cli/issues/4765)), it's a more targeted/secure approach that accomplishes the same end-result; the new options are scoped to a specific registry, and the actual cert/key contents are much less likely to be exposed. See the [RFC](https://github.com/npm/rfcs/pull/591) for more context.

## References
Related to https://github.com/npm/rfcs/pull/591
Depends on https://github.com/npm/npm-registry-fetch/pull/125, https://github.com/npm/config/pull/69
Closes #4765
