### PR TITLE
fix(arborist): tag spec should install the exact version

### DIFF
--- a/workspaces/arborist/lib/dep-valid.js
+++ b/workspaces/arborist/lib/dep-valid.js
@@ -62,11 +62,12 @@ const depValid = (child, requested, requestor) => {
       // check that the alias target is valid
       return depValid(child, requested.subSpec, requestor)
 
-    case 'tag':
-      // if it's a tag, we just verify that it has a tarball resolution
-      // presumably, it came from the registry and was tagged at some point
-      return child.resolved && npa(child.resolved).type === 'remote'
-
+    case 'tag': {
+      // if it's a tag, requestor has the exact version of the requested tag
+      // so child must be the same version as requestor's child version
+      const exactNode = requestor.children ? requestor.children.get(child.name) : null
+      return exactNode ? child.version === exactNode.version : false
+    }
     case 'remote':
       // verify that we got it from the desired location
       return child.resolved === requested.fetchSpec

--- a/workspaces/arborist/test/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/test/arborist/build-ideal-tree.js
@@ -3933,3 +3933,9 @@ t.test('store files with a custom indenting', async t => {
   const tree = await buildIdeal(path)
   t.matchSnapshot(String(tree.meta))
 })
+
+t.test('should install accurate version when deps has dist-tag spec', async t => {
+  const path = resolve(fixtures, 'tag-spec-depencencies')
+  const tree = await buildIdeal(path)
+  t.matchSnapshot(String(tree.meta))
+})

--- a/workspaces/arborist/test/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/test/arborist/build-ideal-tree.js
@@ -3935,7 +3935,14 @@ t.test('store files with a custom indenting', async t => {
 })
 
 t.test('should install accurate version when deps has dist-tag spec', async t => {
-  const path = resolve(fixtures, 'tag-spec-depencencies')
+  const tabIndentedPackageJson =
+    fs.readFileSync(
+      resolve(fixtures, 'tag-spec-depencencies/package.json'),
+      'utf8'
+    ).replace(/\r\n/g, '\n')
+  const path = t.testdir({
+    'package.json': tabIndentedPackageJson,
+  })
   const tree = await buildIdeal(path)
   t.matchSnapshot(String(tree.meta))
 })

--- a/workspaces/arborist/test/dep-valid.js
+++ b/workspaces/arborist/test/dep-valid.js
@@ -126,9 +126,31 @@ t.notOk(depValid({
   },
 }, './tarball.tgz', null, emptyRequestor), 'too uncertain, nope')
 
