### PR TITLE
chore: make all workspaces prerelease

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -30,23 +30,48 @@
       "hidden": true
     }
   ],
+  
   "packages": {
     ".": {
       "package-name": "",
       "prerelease": true
     },
-    "workspaces/arborist": {},
-    "workspaces/libnpmaccess": {},
-    "workspaces/libnpmdiff": {},
-    "workspaces/libnpmexec": {},
-    "workspaces/libnpmfund": {},
-    "workspaces/libnpmhook": {},
-    "workspaces/libnpmorg": {},
-    "workspaces/libnpmpack": {},
-    "workspaces/libnpmpublish": {},
-    "workspaces/libnpmsearch": {},
-    "workspaces/libnpmteam": {},
-    "workspaces/libnpmversion": {}
+    "workspaces/arborist": {
+      "prerelease": true
+    },
+    "workspaces/libnpmaccess": {
+      "prerelease": true
+   },
+    "workspaces/libnpmdiff": {
+      "prerelease": true
+   },
+    "workspaces/libnpmexec": {
+      "prerelease": true
+   },
+    "workspaces/libnpmfund": {
+      "prerelease": true
+   },
+    "workspaces/libnpmhook": {
+      "prerelease": true
+   },
+    "workspaces/libnpmorg": {
+      "prerelease": true
+   },
+    "workspaces/libnpmpack": {
+      "prerelease": true
+   },
+    "workspaces/libnpmpublish": {
+      "prerelease": true
+   },
+    "workspaces/libnpmsearch": {
+      "prerelease": true
+   },
+    "workspaces/libnpmteam": {
+      "prerelease": true
+   },
+    "workspaces/libnpmversion": {
+      "prerelease": true
+   }
   },
   "exclude-packages-from-root": true,
   "group-pull-request-title-pattern": "chore: release ${version}",


### PR DESCRIPTION
Since we are going to (potentially) be making breaking changes to workspaces too, this sets everything as prereleases.