### PR TITLE
fix: Validate username at get-identity

### DIFF
--- a/lib/utils/get-identity.js
+++ b/lib/utils/get-identity.js
@@ -12,7 +12,9 @@ module.exports = async (npm, opts) => {
   // No username, but we have other credentials; fetch the username from registry
   if (creds.token || creds.certfile && creds.keyfile) {
     const registryData = await npmFetch.json('/-/whoami', { ...opts })
-    return registryData.username
+    if (registryData?.username)
+      return registryData.username
+    )  
   }
 
   // At this point, even if they have a credentials object, it doesn't have a

--- a/lib/utils/get-identity.js
+++ b/lib/utils/get-identity.js
@@ -12,7 +12,7 @@ module.exports = async (npm, opts) => {
   // No username, but we have other credentials; fetch the username from registry
   if (creds.token || creds.certfile && creds.keyfile) {
     const registryData = await npmFetch.json('/-/whoami', { ...opts })
-    if (registryData?.username)
+    if (typeof registryData?.username === 'string')
       return registryData.username
     )  
   }

--- a/lib/utils/get-identity.js
+++ b/lib/utils/get-identity.js
@@ -12,9 +12,9 @@ module.exports = async (npm, opts) => {
   // No username, but we have other credentials; fetch the username from registry
   if (creds.token || creds.certfile && creds.keyfile) {
     const registryData = await npmFetch.json('/-/whoami', { ...opts })
-    if (typeof registryData?.username === 'string')
+    if (typeof registryData?.username === 'string') {
       return registryData.username
-    )  
+    }
   }
 
   // At this point, even if they have a credentials object, it doesn't have a

--- a/test/lib/commands/whoami.js
+++ b/test/lib/commands/whoami.js
@@ -1,6 +1,7 @@
 const t = require('tap')
 const { load: loadMockNpm } = require('../../fixtures/mock-npm')
 const MockRegistry = require('@npmcli/mock-registry')
+const nock = require('nock')
 
 const username = 'foo'
 const auth = { '//registry.npmjs.org/:_authToken': 'test-auth-token' }
@@ -66,4 +67,28 @@ t.test('not logged in', async t => {
     },
   })
   await t.rejects(npm.exec('whoami', []), { code: 'ENEEDAUTH' })
+})
+
+t.test('non-string username in response', async t => {
+  nock.disableNetConnect()
+  t.teardown(() => {
+    nock.enableNetConnect()
+  })
+
+  const server = nock('https://registry.npmjs.org', {
+    reqheaders: {
+      authorization: 'Bearer abcd1234',
+    },
+  })
+    .get('/-/whoami')
+    .reply(200, { username: null })
+
+  const { npm } = await loadMockNpm(t, {
+    config: {
+      '//registry.npmjs.org/:_authToken': 'abcd1234',
+    },
+  })
+
+  await t.rejects(npm.exec('whoami', []), { code: 'ENEEDAUTH' })
+  t.ok(server.isDone())
 })


### PR DESCRIPTION
Currently `npm` accept null / undefined / empty string as valid username.
Client should validate incomming data.

## References
  Fixes #5867 (prevent undefined username)
