### PR TITLE
docs(dependency-selectors): fix Arborist example in docs

### DIFF
--- a/docs/content/using-npm/dependency-selectors.md
+++ b/docs/content/using-npm/dependency-selectors.md
@@ -144,7 +144,7 @@ const arb = new Arborist({})
 
 ```js
 // root-level
-arb.loadActual().then((tree) => {
+arb.loadActual().then(async (tree) => {
   // query all production dependencies
   const results = await tree.querySelectorAll('.prod')
   console.log(results)
@@ -153,7 +153,7 @@ arb.loadActual().then((tree) => {
 
 ```js
 // iterative
-arb.loadActual().then((tree) => {
+arb.loadActual().then(async (tree) => {
   // query for the deduped version of react
   const results = await tree.querySelectorAll('#react:not(:deduped)')
   // query the deduped react for git deps

--- a/docs/content/using-npm/dependency-selectors.md
+++ b/docs/content/using-npm/dependency-selectors.md
@@ -144,7 +144,7 @@ const arb = new Arborist({})
 
 ```js
 // root-level
-arb.loadActual((tree) => {
+arb.loadActual().then((tree) => {
   // query all production dependencies
   const results = await tree.querySelectorAll('.prod')
   console.log(results)
@@ -153,7 +153,7 @@ arb.loadActual((tree) => {
 
 ```js
 // iterative
-arb.loadActual((tree) => {
+arb.loadActual().then((tree) => {
   // query for the deduped version of react
   const results = await tree.querySelectorAll('#react:not(:deduped)')
   // query the deduped react for git deps


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

`Arborist.loadActual` [is an async function](https://github.com/npm/cli/blob/c383564213c709aa9d82aeb21333516fc78d5165/workspaces/arborist/lib/arborist/load-actual.js#L93). The docs show it as a callback pattern. Also, `await`'s were being used without being inside an async function. This change fixes those examples.

## References
Mirrored in https://github.com/npm/documentation/pull/178