### PR TITLE
change defaults for `access` config

### DIFF
--- a/docs/content/commands/npm-publish.md
+++ b/docs/content/commands/npm-publish.md
@@ -118,19 +118,19 @@ tarball that will be compared with the local files by default.
 
 #### `access`
 
-* Default: 'restricted' for scoped packages, 'public' for unscoped packages
+* Default: 'public' for new packages, existing packages it will not change the
+  current level
 * Type: null, "restricted", or "public"
 
-When publishing scoped packages, the access level defaults to `restricted`.
-If you want your scoped package to be publicly viewable (and installable)
-set `--access=public`. The only valid values for `access` are `public` and
-`restricted`. Unscoped packages _always_ have an access level of `public`.
+If do not want your scoped package to be publicly viewable (and installable)
+set `--access=restricted`.
 
-Note: Using the `--access` flag on the `npm publish` command will only set
-the package access level on the initial publish of the package. Any
-subsequent `npm publish` commands using the `--access` flag will not have an
-effect to the access level. To make changes to the access level after the
-initial publish use `npm access`.
+Unscoped packages can not be set to `restricted`.
+
+Note: This defaults to not changing the current access level for existing
+packages. Specifying a value of `restricted` or `public` during publish will
+change the access for an existing package the same way that `npm access set
+status` would.
 
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->

--- a/docs/content/using-npm/config.md
+++ b/docs/content/using-npm/config.md
@@ -151,19 +151,19 @@ safer to use a registry-provided authentication bearer token stored in the
 
 #### `access`
 
-* Default: 'restricted' for scoped packages, 'public' for unscoped packages
+* Default: 'public' for new packages, existing packages it will not change the
+  current level
 * Type: null, "restricted", or "public"
 
-When publishing scoped packages, the access level defaults to `restricted`.
-If you want your scoped package to be publicly viewable (and installable)
-set `--access=public`. The only valid values for `access` are `public` and
-`restricted`. Unscoped packages _always_ have an access level of `public`.
+If do not want your scoped package to be publicly viewable (and installable)
+set `--access=restricted`.
 
-Note: Using the `--access` flag on the `npm publish` command will only set
-the package access level on the initial publish of the package. Any
-subsequent `npm publish` commands using the `--access` flag will not have an
-effect to the access level. To make changes to the access level after the
-initial publish use `npm access`.
+Unscoped packages can not be set to `restricted`.
+
+Note: This defaults to not changing the current access level for existing
+packages. Specifying a value of `restricted` or `public` during publish will
+change the access for an existing package the same way that `npm access set
+status` would.
 
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -114,10 +114,13 @@ class Publish extends BaseCommand {
       }
     }
 
