### PR TITLE
fix: add tag to publish log message

### DIFF
--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -114,7 +114,10 @@ class Publish extends BaseCommand {
       }
     }
 
-    log.notice('', `Publishing to ${outputRegistry}${dryRun ? ' (dry-run)' : ''}`)
+    log.notice(
+      '',
+      `Publishing to ${outputRegistry} with tag ${defaultTag}${dryRun ? ' (dry-run)' : ''}`
+    )
 
     if (!dryRun) {
       await otplease(this.npm, opts, opts => libpub(manifest, tarballData, opts))

--- a/tap-snapshots/test/lib/commands/publish.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/publish.js.test.cjs
@@ -51,7 +51,7 @@ Array [
   ],
   Array [
     "",
-    "Publishing to https://registry.npmjs.org/ (dry-run)",
+    "Publishing to https://registry.npmjs.org/ with tag latest (dry-run)",
   ],
 ]
 `
@@ -72,7 +72,7 @@ exports[`test/lib/commands/publish.js TAP json > must match snapshot 1`] = `
 Array [
   Array [
     "",
-    "Publishing to https://registry.npmjs.org/",
+    "Publishing to https://registry.npmjs.org/ with tag latest",
   ],
 ]
 `
@@ -165,7 +165,7 @@ Array [
   ],
   Array [
     "",
-    "Publishing to https://registry.npmjs.org/",
+    "Publishing to https://registry.npmjs.org/ with tag latest",
   ],
 ]
 `


### PR DESCRIPTION
```
npm notice Publishing to https://registry.npmjs.org/ with tag latest (dry-run)
```