### PR TITLE
docs: add instruction to query objects with npm view

### DIFF
--- a/docs/content/commands/npm-view.md
+++ b/docs/content/commands/npm-view.md
@@ -72,6 +72,12 @@ contributor in the list, you can run:
 npm view express contributors[0].email
 ```
 
+If the field value you are querying for is a property of an object, you should run:
+
+```bash
+npm view express time'[14.8.0]'
+```
+
 Multiple fields may be specified, and will be printed one after another.
 For example, to get all the contributor names and email addresses, you
 can do this:

--- a/docs/content/commands/npm-view.md
+++ b/docs/content/commands/npm-view.md
@@ -75,7 +75,7 @@ npm view express contributors[0].email
 If the field value you are querying for is a property of an object, you should run:
 
 ```bash
-npm view express time'[14.8.0]'
+npm view express time'[4.8.0]'
 ```
 
 Multiple fields may be specified, and will be printed one after another.


### PR DESCRIPTION
Add missing section to npm view docs.

Current documentation of npm view does not describe how one can query field that is an object. 
After checking the code and finding:
https://github.com/npm/cli/blob/fa014a5567566c764942600441a5e01c3e2f229b/lib/utils/queryable.js#L25-L60
I was able to query it.

I believe putting this section will make it less cryptic.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #5526
  Closes #5526
-->
