### PR TITLE
fix: only try to run global bin if the bin name exists

### DIFF
--- a/workspaces/libnpmexec/lib/index.js
+++ b/workspaces/libnpmexec/lib/index.js
@@ -161,7 +161,7 @@ const exec = async (opts) => {
       const globalTree = await globalArb.loadActual()
       const { manifest: globalManifest } =
         await missingFromTree({ spec, tree: globalTree, flatOptions })
-      if (!globalManifest) {
+      if (!globalManifest && await fileExists(`${globalBin}/${args[0]}`)) {
         binPaths.push(globalBin)
         return await run()
       }


### PR DESCRIPTION
subdeps are in the tree but they don't have a bin
