### PR TITLE
fix: don't prompt on `npm exec [directory]`

### DIFF
--- a/workspaces/libnpmexec/test/index.js
+++ b/workspaces/libnpmexec/test/index.js
@@ -482,7 +482,16 @@ require('fs').writeFileSync(process.argv.slice(2)[0], 'LOCAL PKG')`,
   const executable = resolve(path, 'a/index.js')
   fs.chmodSync(executable, 0o775)
 
-  await libexec({
+  const mockexec = t.mock('../lib/index.js', {
+    '@npmcli/ci-detect': () => true,
+    'proc-log': {
+      warn (title, msg) {
+        t.fail('should not warn about local file package install')
+      },
+    },
+  })
+
+  await mockexec({
     ...baseOpts,
     args: [`file:${resolve(path, 'a')}`, 'resfile'],
     cache,


### PR DESCRIPTION
Local directories have to be "installed" so that their bins are linked
and set up and callable, the user shouldn't need to be prompted to do
that.  Note that this does NOT affect anything passed via the
`--package` param, because that may also contain non-directory specs so
the existing behavior needs to be preserved.  This is a small QOL
improvement for the isolated use case of "npm exec [directory]"

This also updates the hashing method used to come up with the `.npx`
directory to resolve the paths to packages first, so that `npm exec .`
in different directories don't share the same `.npx` directory.