### PR TITLE
fix(libnpmpack): obey foregroundScripts

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -385,6 +385,7 @@ graph LR;
   libnpmpack-->npmcli-run-script["@npmcli/run-script"];
   libnpmpack-->npmcli-template-oss["@npmcli/template-oss"];
   libnpmpack-->pacote;
+  libnpmpack-->spawk;
   libnpmpack-->tap;
   libnpmpublish-->libnpmpack;
   libnpmpublish-->lodash.clonedeep;

--- a/workspaces/libnpmpack/lib/index.js
+++ b/workspaces/libnpmpack/lib/index.js
@@ -18,13 +18,15 @@ async function pack (spec = 'file:.', opts = {}) {
   // mode
   const banner = !opts.silent
 
+  const stdio = opts.foregroundScripts ? 'inherit' : 'pipe'
+
   if (spec.type === 'directory') {
     // prepack
     await runScript({
       ...opts,
       event: 'prepack',
       path: spec.fetchSpec,
-      stdio: 'inherit',
+      stdio,
       pkg: manifest,
       banner,
     })
@@ -50,7 +52,7 @@ async function pack (spec = 'file:.', opts = {}) {
       ...opts,
       event: 'postpack',
       path: spec.fetchSpec,
-      stdio: 'inherit',
+      stdio,
       pkg: manifest,
       banner,
       env: {

--- a/workspaces/libnpmpack/package.json
+++ b/workspaces/libnpmpack/package.json
@@ -28,6 +28,7 @@
     "@npmcli/eslint-config": "^3.1.0",
     "@npmcli/template-oss": "3.7.1",
     "nock": "^13.0.7",
+    "spawk": "^1.7.1",
     "tap": "^16.0.1"
   },
   "repository": {

--- a/workspaces/libnpmpack/test/fixtures/tspawk.js
+++ b/workspaces/libnpmpack/test/fixtures/tspawk.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const spawk = require('spawk')
+
+module.exports = tspawk
+
+function tspawk (t) {
+  t.teardown(function () {
+    spawk.unload()
+  })
+  t.afterEach(function () {
+    spawk.done()
+  })
+  return spawk
+}


### PR DESCRIPTION
Before this change, `npm pack` would not respect `--foreground-scripts`, so when {pre,post}pack scripts were run, the output would be polluted with output from those scripts.

I'm not sure how I'd test the output of this from `libnpmpack` tests, like the [arborist test](https://github.com/npm/cli/blob/f628431c8a79d7cf00987ca6372dc34d4fbadfcf/workspaces/arborist/test/arborist/rebuild.js#L213) does. If anyone can give me any pointers on that, I'd be happy to add a test.

Also: tips on decreasing the length of the commit message are appreciated, the cutoff is a bit jarring.

## References
Fixes #4121.
