### PR TITLE
docs: modify misleading doc about package.json:bin

### DIFF
--- a/docs/content/configuring-npm/package-json.md
+++ b/docs/content/configuring-npm/package-json.md
@@ -339,12 +339,14 @@ install into the PATH. npm makes this pretty easy (in fact, it uses this
 feature to install the "npm" executable.)
 
 To use this, supply a `bin` field in your package.json which is a map of
-command name to local file name. When this package is installed
-globally, that file will be linked where global bins go so it is
-available to run by name.  When this package is installed as a
-dependency in another package, the file will be linked where it will be
-available to that package either directly by `npm exec` or by name in other
-scripts when invoking them via `npm run-script`.
+command name to local file name. When this package is installed globally,
+that file will be either linked inside the global bins directory or
+a cmd (Windows Command File) will be created which executes the specified 
+file in the `bin` field, so it is available to run by `name` or `name.cmd` (on
+Windows PowerShell). When this package is installed as a dependency in another 
+package, the file will be linked where it will be available to that package
+either directly by `npm exec` or by name in other scripts when invoking them 
+via `npm run-script`.
 
 
 For example, myapp could have this:
@@ -357,8 +359,10 @@ For example, myapp could have this:
 }
 ```
 
-So, when you install myapp, it'll create a symlink from the `cli.js` script
-to `/usr/local/bin/myapp`.
+So, when you install myapp, in case of unix-like OS it'll create a symlink 
+from the `cli.js` script to `/usr/local/bin/myapp` and in case of windows it 
+will create a cmd file usually at `C:\Users\{Username}\AppData\Roaming\npm\myapp.cmd`
+which runs the `cli.js` script. 
 
 If you have a single executable, and its name should be the name of the
 package, then you can just supply it as a string.  For example:


### PR DESCRIPTION
closes #3788

### What / Why
The [documentation](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#bin) about bin field configuration in package.json does not clarify how it works on windows (which is by creating cmd files which executes the provided script file). As it only states, 
>  _To use this, supply a `bin` field in your package.json which is a map of command name to local file name. When this package is installed globally, that file will be linked where global bins go so it is available to run by name.

which is simply not true in case of windows, where it uses the `cmd-shim` module to create cmd files that are usually stored as `C:\Users\{Username}\AppData\Roaming\npm\xxxx.cmd` and can be executed in the Windows PowerShell as `xxxx.cmd`

This PR aims to solve this by appending these information to the doc

<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
Closes #3788 