-t.ok(depValid({
+t.notOk(depValid({
   resolved: 'https://registry.npmjs.org/foo/foo-1.2.3.tgz',
 }, 'latest', null, emptyRequestor), 'tagged registry version needs remote tarball')
+
+t.ok(depValid({ name: 'foo', version: '1.0.0' }, 'latest', null, {
+  children: new Map([
+    ['foo', { name: 'foo', version: '1.0.0' }],
+  ]),
+  edgesOut: new Map(),
+  errors: [],
+}), 'tagged version needs match exact version of requestor\'s children')
+
+t.notOk(depValid({ name: 'foo', version: '1.0.1' }, 'latest', null, {
+  children: new Map([
+    ['foo', { name: 'foo', version: '1.0.0' }],
+  ]),
+  edgesOut: new Map(),
+  errors: [],
+}), 'tagged version doesn\'t match exact version of requestor\'s children')
+
+t.notOk(depValid({ name: 'foo', version: '1.0.1' }, 'latest', null, {
+  children: new Map(),
+  edgesOut: new Map(),
+  errors: [],
+}), 'tagged version doesn\'t match exact version of requestor without children')
 
 t.notOk(depValid({
   resolved: 'git+https://registry.npmjs.org/foo/foo-1.2.3.git',

--- a/workspaces/arborist/test/fixtures/registry-mocks/content/kewu.json
+++ b/workspaces/arborist/test/fixtures/registry-mocks/content/kewu.json
@@ -1,0 +1,62 @@
+{
+  "_id": "kewu",
+  "name": "kewu",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "kewu",
+      "version": "1.0.0",
+      "dependencies": {
+        "wuke": "stable"
+      },
+      "_id": "kewu@1.0.0",
+      "_nodeVersion": "16.15.1",
+      "_npmVersion": "8.17.0",
+      "dist": {
+        "integrity": "sha512-G/C0QhUfovkalJVMBaNsfwG91/zO1TF6c+SqYkLB/+BK0fXZ9mqCh3dGjFyidEIQ3nhcRTFrK0XhbxhaLisMog==",
+        "shasum": "c774cfec9fa5d474ee0ae7b3eb507c70cdaece28",
+        "tarball": "https://registry.npmjs.org/kewu/-/kewu-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 89,
+        "signatures": [
+          {
+            "keyid": "SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA",
+            "sig": "MEYCIQD/q+pX4LJ8FSGCDER4l+HrPoyQvfC8DNBQaqUJYAFR5gIhAL+pLltzzKEHUqqehkfDUTWM1RxLfmSMYToBf2c8fx+U"
+          }
+        ],
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v4.10.10\r\nComment: https://openpgpjs.org\r\n\r\nwsFzBAEBCAAGBQJjBHyPACEJED1NWxICdlZqFiEECWMYAoorWMhJKdjhPU1b\r\nEgJ2Vmr23g/9EfolK7j+JELH6AnjyJVmL24kuAWJiKUsIK1OEnl9GcViYao6\r\nNhDdu2TZql8LctTqMoOOx5ShmjBGjK4bNsgW0mzpI3a81ZL0Gfh8nuM2E2Wo\r\nd2etKhsNpLB66Zv/Crmcr6Kg/i3qxf5qg5x4uNzGHCChU0plahvrgA1K2rym\r\ncVKDkz3Lzr9bR+gSjaOgr5hn/p7ULhuU1FKfdYrRqq2+ZXv9Oy3wud336ztW\r\nrAQLvPdlAvSRdcNgHuAk697IsMbHOeK+msk9GBzaSSPObmqX6CKLVCYiTRGN\r\n24AlFs2qFDSn9aU3dw75cuyeKfmQlDRMGQ4YdX1QZPnZvyDWWyvE7CHaxc1B\r\nndXBIzzFyEmUhuQYBIIzcw582NIg1p6R3pFj+dHtLUQWzTpdUHNAKQpLSEZq\r\nmXDRxIb/r1nOr/I4TZYhewL2ICeu40cO/VH5VGOMVhiUuGfCIyUcHxZs+tFY\r\nKrpBlhTZ8CYQP56n2R6SvBPqZF3m9SNYUwMSkSGaBl/aB52Y403yCMNiN/bW\r\n9gD/tL0sIsJ3+XMwz8Rvm+ZuL1W3+r2qtxhvlGV6bZTzUrRlBjij9p6mPLlq\r\ncciV1m2IYydJjZzGQuIiLg5LFsHUua0848U70K1vNxOuSWr6qz51oJH1LBz4\r\nCVV94hPBk6pYKMHvhT5QWYtEmS89ADDrr0k=\r\n=ihMD\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "gemwuu",
+        "email": "gemwuu@gmail.com"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "gemwuu",
+          "email": "gemwuu@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/kewu_1.0.0_1661238415089_0.8499553394859964"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2022-08-23T07:06:55.088Z",
+    "1.0.0": "2022-08-23T07:06:55.237Z",
+    "modified": "2022-08-23T07:06:55.363Z"
+  },
+  "maintainers": [
+    {
+      "name": "gemwuu",
+      "email": "gemwuu@gmail.com"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/workspaces/arborist/test/fixtures/registry-mocks/content/kewu.min.json
+++ b/workspaces/arborist/test/fixtures/registry-mocks/content/kewu.min.json
@@ -1,0 +1,30 @@
+{
+  "name": "kewu",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "kewu",
+      "version": "1.0.0",
+      "dependencies": {
+        "wuke": "stable"
+      },
+      "dist": {
+        "integrity": "sha512-G/C0QhUfovkalJVMBaNsfwG91/zO1TF6c+SqYkLB/+BK0fXZ9mqCh3dGjFyidEIQ3nhcRTFrK0XhbxhaLisMog==",
+        "shasum": "c774cfec9fa5d474ee0ae7b3eb507c70cdaece28",
+        "tarball": "https://registry.npmjs.org/kewu/-/kewu-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 89,
+        "signatures": [
+          {
+            "keyid": "SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA",
+            "sig": "MEYCIQD/q+pX4LJ8FSGCDER4l+HrPoyQvfC8DNBQaqUJYAFR5gIhAL+pLltzzKEHUqqehkfDUTWM1RxLfmSMYToBf2c8fx+U"
+          }
+        ],
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v4.10.10\r\nComment: https://openpgpjs.org\r\n\r\nwsFzBAEBCAAGBQJjBHyPACEJED1NWxICdlZqFiEECWMYAoorWMhJKdjhPU1b\r\nEgJ2Vmr23g/9EfolK7j+JELH6AnjyJVmL24kuAWJiKUsIK1OEnl9GcViYao6\r\nNhDdu2TZql8LctTqMoOOx5ShmjBGjK4bNsgW0mzpI3a81ZL0Gfh8nuM2E2Wo\r\nd2etKhsNpLB66Zv/Crmcr6Kg/i3qxf5qg5x4uNzGHCChU0plahvrgA1K2rym\r\ncVKDkz3Lzr9bR+gSjaOgr5hn/p7ULhuU1FKfdYrRqq2+ZXv9Oy3wud336ztW\r\nrAQLvPdlAvSRdcNgHuAk697IsMbHOeK+msk9GBzaSSPObmqX6CKLVCYiTRGN\r\n24AlFs2qFDSn9aU3dw75cuyeKfmQlDRMGQ4YdX1QZPnZvyDWWyvE7CHaxc1B\r\nndXBIzzFyEmUhuQYBIIzcw582NIg1p6R3pFj+dHtLUQWzTpdUHNAKQpLSEZq\r\nmXDRxIb/r1nOr/I4TZYhewL2ICeu40cO/VH5VGOMVhiUuGfCIyUcHxZs+tFY\r\nKrpBlhTZ8CYQP56n2R6SvBPqZF3m9SNYUwMSkSGaBl/aB52Y403yCMNiN/bW\r\n9gD/tL0sIsJ3+XMwz8Rvm+ZuL1W3+r2qtxhvlGV6bZTzUrRlBjij9p6mPLlq\r\ncciV1m2IYydJjZzGQuIiLg5LFsHUua0848U70K1vNxOuSWr6qz51oJH1LBz4\r\nCVV94hPBk6pYKMHvhT5QWYtEmS89ADDrr0k=\r\n=ihMD\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2022-08-23T07:06:55.363Z"
+}

--- a/workspaces/arborist/test/fixtures/registry-mocks/content/wuke.json
+++ b/workspaces/arborist/test/fixtures/registry-mocks/content/wuke.json
@@ -1,0 +1,100 @@
+{
+  "_id": "wuke",
+  "_rev": "3-d23303f2f68e74c7f53be5c8dbcccfa0",
+  "name": "wuke",
+  "dist-tags": {
+    "latest": "1.0.1",
+    "stable": "1.0.0",
+    "next": "1.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "wuke",
+      "version": "1.0.0",
+      "_id": "wuke@1.0.0",
+      "_nodeVersion": "16.15.1",
+      "_npmVersion": "8.17.0",
+      "dist": {
+        "integrity": "sha512-zrae28H8/RvjcNGBKQ8ZhXwn4xSWzNnhG+nhSGJK0nB/d1ifUXl150RbHIqBm9B0FQyHcgTko8Y/8SelX/Qdbg==",
+        "shasum": "d050c2b3bf9fa8ec408f42b96bf279be285b4b79",
+        "tarball": "https://registry.npmjs.org/wuke/-/wuke-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 43,
+        "signatures": [
+          {
+            "keyid": "SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA",
+            "sig": "MEUCIDkCRi5/smALz/Cv5fx8S/nWdMpPwVNd9dr4mVCfvQcpAiEA2/99URPwLJTvXmizwCFxdAwC5Sn0l3yg7Z44KwIYyps="
+          }
+        ],
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v4.10.10\r\nComment: https://openpgpjs.org\r\n\r\nwsFzBAEBCAAGBQJjBHv8ACEJED1NWxICdlZqFiEECWMYAoorWMhJKdjhPU1b\r\nEgJ2Vmoh4g//XYRCGOf9Ud42tKIqYp8iy5AwGulatTgK97s3HTMpTsO4rczq\r\nY3yCeGUcGoumcXqE40GOARVWGFLxDhgt0+cNfTFCyw2qKnWZzBnXO7rIsmpe\r\ndrS0PAj+UQ4EiwGMEQMcaRiBO1dH3hue1gW6EEGLEjOjN74LEhYjXfHxAPvb\r\nHlLJtOcuE1CkbW+ZNkQ4ybApwE71wJy2fF0m+qfwxfhbDVLVsj1Toi6l4xxG\r\nDU+2vHHnRbyc90kJ82k1QBIJfS6aL1UYicoxl39Rf9SLWCwffFdtwmOLxPbs\r\neFoO6NIy+BUlCnENdSPBrl6II8MfMR9A1Ckil8CAfXIbVbNOR6L0XKd2nsgg\r\nG2nm8yzvdY1KVpb1mQfYOdCm3KuNSQ5BSPmA9XQUYYusnprMZxaF9x7CtZkd\r\ngcCpsF46S5eBeuzVxyTsBzW4H6zJRHy48DnxMDITMtLuJFqF1s0kk8KxidKw\r\nb3he+35d17kK1YuRvNDRnXgBETSFsN6XubgNeR4jys6mngVu6wI+KcdQMXnq\r\nXOa7rlG5uVmUlWfdhlBZZwdB6SwqhvpnSG8JPWbhCFsjLeoi58JBAVEgRmRz\r\nTRl+GpnHkudS9+DXirZwKBfMTEzPwvSXtqQz9tbd51ThBHD1P3r8eMthHvWY\r\n3W3YfpqId6OgE21npBplIoKwRcWH6B5+4go=\r\n=KHcG\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "gemwuu",
+        "email": "gemwuu@gmail.com"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "gemwuu",
+          "email": "gemwuu@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/wuke_1.0.0_1661238267937_0.5672981357422893"
+      },
+      "_hasShrinkwrap": false
+    },
+    "1.0.1": {
+      "name": "wuke",
+      "version": "1.0.1",
+      "_id": "wuke@1.0.1",
+      "_nodeVersion": "16.15.1",
+      "_npmVersion": "8.17.0",
+      "dist": {
+        "integrity": "sha512-ym3gum9DUBKAQtb1bhdU6LAa1tWAipJm6BuB9wZrHwmMD3slWHIC9041NTWDEfcVfIvbAH3FGnUF4VUqIzcyYw==",
+        "shasum": "382526aa008482c45c88dd5a749909f93ad71b87",
+        "tarball": "https://registry.npmjs.org/wuke/-/wuke-1.0.1.tgz",
+        "fileCount": 1,
+        "unpackedSize": 43,
+        "signatures": [
+          {
+            "keyid": "SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA",
+            "sig": "MEQCIBQ1QL5HHh/Kvd7d2/G0PqrD/oxkF6lMElesGSDP/ENeAiB05w/UchB6ym/gJIp98XKut5/tu5rVC76m3BVTbIJU5Q=="
+          }
+        ],
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v4.10.10\r\nComment: https://openpgpjs.org\r\n\r\nwsFzBAEBCAAGBQJjBHwSACEJED1NWxICdlZqFiEECWMYAoorWMhJKdjhPU1b\r\nEgJ2VmoAIw//YZRkizGDR387mDMDztkywUpkQKUt43v9WxCsqiCLaWMAbV9w\r\nvqNCDym+wU7JfDDfH03ryAron9P31g0ak1nrpdzOjhoSRINZkCrlhETKCWZM\r\nWjwJgz1TkZ6nMrRQCDpadZm+wCEF0ZGqGlJg+dgWhK8Q5guIkAMjR0dfn0+b\r\nnR+ZxAtBMrWJUHApUO1Odi8JWuTlPsZ64yy/UEkEdDvZpd6/qWNjt0+bpWDp\r\nwXH0Z2y+zTtgSS2n9Zfw+WxOuqldBiHowfWa8bX6HBG+KFNJuIA6ODUvTwbS\r\nhMZQ3EKEYWG+zCLLIYMRkhoE0pPa5gKWpuc17bezYsfWWSQBj3v1Dv7+DtB+\r\nuyY+og34xAgEMOJrNn82OmAJWsGXKBOWUvXqKsJGqJosUU1IXK/BnUp/B4lK\r\nA7a0hWLvY6xdGn0Pu+bSp909I3XCVONGdrYzggbsEPZzn8DM4dJ54IYvc/tm\r\nqwH7/cOH/FSUaH7XvgO4rQWWbvON6g+94uVKZosOyaQ8GtPdzPL4KtGH7a00\r\nJrmLzIYwN+f7HJ0D4SPENZTR35/e7y2+ewoYhw6eGyuErRYsy4wyk6dM9ooE\r\n/iippxE4PPbNwxjcXxoCylALs6QZnyzliS7MZd362uCPQdLjqPXoVNzBZxVR\r\nWawB6J85DvluYJtfJbIs5jkIv7mVSzwnF9o=\r\n=if4q\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "_npmUser": {
+        "name": "gemwuu",
+        "email": "gemwuu@gmail.com"
+      },
+      "directories": {},
+      "maintainers": [
+        {
+          "name": "gemwuu",
+          "email": "gemwuu@gmail.com"
+        }
+      ],
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/wuke_1.0.1_1661238290371_0.7887855147024714"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "time": {
+    "created": "2022-08-23T07:04:27.937Z",
+    "1.0.0": "2022-08-23T07:04:28.096Z",
+    "modified": "2022-08-23T07:05:50.354Z",
+    "1.0.1": "2022-08-23T07:04:50.523Z"
+  },
+  "maintainers": [
+    {
+      "name": "gemwuu",
+      "email": "gemwuu@gmail.com"
+    }
+  ],
+  "readme": "ERROR: No README data found!",
+  "readmeFilename": ""
+}

--- a/workspaces/arborist/test/fixtures/registry-mocks/content/wuke.min.json
+++ b/workspaces/arborist/test/fixtures/registry-mocks/content/wuke.min.json
@@ -1,0 +1,47 @@
+{
+  "name": "wuke",
+  "dist-tags": {
+    "latest": "1.0.1",
+    "stable": "1.0.0",
+    "next": "1.0.1"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "wuke",
+      "version": "1.0.0",
+      "dist": {
+        "integrity": "sha512-zrae28H8/RvjcNGBKQ8ZhXwn4xSWzNnhG+nhSGJK0nB/d1ifUXl150RbHIqBm9B0FQyHcgTko8Y/8SelX/Qdbg==",
+        "shasum": "d050c2b3bf9fa8ec408f42b96bf279be285b4b79",
+        "tarball": "https://registry.npmjs.org/wuke/-/wuke-1.0.0.tgz",
+        "fileCount": 1,
+        "unpackedSize": 43,
+        "signatures": [
+          {
+            "keyid": "SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA",
+            "sig": "MEUCIDkCRi5/smALz/Cv5fx8S/nWdMpPwVNd9dr4mVCfvQcpAiEA2/99URPwLJTvXmizwCFxdAwC5Sn0l3yg7Z44KwIYyps="
+          }
+        ],
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v4.10.10\r\nComment: https://openpgpjs.org\r\n\r\nwsFzBAEBCAAGBQJjBHv8ACEJED1NWxICdlZqFiEECWMYAoorWMhJKdjhPU1b\r\nEgJ2Vmoh4g//XYRCGOf9Ud42tKIqYp8iy5AwGulatTgK97s3HTMpTsO4rczq\r\nY3yCeGUcGoumcXqE40GOARVWGFLxDhgt0+cNfTFCyw2qKnWZzBnXO7rIsmpe\r\ndrS0PAj+UQ4EiwGMEQMcaRiBO1dH3hue1gW6EEGLEjOjN74LEhYjXfHxAPvb\r\nHlLJtOcuE1CkbW+ZNkQ4ybApwE71wJy2fF0m+qfwxfhbDVLVsj1Toi6l4xxG\r\nDU+2vHHnRbyc90kJ82k1QBIJfS6aL1UYicoxl39Rf9SLWCwffFdtwmOLxPbs\r\neFoO6NIy+BUlCnENdSPBrl6II8MfMR9A1Ckil8CAfXIbVbNOR6L0XKd2nsgg\r\nG2nm8yzvdY1KVpb1mQfYOdCm3KuNSQ5BSPmA9XQUYYusnprMZxaF9x7CtZkd\r\ngcCpsF46S5eBeuzVxyTsBzW4H6zJRHy48DnxMDITMtLuJFqF1s0kk8KxidKw\r\nb3he+35d17kK1YuRvNDRnXgBETSFsN6XubgNeR4jys6mngVu6wI+KcdQMXnq\r\nXOa7rlG5uVmUlWfdhlBZZwdB6SwqhvpnSG8JPWbhCFsjLeoi58JBAVEgRmRz\r\nTRl+GpnHkudS9+DXirZwKBfMTEzPwvSXtqQz9tbd51ThBHD1P3r8eMthHvWY\r\n3W3YfpqId6OgE21npBplIoKwRcWH6B5+4go=\r\n=KHcG\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    },
+    "1.0.1": {
+      "name": "wuke",
+      "version": "1.0.1",
+      "dist": {
+        "integrity": "sha512-ym3gum9DUBKAQtb1bhdU6LAa1tWAipJm6BuB9wZrHwmMD3slWHIC9041NTWDEfcVfIvbAH3FGnUF4VUqIzcyYw==",
+        "shasum": "382526aa008482c45c88dd5a749909f93ad71b87",
+        "tarball": "https://registry.npmjs.org/wuke/-/wuke-1.0.1.tgz",
+        "fileCount": 1,
+        "unpackedSize": 43,
+        "signatures": [
+          {
+            "keyid": "SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA",
+            "sig": "MEQCIBQ1QL5HHh/Kvd7d2/G0PqrD/oxkF6lMElesGSDP/ENeAiB05w/UchB6ym/gJIp98XKut5/tu5rVC76m3BVTbIJU5Q=="
+          }
+        ],
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v4.10.10\r\nComment: https://openpgpjs.org\r\n\r\nwsFzBAEBCAAGBQJjBHwSACEJED1NWxICdlZqFiEECWMYAoorWMhJKdjhPU1b\r\nEgJ2VmoAIw//YZRkizGDR387mDMDztkywUpkQKUt43v9WxCsqiCLaWMAbV9w\r\nvqNCDym+wU7JfDDfH03ryAron9P31g0ak1nrpdzOjhoSRINZkCrlhETKCWZM\r\nWjwJgz1TkZ6nMrRQCDpadZm+wCEF0ZGqGlJg+dgWhK8Q5guIkAMjR0dfn0+b\r\nnR+ZxAtBMrWJUHApUO1Odi8JWuTlPsZ64yy/UEkEdDvZpd6/qWNjt0+bpWDp\r\nwXH0Z2y+zTtgSS2n9Zfw+WxOuqldBiHowfWa8bX6HBG+KFNJuIA6ODUvTwbS\r\nhMZQ3EKEYWG+zCLLIYMRkhoE0pPa5gKWpuc17bezYsfWWSQBj3v1Dv7+DtB+\r\nuyY+og34xAgEMOJrNn82OmAJWsGXKBOWUvXqKsJGqJosUU1IXK/BnUp/B4lK\r\nA7a0hWLvY6xdGn0Pu+bSp909I3XCVONGdrYzggbsEPZzn8DM4dJ54IYvc/tm\r\nqwH7/cOH/FSUaH7XvgO4rQWWbvON6g+94uVKZosOyaQ8GtPdzPL4KtGH7a00\r\nJrmLzIYwN+f7HJ0D4SPENZTR35/e7y2+ewoYhw6eGyuErRYsy4wyk6dM9ooE\r\n/iippxE4PPbNwxjcXxoCylALs6QZnyzliS7MZd362uCPQdLjqPXoVNzBZxVR\r\nWawB6J85DvluYJtfJbIs5jkIv7mVSzwnF9o=\r\n=if4q\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  },
+  "modified": "2022-08-23T07:05:50.354Z"
+}

--- a/workspaces/arborist/test/fixtures/tag-spec-depencencies/package.json
+++ b/workspaces/arborist/test/fixtures/tag-spec-depencencies/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "tag-spec-dependencies-project",
+  "version": "1.0.0",
+  "dependencies": {
+    "kewu": "1.0.0",
+    "wuke": "1.0.1"
+  }
+}


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Given `package.json` below:
```json
{
  "dependencies": {
    "kewu": "1.0.0",
    "wuke": "1.0.1"
  }
}
```
The two npm package dependencies are:

1. `kewu@1.0.0` has only one dependency `wuke@stable`
2. `wuke@stable` refers to `wuke@1.0.0`

Run code below, would only install `wuke@1.0.1` into the root dir of node_modules.

```javascript
const arborist = new Arborist({
  path: process.cwd(),
})
const idealTree = await arborist.buildIdealTree({})

console.log('idealTree wuke: %s', idealTree.children.get('kewu').children.get('wuke'))
```


`@npmcli/arborist` treats `wuke@1.0.1` as the matched version of `wuke@stable`, which is wrong.

The PR intends to fix this.

As tested, this bug exists from the very beginning implement of arborist.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
