### PR TITLE
fix(arborist): fix bare attribute queries

### DIFF
--- a/workspaces/arborist/lib/query-selector-all.js
+++ b/workspaces/arborist/lib/query-selector-all.js
@@ -366,12 +366,12 @@ const attributeMatch = (matcher, obj) => {
   const operator = matcher.operator || ''
   const attribute = matcher.qualifiedAttribute
   let value = matcher.value || ''
-  if (insensitive) {
-    value = value.toLowerCase()
-  }
-  // if we're checking for existence we can return early & avoid attr coersion
+  // return early if checking existence
   if (operator === '') {
     return Boolean(obj[attribute])
+  }
+  if (insensitive) {
+    value = value.toLowerCase()
   }
   // in case the current object is an array
   // then we try to match every item in the array

--- a/workspaces/arborist/lib/query-selector-all.js
+++ b/workspaces/arborist/lib/query-selector-all.js
@@ -317,10 +317,6 @@ class Results {
 
 // operators for attribute selectors
 const attributeOperators = {
-  // existence of the attribute
-  '' ({ attr }) {
-    return Boolean(attr)
-  },
   // attribute value is equivalent
   '=' ({ attr, value, insensitive }) {
     return attr === value
@@ -372,6 +368,10 @@ const attributeMatch = (matcher, obj) => {
   let value = matcher.value || ''
   if (insensitive) {
     value = value.toLowerCase()
+  }
+  // if we're checking for existence we can return early & avoid attr coersion
+  if (operator === '') {
+    return Boolean(obj[attribute])
   }
   // in case the current object is an array
   // then we try to match every item in the array

--- a/workspaces/arborist/test/query-selector-all.js
+++ b/workspaces/arborist/test/query-selector-all.js
@@ -86,6 +86,9 @@ t.test('query-selector-all', async t => {
           dependencies: {
             lorem: 'latest',
           },
+          scripts: {
+            test: 'tap',
+          },
         }),
       },
       foo: {
@@ -567,6 +570,9 @@ t.test('query-selector-all', async t => {
     [':attr(arbitrary, :attr([foo=10000]))', ['bar@2.0.0']],
 
     // attribute matchers
+    ['[scripts]', [
+      'baz@1.0.0',
+    ]],
     ['[name]', [
       'query-selector-all-tests@1.0.0',
       'a@1.0.0',


### PR DESCRIPTION
- fixes bare attribute specifiers from incorrectly being coerced & failing to match (ex. `[scripts]`)