### PR TITLE
Add a condition to fix third-party registries returning E400

### DIFF
--- a/lib/commands/audit.js
+++ b/lib/commands/audit.js
@@ -156,7 +156,7 @@ class VerifySignatures {
       ...key,
       pemkey: `-----BEGIN PUBLIC KEY-----\n${key.key}\n-----END PUBLIC KEY-----`,
     }))).catch(err => {
-      if (err.code === 'E404') {
+      if (err.code === 'E404' || err.code === 'E400') {
         return null
       } else {
         throw err

--- a/test/lib/commands/audit.js
+++ b/test/lib/commands/audit.js
@@ -1171,7 +1171,7 @@ t.test('audit signatures', async t => {
     t.matchSnapshot(joinedOutput())
   })
 
-  t.test('third-party registry without keys does not verify', async t => {
+  t.test('third-party registry without keys (E404) does not verify', async t => {
     const registryUrl = 'https://verdaccio-clone2.org'
     const { npm } = await loadMockNpm(t, {
       prefixDir: installWithThirdPartyRegistry,
@@ -1198,8 +1198,29 @@ t.test('audit signatures', async t => {
       npm.exec('audit', ['signatures']),
       /found no dependencies to audit that where installed from a supported registry/
     )
+  })
 
-    // Some registries return 400 instead, even though 404 would be more appropriate
+  t.test('third-party registry without keys (E400) does not verify', async t => {
+    const registryUrl = 'https://verdaccio-clone2.org'
+    const { npm } = await loadMockNpm(t, {
+      prefixDir: installWithThirdPartyRegistry,
+      config: {
+        '@npmcli:registry': registryUrl,
+      },
+    })
+    const registry = new MockRegistry({ tap: t, registry: registryUrl })
+    const manifest = registry.manifest({
+      name: '@npmcli/arborist',
+      packuments: [{
+        version: '1.0.14',
+        dist: {
+          tarball: 'https://registry.npmjs.org/@npmcli/arborist/-/@npmcli/arborist-1.0.14.tgz',
+          integrity: 'sha512-caa8hv5rW9VpQKk6tyNRvSaVDySVjo9GkI7Wj/wcsFyxPm3tYrE' +
+              'sFyTjSnJH8HCIfEGVQNjqqKXaXLFVp7UBag==',
+        },
+      }],
+    })
+    await registry.package({ manifest })
     registry.nock.get('/-/npm/v1/keys').reply(400)
 
     await t.rejects(

--- a/test/lib/commands/audit.js
+++ b/test/lib/commands/audit.js
@@ -1198,6 +1198,14 @@ t.test('audit signatures', async t => {
       npm.exec('audit', ['signatures']),
       /found no dependencies to audit that where installed from a supported registry/
     )
+
+    // Some registries return 400 instead, even though 404 would be more appropriate
+    registry.nock.get('/-/npm/v1/keys').reply(400)
+
+    await t.rejects(
+      npm.exec('audit', ['signatures']),
+      /found no dependencies to audit that where installed from a supported registry/
+    )
   })
 
   t.test('third-party registry with keys and signatures', async t => {


### PR DESCRIPTION
Allow for third party registries which return E400 on /-/npm/v1/keys instead of E404. 

This will make the behavior consistent for these repositories and other third party registries which return 400.

## References

Fixes #5479
