### PR TITLE
correct spelling error from verison to version

### DIFF
--- a/docs/content/commands/npm-version.md
+++ b/docs/content/commands/npm-version.md
@@ -13,7 +13,7 @@ description: Bump a package version
 ```bash
 npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease | from-git]
 
-alias: verison
+alias: version
 ```
 
 <!-- automatically generated, do not edit manually -->


### PR DESCRIPTION
<!-- What / Why -->

It appears there's a spelling error in the top code example. It says `verison` instead of `version`.

