### PR TITLE
feat: timings are now written alongside debug log files

### DIFF
--- a/docs/content/using-npm/config.md
+++ b/docs/content/using-npm/config.md
@@ -1707,12 +1707,11 @@ particular, use care when overriding this setting for public packages.
 * Default: false
 * Type: Boolean
 
-If true, writes a debug log to `logs-dir` and timing information to
-`_timing.json` in the cache, even if the command completes successfully.
-`_timing.json` is a newline delimited list of JSON objects.
+If true, writes timing information to a process specific json file in the
+cache or `logs-dir`. The file name ends with `-timing.json`.
 
 You can quickly view it with this [json](https://npm.im/json) command line:
-`npm exec -- json -g < ~/.npm/_timing.json`.
+`cat ~/.npm/_logs/*-timing.json | npm exec -- json -g`.
 
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->

--- a/docs/content/using-npm/logging.md
+++ b/docs/content/using-npm/logging.md
@@ -12,8 +12,7 @@ The `npm` CLI has various mechanisms for showing different levels of information
 
 All logs are written to a debug log, with the path to that file printed if the execution of a command fails.
 
-The default location of the logs directory is a directory named `_logs` inside the npm cache. This can be changed
-with the `logs-dir` config option.
+The default location of the logs directory is a directory named `_logs` inside the npm cache. This can be changed with the `logs-dir` config option.
 
 Log files will be removed from the `logs-dir` when the number of log files exceeds `logs-max`, with the oldest logs being deleted first.
 
@@ -62,9 +61,10 @@ The [`--timing` config](/using-npm/config#timing) can be set which does two
 things:
 
 1. Always shows the full path to the debug log regardless of command exit status
-1. Write timing information to a timing file in the cache or `logs-dir`
+1. Write timing information to a process specific timing file in the cache or `logs-dir`
 
-This file is a newline delimited list of JSON  objects that can be inspected to see timing data for each task in a `npm` CLI run.
+This file contains a `timers` object where the keys are an identifier for the
+portion of the process being timed and the value is the number of milliseconds it took to complete.
 
 ### Registry Response Headers
 

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -18,9 +18,11 @@ const replaceInfo = require('./utils/replace-info.js')
 const updateNotifier = require('./utils/update-notifier.js')
 const pkg = require('../package.json')
 const cmdList = require('./utils/cmd-list.js')
+const runId = require('./utils/run-id.js')
 
 let warnedNonDashArg = false
 const _load = Symbol('_load')
+const RUN_ID = runId()
 
 class Npm extends EventEmitter {
   static get version () {
@@ -38,9 +40,10 @@ class Npm extends EventEmitter {
   #argvClean = []
   #chalk = null
 
-  #logFile = new LogFile()
+  #logFile = new LogFile({ id: RUN_ID })
   #display = new Display()
   #timers = new Timers({
+    id: RUN_ID,
     start: 'npm',
     listener: (name, ms) => {
       const args = ['timing', name, `Completed in ${ms}ms`]
@@ -207,10 +210,6 @@ class Npm extends EventEmitter {
   writeTimingFile () {
     this.#timers.writeFile({
       command: this.#argvClean,
-      // We used to only ever report a single log file
-      // so to be backwards compatible report the last logfile
-      // XXX: remove this in npm 9 or just keep it forever
-      logfile: this.logFiles[this.logFiles.length - 1],
       logfiles: this.logFiles,
       version: this.version,
     })
@@ -298,7 +297,7 @@ class Npm extends EventEmitter {
 
     this.time('npm:load:timers', () =>
       this.#timers.load({
-        dir: this.config.get('timing') ? this.timingDir : null,
+        dir: this.config.get('timing') ? this.logsDir : null,
       })
     )
 
@@ -374,11 +373,6 @@ class Npm extends EventEmitter {
 
   get timingFile () {
     return this.#timers.file
-  }
-
-  get timingDir () {
-    // XXX(npm9): make this always in logs-dir
-    return this.config.get('logs-dir') || this.cache
   }
 
   get cache () {

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -18,11 +18,9 @@ const replaceInfo = require('./utils/replace-info.js')
 const updateNotifier = require('./utils/update-notifier.js')
 const pkg = require('../package.json')
 const cmdList = require('./utils/cmd-list.js')
-const runId = require('./utils/run-id.js')
 
 let warnedNonDashArg = false
 const _load = Symbol('_load')
-const RUN_ID = runId()
 
 class Npm extends EventEmitter {
   static get version () {
@@ -34,16 +32,16 @@ class Npm extends EventEmitter {
   loadErr = null
   argv = []
 
+  #runId = new Date().toISOString().replace(/[.:]/g, '_')
   #loadPromise = null
   #tmpFolder = null
   #title = 'npm'
   #argvClean = []
   #chalk = null
 
-  #logFile = new LogFile({ id: RUN_ID })
+  #logFile = new LogFile()
   #display = new Display()
   #timers = new Timers({
-    id: RUN_ID,
     start: 'npm',
     listener: (name, ms) => {
       const args = ['timing', name, `Completed in ${ms}ms`]
@@ -209,6 +207,7 @@ class Npm extends EventEmitter {
 
   writeTimingFile () {
     this.#timers.writeFile({
+      id: this.#runId,
       command: this.#argvClean,
       logfiles: this.logFiles,
       version: this.version,
@@ -289,7 +288,7 @@ class Npm extends EventEmitter {
 
     this.time('npm:load:logFile', () => {
       this.#logFile.load({
-        dir: this.logsDir,
+        path: this.logPath,
         logsMax: this.config.get('logs-max'),
       })
       log.verbose('logfile', this.#logFile.files[0] || 'no logfile created')
@@ -297,7 +296,7 @@ class Npm extends EventEmitter {
 
     this.time('npm:load:timers', () =>
       this.#timers.load({
-        dir: this.config.get('timing') ? this.logsDir : null,
+        path: this.config.get('timing') ? this.logPath : null,
       })
     )
 
@@ -369,6 +368,10 @@ class Npm extends EventEmitter {
 
   get logsDir () {
     return this.config.get('logs-dir') || join(this.cache, '_logs')
+  }
+
+  get logPath () {
+    return resolve(this.logsDir, `${this.#runId}-`)
   }
 
   get timingFile () {

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -2062,13 +2062,11 @@ define('timing', {
   default: false,
   type: Boolean,
   description: `
-    If true, writes a debug log to \`logs-dir\` and timing information
-    to \`_timing.json\` in the cache, even if the command completes
-    successfully.  \`_timing.json\` is a newline delimited list of JSON
-    objects.
+    If true, writes timing information to a process specific json file in
+    the cache or \`logs-dir\`. The file name ends with \`-timing.json\`.
 
     You can quickly view it with this [json](https://npm.im/json) command
-    line: \`npm exec -- json -g < ~/.npm/_timing.json\`.
+    line: \`cat ~/.npm/_logs/*-timing.json | npm exec -- json -g\`.
   `,
 })
 

--- a/lib/utils/error-message.js
+++ b/lib/utils/error-message.js
@@ -8,6 +8,7 @@ const log = require('./log-shim')
 module.exports = (er, npm) => {
   const short = []
   const detail = []
+  const files = []
 
   if (er.message) {
     er.message = replaceInfo(er.message)
@@ -17,14 +18,17 @@ module.exports = (er, npm) => {
   }
 
   switch (er.code) {
-    case 'ERESOLVE':
+    case 'ERESOLVE': {
       short.push(['ERESOLVE', er.message])
       detail.push(['', ''])
       // XXX(display): error messages are logged so we use the logColor since that is based
       // on stderr. This should be handled solely by the display layer so it could also be
       // printed to stdout if necessary.
-      detail.push(['', report(er, !!npm.logColor, resolve(npm.cache, 'eresolve-report.txt'))])
+      const { explanation, file } = report(er, !!npm.logColor)
+      detail.push(['', explanation])
+      files.push(['eresolve-report.txt', file])
       break
+    }
 
     case 'ENOLOCK': {
       const cmd = npm.command || ''
@@ -398,5 +402,5 @@ module.exports = (er, npm) => {
 
       break
   }
-  return { summary: short, detail: detail }
+  return { summary: short, detail, files }
 }

--- a/lib/utils/log-file.js
+++ b/lib/utils/log-file.js
@@ -7,16 +7,11 @@ const MiniPass = require('minipass')
 const fsMiniPass = require('fs-minipass')
 const fs = require('@npmcli/fs')
 const log = require('./log-shim')
-const runId = require('./run-id')
 
 const padZero = (n, length) => n.toString().padStart(length.toString().length, '0')
 const globify = pattern => pattern.split('\\').join('/')
 
 class LogFiles {
-  // If we write multiple log files we want them all to have the same
-  // identifier for sorting and matching purposes
-  #logId = null
-
   // Default to a plain minipass stream so we can buffer
   // initial writes before we know the cache location
   #logStream = null
@@ -34,16 +29,14 @@ class LogFiles {
 
   #fileLogCount = 0
   #totalLogCount = 0
-  #dir = null
+  #path = null
   #logsMax = null
   #files = []
 
   constructor ({
-    id = runId(),
     maxLogsPerFile = 50_000,
     maxFilesPerProcess = 5,
   } = {}) {
-    this.#logId = id
     this.#MAX_LOGS_PER_FILE = maxLogsPerFile
     this.#MAX_FILES_PER_PROCESS = maxFilesPerProcess
     this.on()
@@ -73,10 +66,10 @@ class LogFiles {
     this.#endStream()
   }
 
-  load ({ dir, logsMax = Infinity } = {}) {
+  load ({ path, logsMax = Infinity } = {}) {
     // dir is user configurable and is required to exist so
     // this can error if the dir is missing or not configured correctly
-    this.#dir = dir
+    this.#path = path
     this.#logsMax = logsMax
 
     // Log stream has already ended
@@ -84,7 +77,7 @@ class LogFiles {
       return
     }
 
-    log.verbose('logfile', `logs-max:${logsMax} dir:${dir}`)
+    log.verbose('logfile', `logs-max:${logsMax} dir:${this.#path}`)
 
     // Pipe our initial stream to our new file stream and
     // set that as the new log logstream for future writes
@@ -164,7 +157,7 @@ class LogFiles {
   }
 
   #getLogFilePath (count = '') {
-    return path.resolve(this.#dir, `${this.#logId}-debug-${count}.log`)
+    return `${this.#path}debug-${count}.log`
   }
 
   #openLogFile () {

--- a/lib/utils/log-file.js
+++ b/lib/utils/log-file.js
@@ -7,17 +7,10 @@ const MiniPass = require('minipass')
 const fsMiniPass = require('fs-minipass')
 const fs = require('@npmcli/fs')
 const log = require('./log-shim')
+const runId = require('./run-id')
 
 const padZero = (n, length) => n.toString().padStart(length.toString().length, '0')
 const globify = pattern => pattern.split('\\').join('/')
-
-const _logHandler = Symbol('logHandler')
-const _formatLogItem = Symbol('formatLogItem')
-const _getLogFilePath = Symbol('getLogFilePath')
-const _openLogFile = Symbol('openLogFile')
-const _cleanLogs = Symbol('cleanlogs')
-const _endStream = Symbol('endStream')
-const _isBuffered = Symbol('isBuffered')
 
 class LogFiles {
   // If we write multiple log files we want them all to have the same
@@ -46,17 +39,14 @@ class LogFiles {
   #files = []
 
   constructor ({
+    id = runId(),
     maxLogsPerFile = 50_000,
     maxFilesPerProcess = 5,
   } = {}) {
-    this.#logId = LogFiles.logId(new Date())
+    this.#logId = id
     this.#MAX_LOGS_PER_FILE = maxLogsPerFile
     this.#MAX_FILES_PER_PROCESS = maxFilesPerProcess
     this.on()
-  }
-
-  static logId (d) {
-    return d.toISOString().replace(/[.:]/g, '_')
   }
 
   static format (count, level, title, ...args) {
@@ -75,12 +65,12 @@ class LogFiles {
 
   on () {
     this.#logStream = new MiniPass()
-    process.on('log', this[_logHandler])
+    process.on('log', this.#logHandler)
   }
 
   off () {
-    process.off('log', this[_logHandler])
-    this[_endStream]()
+    process.off('log', this.#logHandler)
+    this.#endStream()
   }
 
   load ({ dir, logsMax = Infinity } = {}) {
@@ -100,7 +90,7 @@ class LogFiles {
     // set that as the new log logstream for future writes
     // if logs max is 0 then the user does not want a log file
     if (this.#logsMax > 0) {
-      const initialFile = this[_openLogFile]()
+      const initialFile = this.#openLogFile()
       if (initialFile) {
         this.#logStream = this.#logStream.pipe(initialFile)
       }
@@ -109,29 +99,29 @@ class LogFiles {
     // Kickoff cleaning process, even if we aren't writing a logfile.
     // This is async but it will always ignore the current logfile
     // Return the result so it can be awaited in tests
-    return this[_cleanLogs]()
+    return this.#cleanLogs()
   }
 
   log (...args) {
-    this[_logHandler](...args)
+    this.#logHandler(...args)
   }
 
   get files () {
     return this.#files
   }
 
-  get [_isBuffered] () {
+  get #isBuffered () {
     return this.#logStream instanceof MiniPass
   }
 
-  [_endStream] (output) {
+  #endStream (output) {
     if (this.#logStream) {
       this.#logStream.end(output)
       this.#logStream = null
     }
   }
 
-  [_logHandler] = (level, ...args) => {
+  #logHandler = (level, ...args) => {
     // Ignore pause and resume events since we
     // write everything to the log file
     if (level === 'pause' || level === 'resume') {
@@ -143,9 +133,9 @@ class LogFiles {
       return
     }
 
-    const logOutput = this[_formatLogItem](level, ...args)
+    const logOutput = this.#formatLogItem(level, ...args)
 
-    if (this[_isBuffered]) {
+    if (this.#isBuffered) {
       // Cant do anything but buffer the output if we dont
       // have a file stream yet
       this.#logStream.write(logOutput)
@@ -155,29 +145,29 @@ class LogFiles {
     // Open a new log file if we've written too many logs to this one
     if (this.#fileLogCount >= this.#MAX_LOGS_PER_FILE) {
       // Write last chunk to the file and close it
-      this[_endStream](logOutput)
+      this.#endStream(logOutput)
       if (this.#files.length >= this.#MAX_FILES_PER_PROCESS) {
         // but if its way too many then we just stop listening
         this.off()
       } else {
         // otherwise we are ready for a new file for the next event
-        this.#logStream = this[_openLogFile]()
+        this.#logStream = this.#openLogFile()
       }
     } else {
       this.#logStream.write(logOutput)
     }
   }
 
-  [_formatLogItem] (...args) {
+  #formatLogItem (...args) {
     this.#fileLogCount += 1
     return LogFiles.format(this.#totalLogCount++, ...args)
   }
 
-  [_getLogFilePath] (count = '') {
+  #getLogFilePath (count = '') {
     return path.resolve(this.#dir, `${this.#logId}-debug-${count}.log`)
   }
 
-  [_openLogFile] () {
+  #openLogFile () {
     // Count in filename will be 0 indexed
     const count = this.#files.length
 
@@ -186,7 +176,7 @@ class LogFiles {
       // We never want to write files ending in `-9.log` and `-10.log` because
       // log file cleaning is done by deleting the oldest so in this example
       // `-10.log` would be deleted next
-      const f = this[_getLogFilePath](padZero(count, this.#MAX_FILES_PER_PROCESS))
+      const f = this.#getLogFilePath(padZero(count, this.#MAX_FILES_PER_PROCESS))
       // Some effort was made to make the async, but we need to write logs
       // during process.on('exit') which has to be synchronous. So in order
       // to never drop log messages, it is easiest to make it sync all the time
@@ -210,7 +200,7 @@ class LogFiles {
     }
   }
 
-  async [_cleanLogs] () {
+  async #cleanLogs () {
     // module to clean out the old log files
     // this is a best-effort attempt.  if a rm fails, we just
     // log a message about it and move on.  We do return a
@@ -218,7 +208,7 @@ class LogFiles {
     // just for the benefit of testing this function properly.
 
     try {
-      const logPath = this[_getLogFilePath]()
+      const logPath = this.#getLogFilePath()
       const logGlob = path.join(path.dirname(logPath), path.basename(logPath)
         // tell glob to only match digits
         .replace(/\d/g, '[0123456789]')

--- a/lib/utils/run-id.js
+++ b/lib/utils/run-id.js
@@ -1,3 +1,0 @@
-module.exports = (d = new Date()) => {
-  return d.toISOString().replace(/[.:]/g, '_')
-}

--- a/lib/utils/run-id.js
+++ b/lib/utils/run-id.js
@@ -1,0 +1,3 @@
+module.exports = (d = new Date()) => {
+  return d.toISOString().replace(/[.:]/g, '_')
+}

--- a/lib/utils/timers.js
+++ b/lib/utils/timers.js
@@ -2,10 +2,7 @@ const EE = require('events')
 const { resolve } = require('path')
 const fs = require('@npmcli/fs')
 const log = require('./log-shim')
-
-const _timeListener = Symbol('timeListener')
-const _timeEndListener = Symbol('timeEndListener')
-const _init = Symbol('init')
+const runId = require('./run-id')
 
 // This is an event emiiter but on/off
 // only listen on a single internal event that gets
@@ -13,17 +10,19 @@ const _init = Symbol('init')
 class Timers extends EE {
   file = null
 
+  #id = null
   #unfinished = new Map()
   #finished = {}
   #onTimeEnd = Symbol('onTimeEnd')
   #initialListener = null
   #initialTimer = null
 
-  constructor ({ listener = null, start = 'npm' } = {}) {
+  constructor ({ id = runId(), listener = null, start = 'npm' } = {}) {
     super()
+    this.#id = id
     this.#initialListener = listener
     this.#initialTimer = start
-    this[_init]()
+    this.#init()
   }
 
   get unfinished () {
@@ -34,7 +33,7 @@ class Timers extends EE {
     return this.#finished
   }
 
-  [_init] () {
+  #init () {
     this.on()
     if (this.#initialListener) {
       this.on(this.#initialListener)
@@ -47,8 +46,8 @@ class Timers extends EE {
     if (listener) {
       super.on(this.#onTimeEnd, listener)
     } else {
-      process.on('time', this[_timeListener])
-      process.on('timeEnd', this[_timeEndListener])
+      process.on('time', this.#timeListener)
+      process.on('timeEnd', this.#timeEndListener)
     }
   }
 
@@ -57,8 +56,8 @@ class Timers extends EE {
       super.off(this.#onTimeEnd, listener)
     } else {
       this.removeAllListeners(this.#onTimeEnd)
-      process.off('time', this[_timeListener])
-      process.off('timeEnd', this[_timeEndListener])
+      process.off('time', this.#timeListener)
+      process.off('timeEnd', this.#timeEndListener)
     }
   }
 
@@ -74,11 +73,11 @@ class Timers extends EE {
 
   load ({ dir } = {}) {
     if (dir) {
-      this.file = resolve(dir, '_timing.json')
+      this.file = resolve(dir, `${this.#id}-timing.json`)
     }
   }
 
-  writeFile (fileData) {
+  writeFile (metadata) {
     if (!this.file) {
       return
     }
@@ -87,20 +86,20 @@ class Timers extends EE {
       const globalStart = this.started
       const globalEnd = this.#finished.npm || Date.now()
       const content = {
-        ...fileData,
-        ...this.#finished,
+        metadata: {
+          id: this.#id,
+          ...metadata,
+        },
+        timers: this.#finished,
         // add any unfinished timers with their relative start/end
-        unfinished: [...this.#unfinished.entries()].reduce((acc, [name, start]) => {
+        unfinishedTimers: [...this.#unfinished.entries()].reduce((acc, [name, start]) => {
           acc[name] = [start - globalStart, globalEnd - globalStart]
           return acc
         }, {}),
       }
-      // we append line delimited json to this file...forever
-      // XXX: should we also write a process specific timing file?
-      // with similar rules to the debug log (max files, etc)
       fs.withOwnerSync(
         this.file,
-        () => fs.appendFileSync(this.file, JSON.stringify(content) + '\n'),
+        () => fs.writeFileSync(this.file, JSON.stringify(content) + '\n'),
         { owner: 'inherit' }
       )
     } catch (e) {
@@ -109,11 +108,11 @@ class Timers extends EE {
     }
   }
 
-  [_timeListener] = (name) => {
+  #timeListener = (name) => {
     this.#unfinished.set(name, Date.now())
   }
 
-  [_timeEndListener] = (name) => {
+  #timeEndListener = (name) => {
     if (this.#unfinished.has(name)) {
       const ms = Date.now() - this.#unfinished.get(name)
       this.#finished[name] = ms

--- a/lib/utils/timers.js
+++ b/lib/utils/timers.js
@@ -1,8 +1,6 @@
 const EE = require('events')
-const { resolve } = require('path')
 const fs = require('@npmcli/fs')
 const log = require('./log-shim')
-const runId = require('./run-id')
 
 // This is an event emiiter but on/off
 // only listen on a single internal event that gets
@@ -10,16 +8,14 @@ const runId = require('./run-id')
 class Timers extends EE {
   file = null
 
-  #id = null
   #unfinished = new Map()
   #finished = {}
   #onTimeEnd = Symbol('onTimeEnd')
   #initialListener = null
   #initialTimer = null
 
-  constructor ({ id = runId(), listener = null, start = 'npm' } = {}) {
+  constructor ({ listener = null, start = 'npm' } = {}) {
     super()
-    this.#id = id
     this.#initialListener = listener
     this.#initialTimer = start
     this.#init()
@@ -71,9 +67,9 @@ class Timers extends EE {
     return end
   }
 
-  load ({ dir } = {}) {
-    if (dir) {
-      this.file = resolve(dir, `${this.#id}-timing.json`)
+  load ({ path } = {}) {
+    if (path) {
+      this.file = `${path}timing.json`
     }
   }
 
@@ -86,10 +82,7 @@ class Timers extends EE {
       const globalStart = this.started
       const globalEnd = this.#finished.npm || Date.now()
       const content = {
-        metadata: {
-          id: this.#id,
-          ...metadata,
-        },
+        metadata,
         timers: this.#finished,
         // add any unfinished timers with their relative start/end
         unfinishedTimers: [...this.#unfinished.entries()].reduce((acc, [name, start]) => {

--- a/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
@@ -1762,12 +1762,11 @@ exports[`test/lib/utils/config/definitions.js TAP > config description for timin
 * Default: false
 * Type: Boolean
 
-If true, writes a debug log to \`logs-dir\` and timing information to
-\`_timing.json\` in the cache, even if the command completes successfully.
-\`_timing.json\` is a newline delimited list of JSON objects.
+If true, writes timing information to a process specific json file in the
+cache or \`logs-dir\`. The file name ends with \`-timing.json\`.
 
 You can quickly view it with this [json](https://npm.im/json) command line:
-\`npm exec -- json -g < ~/.npm/_timing.json\`.
+\`cat ~/.npm/_logs/*-timing.json | npm exec -- json -g\`.
 `
 
 exports[`test/lib/utils/config/definitions.js TAP > config description for tmp 1`] = `

--- a/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
@@ -1580,12 +1580,11 @@ particular, use care when overriding this setting for public packages.
 * Default: false
 * Type: Boolean
 
-If true, writes a debug log to \`logs-dir\` and timing information to
-\`_timing.json\` in the cache, even if the command completes successfully.
-\`_timing.json\` is a newline delimited list of JSON objects.
+If true, writes timing information to a process specific json file in the
+cache or \`logs-dir\`. The file name ends with \`-timing.json\`.
 
 You can quickly view it with this [json](https://npm.im/json) command line:
-\`npm exec -- json -g < ~/.npm/_timing.json\`.
+\`cat ~/.npm/_logs/*-timing.json | npm exec -- json -g\`.
 
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->

--- a/tap-snapshots/test/lib/utils/error-message.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/error-message.js.test.cjs
@@ -509,7 +509,7 @@ Array [
   ],
   Array [
     "logfile",
-    "logs-max:10 dir:{CWD}/test/lib/utils/tap-testdir-error-message-eacces-eperm--windows-false-loaded-true-cachePath-false-cacheDest-false-/cache/_logs",
+    "logs-max:10 dir:{CWD}/test/lib/utils/tap-testdir-error-message-eacces-eperm--windows-false-loaded-true-cachePath-false-cacheDest-false-/cache/_logs/{DATE}-",
   ],
   Array [
     "logfile",
@@ -549,7 +549,7 @@ Array [
   ],
   Array [
     "logfile",
-    "logs-max:10 dir:{CWD}/test/lib/utils/tap-testdir-error-message-eacces-eperm--windows-false-loaded-true-cachePath-false-cacheDest-true-/cache/_logs",
+    "logs-max:10 dir:{CWD}/test/lib/utils/tap-testdir-error-message-eacces-eperm--windows-false-loaded-true-cachePath-false-cacheDest-true-/cache/_logs/{DATE}-",
   ],
   Array [
     "logfile",
@@ -592,7 +592,7 @@ Array [
   ],
   Array [
     "logfile",
-    "logs-max:10 dir:{CWD}/test/lib/utils/tap-testdir-error-message-eacces-eperm--windows-false-loaded-true-cachePath-true-cacheDest-false-/cache/_logs",
+    "logs-max:10 dir:{CWD}/test/lib/utils/tap-testdir-error-message-eacces-eperm--windows-false-loaded-true-cachePath-true-cacheDest-false-/cache/_logs/{DATE}-",
   ],
   Array [
     "logfile",
@@ -635,7 +635,7 @@ Array [
   ],
   Array [
     "logfile",
-    "logs-max:10 dir:{CWD}/test/lib/utils/tap-testdir-error-message-eacces-eperm--windows-false-loaded-true-cachePath-true-cacheDest-true-/cache/_logs",
+    "logs-max:10 dir:{CWD}/test/lib/utils/tap-testdir-error-message-eacces-eperm--windows-false-loaded-true-cachePath-true-cacheDest-true-/cache/_logs/{DATE}-",
   ],
   Array [
     "logfile",
@@ -825,7 +825,7 @@ Array [
   ],
   Array [
     "logfile",
-    "logs-max:10 dir:{CWD}/test/lib/utils/tap-testdir-error-message-eacces-eperm--windows-true-loaded-true-cachePath-false-cacheDest-false-/cache/_logs",
+    "logs-max:10 dir:{CWD}/test/lib/utils/tap-testdir-error-message-eacces-eperm--windows-true-loaded-true-cachePath-false-cacheDest-false-/cache/_logs/{DATE}-",
   ],
   Array [
     "logfile",
@@ -876,7 +876,7 @@ Array [
   ],
   Array [
     "logfile",
-    "logs-max:10 dir:{CWD}/test/lib/utils/tap-testdir-error-message-eacces-eperm--windows-true-loaded-true-cachePath-false-cacheDest-true-/cache/_logs",
+    "logs-max:10 dir:{CWD}/test/lib/utils/tap-testdir-error-message-eacces-eperm--windows-true-loaded-true-cachePath-false-cacheDest-true-/cache/_logs/{DATE}-",
   ],
   Array [
     "logfile",
@@ -927,7 +927,7 @@ Array [
   ],
   Array [
     "logfile",
-    "logs-max:10 dir:{CWD}/test/lib/utils/tap-testdir-error-message-eacces-eperm--windows-true-loaded-true-cachePath-true-cacheDest-false-/cache/_logs",
+    "logs-max:10 dir:{CWD}/test/lib/utils/tap-testdir-error-message-eacces-eperm--windows-true-loaded-true-cachePath-true-cacheDest-false-/cache/_logs/{DATE}-",
   ],
   Array [
     "logfile",
@@ -978,7 +978,7 @@ Array [
   ],
   Array [
     "logfile",
-    "logs-max:10 dir:{CWD}/test/lib/utils/tap-testdir-error-message-eacces-eperm--windows-true-loaded-true-cachePath-true-cacheDest-true-/cache/_logs",
+    "logs-max:10 dir:{CWD}/test/lib/utils/tap-testdir-error-message-eacces-eperm--windows-true-loaded-true-cachePath-true-cacheDest-true-/cache/_logs/{DATE}-",
   ],
   Array [
     "logfile",
@@ -1174,6 +1174,12 @@ Object {
     Array [
       "",
       "explanation",
+    ],
+  ],
+  "files": Array [
+    Array [
+      "eresolve-report.txt",
+      "report",
     ],
   ],
   "summary": Array [

--- a/tap-snapshots/test/lib/utils/exit-handler.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/exit-handler.js.test.cjs
@@ -15,7 +15,7 @@ exports[`test/lib/utils/exit-handler.js TAP handles unknown error with logs and 
 20 verbose argv
 21 timing npm:load:setTitle Completed in {TIME}ms
 23 timing npm:load:display Completed in {TIME}ms
-24 verbose logfile logs-max:10 dir:{CWD}/test/lib/utils/tap-testdir-exit-handler-handles-unknown-error-with-logs-and-debug-file/cache/_logs
+24 verbose logfile logs-max:10 dir:{CWD}/test/lib/utils/tap-testdir-exit-handler-handles-unknown-error-with-logs-and-debug-file/cache/_logs/{DATE}-
 25 verbose logfile {CWD}/test/lib/utils/tap-testdir-exit-handler-handles-unknown-error-with-logs-and-debug-file/cache/_logs/{DATE}-debug-0.log
 26 timing npm:load:logFile Completed in {TIME}ms
 27 timing npm:load:timers Completed in {TIME}ms
@@ -47,7 +47,7 @@ verbose title npm
 verbose argv 
 timing npm:load:setTitle Completed in {TIME}ms
 timing npm:load:display Completed in {TIME}ms
-verbose logfile logs-max:10 dir:{CWD}/test/lib/utils/tap-testdir-exit-handler-handles-unknown-error-with-logs-and-debug-file/cache/_logs
+verbose logfile logs-max:10 dir:{CWD}/test/lib/utils/tap-testdir-exit-handler-handles-unknown-error-with-logs-and-debug-file/cache/_logs/{DATE}-
 verbose logfile {CWD}/test/lib/utils/tap-testdir-exit-handler-handles-unknown-error-with-logs-and-debug-file/cache/_logs/{DATE}-debug-0.log
 timing npm:load:logFile Completed in {TIME}ms
 timing npm:load:timers Completed in {TIME}ms

--- a/tap-snapshots/test/lib/utils/explain-eresolve.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/explain-eresolve.js.test.cjs
@@ -29,10 +29,8 @@ node_modules/@isaacs/testing-peer-dep-conflict-chain-c
   @isaacs/testing-peer-dep-conflict-chain-c@"1" from the root project
 `
 
-exports[`test/lib/utils/explain-eresolve.js TAP chain-conflict > report 1`] = `
+exports[`test/lib/utils/explain-eresolve.js TAP chain-conflict > report from color 1`] = `
 # npm resolution error report
-
-\${TIME}
 
 While resolving: project@1.2.3
 Found: @isaacs/testing-peer-dep-conflict-chain-d@2.0.0
@@ -45,16 +43,8 @@ node_modules/@isaacs/testing-peer-dep-conflict-chain-c
   @isaacs/testing-peer-dep-conflict-chain-c@"1" from the root project
 
 Fix the upstream dependency conflict, or retry
-this command with --force, or --legacy-peer-deps
+this command with --force or --legacy-peer-deps
 to accept an incorrect (and potentially broken) dependency resolution.
-
-Raw JSON explanation object:
-
-{
-  "name": "chain-conflict",
-  "json": true
-}
-
 `
 
 exports[`test/lib/utils/explain-eresolve.js TAP chain-conflict > report with color 1`] = `
@@ -69,10 +59,8 @@ Could not resolve dependency:
   [1m@isaacs/testing-peer-dep-conflict-chain-c[22m@"[1m1[22m" from the root project
 
 Fix the upstream dependency conflict, or retry
-this command with --force, or --legacy-peer-deps
+this command with --force or --legacy-peer-deps
 to accept an incorrect (and potentially broken) dependency resolution.
-
-See \${REPORT} for a full report.
 `
 
 exports[`test/lib/utils/explain-eresolve.js TAP chain-conflict > report with no color 1`] = `
@@ -87,10 +75,8 @@ node_modules/@isaacs/testing-peer-dep-conflict-chain-c
   @isaacs/testing-peer-dep-conflict-chain-c@"1" from the root project
 
 Fix the upstream dependency conflict, or retry
-this command with --force, or --legacy-peer-deps
+this command with --force or --legacy-peer-deps
 to accept an incorrect (and potentially broken) dependency resolution.
-
-See \${REPORT} for a full report.
 `
 
 exports[`test/lib/utils/explain-eresolve.js TAP cycleNested > explain with color, depth of 2 1`] = `
@@ -130,10 +116,8 @@ node_modules/@isaacs/peer-dep-cycle-c
       @isaacs/peer-dep-cycle-a@"1.x" from the root project
 `
 
-exports[`test/lib/utils/explain-eresolve.js TAP cycleNested > report 1`] = `
+exports[`test/lib/utils/explain-eresolve.js TAP cycleNested > report from color 1`] = `
 # npm resolution error report
-
-\${TIME}
 
 Found: @isaacs/peer-dep-cycle-c@2.0.0
 node_modules/@isaacs/peer-dep-cycle-c
@@ -155,14 +139,6 @@ node_modules/@isaacs/peer-dep-cycle-c
 Fix the upstream dependency conflict, or retry
 this command with --no-strict-peer-deps, --force, or --legacy-peer-deps
 to accept an incorrect (and potentially broken) dependency resolution.
-
-Raw JSON explanation object:
-
-{
-  "name": "cycleNested",
-  "json": true
-}
-
 `
 
 exports[`test/lib/utils/explain-eresolve.js TAP cycleNested > report with color 1`] = `
@@ -186,8 +162,6 @@ Conflicting peer dependency: [1m@isaacs/peer-dep-cycle-c[22m@[1m1.0.0[22m[2
 Fix the upstream dependency conflict, or retry
 this command with --no-strict-peer-deps, --force, or --legacy-peer-deps
 to accept an incorrect (and potentially broken) dependency resolution.
-
-See \${REPORT} for a full report.
 `
 
 exports[`test/lib/utils/explain-eresolve.js TAP cycleNested > report with no color 1`] = `
@@ -211,8 +185,6 @@ node_modules/@isaacs/peer-dep-cycle-c
 Fix the upstream dependency conflict, or retry
 this command with --no-strict-peer-deps, --force, or --legacy-peer-deps
 to accept an incorrect (and potentially broken) dependency resolution.
-
-See \${REPORT} for a full report.
 `
 
 exports[`test/lib/utils/explain-eresolve.js TAP eslint-plugin case > explain with color, depth of 2 1`] = `
@@ -255,10 +227,8 @@ node_modules/eslint
     dev eslint-plugin-eslint-plugin@"^3.1.0" from the root project
 `
 
-exports[`test/lib/utils/explain-eresolve.js TAP eslint-plugin case > report 1`] = `
+exports[`test/lib/utils/explain-eresolve.js TAP eslint-plugin case > report from color 1`] = `
 # npm resolution error report
-
-\${TIME}
 
 While resolving: eslint-plugin-react@7.24.0
 Found: eslint@6.8.0
@@ -287,16 +257,8 @@ node_modules/eslint
     dev eslint-plugin-eslint-plugin@"^3.1.0" from the root project
 
 Fix the upstream dependency conflict, or retry
-this command with --force, or --legacy-peer-deps
+this command with --force or --legacy-peer-deps
 to accept an incorrect (and potentially broken) dependency resolution.
-
-Raw JSON explanation object:
-
-{
-  "name": "eslint-plugin case",
-  "json": true
-}
-
 `
 
 exports[`test/lib/utils/explain-eresolve.js TAP eslint-plugin case > report with color 1`] = `
@@ -319,10 +281,8 @@ Conflicting peer dependency: [1meslint[22m@[1m7.31.0[22m[2m[22m
     [33mdev[39m [1meslint-plugin-eslint-plugin[22m@"[1m^3.1.0[22m" from the root project
 
 Fix the upstream dependency conflict, or retry
-this command with --force, or --legacy-peer-deps
+this command with --force or --legacy-peer-deps
 to accept an incorrect (and potentially broken) dependency resolution.
-
-See \${REPORT} for a full report.
 `
 
 exports[`test/lib/utils/explain-eresolve.js TAP eslint-plugin case > report with no color 1`] = `
@@ -345,10 +305,8 @@ node_modules/eslint
     dev eslint-plugin-eslint-plugin@"^3.1.0" from the root project
 
 Fix the upstream dependency conflict, or retry
-this command with --force, or --legacy-peer-deps
+this command with --force or --legacy-peer-deps
 to accept an incorrect (and potentially broken) dependency resolution.
-
-See \${REPORT} for a full report.
 `
 
 exports[`test/lib/utils/explain-eresolve.js TAP gatsby > explain with color, depth of 2 1`] = `
@@ -391,10 +349,8 @@ node_modules/ink-box
         gatsby@"" from the root project
 `
 
-exports[`test/lib/utils/explain-eresolve.js TAP gatsby > report 1`] = `
+exports[`test/lib/utils/explain-eresolve.js TAP gatsby > report from color 1`] = `
 # npm resolution error report
-
-\${TIME}
 
 While resolving: gatsby-recipes@0.2.31
 Found: ink@3.0.0-7
@@ -421,14 +377,6 @@ node_modules/ink-box
 Fix the upstream dependency conflict, or retry
 this command with --no-strict-peer-deps, --force, or --legacy-peer-deps
 to accept an incorrect (and potentially broken) dependency resolution.
-
-Raw JSON explanation object:
-
-{
-  "name": "gatsby",
-  "json": true
-}
-
 `
 
 exports[`test/lib/utils/explain-eresolve.js TAP gatsby > report with color 1`] = `
@@ -456,8 +404,6 @@ Could not resolve dependency:
 Fix the upstream dependency conflict, or retry
 this command with --no-strict-peer-deps, --force, or --legacy-peer-deps
 to accept an incorrect (and potentially broken) dependency resolution.
-
-See \${REPORT} for a full report.
 `
 
 exports[`test/lib/utils/explain-eresolve.js TAP gatsby > report with no color 1`] = `
@@ -485,8 +431,6 @@ node_modules/ink-box
 Fix the upstream dependency conflict, or retry
 this command with --no-strict-peer-deps, --force, or --legacy-peer-deps
 to accept an incorrect (and potentially broken) dependency resolution.
-
-See \${REPORT} for a full report.
 `
 
 exports[`test/lib/utils/explain-eresolve.js TAP no current node, but has current edge > explain with color, depth of 2 1`] = `
@@ -509,10 +453,8 @@ node_modules/eslint-plugin-jsdoc
   dev eslint-plugin-jsdoc@"^22.1.0" from the root project
 `
 
-exports[`test/lib/utils/explain-eresolve.js TAP no current node, but has current edge > report 1`] = `
+exports[`test/lib/utils/explain-eresolve.js TAP no current node, but has current edge > report from color 1`] = `
 # npm resolution error report
-
-\${TIME}
 
 While resolving: eslint@7.22.0
 Found: dev eslint@"file:." from the root project
@@ -523,16 +465,8 @@ node_modules/eslint-plugin-jsdoc
   dev eslint-plugin-jsdoc@"^22.1.0" from the root project
 
 Fix the upstream dependency conflict, or retry
-this command with --force, or --legacy-peer-deps
+this command with --force or --legacy-peer-deps
 to accept an incorrect (and potentially broken) dependency resolution.
-
-Raw JSON explanation object:
-
-{
-  "name": "no current node, but has current edge",
-  "json": true
-}
-
 `
 
 exports[`test/lib/utils/explain-eresolve.js TAP no current node, but has current edge > report with color 1`] = `
@@ -545,10 +479,8 @@ Could not resolve dependency:
   [33mdev[39m [1meslint-plugin-jsdoc[22m@"[1m^22.1.0[22m" from the root project
 
 Fix the upstream dependency conflict, or retry
-this command with --force, or --legacy-peer-deps
+this command with --force or --legacy-peer-deps
 to accept an incorrect (and potentially broken) dependency resolution.
-
-See \${REPORT} for a full report.
 `
 
 exports[`test/lib/utils/explain-eresolve.js TAP no current node, but has current edge > report with no color 1`] = `
@@ -561,10 +493,8 @@ node_modules/eslint-plugin-jsdoc
   dev eslint-plugin-jsdoc@"^22.1.0" from the root project
 
 Fix the upstream dependency conflict, or retry
-this command with --force, or --legacy-peer-deps
+this command with --force or --legacy-peer-deps
 to accept an incorrect (and potentially broken) dependency resolution.
-
-See \${REPORT} for a full report.
 `
 
 exports[`test/lib/utils/explain-eresolve.js TAP no current node, no current edge, idk > explain with color, depth of 2 1`] = `
@@ -591,10 +521,8 @@ node_modules/eslint-plugin-jsdoc
   dev eslint-plugin-jsdoc@"^22.1.0" from the root project
 `
 
-exports[`test/lib/utils/explain-eresolve.js TAP no current node, no current edge, idk > report 1`] = `
+exports[`test/lib/utils/explain-eresolve.js TAP no current node, no current edge, idk > report from color 1`] = `
 # npm resolution error report
-
-\${TIME}
 
 While resolving: eslint@7.22.0
 Found: peer eslint@"^6.0.0" from eslint-plugin-jsdoc@22.2.0
@@ -607,16 +535,8 @@ node_modules/eslint-plugin-jsdoc
   dev eslint-plugin-jsdoc@"^22.1.0" from the root project
 
 Fix the upstream dependency conflict, or retry
-this command with --force, or --legacy-peer-deps
+this command with --force or --legacy-peer-deps
 to accept an incorrect (and potentially broken) dependency resolution.
-
-Raw JSON explanation object:
-
-{
-  "name": "no current node, no current edge, idk",
-  "json": true
-}
-
 `
 
 exports[`test/lib/utils/explain-eresolve.js TAP no current node, no current edge, idk > report with color 1`] = `
@@ -631,10 +551,8 @@ Could not resolve dependency:
   [33mdev[39m [1meslint-plugin-jsdoc[22m@"[1m^22.1.0[22m" from the root project
 
 Fix the upstream dependency conflict, or retry
-this command with --force, or --legacy-peer-deps
+this command with --force or --legacy-peer-deps
 to accept an incorrect (and potentially broken) dependency resolution.
-
-See \${REPORT} for a full report.
 `
 
 exports[`test/lib/utils/explain-eresolve.js TAP no current node, no current edge, idk > report with no color 1`] = `
@@ -649,10 +567,8 @@ node_modules/eslint-plugin-jsdoc
   dev eslint-plugin-jsdoc@"^22.1.0" from the root project
 
 Fix the upstream dependency conflict, or retry
-this command with --force, or --legacy-peer-deps
+this command with --force or --legacy-peer-deps
 to accept an incorrect (and potentially broken) dependency resolution.
-
-See \${REPORT} for a full report.
 `
 
 exports[`test/lib/utils/explain-eresolve.js TAP withShrinkwrap > explain with color, depth of 2 1`] = `
@@ -682,10 +598,8 @@ node_modules/@isaacs/peer-dep-cycle-b
     @isaacs/peer-dep-cycle-a@"1.x" from the root project
 `
 
-exports[`test/lib/utils/explain-eresolve.js TAP withShrinkwrap > report 1`] = `
+exports[`test/lib/utils/explain-eresolve.js TAP withShrinkwrap > report from color 1`] = `
 # npm resolution error report
-
-\${TIME}
 
 While resolving: @isaacs/peer-dep-cycle-b@1.0.0
 Found: @isaacs/peer-dep-cycle-c@2.0.0
@@ -702,14 +616,6 @@ node_modules/@isaacs/peer-dep-cycle-b
 Fix the upstream dependency conflict, or retry
 this command with --no-strict-peer-deps, --force, or --legacy-peer-deps
 to accept an incorrect (and potentially broken) dependency resolution.
-
-Raw JSON explanation object:
-
-{
-  "name": "withShrinkwrap",
-  "json": true
-}
-
 `
 
 exports[`test/lib/utils/explain-eresolve.js TAP withShrinkwrap > report with color 1`] = `
@@ -728,8 +634,6 @@ Could not resolve dependency:
 Fix the upstream dependency conflict, or retry
 this command with --no-strict-peer-deps, --force, or --legacy-peer-deps
 to accept an incorrect (and potentially broken) dependency resolution.
-
-See \${REPORT} for a full report.
 `
 
 exports[`test/lib/utils/explain-eresolve.js TAP withShrinkwrap > report with no color 1`] = `
@@ -748,6 +652,4 @@ node_modules/@isaacs/peer-dep-cycle-b
 Fix the upstream dependency conflict, or retry
 this command with --no-strict-peer-deps, --force, or --legacy-peer-deps
 to accept an incorrect (and potentially broken) dependency resolution.
-
-See \${REPORT} for a full report.
 `

--- a/tap-snapshots/test/lib/utils/log-file.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/log-file.js.test.cjs
@@ -6,7 +6,7 @@
  */
 'use strict'
 exports[`test/lib/utils/log-file.js TAP snapshot > must match snapshot 1`] = `
-0 verbose logfile logs-max:10 dir:{CWD}/test/lib/utils/tap-testdir-log-file-snapshot
+0 verbose logfile logs-max:10 dir:{CWD}/test/lib/utils/tap-testdir-log-file-snapshot/{DATE}-
 1 silly logfile done cleaning log files
 2 error no prefix
 3 error prefix with prefix

--- a/test/fixtures/mock-npm.js
+++ b/test/fixtures/mock-npm.js
@@ -174,8 +174,8 @@ const LoadMockNpm = async (t, {
         .join('\n')
     },
     timingFile: async () => {
-      const data = await fs.readFile(path.resolve(dirs.cache, '_timing.json'), 'utf8')
-      return JSON.parse(data) // XXX: this fails if multiple timings are written
+      const data = await fs.readFile(npm.timingFile, 'utf8')
+      return JSON.parse(data)
     },
   }
 }

--- a/test/lib/npm.js
+++ b/test/lib/npm.js
@@ -513,19 +513,23 @@ t.test('timings', async t => {
     process.emit('timeEnd', 'foo')
     process.emit('time', 'bar')
     npm.writeTimingFile()
-    t.equal(npm.timingFile, join(cache, '_timing.json'))
+    t.match(npm.timingFile, cache)
+    t.match(npm.timingFile, /-timing.json$/)
     const timings = await timingFile()
     t.match(timings, {
-      command: [],
-      logfile: String,
-      logfiles: [String],
-      version: String,
-      unfinished: {
+      metadata: {
+        command: [],
+        logfiles: [String],
+        version: String,
+      },
+      unfinishedTimers: {
         bar: [Number, Number],
         npm: [Number, Number],
       },
-      foo: Number,
-      'npm:load': Number,
+      timers: {
+        foo: Number,
+        'npm:load': Number,
+      },
     })
   })
 

--- a/test/lib/utils/exit-handler.js
+++ b/test/lib/utils/exit-handler.js
@@ -326,7 +326,7 @@ t.test('timing with no error', async (t) => {
   t.match(msg, /Timing info written to:/)
 
   t.match(
-    timingFileData,
+    timingFileData.timers,
     Object.keys(npm.finishedTimers).reduce((acc, k) => {
       acc[k] = Number
       return acc
@@ -334,11 +334,14 @@ t.test('timing with no error', async (t) => {
   )
   t.strictSame(npm.unfinishedTimers, new Map())
   t.match(timingFileData, {
-    command: [],
-    version: '1.0.0',
-    npm: Number,
-    logfile: String,
-    logfiles: [String],
+    metadata: {
+      command: [],
+      version: '1.0.0',
+      logfiles: [String],
+    },
+    timers: {
+      npm: Number,
+    },
   })
 })
 
@@ -356,12 +359,15 @@ t.test('unfinished timers', async (t) => {
   t.equal(process.exitCode, 0)
   t.match(npm.unfinishedTimers, new Map([['foo', Number], ['bar', Number]]))
   t.match(timingFileData, {
-    command: [],
-    version: '1.0.0',
-    npm: Number,
-    logfile: String,
-    logfiles: [String],
-    unfinished: {
+    metadata: {
+      command: [],
+      version: '1.0.0',
+      logfiles: [String],
+    },
+    timers: {
+      npm: Number,
+    },
+    unfinishedTimers: {
       foo: [Number, Number],
       bar: [Number, Number],
     },

--- a/test/lib/utils/explain-eresolve.js
+++ b/test/lib/utils/explain-eresolve.js
@@ -1,41 +1,32 @@
 const t = require('tap')
-const npm = {}
-const { explain, report } = require('../../../lib/utils/explain-eresolve.js')
-const { statSync, readFileSync, unlinkSync } = require('fs')
-// strip out timestamps from reports
-const read = f => readFileSync(f, 'utf8')
-  .replace(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/g, '${TIME}')
-
 const { resolve } = require('path')
+const { explain, report } = require('../../../lib/utils/explain-eresolve.js')
 
 const cases = require('../../fixtures/eresolve-explanations.js')
+const { cleanDate } = require('../../fixtures/clean-snapshot.js')
 
 for (const [name, expl] of Object.entries(cases)) {
   // no sense storing the whole contents of each object in the snapshot
   // we can trust that JSON.stringify still works just fine.
-  expl.toJSON = () => {
-    return { name, json: true }
-  }
+  expl.toJSON = () => ({ name, json: true })
 
   t.test(name, t => {
-    npm.cache = t.testdir()
-    const reportFile = resolve(npm.cache, 'eresolve-report.txt')
-    t.cleanSnapshot = str => str.split(reportFile).join('${REPORT}')
+    const dir = t.testdir()
+    const fileReport = resolve(dir, 'eresolve-report.txt')
+    const opts = { file: fileReport, date: new Date().toISOString() }
 
-    npm.color = true
-    t.matchSnapshot(report(expl, true, reportFile), 'report with color')
-    const reportData = read(reportFile)
-    t.matchSnapshot(reportData, 'report')
-    unlinkSync(reportFile)
+    t.cleanSnapshot = str => cleanDate(str.split(fileReport).join('${REPORT}'))
 
-    t.matchSnapshot(report(expl, false, reportFile), 'report with no color')
-    t.equal(read(reportFile), reportData, 'same report written for object')
-    unlinkSync(reportFile)
+    const color = report(expl, true, opts)
+    t.matchSnapshot(color.explanation, 'report with color')
+    t.matchSnapshot(color.file, 'report from color')
+
+    const noColor = report(expl, false, opts)
+    t.matchSnapshot(noColor.explanation, 'report with no color')
+    t.equal(noColor.file, color.file, 'same report written for object')
 
     t.matchSnapshot(explain(expl, true, 2), 'explain with color, depth of 2')
-    t.throws(() => statSync(reportFile), { code: 'ENOENT' }, 'no report')
     t.matchSnapshot(explain(expl, false, 6), 'explain with no color, depth of 6')
-    t.throws(() => statSync(reportFile), { code: 'ENOENT' }, 'no report')
 
     t.end()
   })

--- a/test/lib/utils/log-file.js
+++ b/test/lib/utils/log-file.js
@@ -6,6 +6,7 @@ const os = require('os')
 const fsMiniPass = require('fs-minipass')
 const rimraf = require('rimraf')
 const LogFile = require('../../../lib/utils/log-file.js')
+const runId = require('../../../lib/utils/run-id.js')
 const { cleanCwd } = require('../../fixtures/clean-snapshot')
 
 t.cleanSnapshot = (path) => cleanCwd(path)
@@ -19,7 +20,7 @@ const makeOldLogs = (count, oldStyle) => {
   return range(oldStyle ? count : (count / 2)).reduce((acc, i) => {
     const cloneDate = new Date(d.getTime())
     cloneDate.setSeconds(i)
-    const dateId = LogFile.logId(cloneDate)
+    const dateId = runId(cloneDate)
     if (oldStyle) {
       acc[`${dateId}-debug.log`] = 'hello'
     } else {

--- a/test/lib/utils/log-file.js
+++ b/test/lib/utils/log-file.js
@@ -6,11 +6,11 @@ const os = require('os')
 const fsMiniPass = require('fs-minipass')
 const rimraf = require('rimraf')
 const LogFile = require('../../../lib/utils/log-file.js')
-const runId = require('../../../lib/utils/run-id.js')
-const { cleanCwd } = require('../../fixtures/clean-snapshot')
+const { cleanCwd, cleanDate } = require('../../fixtures/clean-snapshot')
 
-t.cleanSnapshot = (path) => cleanCwd(path)
+t.cleanSnapshot = (path) => cleanDate(cleanCwd(path))
 
+const getId = (d = new Date()) => d.toISOString().replace(/[.:]/g, '_')
 const last = arr => arr[arr.length - 1]
 const range = (n) => Array.from(Array(n).keys())
 const makeOldLogs = (count, oldStyle) => {
@@ -20,7 +20,7 @@ const makeOldLogs = (count, oldStyle) => {
   return range(oldStyle ? count : (count / 2)).reduce((acc, i) => {
     const cloneDate = new Date(d.getTime())
     cloneDate.setSeconds(i)
-    const dateId = runId(cloneDate)
+    const dateId = getId(cloneDate)
     if (oldStyle) {
       acc[`${dateId}-debug.log`] = 'hello'
     } else {
@@ -42,10 +42,15 @@ const cleanErr = (message) => {
 
 const loadLogFile = async (t, { buffer = [], mocks, testdir = {}, ...options } = {}) => {
   const root = t.testdir(testdir)
+
   const MockLogFile = t.mock('../../../lib/utils/log-file.js', mocks)
   const logFile = new MockLogFile(Object.keys(options).length ? options : undefined)
+
   buffer.forEach((b) => logFile.log(...b))
-  await logFile.load({ dir: root, ...options })
+
+  const id = getId()
+  await logFile.load({ path: path.join(root, `${id}-`), ...options })
+
   t.teardown(() => logFile.off())
   return {
     root,

--- a/test/lib/utils/timers.js
+++ b/test/lib/utils/timers.js
@@ -68,11 +68,11 @@ t.test('finish unstarted timer', async (t) => {
 })
 
 t.test('writes file', async (t) => {
-  const { timers } = mockTimers(t, { id: 'TIMING_FILE' })
+  const { timers } = mockTimers(t)
   const dir = t.testdir()
   process.emit('time', 'foo')
   process.emit('timeEnd', 'foo')
-  timers.load({ dir })
+  timers.load({ path: resolve(dir, `TIMING_FILE-`) })
   timers.writeFile({ some: 'data' })
   const data = JSON.parse(fs.readFileSync(resolve(dir, 'TIMING_FILE-timing.json')))
   t.match(data, {
@@ -88,7 +88,7 @@ t.test('fails to write file', async (t) => {
   const { logs, timers } = mockTimers(t)
   const dir = t.testdir()
 
-  timers.load({ dir: join(dir, 'does', 'not', 'exist') })
+  timers.load({ path: join(dir, 'does', 'not', 'exist') })
   timers.writeFile()
 
   t.match(logs.warn, [['timing', 'could not write timing file']])

--- a/test/lib/utils/timers.js
+++ b/test/lib/utils/timers.js
@@ -68,17 +68,17 @@ t.test('finish unstarted timer', async (t) => {
 })
 
 t.test('writes file', async (t) => {
-  const { timers } = mockTimers(t)
+  const { timers } = mockTimers(t, { id: 'TIMING_FILE' })
   const dir = t.testdir()
   process.emit('time', 'foo')
   process.emit('timeEnd', 'foo')
   timers.load({ dir })
   timers.writeFile({ some: 'data' })
-  const data = JSON.parse(fs.readFileSync(resolve(dir, '_timing.json')))
+  const data = JSON.parse(fs.readFileSync(resolve(dir, 'TIMING_FILE-timing.json')))
   t.match(data, {
-    some: 'data',
-    foo: Number,
-    unfinished: {
+    metadata: { some: 'data' },
+    timers: { foo: Number },
+    unfinishedTimers: {
       npm: [Number, Number],
     },
   })


### PR DESCRIPTION
BREAKING CHANGE: `--timing` file changes:
- When run with the `--timing` flag, `npm` now writes timing data to a
file alongside the debug log data, respecting the `logs-dir` option and
falling back to the cache dir, instead of directly inside `.npm/`.
- The timing file data is no longer newline delimited JSON, and instead
each run will create a uniquely named `<ID>-timing.json` file, with the
`<ID>` portion being the same as the debug log.
- Finally, the data inside the file now has three top level keys,
`metadata`, `timers, and `unfinishedTimers` instead of everything being
a top level key.

Closes https://github.com/npm/statusboard/issues/456
