### PR TITLE
docs (npm-ci.md): typo "isntall" to "install"

### DIFF
--- a/docs/content/commands/npm-ci.md
+++ b/docs/content/commands/npm-ci.md
@@ -13,7 +13,7 @@ description: Clean install a project
 ```bash
 npm ci
 
-aliases: clean-install, ic, install-clean, isntall-clean
+aliases: clean-install, ic, install-clean, install-clean
 ```
 
 <!-- automatically generated, do not edit manually -->


### PR DESCRIPTION
In the docs, when mentioning the aliases for npm ci, there is a typo ("isntall" is written in place of "install") - fixed that typo :)

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
