### PR TITLE
chore: fix resetdeps.sh to use checkout npm

### DIFF
--- a/scripts/resetdeps.sh
+++ b/scripts/resetdeps.sh
@@ -10,7 +10,7 @@ node . i --ignore-scripts --no-audit --no-fund "$@"
 node . rebuild --ignore-scripts
 node . run dependencies --ignore-scripts
 # check for cmark-gfm bindings
-cmarkbinding=$(find `npm ls cmark-gfm --parseable \
+cmarkbinding=$(find `node . ls cmark-gfm --parseable \
 | head -n 1` -name binding.node)
 if [[ ! $cmarkbinding ]]; then
   node . rebuild cmark-gfm


### PR DESCRIPTION
fix previous `resetdeps.sh` change to use `node .` everywhere instead of `npm`
