### PR TITLE
docs: update description of npm exec

### DIFF
--- a/docs/lib/content/commands/npm-exec.md
+++ b/docs/lib/content/commands/npm-exec.md
@@ -27,8 +27,8 @@ where all specified packages are available.
 
 If any requested packages are not present in the local project
 dependencies, then a prompt is printed, which can be suppressed by
-providing either `--yes` or `--no`. When standard input is not a TTY or a CI
-environment is detected, `--yes` is assumed. The requested packages are 
+providing either `--yes` or `--no`. When standard input is not a TTY or a
+CI environment is detected, `--yes` is assumed. The requested packages are
 installed to a folder in the npm cache, which is added to the `PATH`
 environment variable in the executed process.
 

--- a/docs/lib/content/commands/npm-exec.md
+++ b/docs/lib/content/commands/npm-exec.md
@@ -26,10 +26,11 @@ specified multiple times, to execute the supplied command in an environment
 where all specified packages are available.
 
 If any requested packages are not present in the local project
-dependencies, then they are installed to a folder in the npm cache, which
-is added to the `PATH` environment variable in the executed process.  A
-prompt is printed (which can be suppressed by providing either `--yes` or
-`--no`).
+dependencies, then a prompt is printed, which can be suppressed by
+providing either `--yes` or `--no`. When standard input is a TTY or a CI
+environment is detected, `--yes` is assumed. The requested packages are 
+installed to a folder in the npm cache, which is added to the `PATH`
+environment variable in the executed process.
 
 Package names provided without a specifier will be matched with whatever
 version exists in the local project.  Package names with a specifier will

--- a/docs/lib/content/commands/npm-exec.md
+++ b/docs/lib/content/commands/npm-exec.md
@@ -27,7 +27,7 @@ where all specified packages are available.
 
 If any requested packages are not present in the local project
 dependencies, then a prompt is printed, which can be suppressed by
-providing either `--yes` or `--no`. When standard input is a TTY or a CI
+providing either `--yes` or `--no`. When standard input is not a TTY or a CI
 environment is detected, `--yes` is assumed. The requested packages are 
 installed to a folder in the npm cache, which is added to the `PATH`
 environment variable in the executed process.


### PR DESCRIPTION
This PR explains that `npm exec` will detect TTY or CI environment and change behavior.

https://github.com/npm/cli/blob/latest/workspaces/libnpmexec/lib/index.js#L247-L253


## References

A conversation with @wraithgar 
