### PR TITLE
fix(libnpmpack): obey ignoreScripts

### DIFF
--- a/workspaces/libnpmpack/lib/index.js
+++ b/workspaces/libnpmpack/lib/index.js
@@ -21,7 +21,7 @@ async function pack (spec = 'file:.', opts = {}) {
 
   const stdio = opts.foregroundScripts ? 'inherit' : 'pipe'
 
-  if (spec.type === 'directory') {
+  if (spec.type === 'directory' && !opts.ignoreScripts) {
     // prepack
     await runScript({
       ...opts,
@@ -48,7 +48,7 @@ async function pack (spec = 'file:.', opts = {}) {
     await writeFile(destination, tarball)
   }
 
-  if (spec.type === 'directory') {
+  if (spec.type === 'directory' && !opts.ignoreScripts) {
     // postpack
     await runScript({
       ...opts,

--- a/workspaces/libnpmpack/test/fixtures/tspawk.js
+++ b/workspaces/libnpmpack/test/fixtures/tspawk.js
@@ -5,12 +5,9 @@ const spawk = require('spawk')
 module.exports = tspawk
 
 function tspawk (t) {
-  spawk.preventUnmatched()
   t.teardown(function () {
-    spawk.unload()
-  })
-  t.afterEach(function () {
     spawk.done()
+    spawk.unload()
   })
   return spawk
 }


### PR DESCRIPTION
Per [config](https://docs.npmjs.com/cli/v8/using-npm/config):
> If true, npm does not run scripts specified in package.json files.
>
> Note that commands explicitly intended to run a particular script, such as `npm start`, `npm stop`, `npm restart`, `npm test`, and `npm run-script` will still run their intended script if ignore-scripts is set, **but they will *not* run any pre- or post-scripts.**

## References
None