### PR TITLE
docs: typo missing parenthesis in changelog

### DIFF
--- a/changelogs/CHANGELOG-7.md
+++ b/changelogs/CHANGELOG-7.md
@@ -1811,7 +1811,7 @@ fix(lib/npm): do not clobber config.execPath
   * [`4c6be4a`](https://github.com/npm/config/commit/4c6be4a66a3e89ae607e08172b8543b588a95fb5) Restore npm v6 behavior with `INIT_CWD`
   * [`bbebc66`](https://github.com/npm/config/commit/bbebc668888f71dba57959682364b6ff26ff4fac) Do not set the `PREFIX` environment variable
 
-## v7.5.1 (2021-02-01
+## v7.5.1 (2021-02-01)
 
 ### BUG FIXES
 


### PR DESCRIPTION
<!-- What / Why -->
Typo

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
