### PR TITLE
fix: ensure Arborist constructor gets passed around everywhere for pacote

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -1,3 +1,4 @@
+const Arborist = require('@npmcli/arborist')
 const EventEmitter = require('events')
 const { resolve, dirname, join } = require('path')
 const Config = require('@npmcli/config')
@@ -310,6 +311,9 @@ class Npm extends EventEmitter {
 
   get flatOptions () {
     const { flat } = this.config
+    // the Arborist constructor is used almost everywhere we call pacote, it's easiest
+    // to attach it to flatOptions so it goes everywhere without having to touch every call
+    flat.Arborist = Arborist
     if (this.command) {
       flat.npmCommand = this.command
     }


### PR DESCRIPTION
since pacote now requires the Arborist constructor in order to pack a tarball for git dependencies, and that tarball can be packed as part of fetching the packument or the manifest, the easiest solution seemed to be adding the Arborist constructor directly into flatOptions. this gets it sent everywhere consistently with one change instead of having to track down every single call to pacote.

we need to circle back to fix this dependency loop at some point anyway, so this technical debt felt appropriate to buy us the time to do so.
