### PR TITLE
fix: update `index.js` spelling error in comment

### DIFF
--- a/workspaces/arborist/lib/arborist/index.js
+++ b/workspaces/arborist/lib/arborist/index.js
@@ -134,7 +134,7 @@ class Arborist extends Base {
     return wsDepSet
   }
 
-  // returns a set of root dependencies, excluding depdencies that are
+  // returns a set of root dependencies, excluding dependencies that are
   // exclusively workspace dependencies
   excludeWorkspacesDependencySet (tree) {
     const rootDepSet = new Set()


### PR DESCRIPTION
'depdencies' has a spelling problem.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
