### PR TITLE
chore: remove postpublish

### DIFF
--- a/workspaces/libnpmaccess/package.json
+++ b/workspaces/libnpmaccess/package.json
@@ -6,7 +6,6 @@
   "license": "ISC",
   "main": "lib/index.js",
   "scripts": {
-    "postpublish": "git push origin --follow-tags",
     "lint": "eslint \"**/*.js\"",
     "test": "tap",
     "postlint": "template-oss-check",


### PR DESCRIPTION
template-oss got most of the other ones cause they lived in
`prepublishOnly` but this one was in `postpublish`
