### PR TITLE
docs: Fix link syntax in `dependency-selectors.md`

### DIFF
--- a/docs/content/using-npm/dependency-selectors.md
+++ b/docs/content/using-npm/dependency-selectors.md
@@ -165,4 +165,4 @@ arb.loadActual((tree) => {
 ## See Also
 
 * [npm query](/commands/npm-query)
-* [@npmcli/arborist](https://npm.im/@npmcli/arborist]
+* [@npmcli/arborist](https://npm.im/@npmcli/arborist)


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

Currently, this is being rendered as follows:

![Screenshot 2022-08-04 at 08-52-41 Dependency Selector Syntax   Querying npm Docs](https://user-images.githubusercontent.com/1301152/182782675-7b48e79d-a327-4dec-9f2f-b09f8bdcdce4.png)
