### PR TITLE
docs: Better npx link

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -103,7 +103,7 @@ class Init extends BaseCommand {
         throw Object.assign(new Error(
           'Unrecognized initializer: ' + initerName +
           '\nFor more package binary executing power check out `npx`:' +
-          '\nhttps://docs.npmjs.com/cli/v8/commands/npx'
+          '\nhttps://docs.npmjs.com/cli/commands/npx'
         ), { code: 'EUNSUPPORTED' })
       }
     }

--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -103,7 +103,7 @@ class Init extends BaseCommand {
         throw Object.assign(new Error(
           'Unrecognized initializer: ' + initerName +
           '\nFor more package binary executing power check out `npx`:' +
-          '\nhttps://www.npmjs.com/package/npx'
+          '\nhttps://docs.npmjs.com/cli/v8/commands/npx'
         ), { code: 'EUNSUPPORTED' })
       }
     }


### PR DESCRIPTION
Old link goes to:
https://www.npmjs.com/package/npx
... which is a bit cryptic. Following the link to GitHub goes to:
https://github.com/npm/npx
... which shows:
>This repository has been archived by the owner. It is now read-only.

... up top. Scrolling down reveals:
>⚠️ DEPRECATED: This project has been deprecated - npx is now part of the [npm cli](https://github.com/npm/cli)

... that leads to:
https://github.com/npm/cli
The sidebar gives the link to:
https://docs.npmjs.com/cli/
... and then you just have to search for "npx" (or drill down into "CLI Commands"), and then finally, you get to:
https://docs.npmjs.com/cli/v8/commands/npx