### PR TITLE
feat: Add `prefetch` script to install and ci commands

### DIFF
--- a/lib/commands/ci.js
+++ b/lib/commands/ci.js
@@ -73,9 +73,28 @@ class CI extends ArboristWorkspaceCmd {
       return Promise.all(entries.map(f => rimraf(`${path}/${f}`, { glob: false })))
     })
 
+    const ignoreScripts = this.npm.config.get('ignore-scripts')
+    // run the same set of scripts that `npm install` runs.
+    if (!ignoreScripts) {
+      const scripts = [
+        'prefetch',
+      ]
+      const scriptShell = this.npm.config.get('script-shell') || undefined
+      for (const event of scripts) {
+        await runScript({
+          path: where,
+          args: [],
+          scriptShell,
+          stdio: 'inherit',
+          stdioString: true,
+          banner: !this.npm.silent,
+          event,
+        })
+      }
+    }
+
     await arb.reify(opts)
 
-    const ignoreScripts = this.npm.config.get('ignore-scripts')
     // run the same set of scripts that `npm install` runs.
     if (!ignoreScripts) {
       const scripts = [

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -134,6 +134,23 @@ class Install extends ArboristWorkspaceCmd {
       throw this.usageError()
     }
 
+    if (!args.length && !isGlobalInstall && !ignoreScripts) {
+      const scripts = [
+        'prefetch',
+      ]
+      for (const event of scripts) {
+        await runScript({
+          path: where,
+          args: [],
+          scriptShell,
+          stdio: 'inherit',
+          stdioString: true,
+          banner: !this.npm.silent,
+          event,
+        })
+      }
+    }
+
     const opts = {
       ...this.npm.flatOptions,
       auditLevel: null,

--- a/test/lib/commands/ci.js
+++ b/test/lib/commands/ci.js
@@ -139,6 +139,7 @@ t.test('lifecycle scripts', async t => {
   registry.nock.post('/-/npm/v1/security/advisories/bulk').reply(200, {})
   await npm.exec('ci', [])
   t.same(scripts, [
+    'prefetch',
     'preinstall',
     'install',
     'postinstall',

--- a/test/lib/commands/install.js
+++ b/test/lib/commands/install.js
@@ -81,6 +81,7 @@ t.test('without args', async t => {
   t.match(ARB_ARGS, { global: false, path: npm.prefix })
   t.equal(REIFY_CALLED, true, 'called reify')
   t.strictSame(SCRIPTS, [
+    'prefetch',
     'preinstall',
     'install',
     'postinstall',


### PR DESCRIPTION
In v7 the `preinstall` script was intentionally changed to run after dependencies are installed. This was never documented as a breaking change and has since then been neither fixed nor otherwise remedied. While I personally would argue that since it was never listed as a breaking change it should be considered a bug, I recognize that the time elapsed since then complicates matters.

Because of that, I propose simply adding a new script that will run before dependencies are installed to restore a critical piece of functionality that was removed without being documented. An oft-cited use for a script being run at that point is to authenticate to a private registry before attempting to fetch packages.

I also recognize this issue may be more complicated than my initial single commit attempts to make it seem, but the bug report (#2660) seems to have stagnated since it was submitted in February of 2021, and as far as I can tell no one has even attempted a fix. There is [debate](https://github.com/npm/cli/issues/2660#issuecomment-1081921399) over whether this inaction means that it must be very complicated or not. I hope that this PR will at least spur additional debate. I'm happy to be proven wrong.

I'm largely unfamiliar with the npm codebase, so please do suggest a different script name (I chose `prefetch` fairly arbitrarily just based on my understanding, but have no attachment to it), different placement for the `runScript` call etc., or additional required changes/tests I may have missed. Or if someone with more understanding of the details is inspired to pick this up and run with it, by all means, please do so.

Edit: It looks like there was an early attempt (#2713) to move `preinstall` before `reify` that was closed because it would be "breaking" (even though, again, this would actually just fix an undocumented change), but no alternative remedy was ever acted on.

## References
Fixes #2660 
Related to #2713
Related to https://github.com/npm/rfcs/pull/403