### PR TITLE
fix: when filtering workspaces, make sure the edge has a to before checking if its a workspace

### DIFF
--- a/lib/commands/ls.js
+++ b/lib/commands/ls.js
@@ -92,7 +92,7 @@ class LS extends ArboristWorkspaceCmd {
       }
 
       if (this.npm.flatOptions.includeWorkspaceRoot
-          && !edge.to.isWorkspace) {
+          && edge.to && !edge.to.isWorkspace) {
         return true
       }
 

--- a/tap-snapshots/test/lib/commands/ls.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/ls.js.test.cjs
@@ -678,6 +678,13 @@ dedupe-entries@1.0.0 {CWD}/tap-testdir-ls-ls-with-no-args-dedupe-entries-and-not
 
 `
 
+exports[`test/lib/commands/ls.js TAP ls workspace and missing optional dep > should omit missing optional dep 1`] = `
+root@ {CWD}/tap-testdir-ls-ls-workspace-and-missing-optional-dep
++-- baz@1.0.0 -> ./baz
+\`-- foo@1.0.0
+
+`
+
 exports[`test/lib/commands/ls.js TAP show multiple invalid reasons > ls result 1`] = `
 test-npm-ls@1.0.0 {cwd}/tap-testdir-ls-show-multiple-invalid-reasons
 +-- cat@1.0.0 invalid: "^2.0.0" from the root project

--- a/test/lib/commands/ls.js
+++ b/test/lib/commands/ls.js
@@ -178,6 +178,44 @@ t.test('ls', t => {
     )
   })
 
+  t.test('workspace and missing optional dep', async t => {
+    npm.prefix = npm.localPrefix = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'root',
+        dependencies: {
+          foo: '^1.0.0',
+        },
+        optionalDependencies: {
+          bar: '^1.0.0',
+        },
+        workspaces: ['./baz'],
+      }),
+      baz: {
+        'package.json': JSON.stringify({
+          name: 'baz',
+          version: '1.0.0',
+        }),
+      },
+      node_modules: {
+        baz: t.fixture('symlink', '../baz'),
+        foo: {
+          'package.json': JSON.stringify({
+            name: 'foo',
+            version: '1.0.0',
+          }),
+        },
+      },
+    })
+
+    npm.flatOptions.includeWorkspaceRoot = true
+    t.teardown(() => {
+      delete npm.flatOptions.includeWorkspaceRoot
+    })
+
+    await ls.execWorkspaces([], ['baz'])
+    t.matchSnapshot(redactCwd(result), 'should omit missing optional dep')
+  })
+
   t.test('extraneous deps', async t => {
     npm.prefix = t.testdir({
       'package.json': JSON.stringify({


### PR DESCRIPTION
~WIP: needs tests~

when checking if an edge target is a workspace, we should first make sure the edge even has a target. missing optional dependencies can cause a tree that has an edge with no target.
