### PR TITLE
docs: remove link to cache command

### DIFF
--- a/docs/content/commands/npm-cache.md
+++ b/docs/content/commands/npm-cache.md
@@ -87,7 +87,7 @@ verify`.
 * Default: Windows: `%LocalAppData%\npm-cache`, Posix: `~/.npm`
 * Type: Path
 
-The location of npm's cache directory. 
+The location of npm's cache directory.
 
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->

--- a/docs/content/using-npm/config.md
+++ b/docs/content/using-npm/config.md
@@ -307,8 +307,7 @@ See also the `strict-ssl` config.
 * Default: Windows: `%LocalAppData%\npm-cache`, Posix: `~/.npm`
 * Type: Path
 
-The location of npm's cache directory. See [`npm
-cache`](/commands/npm-cache)
+The location of npm's cache directory.
 
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -326,8 +326,7 @@ define('cache', {
   `,
   type: path,
   description: `
-    The location of npm's cache directory.  See [\`npm
-    cache\`](/commands/npm-cache)
+    The location of npm's cache directory.
   `,
   flatten (key, obj, flatOptions) {
     flatOptions.cache = join(obj.cache, '_cacache')

--- a/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/definitions.js.test.cjs
@@ -336,8 +336,7 @@ exports[`test/lib/utils/config/definitions.js TAP > config description for cache
 * Default: Windows: \`%LocalAppData%\\npm-cache\`, Posix: \`~/.npm\`
 * Type: Path
 
-The location of npm's cache directory. See [\`npm
-cache\`](/commands/npm-cache)
+The location of npm's cache directory.
 `
 
 exports[`test/lib/utils/config/definitions.js TAP > config description for cache-max 1`] = `

--- a/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/describe-all.js.test.cjs
@@ -180,8 +180,7 @@ See also the \`strict-ssl\` config.
 * Default: Windows: \`%LocalAppData%\\npm-cache\`, Posix: \`~/.npm\`
 * Type: Path
 
-The location of npm's cache directory. See [\`npm
-cache\`](/commands/npm-cache)
+The location of npm's cache directory.
 
 <!-- automatically generated, do not edit manually -->
 <!-- see lib/utils/config/definitions.js -->


### PR DESCRIPTION
The cache command itself contains this config making it a circular reference
