### PR TITLE
feat: output json formatted errors on stdout

### DIFF
--- a/lib/commands/ls.js
+++ b/lib/commands/ls.js
@@ -177,7 +177,7 @@ class LS extends ArboristWorkspaceCmd {
     const [rootError] = tree.errors.filter(e =>
       e.code === 'EJSONPARSE' && e.path === resolve(path, 'package.json'))
 
-    this.npm.output(
+    this.npm.outputBuffer(
       json
         ? jsonOutput({ path, problems, result, rootError, seenItems })
         : parseable

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -40,6 +40,7 @@ class Npm extends EventEmitter {
   #argvClean = []
   #chalk = null
 
+  #outputBuffer = []
   #logFile = new LogFile()
   #display = new Display()
   #timers = new Timers({
@@ -464,6 +465,37 @@ class Npm extends EventEmitter {
     // eslint-disable-next-line no-console
     console.log(...msg)
     log.showProgress()
+  }
+
+  outputBuffer (item) {
+    this.#outputBuffer.push(item)
+  }
+
+  flushOutput (jsonError) {
+    if (!jsonError && !this.#outputBuffer.length) {
+      return
+    }
+
+    if (this.config.get('json')) {
+      const jsonOutput = this.#outputBuffer.reduce((acc, item) => {
+        if (typeof item === 'string') {
+          // try to parse it as json in case its a string
+          try {
+            item = JSON.parse(item)
+          } catch {
+            return acc
+          }
+        }
+        return { ...acc, ...item }
+      }, {})
+      this.output(JSON.stringify({ ...jsonOutput, ...jsonError }, null, 2))
+    } else {
+      for (const item of this.#outputBuffer) {
+        this.output(item)
+      }
+    }
+
+    this.#outputBuffer.length = 0
   }
 
   outputError (...msg) {

--- a/lib/utils/exit-handler.js
+++ b/lib/utils/exit-handler.js
@@ -136,6 +136,7 @@ const exitHandler = err => {
 
   let exitCode
   let noLogMessage
+  let jsonError
 
   if (err) {
     exitCode = 1
@@ -198,14 +199,13 @@ const exitHandler = err => {
       }
 
       if (hasLoadedNpm && npm.config.get('json')) {
-        const error = {
+        jsonError = {
           error: {
             code: err.code,
             summary: messageText(summary),
             detail: messageText(detail),
           },
         }
-        npm.outputError(JSON.stringify(error, null, 2))
       }
 
       if (typeof err.errno === 'number') {
@@ -214,6 +214,10 @@ const exitHandler = err => {
         exitCode = err.code
       }
     }
+  }
+
+  if (hasLoadedNpm) {
+    npm.flushOutput(jsonError)
   }
 
   log.verbose('exit', exitCode || 0)

--- a/test/fixtures/mock-npm.js
+++ b/test/fixtures/mock-npm.js
@@ -238,6 +238,15 @@ class MockNpm {
     }
     this._mockOutputs.push(msg)
   }
+
+  // with the older fake mock npm there is no
+  // difference between output and outputBuffer
+  // since it just collects the output and never
+  // calls the exit handler, so we just mock the
+  // method the same as output.
+  outputBuffer (...msg) {
+    this.output(...msg)
+  }
 }
 
 const FakeMockNpm = (base = {}, t) => {


### PR DESCRIPTION
This also adds a new output method `outputBuffer()` which will buffer
all output until it is flushed in the exit handler. This allows the exit
handler to catch any errors and append them to the output when in json
mode. This was necessary to not introduce a regression in the case of
npm/cli#2150.

BREAKING CHANGE: `npm` now outputs some json errors on stdout.
Previously `npm` would output all json formatted errors on stderr,
making it difficult to parse as the stderr stream usually has logs
already written to it. In the future, `npm` will differentiate between
errors and crashes. Errors, such as `E404` and `ERESOLVE`, will be
handled and will continue to be output on stdout. In the case of a
crash, `npm` will log the error as usual but will not attempt to display
it as json, even in `--json` mode. Moving a case from the category of an
error to a crash will not be considered a breaking change. For more
information see npm/rfcs#482.

Closes #2740
Closes https://github.com/npm/statusboard/issues/589
