### PR TITLE
feat: rootless workspace init provides suggestion

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -54,7 +54,12 @@ class Init extends BaseCommand {
     // reads package.json for the top-level folder first, by doing this we
     // ensure the command throw if no package.json is found before trying
     // to create a workspace package.json file or its folders
-    const pkg = await rpj(resolve(this.npm.localPrefix, 'package.json'))
+    const pkg = await rpj(resolve(this.npm.localPrefix, 'package.json')).catch((err) => {
+      if (err.code === 'ENOENT') {
+        log.warn('Missing package.json. Try with `--include-workspace-root`.')
+      }
+      throw err
+    })
 
     // these are workspaces that are being created, so we cant use
     // this.setWorkspaces()

--- a/test/lib/commands/init.js
+++ b/test/lib/commands/init.js
@@ -335,7 +335,7 @@ t.test('workspaces', async t => {
   })
 
   await t.test('missing top-level package.json when settting workspace', async t => {
-    const { npm } = await mockNpm(t, {
+    const { npm, logs } = await mockNpm(t, {
       config: { workspace: 'a' },
     })
 
@@ -344,6 +344,25 @@ t.test('workspaces', async t => {
       { code: 'ENOENT' },
       'should exit with missing package.json file error'
     )
+
+    t.equal(logs.warn[0][0], 'Missing package.json. Try with `--include-workspace-root`.')
+  })
+
+  await t.test('bad package.json when settting workspace', async t => {
+    const { npm, logs } = await mockNpm(t, {
+      prefixDir: {
+        'package.json': '{{{{',
+      },
+      config: { workspace: 'a' },
+    })
+
+    await t.rejects(
+      npm.exec('init', []),
+      { code: 'EJSONPARSE' },
+      'should exit with parse file error'
+    )
+
+    t.strictSame(logs.warn, [])
   })
 
   await t.test('using args - no package.json', async t => {


### PR DESCRIPTION
Adds a warning message suggesting the use of `--include-workspace-root` when ENOENT is thrown for the `npm init` command when specifying one or more workspaces.