### PR TITLE
feat: default auth-type to web

### DIFF
--- a/docs/content/commands/npm-adduser.md
+++ b/docs/content/commands/npm-adduser.md
@@ -82,7 +82,7 @@ npm init --scope=@foo --yes
 
 #### `auth-type`
 
-* Default: "legacy"
+* Default: "web"
 * Type: "legacy" or "web"
 
 What authentication strategy to use with `login`.

--- a/docs/content/commands/npm-login.md
+++ b/docs/content/commands/npm-login.md
@@ -89,7 +89,7 @@ npm init --scope=@foo --yes
 
 #### `auth-type`
 
-* Default: "legacy"
+* Default: "web"
 * Type: "legacy" or "web"
 
 What authentication strategy to use with `login`.

--- a/docs/content/using-npm/config.md
+++ b/docs/content/using-npm/config.md
@@ -217,7 +217,7 @@ exit code.
 
 #### `auth-type`
 
-* Default: "legacy"
+* Default: "web"
 * Type: "legacy" or "web"
 
 What authentication strategy to use with `login`.

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -237,7 +237,7 @@ define('audit-level', {
 })
 
 define('auth-type', {
-  default: 'legacy',
+  default: 'web',
   type: ['legacy', 'web'],
   description: `
     What authentication strategy to use with \`login\`.

--- a/tap-snapshots/test/lib/commands/config.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/config.js.test.cjs
@@ -20,7 +20,7 @@ exports[`test/lib/commands/config.js TAP config list --json > output matches sna
   "also": null,
   "audit": true,
   "audit-level": null,
-  "auth-type": "legacy",
+  "auth-type": "web",
   "before": null,
   "bin-links": true,
   "browser": null,
@@ -173,7 +173,7 @@ allow-same-version = false
 also = null 
 audit = true 
 audit-level = null 
-auth-type = "legacy" 
+auth-type = "web" 
 before = null 
 bin-links = true 
 browser = null 

--- a/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
@@ -251,7 +251,7 @@ exit code.
 exports[`test/lib/utils/config/definitions.js TAP > config description for auth-type 1`] = `
 #### \`auth-type\`
 
-* Default: "legacy"
+* Default: "web"
 * Type: "legacy" or "web"
 
 What authentication strategy to use with \`login\`.

--- a/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
@@ -90,7 +90,7 @@ exit code.
 
 #### \`auth-type\`
 
-* Default: "legacy"
+* Default: "web"
 * Type: "legacy" or "web"
 
 What authentication strategy to use with \`login\`.

--- a/test/lib/commands/adduser.js
+++ b/test/lib/commands/adduser.js
@@ -25,6 +25,7 @@ t.test('legacy', async t => {
       'process.stdout': new stream.PassThrough(), // to quiet readline
     }, { replace: true })
     const { npm, home } = await loadMockNpm(t, {
+      config: { 'auth-type': 'legacy' },
       homeDir: {
         // These all get cleaned up by config.setCredentialsByURI
         '.npmrc': [
@@ -72,6 +73,7 @@ t.test('legacy', async t => {
     }, { replace: true })
     const { npm, home } = await loadMockNpm(t, {
       config: {
+        'auth-type': 'legacy',
         scope: '@myscope',
       },
     })
@@ -109,6 +111,7 @@ t.test('legacy', async t => {
         '.npmrc': '@myscope:registry=https://diff-registry.npmjs.org',
       },
       config: {
+        'auth-type': 'legacy',
         scope: '@myscope',
       },
     })
@@ -142,6 +145,7 @@ t.test('legacy', async t => {
       'process.stdout': new stream.PassThrough(), // to quiet readline
     }, { replace: true })
     const { npm } = await loadMockNpm(t, {
+      config: { 'auth-type': 'legacy' },
       homeDir: {
         '.npmrc': {},
       },


### PR DESCRIPTION
BREAKING CHANGE: the default `auth-type` config value is now `web`