### PR TITLE
fix: npm exec does not use script-shell option to run commands

### DIFF
--- a/workspaces/libnpmexec/lib/run-script.js
+++ b/workspaces/libnpmexec/lib/run-script.js
@@ -73,6 +73,7 @@ const run = async ({
       event: 'npx',
       args,
       stdio: 'inherit',
+      scriptShell,
     })
   } finally {
     npmlog.enableProgress()


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
`npm exec`/`npx` do not fully respect the `script-shell` parameter. When combined with https://github.com/npm/run-script/issues/103 this means that users on AIX cannot run `npx`/`npm exec` commands even with `script-shell` set to `bash`.

For example:
```
$ npm config get script-shell
bash
$ npx

Entering npm script environment at location:
/home/gb120268/package/bin
Type 'exit' or ^D when finished

bash: --:  not found
$ npm config delete script-shell
$ ./npx

Entering npm script environment at location:
/home/gb120268/package/bin
Type 'exit' or ^D when finished

sh: --:  not found
```

## References

Related to https://github.com/npm/run-script/issues/103