### PR TITLE
docs: Use the full proper name of Travis CI

### DIFF
--- a/docs/content/commands/npm-ci.md
+++ b/docs/content/commands/npm-ci.md
@@ -67,7 +67,7 @@ $ npm ci
 added 154 packages in 5s
 ```
 
-Configure Travis to build using `npm ci` instead of `npm install`:
+Configure Travis CI to build using `npm ci` instead of `npm install`:
 
 ```bash
 # .travis.yml


### PR DESCRIPTION
As per https://www.travis-ci.com/about-us/, the proper name looks like `Travis CI`.

## References
n/a

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>
