### PR TITLE
Gracefully exit login and publish commands on Ctrl+C (SIGINT) in the new webAuthn flow 

### DIFF
--- a/lib/utils/open-url-prompt.js
+++ b/lib/utils/open-url-prompt.js
@@ -34,7 +34,12 @@ const promptOpen = async (npm, url, title, prompt, emitter) => {
   })
 
   const tryOpen = await new Promise(resolve => {
-    rl.question(prompt, () => {
+    rl.on('SIGINT', () => {
+      rl.close()
+      throw Error('canceled')
+    });
+
+    rl.question(prompt, (userInput) => {
       resolve(true)
     })
 

--- a/lib/utils/open-url-prompt.js
+++ b/lib/utils/open-url-prompt.js
@@ -37,8 +37,8 @@ const promptOpen = async (npm, url, title, prompt, emitter) => {
     rl.on('SIGINT', () => {
       rl.close()
       resolve('SIGINT')
-    });
-    
+    })
+
     rl.question(prompt, () => {
       resolve(true)
     })

--- a/lib/utils/open-url-prompt.js
+++ b/lib/utils/open-url-prompt.js
@@ -36,10 +36,10 @@ const promptOpen = async (npm, url, title, prompt, emitter) => {
   const tryOpen = await new Promise(resolve => {
     rl.on('SIGINT', () => {
       rl.close()
-      throw Error('canceled')
+      resolve('SIGINT')
     });
-
-    rl.question(prompt, (userInput) => {
+    
+    rl.question(prompt, () => {
       resolve(true)
     })
 
@@ -54,6 +54,10 @@ const promptOpen = async (npm, url, title, prompt, emitter) => {
       })
     }
   })
+
+  if (tryOpen === 'SIGINT') {
+    throw new Error('canceled')
+  }
 
   if (!tryOpen) {
     return

--- a/test/lib/utils/open-url-prompt.js
+++ b/test/lib/utils/open-url-prompt.js
@@ -36,7 +36,10 @@ const readline = {
       }
     },
     close: () => {},
-  }),
+    on: (_signal, cb) => { 
+      cb()
+    }
+  })
 }
 
 const openUrlPrompt = t.mock('../../../lib/utils/open-url-prompt.js', {

--- a/test/lib/utils/open-url-prompt.js
+++ b/test/lib/utils/open-url-prompt.js
@@ -28,6 +28,8 @@ const opener = (url, opts, cb) => {
 }
 
 let questionShouldResolve = true
+let openUrlPromptInterrupted = false
+
 const readline = {
   createInterface: () => ({
     question: (_q, cb) => {
@@ -36,10 +38,12 @@ const readline = {
       }
     },
     close: () => {},
-    on: (_signal, cb) => { 
-      cb()
-    }
-  })
+    on: (_signal, cb) => {
+      if (openUrlPromptInterrupted && _signal === 'SIGINT') {
+        cb()
+      }
+    },
+  }),
 }
 
 const openUrlPrompt = t.mock('../../../lib/utils/open-url-prompt.js', {
@@ -150,4 +154,26 @@ t.test('returns error when opener errors', async t => {
     'got the correct error'
   )
   t.equal(openerUrl, 'https://www.npmjs.com', 'did not open')
+})
+
+t.test('throws "canceled" error on SIGINT', async t => {
+  t.teardown(() => {
+    openerUrl = null
+    openerOpts = null
+    OUTPUT.length = 0
+    questionShouldResolve = true
+    openUrlPromptInterrupted = false
+  })
+
+  questionShouldResolve = false
+  openUrlPromptInterrupted = true
+  const emitter = new EventEmitter()
+
+  const open = openUrlPrompt(npm, 'https://www.npmjs.com', 'npm home', 'prompt', emitter)
+
+  try {
+    await open
+  } catch (err) {
+    t.equal(err.message, 'canceled')
+  }
 })


### PR DESCRIPTION
## What / Why 
This PR resolves the bug which did not allow users to exit the CLI process on hitting CTRL + C for `npm publish --auth-type=web` and `npm login auth-type=web` commands. 

### Approach
We use `readline` to prompt the user to hit ENTER. However, the first time the user hits CTRL+C, it closes the `readline` instance ([docs](https://nodejs.org/api/readline.html#event-sigint:~:text=Emit%20SIGINT%20or%20close%20the%20readline%20instance)). The second CTRL+C then kills the CLI process. This PR adds an event listener which listens to `readline`'s SIGINT event  ([docs](https://nodejs.org/api/readline.html#event-sigint:~:text=supported%20on%20Windows.-,Event%3A%20%27SIGINT%27,-%23)) and then gracefully kills the CLI process from the `cb` function. 

Note: The experience shown after hitting CTRL+C is kept similar to the existing experience when the user hits CTRL+C for login and publish commands without the `auth-type=web` flag

The PR also adds a test case to validate the same.

### Experience

#### Login

https://user-images.githubusercontent.com/23032255/182382195-f1236d9a-1047-4f4b-8eaf-50f526b8ca8a.mov

#### Publish

https://user-images.githubusercontent.com/23032255/182382242-9ce7d191-3c8c-4840-bbf8-a88f740e41ae.mov


## References
Resolves https://github.com/npm/cli/issues/5231
