### PR TITLE
fix: Turn off progress bar when using web based authorization

### DIFF
--- a/lib/utils/otplease.js
+++ b/lib/utils/otplease.js
@@ -1,3 +1,4 @@
+const log = require('./log-shim')
 async function otplease (npm, opts, fn) {
   try {
     return await fn(opts)
@@ -7,6 +8,7 @@ async function otplease (npm, opts, fn) {
     }
 
     if (isWebOTP(err)) {
+      log.disableProgress()
       const webAuth = require('./web-auth')
       const openUrlPrompt = require('./open-url-prompt')
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Support for web based authorization was added for all commands as part of https://github.com/npm/cli/pull/5098. At that time only `publish` supported web based authorization on registry side and to fix unintended output after the URL we disabled progress bar for `publish` as helpfully suggested by @wraithgar in this [Slack thread](https://github.slack.com/archives/C0127EPHNPQ/p1658250931313339?thread_ts=1657721180.117389&cid=C0127EPHNPQ).

As part of https://github.com/github/npm/issues/5736 we are updating registry to support web based authorization for all commands which require TFA. To support that change this PR disables progress bar in a central place within `otplease` when registry requires `WebOTP` to avoid the additional unintended output displayed after URL as seen in 👇🏻 screen recordings.

### Before Fix
https://user-images.githubusercontent.com/73886592/187214071-737cd1f7-9c1a-4b6e-82d0-8a80299597d8.mov

### After Fix
https://user-images.githubusercontent.com/73886592/187214832-ad64bfc2-8417-4848-96bc-537250183ef9.mov

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Resolves github/npm#6111
##
cc @jumoel @neeldani @MylesBorins