### PR TITLE
docs: Removed run-script from `npm build` description

### DIFF
--- a/docs/content/commands/npm-build.md
+++ b/docs/content/commands/npm-build.md
@@ -19,7 +19,7 @@ This is the plumbing command called by `npm link` and `npm install`.
 It should generally be called during installation, but if you need to run it
 directly, run:
 ```bash
-    npm run-script build
+    npm build
 ```
 
 ### See Also


### PR DESCRIPTION
<!-- What / Why -->

Removed `run-script` from the description of the `build` command. This has been confirmed as an error on #5185.

<!-- Describe the request in detail. What it does and why it's being changed. -->

<!-- N/A: This is a simple change-->

## References

Related to #5185
