### PR TITLE
chore: ignore-scripts when installing docs deps

### DIFF
--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -85,7 +85,7 @@ const main = async (opts) => {
   }
 
   await npm('prune', '--omit=dev', '--no-save', '--no-audit', '--no-fund')
-  await npm('install', '-w', 'docs')
+  await npm('install', '-w', 'docs', '--ignore-scripts', '--no-audit', '--no-fund')
   await git.dirty()
 
   for (const p of publishes) {


### PR DESCRIPTION
This should allow CI to still run in node 12 for the v8 releases. Previously it was failing because the postinstall script required >= node 14: https://github.com/npm/cli/actions/runs/3372720489/jobs/5596504990