### PR TITLE
fix: disable progress bar on publish

### DIFF
--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -61,7 +61,7 @@ class Publish extends BaseCommand {
       throw new Error('Tag name must not be a valid SemVer range: ' + defaultTag.trim())
     }
 
-    const opts = { ...this.npm.flatOptions }
+    const opts = { ...this.npm.flatOptions, progress: false }
 
     // you can publish name@version, ./foo.tgz, etc.
     // even though the default is the 'file:.' cwd.


### PR DESCRIPTION
It is not supposed to be there, in that it doesn't get any updates and
gets in the way of logging messages.  We already log the server we are
publishing to in the `notice` headers so the one `http` log message that
we get during publish isn't needed on stdout.
