### PR TITLE
Fix update-notifier using deprecated -g config

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -847,3 +847,4 @@ Patryk Ludwikowski <psychoxivi@gmail.com>
 Takuya N <takninnovationresearch@gmail.com>
 Neel Dani <neeldani@github.com>
 Anton Rieder <1301152+aried3r@users.noreply.github.com>
+Dimitri Masson <5263585+dhmmasson@users.noreply.github.com>

--- a/lib/utils/update-notifier.js
+++ b/lib/utils/update-notifier.js
@@ -107,7 +107,7 @@ const updateNotifier = async (npm, spec = 'latest') => {
   const latestc = !useColor ? latest : chalk.green(latest)
   const changelog = `https://github.com/npm/cli/releases/tag/v${latest}`
   const changelogc = !useColor ? `<${changelog}>` : chalk.cyan(changelog)
-  const cmd = `npm install -g npm@${latest}`
+  const cmd = `npm install --location=global npm@${latest}`
   const cmdc = !useColor ? `\`${cmd}\`` : chalk.green(cmd)
   const message = `\nNew ${typec} version of npm available! ` +
     `${oldc} -> ${latestc}\n` +

--- a/tap-snapshots/test/lib/utils/update-notifier.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/update-notifier.js.test.cjs
@@ -9,7 +9,7 @@ exports[`test/lib/utils/update-notifier.js TAP notification situations major to 
 
 New [31mmajor[39m version of npm available! [31m122.420.69[39m -> [32m123.420.69[39m
 Changelog: [36mhttps://github.com/npm/cli/releases/tag/v123.420.69[39m
-Run [32mnpm install -g npm@123.420.69[39m to update!
+Run [32mnpm install --location=global npm@123.420.69[39m to update!
 
 `
 
@@ -17,7 +17,7 @@ exports[`test/lib/utils/update-notifier.js TAP notification situations major to 
 
 New major version of npm available! 122.420.69 -> 123.420.69
 Changelog: <https://github.com/npm/cli/releases/tag/v123.420.69>
-Run \`npm install -g npm@123.420.69\` to update!
+Run \`npm install --location=global npm@123.420.69\` to update!
 
 `
 
@@ -25,7 +25,7 @@ exports[`test/lib/utils/update-notifier.js TAP notification situations minor to 
 
 New [33mminor[39m version of npm available! [31m123.419.69[39m -> [32m123.420.69[39m
 Changelog: [36mhttps://github.com/npm/cli/releases/tag/v123.420.69[39m
-Run [32mnpm install -g npm@123.420.69[39m to update!
+Run [32mnpm install --location=global npm@123.420.69[39m to update!
 
 `
 
@@ -33,7 +33,7 @@ exports[`test/lib/utils/update-notifier.js TAP notification situations minor to 
 
 New minor version of npm available! 123.419.69 -> 123.420.69
 Changelog: <https://github.com/npm/cli/releases/tag/v123.420.69>
-Run \`npm install -g npm@123.420.69\` to update!
+Run \`npm install --location=global npm@123.420.69\` to update!
 
 `
 
@@ -41,7 +41,7 @@ exports[`test/lib/utils/update-notifier.js TAP notification situations minor to 
 
 New [33mminor[39m version of npm available! [31m123.420.70[39m -> [32m123.421.70[39m
 Changelog: [36mhttps://github.com/npm/cli/releases/tag/v123.421.70[39m
-Run [32mnpm install -g npm@123.421.70[39m to update!
+Run [32mnpm install --location=global npm@123.421.70[39m to update!
 
 `
 
@@ -49,7 +49,7 @@ exports[`test/lib/utils/update-notifier.js TAP notification situations minor to 
 
 New minor version of npm available! 123.420.70 -> 123.421.70
 Changelog: <https://github.com/npm/cli/releases/tag/v123.421.70>
-Run \`npm install -g npm@123.421.70\` to update!
+Run \`npm install --location=global npm@123.421.70\` to update!
 
 `
 
@@ -57,7 +57,7 @@ exports[`test/lib/utils/update-notifier.js TAP notification situations new beta 
 
 New [32mprerelease[39m version of npm available! [31m124.0.0-beta.0[39m -> [32m124.0.0-beta.99999[39m
 Changelog: [36mhttps://github.com/npm/cli/releases/tag/v124.0.0-beta.99999[39m
-Run [32mnpm install -g npm@124.0.0-beta.99999[39m to update!
+Run [32mnpm install --location=global npm@124.0.0-beta.99999[39m to update!
 
 `
 
@@ -65,7 +65,7 @@ exports[`test/lib/utils/update-notifier.js TAP notification situations new beta 
 
 New prerelease version of npm available! 124.0.0-beta.0 -> 124.0.0-beta.99999
 Changelog: <https://github.com/npm/cli/releases/tag/v124.0.0-beta.99999>
-Run \`npm install -g npm@124.0.0-beta.99999\` to update!
+Run \`npm install --location=global npm@124.0.0-beta.99999\` to update!
 
 `
 
@@ -73,7 +73,7 @@ exports[`test/lib/utils/update-notifier.js TAP notification situations patch to 
 
 New [32mpatch[39m version of npm available! [31m123.420.68[39m -> [32m123.420.69[39m
 Changelog: [36mhttps://github.com/npm/cli/releases/tag/v123.420.69[39m
-Run [32mnpm install -g npm@123.420.69[39m to update!
+Run [32mnpm install --location=global npm@123.420.69[39m to update!
 
 `
 
@@ -81,7 +81,7 @@ exports[`test/lib/utils/update-notifier.js TAP notification situations patch to 
 
 New patch version of npm available! 123.420.68 -> 123.420.69
 Changelog: <https://github.com/npm/cli/releases/tag/v123.420.69>
-Run \`npm install -g npm@123.420.69\` to update!
+Run \`npm install --location=global npm@123.420.69\` to update!
 
 `
 
@@ -89,7 +89,7 @@ exports[`test/lib/utils/update-notifier.js TAP notification situations patch to 
 
 New [32mpatch[39m version of npm available! [31m123.421.69[39m -> [32m123.421.70[39m
 Changelog: [36mhttps://github.com/npm/cli/releases/tag/v123.421.70[39m
-Run [32mnpm install -g npm@123.421.70[39m to update!
+Run [32mnpm install --location=global npm@123.421.70[39m to update!
 
 `
 
@@ -97,6 +97,6 @@ exports[`test/lib/utils/update-notifier.js TAP notification situations patch to 
 
 New patch version of npm available! 123.421.69 -> 123.421.70
 Changelog: <https://github.com/npm/cli/releases/tag/v123.421.70>
-Run \`npm install -g npm@123.421.70\` to update!
+Run \`npm install --location=global npm@123.421.70\` to update!
 
 `


### PR DESCRIPTION
The notification message reads `Run npm install -g npm@8.17.0 to update!` instead of `Run npm install --location=global npm@8.17.0 to update!`

I updated the command in the update-notifier to 
```javascript
const cmd = `npm install --location=global npm@${latest}`
``` 



## References
  Fixes #5299

