### PR TITLE
fix: fix missing fields, like scripts, in npm query when the virtual tree is loaded

### DIFF
--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -58,6 +58,7 @@ class Query extends BaseCommand {
     const opts = {
       ...this.npm.flatOptions,
       path: where,
+      forceActual: true,
     }
     const arb = new Arborist(opts)
     const tree = await arb.loadActual(opts)

--- a/workspaces/arborist/tap-snapshots/test/arborist/load-actual.js.test.cjs
+++ b/workspaces/arborist/tap-snapshots/test/arborist/load-actual.js.test.cjs
@@ -1084,6 +1084,39 @@ ArboristNode {
 }
 `
 
+exports[`test/arborist/load-actual.js TAP do not load from a hidden lockfile when forceActual is set > must match snapshot 1`] = `
+ArboristNode {
+  "children": Map {
+    "abbrev" => ArboristNode {
+      "edgesIn": Set {
+        EdgeIn {
+          "from": "",
+          "name": "abbrev",
+          "spec": "^1.1.1",
+          "type": "prod",
+        },
+      },
+      "location": "node_modules/abbrev",
+      "name": "abbrev",
+      "path": "hidden-lockfile/node_modules/abbrev",
+      "version": "1.1.1",
+    },
+  },
+  "edgesOut": Map {
+    "abbrev" => EdgeOut {
+      "name": "abbrev",
+      "spec": "^1.1.1",
+      "to": "node_modules/abbrev",
+      "type": "prod",
+    },
+  },
+  "isProjectRoot": true,
+  "location": "",
+  "name": "hidden-lockfile",
+  "path": "hidden-lockfile",
+}
+`
+
 exports[`test/arborist/load-actual.js TAP external-dep/root > loaded tree 1`] = `
 ArboristNode {
   "edgesOut": Map {
@@ -3760,7 +3793,7 @@ ArboristNode {
 }
 `
 
-exports[`test/arborist/load-actual.js TAP load from a hidden lockfile > expect resolving Promise 1`] = `
+exports[`test/arborist/load-actual.js TAP load from a hidden lockfile > must match snapshot 1`] = `
 ArboristNode {
   "children": Map {
     "abbrev" => ArboristNode {

--- a/workspaces/arborist/test/arborist/load-actual.js
+++ b/workspaces/arborist/test/arborist/load-actual.js
@@ -199,8 +199,17 @@ t.test('missing symlinks', t =>
       'bar has error')
   }))
 
-t.test('load from a hidden lockfile', t =>
-  t.resolveMatchSnapshot(loadActual(resolve(fixtures, 'hidden-lockfile'))))
+t.test('load from a hidden lockfile', async (t) => {
+  const tree = await loadActual(resolve(fixtures, 'hidden-lockfile'))
+  t.ok(tree.meta.loadedFromDisk, 'meta was loaded from disk')
+  t.matchSnapshot(tree)
+})
+
+t.test('do not load from a hidden lockfile when forceActual is set', async (t) => {
+  const tree = await loadActual(resolve(fixtures, 'hidden-lockfile'), { forceActual: true })
+  t.not(tree.meta.loadedFromDisk, 'meta was NOT loaded from disk')
+  t.matchSnapshot(tree)
+})
 
 t.test('load a global space', t =>
   t.resolveMatchSnapshot(loadActual(resolve(fixtures, 'global-style/lib'), {


### PR DESCRIPTION
arborist's `loadActual()` method checks for a hidden lockfile first, if one exists we load the tree virtually which causes us to lose quite a lot of data. this pull request introduces a new flag for arborist to forcibly skip this virtual loading and instead do an actual tree load, which brings back the properties we were missing
