### PR TITLE
docs: update registry docs header

### DIFF
--- a/docs/content/using-npm/registry.md
+++ b/docs/content/using-npm/registry.md
@@ -69,7 +69,7 @@ to force it to be published only to your internal/private registry.
 
 See [`package.json`](/configuring-npm/package-json) for more info on what goes in the package.json file.
 
-### Where can I find my own, & other's, published packages?
+### Where can I find my (and others') published packages?
 
 <https://www.npmjs.com/>
 


### PR DESCRIPTION
Corrects grammar of a heading (previously said `other’s`).

## References
n/a