### PR TITLE
fix: don't mark workspaces as invalid if installing links

### DIFF
--- a/workspaces/arborist/lib/dep-valid.js
+++ b/workspaces/arborist/lib/dep-valid.js
@@ -109,8 +109,8 @@ const depValid = (child, requested, requestor) => {
 const linkValid = (child, requested, requestor) => {
   const isLink = !!child.isLink
   // if we're installing links and the node is a link, then it's invalid because we want
-  // a real node to be there
-  if (requestor.installLinks) {
+  // a real node to be there.  Except for workspaces. They are always links.
+  if (requestor.installLinks && !child.isWorkspace) {
     return !isLink
   }
 

--- a/workspaces/arborist/test/dep-valid.js
+++ b/workspaces/arborist/test/dep-valid.js
@@ -184,8 +184,21 @@ t.test('invalid request all together', t => {
 
 t.test('installLinks makes Link nodes invalid', t => {
   const requestor = { errors: [], installLinks: true, edgesOut: new Map() }
-  const child = { isLink: true, name: 'kid' }
+  const child = { isLink: true, isWorkspace: false, name: 'kid' }
   const request = { type: 'directory' }
   t.notOk(depValid(child, request, null, requestor))
+  t.end()
+})
+
+t.test('installLinks does not make workspace nodes invalid', t => {
+  const requestor = { errors: [], installLinks: true, edgesOut: new Map() }
+  const child = {
+    isLink: true,
+    isWorkspace: true,
+    name: 'kid',
+    realpath: '/some/path',
+  }
+  const request = normalizePaths(npa('file:/some/path'))
+  t.ok(depValid(child, request, null, requestor))
   t.end()
 })


### PR DESCRIPTION
Workspaces are always links, even if we are installing links
