### PR TITLE
chore: remove some outdated release steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 SHELL = bash
 
 PUBLISHTAG = $(shell node scripts/publish-tag.js)
-BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
 
 # these docs have the @VERSION@ tag in them, so they have to be rebuilt
 # whenever the package.json is touched, in case the version changed.
@@ -112,8 +111,6 @@ prune: deps
 	node scripts/git-dirty.js
 
 publish: gitclean ls-ok link test-all docs prune
-	git push origin $(BRANCH) &&\
-	git push origin --tags &&\
 	node bin/npm-cli.js publish --tag=$(PUBLISHTAG)
 
 release: gitclean ls-ok docs prune

--- a/docs/package.json
+++ b/docs/package.json
@@ -47,7 +47,8 @@
     "statements": 81,
     "branches": 72,
     "functions": 75,
-    "lines": 81
+    "lines": 81,
+    "timeout": 600
   },
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",


### PR DESCRIPTION
Also increase docs tests so they dont timeout when
rebuilding cmark-gfm
