### PR TITLE
feat(audit): do not run audit outside of project locations

### DIFF
--- a/workspaces/arborist/lib/arborist/index.js
+++ b/workspaces/arborist/lib/arborist/index.js
@@ -77,7 +77,12 @@ class Arborist extends Base {
       replaceRegistryHost: options.replaceRegistryHost,
       lockfileVersion: lockfileVersion(options.lockfileVersion),
       installStrategy: options.global ? 'shallow' : (options.installStrategy ? options.installStrategy : 'hoisted'),
+      location: options.global ? 'global' : options.location,
     }
+    // don't audit when run in a non-project location
+    this.options.audit = (!this.options.location || this.options.location === 'project')
+      && options.audit !== false
+
     this.replaceRegistryHost = this.options.replaceRegistryHost =
       (!this.options.replaceRegistryHost || this.options.replaceRegistryHost === 'npmjs') ?
         'registry.npmjs.org' : this.options.replaceRegistryHost

--- a/workspaces/arborist/test/arborist/index.js
+++ b/workspaces/arborist/test/arborist/index.js
@@ -253,3 +253,13 @@ t.test('valid global/installStrategy values', t => {
   t.equal(new Arborist({ installStrategy: 'hoisted' }).options.installStrategy, 'hoisted')
   t.end()
 })
+
+t.test('disable audit when location is not project', t => {
+  t.equal(new Arborist({ location: 'global' }).options.audit, false)
+  t.equal(new Arborist({ location: undefined }).options.audit, true)
+  t.equal(new Arborist({ audit: undefined }).options.audit, true)
+  t.equal(new Arborist({ audit: false, location: 'project' }).options.audit, false)
+  t.equal(new Arborist({ global: true }).options.audit, false)
+  t.equal(new Arborist({ global: false }).options.audit, true)
+  t.end()
+})


### PR DESCRIPTION
Audits should not be run in non-project locations (ex. `'global'` & `'user'` locations). Notably, we can revisit auditing global installs in the future but the current flow is confusing given that `npm audit -g` errors today.

fixes: #4318