### PR TITLE
docs: name and version description change

### DIFF
--- a/docs/content/configuring-npm/package-json.md
+++ b/docs/content/configuring-npm/package-json.md
@@ -20,7 +20,6 @@ package.json are the name and version fields as they will be required. The
 name and version together form an identifier that is assumed to be
 completely unique. If you don't plan to publish your package, the name and
 version fields are optional.
-  
 The name field contains your package name.
 
 Some rules:

--- a/docs/content/configuring-npm/package-json.md
+++ b/docs/content/configuring-npm/package-json.md
@@ -61,7 +61,7 @@ npm as a dependency.  (`npm install semver` to use it yourself.)
 
 ### description
 
-Put a description in it. It's a string.  This helps people discover your
+Put a description in it.  It's a string.  This helps people discover your
 package, as it's listed in `npm search`.
 
 ### keywords

--- a/docs/content/configuring-npm/package-json.md
+++ b/docs/content/configuring-npm/package-json.md
@@ -16,10 +16,9 @@ settings described in [`config`](/using-npm/config).
 ### name
 
 If you plan to publish your package, the *most* important things in your
-package.json are the name and version fields as they will be required.
-The name and version together form an identifier that is assumed to be
+package.json are the name and version fields as they will be required. The
+name and version together form an identifier that is assumed to be
 completely unique. If you don't plan to publish your package, the name and
-version fields are optional.
   
 The name field contains your package name.
 

--- a/docs/content/configuring-npm/package-json.md
+++ b/docs/content/configuring-npm/package-json.md
@@ -16,13 +16,11 @@ settings described in [`config`](/using-npm/config).
 ### name
 
 If you plan to publish your package, the *most* important things in your
-package.json are the name and version fields as they will be required. The
-name and version together form an identifier that is assumed to be
-completely unique.  Changes to the package should come along with changes
-to the version. If you don't plan to publish your package, the name and
-version fields are optional.
-
-The name is what your thing is called.
+package.json are the name and version fields as they will be required.
+The name and version together form an identifier that is assumed to be
+completely unique. 
+  
+The name field contains your package name.
 
 Some rules:
 
@@ -52,12 +50,9 @@ A name can be optionally prefixed by a scope, e.g. `@myorg/mypackage`. See
 
 ### version
 
-If you plan to publish your package, the *most* important things in your
-package.json are the name and version fields as they will be required. The
-name and version together form an identifier that is assumed to be
-completely unique.  Changes to the package should come along with changes
-to the version. If you don't plan to publish your package, the name and
-version fields are optional.
+Changes to the package should come along with changes to the version.
+You can show developers how much they need to adjust on a new update by
+using [semantic versioning](../../about-semantic-versioning) 
 
 Version must be parseable by
 [node-semver](https://github.com/npm/node-semver), which is bundled with
@@ -65,7 +60,7 @@ npm as a dependency.  (`npm install semver` to use it yourself.)
 
 ### description
 
-Put a description in it.  It's a string.  This helps people discover your
+Put a description in it. It's a string.  This helps people discover your
 package, as it's listed in `npm search`.
 
 ### keywords

--- a/docs/content/configuring-npm/package-json.md
+++ b/docs/content/configuring-npm/package-json.md
@@ -51,8 +51,6 @@ A name can be optionally prefixed by a scope, e.g. `@myorg/mypackage`. See
 
 ### version
 
-If you plan to publish your package, the *most* important things in your
-package.json are the name and version fields as they will be required.
 Changes to the package should come along with changes to the version.
 You can show developers how much they need to adjust on a new update by
 using [semantic versioning](../../about-semantic-versioning) 

--- a/docs/content/configuring-npm/package-json.md
+++ b/docs/content/configuring-npm/package-json.md
@@ -19,6 +19,7 @@ If you plan to publish your package, the *most* important things in your
 package.json are the name and version fields as they will be required. The
 name and version together form an identifier that is assumed to be
 completely unique. If you don't plan to publish your package, the name and
+version fields are optional.
   
 The name field contains your package name.
 

--- a/docs/content/configuring-npm/package-json.md
+++ b/docs/content/configuring-npm/package-json.md
@@ -18,7 +18,8 @@ settings described in [`config`](/using-npm/config).
 If you plan to publish your package, the *most* important things in your
 package.json are the name and version fields as they will be required.
 The name and version together form an identifier that is assumed to be
-completely unique. 
+completely unique. If you don't plan to publish your package, the name and
+version fields are optional.
   
 The name field contains your package name.
 
@@ -50,6 +51,8 @@ A name can be optionally prefixed by a scope, e.g. `@myorg/mypackage`. See
 
 ### version
 
+If you plan to publish your package, the *most* important things in your
+package.json are the name and version fields as they will be required.
 Changes to the package should come along with changes to the version.
 You can show developers how much they need to adjust on a new update by
 using [semantic versioning](../../about-semantic-versioning) 


### PR DESCRIPTION
Reducing redundancy by deleting repeated code and changing other slight things about those two fields.