### PR TITLE
docs: link mentions of config parameters

### DIFF
--- a/docs/content/commands/npm-audit.md
+++ b/docs/content/commands/npm-audit.md
@@ -109,9 +109,9 @@ the path `/-/npm/v1/security/advisories/bulk`.
 
 Any packages in the tree that do not have a `version` field in their
 package.json file will be ignored.  If any `--omit` options are specified
-(either via the `--omit` config, or one of the shorthands such as
-`--production`, `--only=dev`, and so on), then packages will be omitted
-from the submitted payload as appropriate.
+(either via the [`--omit` config](/using-npm/config#omit), or one of the
+shorthands such as `--production`, `--only=dev`, and so on), then packages will
+be omitted from the submitted payload as appropriate.
 
 If the registry responds with an error, or with an invalid response, then
 npm will attempt to load advisory data from the `Quick Audit` endpoint.
@@ -188,7 +188,7 @@ vulnerabilities are found _or_ if the remediation is able to successfully
 fix all vulnerabilities.
 
 If vulnerabilities were found the exit code will depend on the
-`audit-level` configuration setting.
+[`audit-level` config](/using-npm/config#audit-level).
 
 ### Examples
 

--- a/docs/content/commands/npm-bugs.md
+++ b/docs/content/commands/npm-bugs.md
@@ -25,8 +25,9 @@ alias: issues
 
 This command tries to guess at the likely location of a package's bug
 tracker URL or the `mailto` URL of the support email, and then tries to
-open it using the `--browser` config param. If no package name is provided, it
-will search for a `package.json` in the current folder and use the `name` property.
+open it using the [`--browser` config](/using-npm/config#browser) param. If no
+package name is provided, it will search for a `package.json` in the current
+folder and use the `name` property.
 
 ### Configuration
 

--- a/docs/content/commands/npm-dist-tag.md
+++ b/docs/content/commands/npm-dist-tag.md
@@ -28,8 +28,8 @@ alias: dist-tags
 Add, remove, and enumerate distribution tags on a package:
 
 * add: Tags the specified version of the package with the specified tag,
-  or the `--tag` config if not specified. If you have two-factor
-  authentication on auth-and-writes then you’ll need to include a
+  or the [`--tag` config](/using-npm/config#tag) if not specified. If you have
+  two-factor authentication on auth-and-writes then you’ll need to include a
   one-time password on the command line with
   `--otp <one-time password>`, or at the OTP prompt.
 

--- a/docs/content/commands/npm-docs.md
+++ b/docs/content/commands/npm-docs.md
@@ -24,10 +24,10 @@ alias: home
 ### Description
 
 This command tries to guess at the likely location of a package's
-documentation URL, and then tries to open it using the `--browser` config
-param. You can pass multiple package names at once. If no package name is
-provided, it will search for a `package.json` in the current folder and use
-the `name` property.
+documentation URL, and then tries to open it using the
+[`--browser` config](/using-npm/config#browser) param. You can pass multiple
+package names at once. If no package name is provided, it will search for a
+`package.json` in the current folder and use the `name` property.
 
 ### Configuration
 

--- a/docs/content/commands/npm-exec.md
+++ b/docs/content/commands/npm-exec.md
@@ -240,7 +240,8 @@ $ npx -c 'eslint && say "hooray, lint passed"'
 
 ### Workspaces support
 
-You may use the `workspace` or `workspaces` configs in order to run an
+You may use the [`workspace`](/using-npm/config#workspace) or
+[`workspaces`](/using-npm/config#workspaces) configs in order to run an
 arbitrary command from an npm package (either one installed locally, or fetched
 remotely) in the context of the specified workspaces.
 If no positional argument or `--call` option is provided, it will open an
@@ -271,9 +272,9 @@ Assuming the workspace configuration is properly set up at the root level
 ```
 
 You can execute an arbitrary command from a package in the context of each of
-the configured workspaces when using the `workspaces` configuration options,
-in this example we're using **eslint** to lint any js file found within each
-workspace folder:
+the configured workspaces when using the
+[`workspaces` config options](/using-npm/config#workspace), in this example
+we're using **eslint** to lint any js file found within each workspace folder:
 
 ```
 npm exec --ws -- eslint ./*.js

--- a/docs/content/commands/npm-fund.md
+++ b/docs/content/commands/npm-fund.md
@@ -25,9 +25,10 @@ This command retrieves information on how to fund the dependencies of a
 given project. If no package name is provided, it will list all
 dependencies that are looking for funding in a tree structure, listing
 the type of funding and the url to visit. If a package name is provided
-then it tries to open its funding url using the `--browser` config
-param; if there are multiple funding sources for the package, the user
-will be instructed to pass the `--which` option to disambiguate.
+then it tries to open its funding url using the
+[`--browser` config](/using-npm/config#browser) param; if there are multiple
+funding sources for the package, the user will be instructed to pass the
+`--which` option to disambiguate.
 
 The list will avoid duplicated entries and will stack all packages that
 share the same url as a single entry. Thus, the list does not have the

--- a/docs/content/commands/npm-fund.md
+++ b/docs/content/commands/npm-fund.md
@@ -39,7 +39,8 @@ same shape of the output from `npm ls`.
 ### Workspaces support
 
 It's possible to filter the results to only include a single workspace
-and its dependencies using the `workspace` config option.
+and its dependencies using the
+[`workspace` config](/using-npm/config#workspace) option.
 
 #### Example:
 

--- a/docs/content/commands/npm-pkg.md
+++ b/docs/content/commands/npm-pkg.md
@@ -153,7 +153,8 @@ Returned values are always in **json** format.
 ### Workspaces support
 
 You can set/get/delete items across your configured workspaces by using the
-`workspace` or `workspaces` config options.
+[`workspace`](/using-npm/config#workspace) or
+[`workspaces`](/using-npm/config#workspaces) config options.
 
 For example, setting a `funding` value across all configured workspaces
 of a project:

--- a/docs/content/commands/npm-repo.md
+++ b/docs/content/commands/npm-repo.md
@@ -22,9 +22,10 @@ npm repo [<pkgname> [<pkgname> ...]]
 ### Description
 
 This command tries to guess at the likely location of a package's
-repository URL, and then tries to open it using the `--browser` config
-param. If no package name is provided, it will search for a `package.json`
-in the current folder and use the `repository` property.
+repository URL, and then tries to open it using the
+[`--browser` config](/using-npm/config#browser) param. If no package name is
+provided, it will search for a `package.json` in the current folder and use the
+`repository` property.
 
 ### Configuration
 

--- a/docs/content/commands/npm-run-script.md
+++ b/docs/content/commands/npm-run-script.md
@@ -68,7 +68,8 @@ The actual shell your script is run within is platform dependent. By default,
 on Unix-like systems it is the `/bin/sh` command, on Windows it is
 `cmd.exe`.
 The actual shell referred to by `/bin/sh` also depends on the system.
-You can customize the shell with the `script-shell` configuration.
+You can customize the shell with the
+[`script-shell` config](/using-npm/config#script-shell).
 
 Scripts are run from the root of the package folder, regardless of what the
 current working directory is when `npm run` is called. If you want your
@@ -85,7 +86,8 @@ forgotten.
 
 ### Workspaces support
 
-You may use the `workspace` or `workspaces` configs in order to run an
+You may use the [`workspace`](/using-npm/config#workspace) or
+[`workspaces`](/using-npm/config#workspaces) configs in order to run an
 arbitrary command from a package's `"scripts"` object in the context of the
 specified workspaces. If no `"command"` is provided, it will list the available
 scripts for each of these configured workspaces.
@@ -114,7 +116,8 @@ Assuming the workspace configuration is properly set up at the root level
 ```
 
 And that each of the configured workspaces has a configured `test` script,
-we can run tests in all of them using the `workspaces` config:
+we can run tests in all of them using the
+[`workspaces` config](/using-npm/config#workspaces):
 
 ```
 npm test --workspaces

--- a/docs/content/commands/npm-update.md
+++ b/docs/content/commands/npm-update.md
@@ -24,9 +24,9 @@ aliases: up, upgrade, udpate
 ### Description
 
 This command will update all the packages listed to the latest version
-(specified by the `tag` config), respecting the semver constraints of
-both your package and its dependencies (if they also require the same
-package).
+(specified by the [`tag` config](/using-npm/config#tag)), respecting the semver
+constraints of both your package and its dependencies (if they also require the
+same package).
 
 It will also install missing packages.
 

--- a/docs/content/commands/npm-version.md
+++ b/docs/content/commands/npm-version.md
@@ -192,18 +192,18 @@ disabled on the command line by running `npm --no-git-tag-version version`.
 It will fail if the working directory is not clean, unless the `-f` or
 `--force` flag is set.
 
-If supplied with `-m` or [`--message` config](/using-npm/config#message) option, npm will use it as a
-commit message when creating a version commit.  If the `message` config
-contains `%s` then that will be replaced with the resulting version number.
-For example:
+If supplied with `-m` or [`--message` config](/using-npm/config#message) option,
+npm will use it as a commit message when creating a version commit.  If the
+`message` config contains `%s` then that will be replaced with the resulting
+version number. For example:
 
 ```bash
 npm version patch -m "Upgrade to %s for reasons"
 ```
 
-If the [`sign-git-tag` config](/using-npm/config#sign-git-tag) is set, then the tag will be signed using the
-`-s` flag to git.  Note that you must have a default GPG key set up in your
-git config for this to work properly.  For example:
+If the [`sign-git-tag` config](/using-npm/config#sign-git-tag) is set, then the
+tag will be signed using the `-s` flag to git. Note that you must have a default
+GPG key set up in your git config for this to work properly. For example:
 
 ```bash
 $ npm config set sign-git-tag true

--- a/docs/content/commands/npm-version.md
+++ b/docs/content/commands/npm-version.md
@@ -192,7 +192,7 @@ disabled on the command line by running `npm --no-git-tag-version version`.
 It will fail if the working directory is not clean, unless the `-f` or
 `--force` flag is set.
 
-If supplied with `-m` or `--message` config option, npm will use it as a
+If supplied with `-m` or [`--message` config](/using-npm/config#message) option, npm will use it as a
 commit message when creating a version commit.  If the `message` config
 contains `%s` then that will be replaced with the resulting version number.
 For example:
@@ -201,7 +201,7 @@ For example:
 npm version patch -m "Upgrade to %s for reasons"
 ```
 
-If the `sign-git-tag` config is set, then the tag will be signed using the
+If the [`sign-git-tag` config](/using-npm/config#sign-git-tag) is set, then the tag will be signed using the
 `-s` flag to git.  Note that you must have a default GPG key set up in your
 git config for this to work properly.  For example:
 

--- a/docs/content/configuring-npm/folders.md
+++ b/docs/content/configuring-npm/folders.md
@@ -22,10 +22,10 @@ This document will tell you what it puts where.
 
 #### prefix Configuration
 
-The `prefix` config defaults to the location where node is installed.
-On most systems, this is `/usr/local`. On Windows, it's `%AppData%\npm`.
-On Unix systems, it's one level up, since node is typically installed at
-`{prefix}/bin/node` rather than `{prefix}/node.exe`.
+The [`prefix` config](/using-npm/config#prefix) defaults to the location where
+node is installed. On most systems, this is `/usr/local`. On Windows, it's
+`%AppData%\npm`. On Unix systems, it's one level up, since node is typically
+installed at `{prefix}/bin/node` rather than `{prefix}/node.exe`.
 
 When the `global` flag is set, npm installs things into this prefix.
 When it is not set, it uses the root of the current package, or the
@@ -74,13 +74,13 @@ Man pages are not installed on Windows systems.
 See [`npm cache`](/commands/npm-cache).  Cache files are stored in `~/.npm` on Posix, or
 `%AppData%/npm-cache` on Windows.
 
-This is controlled by the `cache` configuration param.
+This is controlled by the [`cache` config](/using-npm/config#cache) param.
 
 #### Temp Files
 
 Temporary files are stored by default in the folder specified by the
-`tmp` config, which defaults to the TMPDIR, TMP, or TEMP environment
-variables, or `/tmp` on Unix and `c:\windows\temp` on Windows.
+[`tmp` config](/using-npm/config#tmp), which defaults to the TMPDIR, TMP, or
+TEMP environment variables, or `/tmp` on Unix and `c:\windows\temp` on Windows.
 
 Temp files are given a unique folder under this root for each run of the
 program, and are deleted upon successful exit.
@@ -111,7 +111,7 @@ be found by npm scripts when necessary.
 
 #### Global Installation
 
-If the `global` configuration is set to true, then npm will
+If the [`global` config](/using-npm/config#global) is set to true, then npm will
 install packages "globally".
 
 For global installation, packages are installed roughly the same way,

--- a/docs/content/configuring-npm/package-json.md
+++ b/docs/content/configuring-npm/package-json.md
@@ -1028,9 +1028,10 @@ capable of properly installing your program.  For example:
 }
 ```
 
-Unless the user has set the `engine-strict` config flag, this field is
-advisory only and will only produce warnings when your package is installed
-as a dependency.
+Unless the user has set the
+[`engine-strict` config](/using-npm/config#engine-strict) flag, this field is
+advisory only and will only produce warnings when your package is installed as a
+dependency.
 
 ### os
 

--- a/docs/content/using-npm/logging.md
+++ b/docs/content/using-npm/logging.md
@@ -58,7 +58,8 @@ The `npm` CLI began hiding the output of lifecycle scripts for `npm install` as 
 
 ### Timing Information
 
-The `--timing` config can be set which does two things:
+The [`--timing` config](/using-npm/config#timing) can be set which does two
+things:
 
 1. Always shows the full path to the debug log regardless of command exit status
 1. Write timing information to a timing file in the cache or `logs-dir`

--- a/docs/content/using-npm/registry.md
+++ b/docs/content/using-npm/registry.md
@@ -26,9 +26,11 @@ The npm public registry is powered by a CouchDB database,
 of which there is a public mirror at <https://skimdb.npmjs.com/registry>.
 
 The registry URL used is determined by the scope of the package (see
-[`scope`](/using-npm/scope). If no scope is specified, the default registry is used, which is
-supplied by the `registry` config parameter.  See [`npm config`](/commands/npm-config),
-[`npmrc`](/configuring-npm/npmrc), and [`config`](/using-npm/config) for more on managing npm's configuration.
+[`scope`](/using-npm/scope). If no scope is specified, the default registry is
+used, which is supplied by the [`registry` config](/using-npm/config#registry)
+parameter.  See [`npm config`](/commands/npm-config),
+[`npmrc`](/configuring-npm/npmrc), and [`config`](/using-npm/config) for more on
+managing npm's configuration.
 
 When the default registry is used in a package-lock or shrinkwrap is has the
 special meaning of "the currently configured registry". If you create a lock


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Inspired by https://github.com/npm/cli/pull/5519#pullrequestreview-1109795416, went looking for config parameter references in docs that could use a hash in their link, ended up finding unlinked references instead. This PR links them to `/using-npm/config`.

I tried to be thoughtful about which ones I linked and which I skipped. For example, in `docs/content/using-npm/logging.md`, I didn't link `logs-dir` or `loglevel` because the information in `/using-npm/config` didn't add anything new.

I _think_ I avoided making any edits inside "automatically generated" sections.

I initially used this search:
``(?<!`workspace)` config[^\]]``
... including `*.md` files, and excluding `CHANGELOG.md,CHANGELOG-*.md` files.

I started out excluding `` `workspace` config `` because it occurs often in automatically generated sections.

I later went back and checked all occurrences of `` `workspace` config ``, I found one that seemed worth linking.

I searched for:
`^.{81}`
(including `*.md` files, and excluding `CHANGELOG.md,CHANGELOG-*.md` files)
... to make sure I respected what seem to be the norm (lines wrapped at 80 chars). Seems like there are lots of exceptions, should those be fixed, and should that norm be documented somewhere?

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

Continuation of https://github.com/npm/cli/pull/5519