### PR TITLE
remove command that is not working anymore in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,12 +39,6 @@ $ node . run test
 
 We use [`tap`](https://node-tap.org/) for testing & expect that every new feature or bug fix comes with corresponding tests that validate the solutions. We strive to have as close to, if not exactly, 100% code coverage.
 
-**You can find out what the current test coverage percentage is by running...**
-
-```bash
-$ node . run check-coverage
-```
-
 ## Performance & Benchmarks
 
 We've set up an automated [benchmark](https://github.com/npm/benchmarks) integration that will run against all Pull Requests; Posting back a comment with the results of the run.


### PR DESCRIPTION
Removing the `check-coverage` command from the _CONTRIBUTING.md_ docs as it doesn't seem to work anymore, even after running tests once.
```sh
% node . run check-coverage
npm ERR! Missing script: "check-coverage"
npm ERR!
npm ERR! To see a list of scripts, run:
npm ERR!   npm run

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/owenbuckley/.npm/_logs/2022-07-17T18_33_56_029Z-debug-0.log
```

Fwiw, `node . run test` works fine.


## References
N / A

----

If there is an equivalent command to replace instead, let me know and would be happy to update it.  I didn't see anything obvious just from looking in the `script` section of _package.json_.  👍 