### PR TITLE
chore: only audit production workspaces

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Reset Deps
         run: node . run resetdeps -- --package-lock
       - name: Run Audit
-        run: node . audit
+        run: node . audit -iwr -w workspaces

--- a/scripts/template-oss/audit.yml
+++ b/scripts/template-oss/audit.yml
@@ -1,0 +1,13 @@
+name: Audit
+
+on:
+  workflow_dispatch:
+  schedule:
+    # "At 08:00 UTC (01:00 PT) on Monday" https://crontab.guru/#0_8_*_*_1
+    - cron: "0 8 * * 1"
+
+jobs:
+  audit:
+    {{> job jobName="Audit Dependencies" jobDepFlags="--package-lock" }}
+      - name: Run Audit
+        run: {{ rootNpmPath }} audit -iwr -w workspaces

--- a/scripts/template-oss/root.js
+++ b/scripts/template-oss/root.js
@@ -7,6 +7,7 @@ module.exports = {
       '.github/workflows/ci-release.yml': 'ci-release.yml',
       '.github/dependabot.yml': false,
       '.github/workflows/post-dependabot.yml': false,
+      '.github/workflows/audit.yml': 'audit.yml',
     },
   },
   workspaceRepo: {


### PR DESCRIPTION
After #5309 moved docs dependencies to proudction deps, we started
failing our daily audit CI check. Currently these deps are production
so they are available when we run `pack`, but they don't need to be
audited since they are never present in our published tarball.

This change runs `audit` on the root CLI and all workspaces within the
`workspaces/` directory, which are the only production workspaces.
