### PR TITLE
chore: ignore-scripts when installing docs deps

### DIFF
--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -85,7 +85,7 @@ const main = async (opts) => {
   }
 
   await npm('prune', '--omit=dev', '--no-save', '--no-audit', '--no-fund')
-  await npm('install', '-w', 'docs')
+  await npm('install', '-w', 'docs', '--ignore-scripts', '--no-audit', '--no-fund')
   await git.dirty()
 
   for (const p of publishes) {


### PR DESCRIPTION
This doesn't fix anything like it did in #5790, but we should always be using `--ignore-scripts` for commands that accept it in scripts that run in CI.