-    log.notice(
-      '',
-      `Publishing to ${outputRegistry} with tag ${defaultTag}${dryRun ? ' (dry-run)' : ''}`
-    )
+    const access = opts.access === null ? 'default' : opts.access
+    let msg = `Publishing to ${outputRegistry} with tag ${defaultTag} and ${access} access`
+    if (dryRun) {
+      msg = `${msg} (dry-run)`
+    }
+
+    log.notice('', msg)
 
     if (!dryRun) {
       await otplease(this.npm, opts, opts => libpub(manifest, tarballData, opts))

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -160,21 +160,19 @@ define('_auth', {
 define('access', {
   default: null,
   defaultDescription: `
-    'restricted' for scoped packages, 'public' for unscoped packages
+    'public' for new packages, existing packages it will not change the current level
   `,
   type: [null, 'restricted', 'public'],
   description: `
-    When publishing scoped packages, the access level defaults to
-    \`restricted\`.  If you want your scoped package to be publicly viewable
-    (and installable) set \`--access=public\`. The only valid values for
-    \`access\` are \`public\` and \`restricted\`. Unscoped packages _always_
-    have an access level of \`public\`.
+    If do not want your scoped package to be publicly viewable (and
+    installable) set \`--access=restricted\`.
 
-    Note: Using the \`--access\` flag on the \`npm publish\` command will only
-    set the package access level on the initial publish of the package. Any
-    subsequent \`npm publish\` commands using the \`--access\` flag will not
-    have an effect to the access level.  To make changes to the access level
-    after the initial publish use \`npm access\`.
+    Unscoped packages can not be set to \`restricted\`.
+
+    Note: This defaults to not changing the current access level for existing
+    packages.  Specifying a value of \`restricted\` or \`public\` during
+    publish will change the access for an existing package the same way that
+    \`npm access set status\` would.
   `,
   flatten,
 })

--- a/tap-snapshots/test/lib/commands/publish.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/publish.js.test.cjs
@@ -51,7 +51,7 @@ Array [
   ],
   Array [
     "",
-    "Publishing to https://registry.npmjs.org/ with tag latest (dry-run)",
+    "Publishing to https://registry.npmjs.org/ with tag latest and default access (dry-run)",
   ],
 ]
 `
@@ -72,7 +72,7 @@ exports[`test/lib/commands/publish.js TAP json > must match snapshot 1`] = `
 Array [
   Array [
     "",
-    "Publishing to https://registry.npmjs.org/ with tag latest",
+    "Publishing to https://registry.npmjs.org/ with tag latest and default access",
   ],
 ]
 `
@@ -112,12 +112,106 @@ Array [
 ]
 `
 
+exports[`test/lib/commands/publish.js TAP public access > must match snapshot 1`] = `
+Array [
+  Array [
+    "",
+  ],
+  Array [
+    "",
+    "package: @npm/test-package@1.0.0",
+  ],
+  Array [
+    "=== Tarball Contents ===",
+  ],
+  Array [
+    "",
+    "55B package.json",
+  ],
+  Array [
+    "=== Tarball Details ===",
+  ],
+  Array [
+    "",
+    String(
+      name:          @npm/test-package                       
+      version:       1.0.0                                   
+      filename:      @npm/test-package-1.0.0.tgz             
+      package size:  147 B                                   
+      unpacked size: 55 B                                    
+      shasum:{sha}
+      integrity:{sha}
+      total files:   1                                       
+    ),
+  ],
+  Array [
+    "",
+    "",
+  ],
+  Array [
+    "",
+    "Publishing to https://registry.npmjs.org/ with tag latest and public access",
+  ],
+]
+`
+
+exports[`test/lib/commands/publish.js TAP public access > new package version 1`] = `
++ @npm/test-package@1.0.0
+`
+
 exports[`test/lib/commands/publish.js TAP re-loads publishConfig.registry if added during script process > new package version 1`] = `
 + test-package@1.0.0
 `
 
 exports[`test/lib/commands/publish.js TAP respects publishConfig.registry, runs appropriate scripts > new package version 1`] = `
 
+`
+
+exports[`test/lib/commands/publish.js TAP restricted access > must match snapshot 1`] = `
+Array [
+  Array [
+    "",
+  ],
+  Array [
+    "",
+    "package: @npm/test-package@1.0.0",
+  ],
+  Array [
+    "=== Tarball Contents ===",
+  ],
+  Array [
+    "",
+    "55B package.json",
+  ],
+  Array [
+    "=== Tarball Details ===",
+  ],
+  Array [
+    "",
+    String(
+      name:          @npm/test-package                       
+      version:       1.0.0                                   
+      filename:      @npm/test-package-1.0.0.tgz             
+      package size:  147 B                                   
+      unpacked size: 55 B                                    
+      shasum:{sha}
+      integrity:{sha}
+      total files:   1                                       
+    ),
+  ],
+  Array [
+    "",
+    "",
+  ],
+  Array [
+    "",
+    "Publishing to https://registry.npmjs.org/ with tag latest and restricted access",
+  ],
+]
+`
+
+exports[`test/lib/commands/publish.js TAP restricted access > new package version 1`] = `
++ @npm/test-package@1.0.0
 `
 
 exports[`test/lib/commands/publish.js TAP scoped _auth config scoped registry > new package version 1`] = `
@@ -165,7 +259,7 @@ Array [
   ],
   Array [
     "",
-    "Publishing to https://registry.npmjs.org/ with tag latest",
+    "Publishing to https://registry.npmjs.org/ with tag latest and default access",
   ],
 ]
 `

--- a/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
@@ -180,19 +180,19 @@ safer to use a registry-provided authentication bearer token stored in the
 exports[`test/lib/utils/config/definitions.js TAP > config description for access 1`] = `
 #### \`access\`
 
-* Default: 'restricted' for scoped packages, 'public' for unscoped packages
+* Default: 'public' for new packages, existing packages it will not change the
+  current level
 * Type: null, "restricted", or "public"
 
-When publishing scoped packages, the access level defaults to \`restricted\`.
-If you want your scoped package to be publicly viewable (and installable)
-set \`--access=public\`. The only valid values for \`access\` are \`public\` and
-\`restricted\`. Unscoped packages _always_ have an access level of \`public\`.
+If do not want your scoped package to be publicly viewable (and installable)
+set \`--access=restricted\`.
 
-Note: Using the \`--access\` flag on the \`npm publish\` command will only set
-the package access level on the initial publish of the package. Any
-subsequent \`npm publish\` commands using the \`--access\` flag will not have an
-effect to the access level. To make changes to the access level after the
-initial publish use \`npm access\`.
+Unscoped packages can not be set to \`restricted\`.
+
+Note: This defaults to not changing the current access level for existing
+packages. Specifying a value of \`restricted\` or \`public\` during publish will
+change the access for an existing package the same way that \`npm access set
+status\` would.
 `
 
 exports[`test/lib/utils/config/definitions.js TAP > config description for all 1`] = `

--- a/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
@@ -24,19 +24,19 @@ safer to use a registry-provided authentication bearer token stored in the
 
 #### \`access\`
 
-* Default: 'restricted' for scoped packages, 'public' for unscoped packages
+* Default: 'public' for new packages, existing packages it will not change the
+  current level
 * Type: null, "restricted", or "public"
 
-When publishing scoped packages, the access level defaults to \`restricted\`.
-If you want your scoped package to be publicly viewable (and installable)
-set \`--access=public\`. The only valid values for \`access\` are \`public\` and
-\`restricted\`. Unscoped packages _always_ have an access level of \`public\`.
+If do not want your scoped package to be publicly viewable (and installable)
+set \`--access=restricted\`.
 
-Note: Using the \`--access\` flag on the \`npm publish\` command will only set
-the package access level on the initial publish of the package. Any
-subsequent \`npm publish\` commands using the \`--access\` flag will not have an
-effect to the access level. To make changes to the access level after the
-initial publish use \`npm access\`.
+Unscoped packages can not be set to \`restricted\`.
+
+Note: This defaults to not changing the current access level for existing
+packages. Specifying a value of \`restricted\` or \`public\` during publish will
+change the access for an existing package the same way that \`npm access set
+status\` would.
 
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->

--- a/workspaces/libnpmpublish/README.md
+++ b/workspaces/libnpmpublish/README.md
@@ -44,8 +44,8 @@ A couple of options of note:
   defaults to `latest`.
 
 * `opts.access` - tells the registry whether this package should be
-  published as public or restricted. Only applies to scoped packages, which
-  default to restricted.
+  published as `public` or `restricted`. Only applies to scoped
+  packages.  Defaults to `public`.
 
 * `opts.token` - can be passed in and will be used as the authentication
   token for the registry. For other ways to pass in auth details, see the

--- a/workspaces/libnpmpublish/lib/publish.js
+++ b/workspaces/libnpmpublish/lib/publish.js
@@ -17,10 +17,9 @@ Remove the 'private' field from the package.json to publish it.`),
   // spec is used to pick the appropriate registry/auth combo
   const spec = npa.resolve(manifest.name, manifest.version)
   opts = {
-    defaultTag: 'latest',
-    // if scoped, restricted by default
-    access: spec.scope ? 'restricted' : 'public',
+    access: 'public',
     algorithms: ['sha512'],
+    defaultTag: 'latest',
     ...opts,
     spec,
   }


### PR DESCRIPTION
This PR is two commits, one the breaking change to libnpmpublish, and the other a docs/logging update for the cli to be telling folks the truth.  Please rebase/merge.
- feat: default access to `public`
- docs: update docs/logging for new --access default
