### PR TITLE
chore: scripts/resetdeps.sh checks for cmark-gfm bindings

### DIFF
--- a/scripts/resetdeps.sh
+++ b/scripts/resetdeps.sh
@@ -9,3 +9,9 @@ git checkout node_modules
 node . i --ignore-scripts --no-audit --no-fund "$@"
 node . rebuild --ignore-scripts
 node . run dependencies --ignore-scripts
+# check for cmark-gfm bindings
+cmarkbinding=$(find `npm ls cmark-gfm --parseable \
+| head -n 1` -name binding.node)
+if [[ ! $cmarkbinding ]]; then
+  node . rebuild cmark-gfm
+fi


### PR DESCRIPTION
When resetting deps, rebuild the cmark-gfm node bindings if they're not found.

```
❯ ./scripts/resetdeps.sh 
+ rm -rf node_modules
+ rm -rf docs/node_modules
+ rm -rf smoke-tests/node_modules
+ rm -rf 'workspaces/*/node_modules'
+ git checkout node_modules
Updated 1332 paths from the index
+ node . i --ignore-scripts --no-audit --no-fund

added 857 packages, and changed 14 packages in 10s
+ node . rebuild --ignore-scripts
rebuilt dependencies successfully
+ node . run dependencies --ignore-scripts

> npm@9.0.0-pre.4 dependencies
> node scripts/bundle-and-gitignore-deps.js && node scripts/dependency-graph.js

Wrote to node_modules/.gitignore
wrote to DEPENDENCIES.md
+++ npm ls cmark-gfm --parseable
+++ head -n 1
++ find /Users/fritzy/projects/npm/cli/node_modules/cmark-gfm -name binding.node
+ cmarkbinding=
+ [[ ! -n '' ]]
+ node . rebuild cmark-gfm
rebuilt dependencies successfully```