### PR TITLE
fix(docs): remove unnecessary indentation in `npm link` examples

### DIFF
--- a/docs/content/commands/npm-link.md
+++ b/docs/content/commands/npm-link.md
@@ -41,10 +41,10 @@ test it iteratively without having to continually rebuild.
 For example:
 
 ```bash
-    cd ~/projects/node-redis    # go into the package directory
-    npm link                    # creates global link
-    cd ~/projects/node-bloggy   # go into some other package directory.
-    npm link redis              # link-install the package
+cd ~/projects/node-redis    # go into the package directory
+npm link                    # creates global link
+cd ~/projects/node-bloggy   # go into some other package directory.
+npm link redis              # link-install the package
 ```
 
 Now, any changes to ~/projects/node-redis will be reflected in


### PR DESCRIPTION
Fixes indentation in Bash snippet.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
