### PR TITLE
feat: discrete npm doctor commands

### DIFF
--- a/docs/lib/content/commands/npm-doctor.md
+++ b/docs/lib/content/commands/npm-doctor.md
@@ -31,8 +31,10 @@ Also, in addition to this, there are also very many issue reports due to
 using old versions of npm. Since npm is constantly improving, running
 `npm@latest` is better than an old version.
 
-`npm doctor` verifies the following items in your environment, and if there
-are any recommended changes, it will display them.
+`npm doctor` verifies the following items in your environment, and if
+there are any recommended changes, it will display them.  By default npm
+runs all of these checks. You can limit what checks are ran by
+specifying them as extra arguments.
 
 #### `npm ping`
 

--- a/lib/commands/doctor.js
+++ b/lib/commands/doctor.js
@@ -34,30 +34,104 @@ const maskLabel = mask => {
   return label.join(', ')
 }
 
+const subcommands = [
+  {
+    groups: ['ping', 'registry'],
+    title: 'npm ping',
+    cmd: 'checkPing',
+  }, {
+    groups: ['versions'],
+    title: 'npm -v',
+    cmd: 'getLatestNpmVersion',
+  }, {
+    groups: ['versions'],
+    title: 'node -v',
+    cmd: 'getLatestNodejsVersion',
+  }, {
+    groups: ['registry'],
+    title: 'npm config get registry',
+    cmd: 'checkNpmRegistry',
+  }, {
+    groups: ['environment'],
+    title: 'git executable in PATH',
+    cmd: 'getGitPath',
+  }, {
+    groups: ['environment'],
+    title: 'global bin folder in PATH',
+    cmd: 'getBinPath',
+  }, {
+    groups: ['permissions', 'cache'],
+    title: 'Perms check on cached files',
+    cmd: 'checkCachePermission',
+    windows: false,
+  }, {
+    groups: ['permissions'],
+    title: 'Perms check on local node_modules',
+    cmd: 'checkLocalModulesPermission',
+    windows: false,
+  }, {
+    groups: ['permissions'],
+    title: 'Perms check on global node_modules',
+    cmd: 'checkGlobalModulesPermission',
+    windows: false,
+  }, {
+    groups: ['permissions'],
+    title: 'Perms check on local bin folder',
+    cmd: 'checkLocalBinPermission',
+    windows: false,
+  }, {
+    groups: ['permissions'],
+    title: 'Perms check on global bin folder',
+    cmd: 'checkGlobalBinPermission',
+    windows: false,
+  }, {
+    groups: ['cache'],
+    title: 'Verify cache contents',
+    cmd: 'verifyCachedFiles',
+    windows: false,
+  },
+  // TODO:
+  // group === 'dependencies'?
+  //   - ensure arborist.loadActual() runs without errors and no invalid edges
+  //   - ensure package-lock.json matches loadActual()
+  //   - verify loadActual without hidden lock file matches hidden lockfile
+  // group === '???'
+  //   - verify all local packages have bins linked
+  // What is the fix for these?
+]
 const BaseCommand = require('../base-command.js')
 class Doctor extends BaseCommand {
   static description = 'Check your npm environment'
   static name = 'doctor'
   static params = ['registry']
   static ignoreImplicitWorkspace = false
+  static usage = [`[${subcommands.flatMap(s => s.groups)
+    .filter((value, index, self) => self.indexOf(value) === index)
+    .join('] [')}]`]
+
+  static subcommands = subcommands
+
+  // minimum width of check column, enough for the word `Check`
+  #checkWidth = 5
 
   async exec (args) {
     log.info('Running checkup')
     let allOk = true
 
     const actions = this.actions(args)
-    this.checkWidth = actions.reduce((length, item) => Math.max(item[0].length, length), 5)
+    this.#checkWidth = actions.reduce((length, item) =>
+      Math.max(item.title.length, length), this.#checkWidth)
 
     if (!this.npm.silent) {
       this.output(['Check', 'Value', 'Recommendation/Notes'].map(h => this.npm.chalk.underline(h)))
     }
     // Do the actual work
-    for (const [msg, fn, args] of actions) {
-      const item = [msg]
+    for (const { title, cmd } of actions) {
+      const item = [title]
       try {
-        item.push(true, await this[fn](...args))
-      } catch (er) {
-        item.push(false, er)
+        item.push(true, await this[cmd]())
+      } catch (err) {
+        item.push(false, err)
       }
       if (!item[1]) {
         allOk = false
@@ -72,11 +146,13 @@ class Doctor extends BaseCommand {
       }
     }
 
-    if (!this.npm.silent) {
-      // this.npm.output(table(outTable, tableOpts))
-    }
     if (!allOk) {
-      throw new Error('Some problems found. See above for recommendations.')
+      if (this.npm.silent) {
+        /* eslint-disable-next-line max-len */
+        throw new Error('Some problems found. Check logs or disable silent mode for recommendations.')
+      } else {
+        throw new Error('Some problems found. See above for recommendations.')
+      }
     }
   }
 
@@ -144,13 +220,33 @@ class Doctor extends BaseCommand {
     }
   }
 
-  async checkBinPath (dir) {
-    const tracker = log.newItem('checkBinPath', 1)
-    tracker.info('checkBinPath', 'Finding npm global bin in your PATH')
+  async getBinPath (dir) {
+    const tracker = log.newItem('getBinPath', 1)
+    tracker.info('getBinPath', 'Finding npm global bin in your PATH')
     if (!process.env.PATH.includes(this.npm.globalBin)) {
       throw new Error(`Add ${this.npm.globalBin} to your $PATH`)
     }
     return this.npm.globalBin
+  }
+
+  async checkCachePermission () {
+    return this.checkFilesPermission(this.npm.cache, true, R_OK)
+  }
+
+  async checkLocalModulesPermission () {
+    return this.checkFilesPermission(this.npm.localDir, true, R_OK | W_OK, true)
+  }
+
+  async checkGlobalModulesPermission () {
+    return this.checkFilesPermission(this.npm.globalDir, false, R_OK)
+  }
+
+  async checkLocalBinPermission () {
+    return this.checkFilesPermission(this.npm.localBin, false, R_OK | W_OK | X_OK, true)
+  }
+
+  async checkGlobalBinPermission () {
+    return this.checkFilesPermission(this.npm.globalBin, false, X_OK)
   }
 
   async checkFilesPermission (root, shouldOwn, mask, missingOk) {
@@ -293,79 +389,22 @@ class Doctor extends BaseCommand {
         'right-mid': '',
         middle: '  ' },
       style: { 'padding-left': 0, 'padding-right': 0 },
-      colWidths: [this.checkWidth, 6],
+      colWidths: [this.#checkWidth, 6],
     })
     t.push(row)
     this.npm.output(t.toString())
   }
 
-  actions (subcmds) {
-    const a = []
-    if (!subcmds.length || subcmds.includes('ping')) {
-      a.push(['npm ping', 'checkPing', []])
-    }
-    if (!subcmds.length || subcmds.includes('versions')) {
-      a.push(['npm -v', 'getLatestNpmVersion', []])
-      a.push(['node -v', 'getLatestNodejsVersion', []])
-    }
-    if (!subcmds.length || subcmds.includes('registry')) {
-      a.push(['npm config get registry', 'checkNpmRegistry', []])
-    }
-    if (!subcmds.length || subcmds.includes('git')) {
-      a.push(['which git', 'getGitPath', []])
-    }
-    if (!subcmds.length || subcmds.includes('permissions')) {
-      if (subcmds.includes('permissions') && process.platform === 'win32') {
-        log.warn('Ignoring permissions checks for windows')
-      } else if (process.platform !== 'win32') {
-        a.push([
-          'Perms check on cached files',
-          'checkFilesPermission',
-          [this.npm.cache, true, R_OK],
-        ])
-        a.push([
-          'Perms check on local node_modules',
-          'checkFilesPermission',
-          [this.npm.localDir, true, R_OK | W_OK, true],
-        ])
-        a.push([
-          'Perms check on global node_modules',
-          'checkFilesPermission',
-          [this.npm.globalDir, false, R_OK],
-        ])
-        a.push([
-          'Perms check on local bin folder',
-          'checkFilesPermission',
-          [this.npm.localBin, false, R_OK | W_OK | X_OK, true],
-        ])
-        a.push([
-          'Perms check on global bin folder',
-          'checkFilesPermission',
-          [this.npm.globalBin, false, X_OK],
-        ])
+  actions (params) {
+    return this.constructor.subcommands.filter(subcmd => {
+      if (process.platform === 'win32' && subcmd.windows === false) {
+        return false
       }
-    }
-    if (!subcmds.length || subcmds.includes('cache')) {
-      a.push([
-        'Verify cache contents',
-        'verifyCachedFiles',
-        [this.npm.flatOptions.cache],
-      ])
-    }
-
-    if (!subcmds.length || subcmds.includes('environment')) {
-      a.push(['Global bin folder in PATH', 'checkBinPath', []])
-    }
-
-    // TODO:
-    // subcmd === 'dependencies'?
-    //   - ensure arborist.loadActual() runs without errors and no invalid edges
-    //   - ensure package-lock.json matches loadActual()
-    //   - verify loadActual without hidden lock file matches hidden lockfile
-    // subcmd === '???'
-    //   - verify all local packages have bins linked
-    // What is the fix for these?
-    return a
+      if (params.length) {
+        return params.some(param => subcmd.groups.includes(param))
+      }
+      return true
+    })
   }
 }
 

--- a/lib/commands/doctor.js
+++ b/lib/commands/doctor.js
@@ -8,7 +8,6 @@ const { resolve } = require('path')
 const semver = require('semver')
 const { promisify } = require('util')
 const log = require('../utils/log-shim.js')
-const ansiTrim = require('../utils/ansi-trim.js')
 const ping = require('../utils/ping.js')
 const {
   registry: { default: defaultRegistry },
@@ -17,9 +16,6 @@ const lstat = promisify(fs.lstat)
 const readdir = promisify(fs.readdir)
 const access = promisify(fs.access)
 const { R_OK, W_OK, X_OK } = fs.constants
-
-const table = (colWidths, rows) => {
-}
 
 const maskLabel = mask => {
   const label = []
@@ -47,52 +43,11 @@ class Doctor extends BaseCommand {
 
   async exec (args) {
     log.info('Running checkup')
-
-    const actions = [
-      ['npm ping', 'checkPing', []],
-      ['npm -v', 'getLatestNpmVersion', []],
-      ['node -v', 'getLatestNodejsVersion', []],
-      ['npm config get registry', 'checkNpmRegistry', []],
-      ['which git', 'getGitPath', []],
-      ...(process.platform === 'win32'
-        ? []
-        : [
-          [
-            'Perms check on cached files',
-            'checkFilesPermission',
-            [this.npm.cache, true, R_OK],
-          ], [
-            'Perms check on local node_modules',
-            'checkFilesPermission',
-            [this.npm.localDir, true, R_OK | W_OK, true],
-          ], [
-            'Perms check on global node_modules',
-            'checkFilesPermission',
-            [this.npm.globalDir, false, R_OK],
-          ], [
-            'Perms check on local bin folder',
-            'checkFilesPermission',
-            [this.npm.localBin, false, R_OK | W_OK | X_OK, true],
-          ], [
-            'Perms check on global bin folder',
-            'checkFilesPermission',
-            [this.npm.globalBin, false, X_OK],
-          ],
-        ]),
-      [
-        'Verify cache contents',
-        'verifyCachedFiles',
-        [this.npm.flatOptions.cache],
-      ],
-      // TODO:
-      // - ensure arborist.loadActual() runs without errors and no invalid edges
-      // - ensure package-lock.json matches loadActual()
-      // - verify loadActual without hidden lock file matches hidden lockfile
-      // - verify all local packages have bins linked
-    ]
-
     let allOk = true
-    this.checkWidth = actions.reduce((length, item) => Math.max(item[0].length, length), 0)
+
+    const actions = this.actions(args)
+    this.checkWidth = actions.reduce((length, item) => Math.max(item[0].length, length), 5)
+
     if (!this.npm.silent) {
       this.output(['Check', 'Value', 'Recommendation/Notes'].map(h => this.npm.chalk.underline(h)))
     }
@@ -116,7 +71,6 @@ class Doctor extends BaseCommand {
         this.output(item)
       }
     }
-
 
     if (!this.npm.silent) {
       // this.npm.output(table(outTable, tableOpts))
@@ -314,15 +268,95 @@ class Doctor extends BaseCommand {
 
   output (row) {
     const t = new Table({
-      chars: { 'top': '' , 'top-mid': '' , 'top-left': '' , 'top-right': ''
-        , 'bottom': '' , 'bottom-mid': '' , 'bottom-left': '' , 'bottom-right': ''
-        , 'left': '' , 'left-mid': '' , 'mid': '' , 'mid-mid': ''
-        , 'right': '' , 'right-mid': '' , 'middle': '  ' },
+      chars: { top: '',
+        'top-mid': '',
+        'top-left': '',
+        'top-right': '',
+        bottom: '',
+        'bottom-mid': '',
+        'bottom-left': '',
+        'bottom-right': '',
+        left: '',
+        'left-mid': '',
+        mid: '',
+        'mid-mid': '',
+        right: '',
+        'right-mid': '',
+        middle: '  ' },
       style: { 'padding-left': 0, 'padding-right': 0 },
       colWidths: [this.checkWidth, 6],
-    });
+    })
     t.push(row)
     this.npm.output(t.toString())
+  }
+
+  actions (subcmds) {
+    const a = []
+    if (!subcmds.length || subcmds.includes('ping')) {
+      a.push(['npm ping', 'checkPing', []])
+    }
+    if (!subcmds.length || subcmds.includes('versions')) {
+      a.push(['npm -v', 'getLatestNpmVersion', []])
+      a.push(['node -v', 'getLatestNodejsVersion', []])
+    }
+    if (!subcmds.length || subcmds.includes('registry')) {
+      a.push(['npm config get registry', 'checkNpmRegistry', []])
+    }
+    if (!subcmds.length || subcmds.includes('git')) {
+      a.push(['which git', 'getGitPath', []])
+    }
+    if (!subcmds.length || subcmds.includes('permissions')) {
+      if (subcmds.includes('permissions') && process.platform === 'win32') {
+        log.warn('Ignoring permissions checks for windows')
+      } else if (process.platform !== 'win32') {
+        a.push([
+          'Perms check on cached files',
+          'checkFilesPermission',
+          [this.npm.cache, true, R_OK],
+        ])
+        a.push([
+          'Perms check on local node_modules',
+          'checkFilesPermission',
+          [this.npm.localDir, true, R_OK | W_OK, true],
+        ])
+        a.push([
+          'Perms check on global node_modules',
+          'checkFilesPermission',
+          [this.npm.globalDir, false, R_OK],
+        ])
+        a.push([
+          'Perms check on local bin folder',
+          'checkFilesPermission',
+          [this.npm.localBin, false, R_OK | W_OK | X_OK, true],
+        ])
+        a.push([
+          'Perms check on global bin folder',
+          'checkFilesPermission',
+          [this.npm.globalBin, false, X_OK],
+        ])
+      }
+    }
+    if (!subcmds.length || subcmds.includes('cache')) {
+      a.push([
+        'Verify cache contents',
+        'verifyCachedFiles',
+        [this.npm.flatOptions.cache],
+      ])
+    }
+
+    // TODO
+    // subcmd === 'environment'
+    //  - ensure global bin is in process.env.PATH
+
+    // TODO:
+    // subcmd === 'dependencies'?
+    //   - ensure arborist.loadActual() runs without errors and no invalid edges
+    //   - ensure package-lock.json matches loadActual()
+    //   - verify loadActual without hidden lock file matches hidden lockfile
+    // subcmd === '???'
+    //   - verify all local packages have bins linked
+    // What is the fix for these?
+    return a
   }
 }
 

--- a/lib/commands/doctor.js
+++ b/lib/commands/doctor.js
@@ -1,7 +1,7 @@
 const cacache = require('cacache')
 const fs = require('fs')
 const fetch = require('make-fetch-happen')
-const table = require('text-table')
+const Table = require('cli-table3')
 const which = require('which')
 const pacote = require('pacote')
 const { resolve } = require('path')
@@ -17,6 +17,10 @@ const lstat = promisify(fs.lstat)
 const readdir = promisify(fs.readdir)
 const access = promisify(fs.access)
 const { R_OK, W_OK, X_OK } = fs.constants
+
+const table = (colWidths, rows) => {
+}
+
 const maskLabel = mask => {
   const label = []
   if (mask & R_OK) {
@@ -43,9 +47,6 @@ class Doctor extends BaseCommand {
 
   async exec (args) {
     log.info('Running checkup')
-
-    // each message is [title, ok, message]
-    const messages = []
 
     const actions = [
       ['npm ping', 'checkPing', []],
@@ -90,20 +91,19 @@ class Doctor extends BaseCommand {
       // - verify all local packages have bins linked
     ]
 
+    let allOk = true
+    this.checkWidth = actions.reduce((length, item) => Math.max(item[0].length, length), 0)
+    if (!this.npm.silent) {
+      this.output(['Check', 'Value', 'Recommendation/Notes'].map(h => this.npm.chalk.underline(h)))
+    }
     // Do the actual work
     for (const [msg, fn, args] of actions) {
-      const line = [msg]
+      const item = [msg]
       try {
-        line.push(true, await this[fn](...args))
+        item.push(true, await this[fn](...args))
       } catch (er) {
-        line.push(false, er)
+        item.push(false, er)
       }
-      messages.push(line)
-    }
-
-    const outHead = ['Check', 'Value', 'Recommendation/Notes'].map(h => this.npm.chalk.underline(h))
-    let allOk = true
-    const outBody = messages.map(item => {
       if (!item[1]) {
         allOk = false
         item[0] = this.npm.chalk.red(item[0])
@@ -112,15 +112,14 @@ class Doctor extends BaseCommand {
       } else {
         item[1] = this.npm.chalk.green('ok')
       }
-      return item
-    })
-    const outTable = [outHead, ...outBody]
-    const tableOpts = {
-      stringLength: s => ansiTrim(s).length,
+      if (!this.npm.silent) {
+        this.output(item)
+      }
     }
 
+
     if (!this.npm.silent) {
-      this.npm.output(table(outTable, tableOpts))
+      // this.npm.output(table(outTable, tableOpts))
     }
     if (!allOk) {
       throw new Error('Some problems found. See above for recommendations.')
@@ -311,6 +310,19 @@ class Doctor extends BaseCommand {
     } else {
       return `using default registry (${defaultRegistry})`
     }
+  }
+
+  output (row) {
+    const t = new Table({
+      chars: { 'top': '' , 'top-mid': '' , 'top-left': '' , 'top-right': ''
+        , 'bottom': '' , 'bottom-mid': '' , 'bottom-left': '' , 'bottom-right': ''
+        , 'left': '' , 'left-mid': '' , 'mid': '' , 'mid-mid': ''
+        , 'right': '' , 'right-mid': '' , 'middle': '  ' },
+      style: { 'padding-left': 0, 'padding-right': 0 },
+      colWidths: [this.checkWidth, 6],
+    });
+    t.push(row)
+    this.npm.output(t.toString())
   }
 }
 

--- a/lib/commands/doctor.js
+++ b/lib/commands/doctor.js
@@ -144,6 +144,15 @@ class Doctor extends BaseCommand {
     }
   }
 
+  async checkBinPath (dir) {
+    const tracker = log.newItem('checkBinPath', 1)
+    tracker.info('checkBinPath', 'Finding npm global bin in your PATH')
+    if (!process.env.PATH.includes(this.npm.globalBin)) {
+      throw new Error(`Add ${this.npm.globalBin} to your $PATH`)
+    }
+    return this.npm.globalBin
+  }
+
   async checkFilesPermission (root, shouldOwn, mask, missingOk) {
     let ok = true
 
@@ -217,7 +226,7 @@ class Doctor extends BaseCommand {
     try {
       return await which('git').catch(er => {
         tracker.warn(er)
-        throw "Install git and ensure it's in your PATH."
+        throw new Error("Install git and ensure it's in your PATH.")
       })
     } finally {
       tracker.finish()
@@ -344,9 +353,9 @@ class Doctor extends BaseCommand {
       ])
     }
 
-    // TODO
-    // subcmd === 'environment'
-    //  - ensure global bin is in process.env.PATH
+    if (!subcmds.length || subcmds.includes('environment')) {
+      a.push(['Global bin folder in PATH', 'checkBinPath', []])
+    }
 
     // TODO:
     // subcmd === 'dependencies'?

--- a/tap-snapshots/test/lib/commands/doctor.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/doctor.js.test.cjs
@@ -29,6 +29,10 @@ Object {
       "Finding git in your PATH",
     ],
     Array [
+      "getBinPath",
+      "Finding npm global bin in your PATH",
+    ],
+    Array [
       "verifyCachedFiles",
       "Verifying the npm cache",
     ],
@@ -43,10 +47,6 @@ Object {
         }
       ),
     ],
-    Array [
-      "checkBinPath",
-      "Finding npm global bin in your PATH",
-    ],
   ],
   "warn": Array [],
 }
@@ -58,14 +58,14 @@ npm ping                          [90m  [39mok    [90m  [39m
 npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
 node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
 npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
-which git                         [90m  [39mok    [90m  [39m/path/to/git
+git executable in PATH            [90m  [39mok    [90m  [39m/path/to/git
+global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-all-clear/global/bin
 Perms check on cached files       [90m  [39mok    [90m  [39m 
 Perms check on local node_modules [90m  [39mok    [90m  [39m 
 Perms check on global node_modules[90m  [39mok    [90m  [39m 
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
-Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-all-clear/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP all clear in color > everything is ok in color 1`] = `
@@ -74,14 +74,14 @@ npm ping                          [90m  [39m[32mok[39m    [90m  [39m
 npm -v                            [90m  [39m[32mok[39m    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
 node -v                           [90m  [39m[32mok[39m    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
 npm config get registry           [90m  [39m[32mok[39m    [90m  [39musing default registry (https://registry.npmjs.org/)
-which git                         [90m  [39m[32mok[39m    [90m  [39m/path/to/git
+git executable in PATH            [90m  [39m[32mok[39m    [90m  [39m/path/to/git
+global bin folder in PATH         [90m  [39m[32mok[39m    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-all-clear-in-color/global/bin
 Perms check on cached files       [90m  [39m[32mok[39m    [90m  [39m 
 Perms check on local node_modules [90m  [39m[32mok[39m    [90m  [39m 
 Perms check on global node_modules[90m  [39m[32mok[39m    [90m  [39m 
 Perms check on local bin folder   [90m  [39m[32mok[39m    [90m  [39m 
 Perms check on global bin folder  [90m  [39m[32mok[39m    [90m  [39m 
 Verify cache contents             [90m  [39m[32mok[39m    [90m  [39mverified 0 tarballs
-Global bin folder in PATH         [90m  [39m[32mok[39m    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-all-clear-in-color/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP all clear in color > logs 1`] = `
@@ -108,6 +108,10 @@ Object {
       "Finding git in your PATH",
     ],
     Array [
+      "getBinPath",
+      "Finding npm global bin in your PATH",
+    ],
+    Array [
       "verifyCachedFiles",
       "Verifying the npm cache",
     ],
@@ -121,10 +125,6 @@ Object {
           "verifiedContent": 0
         }
       ),
-    ],
-    Array [
-      "checkBinPath",
-      "Finding npm global bin in your PATH",
     ],
   ],
   "warn": Array [],
@@ -155,6 +155,10 @@ Object {
       "Finding git in your PATH",
     ],
     Array [
+      "getBinPath",
+      "Finding npm global bin in your PATH",
+    ],
+    Array [
       "verifyCachedFiles",
       "Verifying the npm cache",
     ],
@@ -169,10 +173,6 @@ Object {
         }
       ),
     ],
-    Array [
-      "checkBinPath",
-      "Finding npm global bin in your PATH",
-    ],
   ],
   "warn": Array [],
 }
@@ -184,14 +184,14 @@ npm ping                          [90m  [39mnot ok[90m  [39munsupported prox
 npm -v                            [90m  [39mnot ok[90m  [39mError: unsupported proxy protocol: 'ssh:'
 node -v                           [90m  [39mnot ok[90m  [39mError: unsupported proxy protocol: 'ssh:'
 npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
-which git                         [90m  [39mok    [90m  [39m/path/to/git
+git executable in PATH            [90m  [39mok    [90m  [39m/path/to/git
+global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-bad-proxy/global/bin
 Perms check on cached files       [90m  [39mok    [90m  [39m 
 Perms check on local node_modules [90m  [39mok    [90m  [39m 
 Perms check on global node_modules[90m  [39mok    [90m  [39m 
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
-Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-bad-proxy/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP cacache badContent > corrupted cache content 1`] = `
@@ -200,14 +200,14 @@ npm ping                          [90m  [39mok    [90m  [39m
 npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
 node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
 npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
-which git                         [90m  [39mok    [90m  [39m/path/to/git
+git executable in PATH            [90m  [39mok    [90m  [39m/path/to/git
+global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-cacache-badContent/global/bin
 Perms check on cached files       [90m  [39mok    [90m  [39m 
 Perms check on local node_modules [90m  [39mok    [90m  [39m 
 Perms check on global node_modules[90m  [39mok    [90m  [39m 
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 2 tarballs
-Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-cacache-badContent/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP cacache badContent > logs 1`] = `
@@ -234,6 +234,10 @@ Object {
       "Finding git in your PATH",
     ],
     Array [
+      "getBinPath",
+      "Finding npm global bin in your PATH",
+    ],
+    Array [
       "verifyCachedFiles",
       "Verifying the npm cache",
     ],
@@ -247,10 +251,6 @@ Object {
           "verifiedContent": 2
         }
       ),
-    ],
-    Array [
-      "checkBinPath",
-      "Finding npm global bin in your PATH",
     ],
   ],
   "warn": Array [
@@ -290,6 +290,10 @@ Object {
       "Finding git in your PATH",
     ],
     Array [
+      "getBinPath",
+      "Finding npm global bin in your PATH",
+    ],
+    Array [
       "verifyCachedFiles",
       "Verifying the npm cache",
     ],
@@ -303,10 +307,6 @@ Object {
           "verifiedContent": 2
         }
       ),
-    ],
-    Array [
-      "checkBinPath",
-      "Finding npm global bin in your PATH",
     ],
   ],
   "warn": Array [
@@ -328,14 +328,14 @@ npm ping                          [90m  [39mok    [90m  [39m
 npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
 node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
 npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
-which git                         [90m  [39mok    [90m  [39m/path/to/git
+git executable in PATH            [90m  [39mok    [90m  [39m/path/to/git
+global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-cacache-missingContent/global/bin
 Perms check on cached files       [90m  [39mok    [90m  [39m 
 Perms check on local node_modules [90m  [39mok    [90m  [39m 
 Perms check on global node_modules[90m  [39mok    [90m  [39m 
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 2 tarballs
-Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-cacache-missingContent/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP cacache reclaimedCount > content garbage collected 1`] = `
@@ -344,14 +344,14 @@ npm ping                          [90m  [39mok    [90m  [39m
 npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
 node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
 npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
-which git                         [90m  [39mok    [90m  [39m/path/to/git
+git executable in PATH            [90m  [39mok    [90m  [39m/path/to/git
+global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-cacache-reclaimedCount/global/bin
 Perms check on cached files       [90m  [39mok    [90m  [39m 
 Perms check on local node_modules [90m  [39mok    [90m  [39m 
 Perms check on global node_modules[90m  [39mok    [90m  [39m 
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 2 tarballs
-Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-cacache-reclaimedCount/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP cacache reclaimedCount > logs 1`] = `
@@ -378,6 +378,10 @@ Object {
       "Finding git in your PATH",
     ],
     Array [
+      "getBinPath",
+      "Finding npm global bin in your PATH",
+    ],
+    Array [
       "verifyCachedFiles",
       "Verifying the npm cache",
     ],
@@ -391,10 +395,6 @@ Object {
           "verifiedContent": 2
         }
       ),
-    ],
-    Array [
-      "checkBinPath",
-      "Finding npm global bin in your PATH",
     ],
   ],
   "warn": Array [
@@ -438,8 +438,9 @@ Object {
 `
 
 exports[`test/lib/commands/doctor.js TAP discrete checks cache > output 1`] = `
-Check                [90m  [39mValue [90m  [39mRecommendation/Notes
-Verify cache contents[90m  [39mok    [90m  [39mverified 0 tarballs
+Check                      [90m  [39mValue [90m  [39mRecommendation/Notes
+Perms check on cached files[90m  [39mok    [90m  [39m 
+Verify cache contents      [90m  [39mok    [90m  [39mverified 0 tarballs
 `
 
 exports[`test/lib/commands/doctor.js TAP discrete checks git > logs 1`] = `
@@ -449,18 +450,13 @@ Object {
     Array [
       "Running checkup",
     ],
-    Array [
-      "getGitPath",
-      "Finding git in your PATH",
-    ],
   ],
   "warn": Array [],
 }
 `
 
 exports[`test/lib/commands/doctor.js TAP discrete checks git > output 1`] = `
-Check    [90m  [39mValue [90m  [39mRecommendation/Notes
-which git[90m  [39mok    [90m  [39m/path/to/git
+Check[90m  [39mValue [90m  [39mRecommendation/Notes
 `
 
 exports[`test/lib/commands/doctor.js TAP discrete checks invalid environment > logs 1`] = `
@@ -471,7 +467,11 @@ Object {
       "Running checkup",
     ],
     Array [
-      "checkBinPath",
+      "getGitPath",
+      "Finding git in your PATH",
+    ],
+    Array [
+      "getBinPath",
       "Finding npm global bin in your PATH",
     ],
   ],
@@ -481,7 +481,8 @@ Object {
 
 exports[`test/lib/commands/doctor.js TAP discrete checks invalid environment > output 1`] = `
 Check                    [90m  [39mValue [90m  [39mRecommendation/Notes
-Global bin folder in PATH[90m  [39mnot ok[90m  [39mError: Add {CWD}/test/lib/commands/tap-testdir-doctor-discrete-checks-invalid-environment/global/bin to your $PATH
+git executable in PATH   [90m  [39mok    [90m  [39m/path/to/git
+global bin folder in PATH[90m  [39mnot ok[90m  [39mError: Add {CWD}/test/lib/commands/tap-testdir-doctor-discrete-checks-invalid-environment/global/bin to your $PATH
 `
 
 exports[`test/lib/commands/doctor.js TAP discrete checks permissions - not windows > logs 1`] = `
@@ -513,11 +514,7 @@ Object {
       "Running checkup",
     ],
   ],
-  "warn": Array [
-    Array [
-      "Ignoring permissions checks for windows",
-    ],
-  ],
+  "warn": Array [],
 }
 `
 
@@ -553,6 +550,10 @@ Object {
     Array [
       "Running checkup",
     ],
+    Array [
+      "checkPing",
+      "Pinging registry",
+    ],
   ],
   "warn": Array [],
 }
@@ -560,6 +561,7 @@ Object {
 
 exports[`test/lib/commands/doctor.js TAP discrete checks registry > output 1`] = `
 Check                  [90m  [39mValue [90m  [39mRecommendation/Notes
+npm ping               [90m  [39mok    [90m  [39m 
 npm config get registry[90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
 `
 
@@ -613,6 +615,10 @@ Object {
       "Finding git in your PATH",
     ],
     Array [
+      "getBinPath",
+      "Finding npm global bin in your PATH",
+    ],
+    Array [
       "verifyCachedFiles",
       "Verifying the npm cache",
     ],
@@ -626,10 +632,6 @@ Object {
           "verifiedContent": 0
         }
       ),
-    ],
-    Array [
-      "checkBinPath",
-      "Finding npm global bin in your PATH",
     ],
   ],
   "warn": Array [
@@ -663,14 +665,14 @@ npm ping                          [90m  [39mok    [90m  [39m
 npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
 node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
 npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
-which git                         [90m  [39mok    [90m  [39m/path/to/git
+git executable in PATH            [90m  [39mok    [90m  [39m/path/to/git
+global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-error-reading-directory/global/bin
 Perms check on cached files       [90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-error-reading-directory/cache (should be owned by current user)
 Perms check on local node_modules [90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-error-reading-directory/prefix/node_modules (should be owned by current user)
 Perms check on global node_modules[90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-error-reading-directory/global/lib/node_modules
 Perms check on local bin folder   [90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-error-reading-directory/prefix/node_modules/.bin
 Perms check on global bin folder  [90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-error-reading-directory/global/bin
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
-Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-error-reading-directory/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP incorrect owner > incorrect owner 1`] = `
@@ -679,14 +681,14 @@ npm ping                          [90m  [39mok    [90m  [39m
 npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
 node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
 npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
-which git                         [90m  [39mok    [90m  [39m/path/to/git
+git executable in PATH            [90m  [39mok    [90m  [39m/path/to/git
+global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-incorrect-owner/global/bin
 Perms check on cached files       [90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-incorrect-owner/cache (should be owned by current user)
 Perms check on local node_modules [90m  [39mok    [90m  [39m 
 Perms check on global node_modules[90m  [39mok    [90m  [39m 
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
-Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-incorrect-owner/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP incorrect owner > logs 1`] = `
@@ -713,6 +715,10 @@ Object {
       "Finding git in your PATH",
     ],
     Array [
+      "getBinPath",
+      "Finding npm global bin in your PATH",
+    ],
+    Array [
       "verifyCachedFiles",
       "Verifying the npm cache",
     ],
@@ -726,10 +732,6 @@ Object {
           "verifiedContent": 0
         }
       ),
-    ],
-    Array [
-      "checkBinPath",
-      "Finding npm global bin in your PATH",
     ],
   ],
   "warn": Array [
@@ -747,14 +749,14 @@ npm ping                          [90m  [39mok    [90m  [39m
 npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
 node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
 npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
-which git                         [90m  [39mok    [90m  [39m/path/to/git
+git executable in PATH            [90m  [39mok    [90m  [39m/path/to/git
+global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-incorrect-permissions/global/bin
 Perms check on cached files       [90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-incorrect-permissions/cache (should be owned by current user)
 Perms check on local node_modules [90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-incorrect-permissions/prefix/node_modules (should be owned by current user)
 Perms check on global node_modules[90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-incorrect-permissions/global/lib/node_modules
 Perms check on local bin folder   [90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-incorrect-permissions/prefix/node_modules/.bin
 Perms check on global bin folder  [90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-incorrect-permissions/global/bin
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
-Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-incorrect-permissions/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP incorrect permissions > logs 1`] = `
@@ -802,6 +804,10 @@ Object {
       "Finding git in your PATH",
     ],
     Array [
+      "getBinPath",
+      "Finding npm global bin in your PATH",
+    ],
+    Array [
       "verifyCachedFiles",
       "Verifying the npm cache",
     ],
@@ -815,10 +821,6 @@ Object {
           "verifiedContent": 0
         }
       ),
-    ],
-    Array [
-      "checkBinPath",
-      "Finding npm global bin in your PATH",
     ],
   ],
   "warn": Array [],
@@ -849,6 +851,10 @@ Object {
       "Finding git in your PATH",
     ],
     Array [
+      "getBinPath",
+      "Finding npm global bin in your PATH",
+    ],
+    Array [
       "verifyCachedFiles",
       "Verifying the npm cache",
     ],
@@ -862,10 +868,6 @@ Object {
           "verifiedContent": 0
         }
       ),
-    ],
-    Array [
-      "checkBinPath",
-      "Finding npm global bin in your PATH",
     ],
   ],
   "warn": Array [
@@ -882,14 +884,14 @@ npm ping                          [90m  [39mok    [90m  [39m
 npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
 node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
 npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
-which git                         [90m  [39mnot ok[90m  [39mError: Install git and ensure it's in your PATH.
+git executable in PATH            [90m  [39mnot ok[90m  [39mError: Install git and ensure it's in your PATH.
+global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-missing-git/global/bin
 Perms check on cached files       [90m  [39mok    [90m  [39m 
 Perms check on local node_modules [90m  [39mok    [90m  [39m 
 Perms check on global node_modules[90m  [39mok    [90m  [39m 
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
-Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-missing-git/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP missing global directories > logs 1`] = `
@@ -916,6 +918,10 @@ Object {
       "Finding git in your PATH",
     ],
     Array [
+      "getBinPath",
+      "Finding npm global bin in your PATH",
+    ],
+    Array [
       "verifyCachedFiles",
       "Verifying the npm cache",
     ],
@@ -929,10 +935,6 @@ Object {
           "verifiedContent": 0
         }
       ),
-    ],
-    Array [
-      "checkBinPath",
-      "Finding npm global bin in your PATH",
     ],
   ],
   "warn": Array [
@@ -954,14 +956,14 @@ npm ping                          [90m  [39mok    [90m  [39m
 npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
 node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
 npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
-which git                         [90m  [39mok    [90m  [39m/path/to/git
+git executable in PATH            [90m  [39mok    [90m  [39m/path/to/git
+global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-missing-global-directories/global/bin
 Perms check on cached files       [90m  [39mok    [90m  [39m 
 Perms check on local node_modules [90m  [39mok    [90m  [39m 
 Perms check on global node_modules[90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-missing-global-directories/global/lib/node_modules
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-missing-global-directories/global/bin
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
-Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-missing-global-directories/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP missing local node_modules > logs 1`] = `
@@ -988,6 +990,10 @@ Object {
       "Finding git in your PATH",
     ],
     Array [
+      "getBinPath",
+      "Finding npm global bin in your PATH",
+    ],
+    Array [
       "verifyCachedFiles",
       "Verifying the npm cache",
     ],
@@ -1002,10 +1008,6 @@ Object {
         }
       ),
     ],
-    Array [
-      "checkBinPath",
-      "Finding npm global bin in your PATH",
-    ],
   ],
   "warn": Array [],
 }
@@ -1017,14 +1019,14 @@ npm ping                          [90m  [39mok    [90m  [39m
 npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
 node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
 npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
-which git                         [90m  [39mok    [90m  [39m/path/to/git
+git executable in PATH            [90m  [39mok    [90m  [39m/path/to/git
+global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-missing-local-node_modules/global/bin
 Perms check on cached files       [90m  [39mok    [90m  [39m 
 Perms check on local node_modules [90m  [39mok    [90m  [39m 
 Perms check on global node_modules[90m  [39mok    [90m  [39m 
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
-Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-missing-local-node_modules/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP node out of date - current > logs 1`] = `
@@ -1051,6 +1053,10 @@ Object {
       "Finding git in your PATH",
     ],
     Array [
+      "getBinPath",
+      "Finding npm global bin in your PATH",
+    ],
+    Array [
       "verifyCachedFiles",
       "Verifying the npm cache",
     ],
@@ -1065,10 +1071,6 @@ Object {
         }
       ),
     ],
-    Array [
-      "checkBinPath",
-      "Finding npm global bin in your PATH",
-    ],
   ],
   "warn": Array [],
 }
@@ -1080,14 +1082,14 @@ npm ping                          [90m  [39mok    [90m  [39m
 npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
 node -v                           [90m  [39mnot ok[90m  [39mUse node v2.0.1 (current: v2.0.0)
 npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
-which git                         [90m  [39mok    [90m  [39m/path/to/git
+git executable in PATH            [90m  [39mok    [90m  [39m/path/to/git
+global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-node-out-of-date---current/global/bin
 Perms check on cached files       [90m  [39mok    [90m  [39m 
 Perms check on local node_modules [90m  [39mok    [90m  [39m 
 Perms check on global node_modules[90m  [39mok    [90m  [39m 
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
-Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-node-out-of-date---current/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP node out of date - lts > logs 1`] = `
@@ -1114,6 +1116,10 @@ Object {
       "Finding git in your PATH",
     ],
     Array [
+      "getBinPath",
+      "Finding npm global bin in your PATH",
+    ],
+    Array [
       "verifyCachedFiles",
       "Verifying the npm cache",
     ],
@@ -1128,10 +1134,6 @@ Object {
         }
       ),
     ],
-    Array [
-      "checkBinPath",
-      "Finding npm global bin in your PATH",
-    ],
   ],
   "warn": Array [],
 }
@@ -1143,14 +1145,14 @@ npm ping                          [90m  [39mok    [90m  [39m
 npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
 node -v                           [90m  [39mnot ok[90m  [39mUse node v1.0.0 (current: v0.0.1)
 npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
-which git                         [90m  [39mok    [90m  [39m/path/to/git
+git executable in PATH            [90m  [39mok    [90m  [39m/path/to/git
+global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-node-out-of-date---lts/global/bin
 Perms check on cached files       [90m  [39mok    [90m  [39m 
 Perms check on local node_modules [90m  [39mok    [90m  [39m 
 Perms check on global node_modules[90m  [39mok    [90m  [39m 
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
-Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-node-out-of-date---lts/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP non-default registry > logs 1`] = `
@@ -1177,6 +1179,10 @@ Object {
       "Finding git in your PATH",
     ],
     Array [
+      "getBinPath",
+      "Finding npm global bin in your PATH",
+    ],
+    Array [
       "verifyCachedFiles",
       "Verifying the npm cache",
     ],
@@ -1191,10 +1197,6 @@ Object {
         }
       ),
     ],
-    Array [
-      "checkBinPath",
-      "Finding npm global bin in your PATH",
-    ],
   ],
   "warn": Array [],
 }
@@ -1206,14 +1208,14 @@ npm ping                          [90m  [39mok    [90m  [39m
 npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
 node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
 npm config get registry           [90m  [39mnot ok[90m  [39mTry \`npm config set registry=https://registry.npmjs.org/\`
-which git                         [90m  [39mok    [90m  [39m/path/to/git
+git executable in PATH            [90m  [39mok    [90m  [39m/path/to/git
+global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-non-default-registry/global/bin
 Perms check on cached files       [90m  [39mok    [90m  [39m 
 Perms check on local node_modules [90m  [39mok    [90m  [39m 
 Perms check on global node_modules[90m  [39mok    [90m  [39m 
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
-Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-non-default-registry/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP npm out of date > logs 1`] = `
@@ -1240,6 +1242,10 @@ Object {
       "Finding git in your PATH",
     ],
     Array [
+      "getBinPath",
+      "Finding npm global bin in your PATH",
+    ],
+    Array [
       "verifyCachedFiles",
       "Verifying the npm cache",
     ],
@@ -1254,10 +1260,6 @@ Object {
         }
       ),
     ],
-    Array [
-      "checkBinPath",
-      "Finding npm global bin in your PATH",
-    ],
   ],
   "warn": Array [],
 }
@@ -1269,14 +1271,14 @@ npm ping                          [90m  [39mok    [90m  [39m
 npm -v                            [90m  [39mnot ok[90m  [39mUse npm v2.0.0
 node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
 npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
-which git                         [90m  [39mok    [90m  [39m/path/to/git
+git executable in PATH            [90m  [39mok    [90m  [39m/path/to/git
+global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-npm-out-of-date/global/bin
 Perms check on cached files       [90m  [39mok    [90m  [39m 
 Perms check on local node_modules [90m  [39mok    [90m  [39m 
 Perms check on global node_modules[90m  [39mok    [90m  [39m 
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
-Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-npm-out-of-date/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP ping 404 > logs 1`] = `
@@ -1303,6 +1305,10 @@ Object {
       "Finding git in your PATH",
     ],
     Array [
+      "getBinPath",
+      "Finding npm global bin in your PATH",
+    ],
+    Array [
       "verifyCachedFiles",
       "Verifying the npm cache",
     ],
@@ -1317,10 +1323,6 @@ Object {
         }
       ),
     ],
-    Array [
-      "checkBinPath",
-      "Finding npm global bin in your PATH",
-    ],
   ],
   "warn": Array [],
 }
@@ -1332,14 +1334,14 @@ npm ping                          [90m  [39mnot ok[90m  [39m404 404 Not Foun
 npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
 node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
 npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
-which git                         [90m  [39mok    [90m  [39m/path/to/git
+git executable in PATH            [90m  [39mok    [90m  [39m/path/to/git
+global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-ping-404/global/bin
 Perms check on cached files       [90m  [39mok    [90m  [39m 
 Perms check on local node_modules [90m  [39mok    [90m  [39m 
 Perms check on global node_modules[90m  [39mok    [90m  [39m 
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
-Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-ping-404/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP ping 404 in color > logs 1`] = `
@@ -1366,6 +1368,10 @@ Object {
       "Finding git in your PATH",
     ],
     Array [
+      "getBinPath",
+      "Finding npm global bin in your PATH",
+    ],
+    Array [
       "verifyCachedFiles",
       "Verifying the npm cache",
     ],
@@ -1380,10 +1386,6 @@ Object {
         }
       ),
     ],
-    Array [
-      "checkBinPath",
-      "Finding npm global bin in your PATH",
-    ],
   ],
   "warn": Array [],
 }
@@ -1395,14 +1397,14 @@ exports[`test/lib/commands/doctor.js TAP ping 404 in color > ping 404 in color 1
 npm -v                            [90m  [39m[32mok[39m    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
 node -v                           [90m  [39m[32mok[39m    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
 npm config get registry           [90m  [39m[32mok[39m    [90m  [39musing default registry (https://registry.npmjs.org/)
-which git                         [90m  [39m[32mok[39m    [90m  [39m/path/to/git
+git executable in PATH            [90m  [39m[32mok[39m    [90m  [39m/path/to/git
+global bin folder in PATH         [90m  [39m[32mok[39m    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-ping-404-in-color/global/bin
 Perms check on cached files       [90m  [39m[32mok[39m    [90m  [39m 
 Perms check on local node_modules [90m  [39m[32mok[39m    [90m  [39m 
 Perms check on global node_modules[90m  [39m[32mok[39m    [90m  [39m 
 Perms check on local bin folder   [90m  [39m[32mok[39m    [90m  [39m 
 Perms check on global bin folder  [90m  [39m[32mok[39m    [90m  [39m 
 Verify cache contents             [90m  [39m[32mok[39m    [90m  [39mverified 0 tarballs
-Global bin folder in PATH         [90m  [39m[32mok[39m    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-ping-404-in-color/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP ping exception with code > logs 1`] = `
@@ -1429,6 +1431,10 @@ Object {
       "Finding git in your PATH",
     ],
     Array [
+      "getBinPath",
+      "Finding npm global bin in your PATH",
+    ],
+    Array [
       "verifyCachedFiles",
       "Verifying the npm cache",
     ],
@@ -1443,10 +1449,6 @@ Object {
         }
       ),
     ],
-    Array [
-      "checkBinPath",
-      "Finding npm global bin in your PATH",
-    ],
   ],
   "warn": Array [],
 }
@@ -1458,14 +1460,14 @@ npm ping                          [90m  [39mnot ok[90m  [39mrequest to https
 npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
 node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
 npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
-which git                         [90m  [39mok    [90m  [39m/path/to/git
+git executable in PATH            [90m  [39mok    [90m  [39m/path/to/git
+global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-ping-exception-with-code/global/bin
 Perms check on cached files       [90m  [39mok    [90m  [39m 
 Perms check on local node_modules [90m  [39mok    [90m  [39m 
 Perms check on global node_modules[90m  [39mok    [90m  [39m 
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
-Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-ping-exception-with-code/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP ping exception without code > logs 1`] = `
@@ -1492,6 +1494,10 @@ Object {
       "Finding git in your PATH",
     ],
     Array [
+      "getBinPath",
+      "Finding npm global bin in your PATH",
+    ],
+    Array [
       "verifyCachedFiles",
       "Verifying the npm cache",
     ],
@@ -1506,10 +1512,6 @@ Object {
         }
       ),
     ],
-    Array [
-      "checkBinPath",
-      "Finding npm global bin in your PATH",
-    ],
   ],
   "warn": Array [],
 }
@@ -1521,17 +1523,37 @@ npm ping                          [90m  [39mnot ok[90m  [39mrequest to https
 npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
 node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
 npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
-which git                         [90m  [39mok    [90m  [39m/path/to/git
+git executable in PATH            [90m  [39mok    [90m  [39m/path/to/git
+global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-ping-exception-without-code/global/bin
 Perms check on cached files       [90m  [39mok    [90m  [39m 
 Perms check on local node_modules [90m  [39mok    [90m  [39m 
 Perms check on global node_modules[90m  [39mok    [90m  [39m 
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
-Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-ping-exception-without-code/global/bin
 `
 
-exports[`test/lib/commands/doctor.js TAP silent > logs 1`] = `
+exports[`test/lib/commands/doctor.js TAP silent errors > logs 1`] = `
+Object {
+  "error": Array [],
+  "info": Array [
+    Array [
+      "Running checkup",
+    ],
+    Array [
+      "checkPing",
+      "Pinging registry",
+    ],
+  ],
+  "warn": Array [],
+}
+`
+
+exports[`test/lib/commands/doctor.js TAP silent errors > output 1`] = `
+
+`
+
+exports[`test/lib/commands/doctor.js TAP silent success > logs 1`] = `
 Object {
   "error": Array [],
   "info": Array [
@@ -1555,6 +1577,10 @@ Object {
       "Finding git in your PATH",
     ],
     Array [
+      "getBinPath",
+      "Finding npm global bin in your PATH",
+    ],
+    Array [
       "verifyCachedFiles",
       "Verifying the npm cache",
     ],
@@ -1569,16 +1595,12 @@ Object {
         }
       ),
     ],
-    Array [
-      "checkBinPath",
-      "Finding npm global bin in your PATH",
-    ],
   ],
   "warn": Array [],
 }
 `
 
-exports[`test/lib/commands/doctor.js TAP silent > output 1`] = `
+exports[`test/lib/commands/doctor.js TAP silent success > output 1`] = `
 
 `
 
@@ -1606,22 +1628,7 @@ Object {
       "Finding git in your PATH",
     ],
     Array [
-      "verifyCachedFiles",
-      "Verifying the npm cache",
-    ],
-    Array [
-      "verifyCachedFiles",
-      String(
-        Verification complete. Stats: {
-          "badContentCount": 0,
-          "reclaimedCount": 0,
-          "missingContent": 0,
-          "verifiedContent": 0
-        }
-      ),
-    ],
-    Array [
-      "checkBinPath",
+      "getBinPath",
       "Finding npm global bin in your PATH",
     ],
   ],
@@ -1635,7 +1642,6 @@ npm ping                 [90m  [39mok    [90m  [39m
 npm -v                   [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
 node -v                  [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
 npm config get registry  [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
-which git                [90m  [39mok    [90m  [39m/path/to/git
-Verify cache contents    [90m  [39mok    [90m  [39mverified 0 tarballs
-Global bin folder in PATH[90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-windows-skips-permissions-checks/global
+git executable in PATH   [90m  [39mok    [90m  [39m/path/to/git
+global bin folder in PATH[90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-windows-skips-permissions-checks/global
 `

--- a/tap-snapshots/test/lib/commands/doctor.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/doctor.js.test.cjs
@@ -43,6 +43,10 @@ Object {
         }
       ),
     ],
+    Array [
+      "checkBinPath",
+      "Finding npm global bin in your PATH",
+    ],
   ],
   "warn": Array [],
 }
@@ -61,6 +65,7 @@ Perms check on global node_modules[90m  [39mok    [90m  [39m
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
+Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-all-clear/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP all clear in color > everything is ok in color 1`] = `
@@ -76,6 +81,7 @@ Perms check on global node_modules[90m  [39m[32mok[39m    [90m  [39m
 Perms check on local bin folder   [90m  [39m[32mok[39m    [90m  [39m 
 Perms check on global bin folder  [90m  [39m[32mok[39m    [90m  [39m 
 Verify cache contents             [90m  [39m[32mok[39m    [90m  [39mverified 0 tarballs
+Global bin folder in PATH         [90m  [39m[32mok[39m    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-all-clear-in-color/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP all clear in color > logs 1`] = `
@@ -115,6 +121,10 @@ Object {
           "verifiedContent": 0
         }
       ),
+    ],
+    Array [
+      "checkBinPath",
+      "Finding npm global bin in your PATH",
     ],
   ],
   "warn": Array [],
@@ -159,6 +169,10 @@ Object {
         }
       ),
     ],
+    Array [
+      "checkBinPath",
+      "Finding npm global bin in your PATH",
+    ],
   ],
   "warn": Array [],
 }
@@ -177,6 +191,7 @@ Perms check on global node_modules[90m  [39mok    [90m  [39m
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
+Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-bad-proxy/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP cacache badContent > corrupted cache content 1`] = `
@@ -192,6 +207,7 @@ Perms check on global node_modules[90m  [39mok    [90m  [39m
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 2 tarballs
+Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-cacache-badContent/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP cacache badContent > logs 1`] = `
@@ -231,6 +247,10 @@ Object {
           "verifiedContent": 2
         }
       ),
+    ],
+    Array [
+      "checkBinPath",
+      "Finding npm global bin in your PATH",
     ],
   ],
   "warn": Array [
@@ -284,6 +304,10 @@ Object {
         }
       ),
     ],
+    Array [
+      "checkBinPath",
+      "Finding npm global bin in your PATH",
+    ],
   ],
   "warn": Array [
     Array [
@@ -311,6 +335,7 @@ Perms check on global node_modules[90m  [39mok    [90m  [39m
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 2 tarballs
+Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-cacache-missingContent/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP cacache reclaimedCount > content garbage collected 1`] = `
@@ -326,6 +351,7 @@ Perms check on global node_modules[90m  [39mok    [90m  [39m
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 2 tarballs
+Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-cacache-reclaimedCount/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP cacache reclaimedCount > logs 1`] = `
@@ -365,6 +391,10 @@ Object {
           "verifiedContent": 2
         }
       ),
+    ],
+    Array [
+      "checkBinPath",
+      "Finding npm global bin in your PATH",
     ],
   ],
   "warn": Array [
@@ -431,6 +461,27 @@ Object {
 exports[`test/lib/commands/doctor.js TAP discrete checks git > output 1`] = `
 Check    [90m  [39mValue [90m  [39mRecommendation/Notes
 which git[90m  [39mok    [90m  [39m/path/to/git
+`
+
+exports[`test/lib/commands/doctor.js TAP discrete checks invalid environment > logs 1`] = `
+Object {
+  "error": Array [],
+  "info": Array [
+    Array [
+      "Running checkup",
+    ],
+    Array [
+      "checkBinPath",
+      "Finding npm global bin in your PATH",
+    ],
+  ],
+  "warn": Array [],
+}
+`
+
+exports[`test/lib/commands/doctor.js TAP discrete checks invalid environment > output 1`] = `
+Check                    [90m  [39mValue [90m  [39mRecommendation/Notes
+Global bin folder in PATH[90m  [39mnot ok[90m  [39mError: Add {CWD}/test/lib/commands/tap-testdir-doctor-discrete-checks-invalid-environment/global/bin to your $PATH
 `
 
 exports[`test/lib/commands/doctor.js TAP discrete checks permissions - not windows > logs 1`] = `
@@ -576,6 +627,10 @@ Object {
         }
       ),
     ],
+    Array [
+      "checkBinPath",
+      "Finding npm global bin in your PATH",
+    ],
   ],
   "warn": Array [
     Array [
@@ -615,6 +670,7 @@ Perms check on global node_modules[90m  [39mnot ok[90m  [39mCheck the permis
 Perms check on local bin folder   [90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-error-reading-directory/prefix/node_modules/.bin
 Perms check on global bin folder  [90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-error-reading-directory/global/bin
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
+Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-error-reading-directory/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP incorrect owner > incorrect owner 1`] = `
@@ -630,6 +686,7 @@ Perms check on global node_modules[90m  [39mok    [90m  [39m
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
+Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-incorrect-owner/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP incorrect owner > logs 1`] = `
@@ -670,6 +727,10 @@ Object {
         }
       ),
     ],
+    Array [
+      "checkBinPath",
+      "Finding npm global bin in your PATH",
+    ],
   ],
   "warn": Array [
     Array [
@@ -693,6 +754,7 @@ Perms check on global node_modules[90m  [39mnot ok[90m  [39mCheck the permis
 Perms check on local bin folder   [90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-incorrect-permissions/prefix/node_modules/.bin
 Perms check on global bin folder  [90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-incorrect-permissions/global/bin
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
+Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-incorrect-permissions/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP incorrect permissions > logs 1`] = `
@@ -754,6 +816,10 @@ Object {
         }
       ),
     ],
+    Array [
+      "checkBinPath",
+      "Finding npm global bin in your PATH",
+    ],
   ],
   "warn": Array [],
 }
@@ -797,6 +863,10 @@ Object {
         }
       ),
     ],
+    Array [
+      "checkBinPath",
+      "Finding npm global bin in your PATH",
+    ],
   ],
   "warn": Array [
     Array [
@@ -812,13 +882,14 @@ npm ping                          [90m  [39mok    [90m  [39m
 npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
 node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
 npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
-which git                         [90m  [39mnot ok[90m  [39mInstall git and ensure it's in your PATH.
+which git                         [90m  [39mnot ok[90m  [39mError: Install git and ensure it's in your PATH.
 Perms check on cached files       [90m  [39mok    [90m  [39m 
 Perms check on local node_modules [90m  [39mok    [90m  [39m 
 Perms check on global node_modules[90m  [39mok    [90m  [39m 
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
+Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-missing-git/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP missing global directories > logs 1`] = `
@@ -859,6 +930,10 @@ Object {
         }
       ),
     ],
+    Array [
+      "checkBinPath",
+      "Finding npm global bin in your PATH",
+    ],
   ],
   "warn": Array [
     Array [
@@ -886,6 +961,7 @@ Perms check on global node_modules[90m  [39mnot ok[90m  [39mCheck the permis
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-missing-global-directories/global/bin
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
+Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-missing-global-directories/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP missing local node_modules > logs 1`] = `
@@ -926,6 +1002,10 @@ Object {
         }
       ),
     ],
+    Array [
+      "checkBinPath",
+      "Finding npm global bin in your PATH",
+    ],
   ],
   "warn": Array [],
 }
@@ -944,6 +1024,7 @@ Perms check on global node_modules[90m  [39mok    [90m  [39m
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
+Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-missing-local-node_modules/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP node out of date - current > logs 1`] = `
@@ -984,6 +1065,10 @@ Object {
         }
       ),
     ],
+    Array [
+      "checkBinPath",
+      "Finding npm global bin in your PATH",
+    ],
   ],
   "warn": Array [],
 }
@@ -1002,6 +1087,7 @@ Perms check on global node_modules[90m  [39mok    [90m  [39m
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
+Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-node-out-of-date---current/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP node out of date - lts > logs 1`] = `
@@ -1042,6 +1128,10 @@ Object {
         }
       ),
     ],
+    Array [
+      "checkBinPath",
+      "Finding npm global bin in your PATH",
+    ],
   ],
   "warn": Array [],
 }
@@ -1060,6 +1150,7 @@ Perms check on global node_modules[90m  [39mok    [90m  [39m
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
+Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-node-out-of-date---lts/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP non-default registry > logs 1`] = `
@@ -1100,6 +1191,10 @@ Object {
         }
       ),
     ],
+    Array [
+      "checkBinPath",
+      "Finding npm global bin in your PATH",
+    ],
   ],
   "warn": Array [],
 }
@@ -1118,6 +1213,7 @@ Perms check on global node_modules[90m  [39mok    [90m  [39m
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
+Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-non-default-registry/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP npm out of date > logs 1`] = `
@@ -1158,6 +1254,10 @@ Object {
         }
       ),
     ],
+    Array [
+      "checkBinPath",
+      "Finding npm global bin in your PATH",
+    ],
   ],
   "warn": Array [],
 }
@@ -1176,6 +1276,7 @@ Perms check on global node_modules[90m  [39mok    [90m  [39m
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
+Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-npm-out-of-date/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP ping 404 > logs 1`] = `
@@ -1216,6 +1317,10 @@ Object {
         }
       ),
     ],
+    Array [
+      "checkBinPath",
+      "Finding npm global bin in your PATH",
+    ],
   ],
   "warn": Array [],
 }
@@ -1234,6 +1339,7 @@ Perms check on global node_modules[90m  [39mok    [90m  [39m
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
+Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-ping-404/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP ping 404 in color > logs 1`] = `
@@ -1274,6 +1380,10 @@ Object {
         }
       ),
     ],
+    Array [
+      "checkBinPath",
+      "Finding npm global bin in your PATH",
+    ],
   ],
   "warn": Array [],
 }
@@ -1292,6 +1402,7 @@ Perms check on global node_modules[90m  [39m[32mok[39m    [90m  [39m
 Perms check on local bin folder   [90m  [39m[32mok[39m    [90m  [39m 
 Perms check on global bin folder  [90m  [39m[32mok[39m    [90m  [39m 
 Verify cache contents             [90m  [39m[32mok[39m    [90m  [39mverified 0 tarballs
+Global bin folder in PATH         [90m  [39m[32mok[39m    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-ping-404-in-color/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP ping exception with code > logs 1`] = `
@@ -1332,6 +1443,10 @@ Object {
         }
       ),
     ],
+    Array [
+      "checkBinPath",
+      "Finding npm global bin in your PATH",
+    ],
   ],
   "warn": Array [],
 }
@@ -1350,6 +1465,7 @@ Perms check on global node_modules[90m  [39mok    [90m  [39m
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
+Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-ping-exception-with-code/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP ping exception without code > logs 1`] = `
@@ -1390,6 +1506,10 @@ Object {
         }
       ),
     ],
+    Array [
+      "checkBinPath",
+      "Finding npm global bin in your PATH",
+    ],
   ],
   "warn": Array [],
 }
@@ -1408,6 +1528,7 @@ Perms check on global node_modules[90m  [39mok    [90m  [39m
 Perms check on local bin folder   [90m  [39mok    [90m  [39m 
 Perms check on global bin folder  [90m  [39mok    [90m  [39m 
 Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
+Global bin folder in PATH         [90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-ping-exception-without-code/global/bin
 `
 
 exports[`test/lib/commands/doctor.js TAP silent > logs 1`] = `
@@ -1447,6 +1568,10 @@ Object {
           "verifiedContent": 0
         }
       ),
+    ],
+    Array [
+      "checkBinPath",
+      "Finding npm global bin in your PATH",
     ],
   ],
   "warn": Array [],
@@ -1495,17 +1620,22 @@ Object {
         }
       ),
     ],
+    Array [
+      "checkBinPath",
+      "Finding npm global bin in your PATH",
+    ],
   ],
   "warn": Array [],
 }
 `
 
 exports[`test/lib/commands/doctor.js TAP windows skips permissions checks > no permissions checks 1`] = `
-Check                  [90m  [39mValue [90m  [39mRecommendation/Notes
-npm ping               [90m  [39mok    [90m  [39m 
-npm -v                 [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
-node -v                [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
-npm config get registry[90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
-which git              [90m  [39mok    [90m  [39m/path/to/git
-Verify cache contents  [90m  [39mok    [90m  [39mverified 0 tarballs
+Check                    [90m  [39mValue [90m  [39mRecommendation/Notes
+npm ping                 [90m  [39mok    [90m  [39m 
+npm -v                   [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
+node -v                  [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
+npm config get registry  [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
+which git                [90m  [39mok    [90m  [39m/path/to/git
+Verify cache contents    [90m  [39mok    [90m  [39mverified 0 tarballs
+Global bin folder in PATH[90m  [39mok    [90m  [39m{CWD}/test/lib/commands/tap-testdir-doctor-windows-skips-permissions-checks/global
 `

--- a/tap-snapshots/test/lib/commands/doctor.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/doctor.js.test.cjs
@@ -380,6 +380,164 @@ Object {
 }
 `
 
+exports[`test/lib/commands/doctor.js TAP discrete checks cache > logs 1`] = `
+Object {
+  "error": Array [],
+  "info": Array [
+    Array [
+      "Running checkup",
+    ],
+    Array [
+      "verifyCachedFiles",
+      "Verifying the npm cache",
+    ],
+    Array [
+      "verifyCachedFiles",
+      String(
+        Verification complete. Stats: {
+          "badContentCount": 0,
+          "reclaimedCount": 0,
+          "missingContent": 0,
+          "verifiedContent": 0
+        }
+      ),
+    ],
+  ],
+  "warn": Array [],
+}
+`
+
+exports[`test/lib/commands/doctor.js TAP discrete checks cache > output 1`] = `
+Check                [90m  [39mValue [90m  [39mRecommendation/Notes
+Verify cache contents[90m  [39mok    [90m  [39mverified 0 tarballs
+`
+
+exports[`test/lib/commands/doctor.js TAP discrete checks git > logs 1`] = `
+Object {
+  "error": Array [],
+  "info": Array [
+    Array [
+      "Running checkup",
+    ],
+    Array [
+      "getGitPath",
+      "Finding git in your PATH",
+    ],
+  ],
+  "warn": Array [],
+}
+`
+
+exports[`test/lib/commands/doctor.js TAP discrete checks git > output 1`] = `
+Check    [90m  [39mValue [90m  [39mRecommendation/Notes
+which git[90m  [39mok    [90m  [39m/path/to/git
+`
+
+exports[`test/lib/commands/doctor.js TAP discrete checks permissions - not windows > logs 1`] = `
+Object {
+  "error": Array [],
+  "info": Array [
+    Array [
+      "Running checkup",
+    ],
+  ],
+  "warn": Array [],
+}
+`
+
+exports[`test/lib/commands/doctor.js TAP discrete checks permissions - not windows > output 1`] = `
+Check                             [90m  [39mValue [90m  [39mRecommendation/Notes
+Perms check on cached files       [90m  [39mok    [90m  [39m 
+Perms check on local node_modules [90m  [39mok    [90m  [39m 
+Perms check on global node_modules[90m  [39mok    [90m  [39m 
+Perms check on local bin folder   [90m  [39mok    [90m  [39m 
+Perms check on global bin folder  [90m  [39mok    [90m  [39m 
+`
+
+exports[`test/lib/commands/doctor.js TAP discrete checks permissions - windows > logs 1`] = `
+Object {
+  "error": Array [],
+  "info": Array [
+    Array [
+      "Running checkup",
+    ],
+  ],
+  "warn": Array [
+    Array [
+      "Ignoring permissions checks for windows",
+    ],
+  ],
+}
+`
+
+exports[`test/lib/commands/doctor.js TAP discrete checks permissions - windows > output 1`] = `
+Check[90m  [39mValue [90m  [39mRecommendation/Notes
+`
+
+exports[`test/lib/commands/doctor.js TAP discrete checks ping > logs 1`] = `
+Object {
+  "error": Array [],
+  "info": Array [
+    Array [
+      "Running checkup",
+    ],
+    Array [
+      "checkPing",
+      "Pinging registry",
+    ],
+  ],
+  "warn": Array [],
+}
+`
+
+exports[`test/lib/commands/doctor.js TAP discrete checks ping > output 1`] = `
+Check   [90m  [39mValue [90m  [39mRecommendation/Notes
+npm ping[90m  [39mok    [90m  [39m 
+`
+
+exports[`test/lib/commands/doctor.js TAP discrete checks registry > logs 1`] = `
+Object {
+  "error": Array [],
+  "info": Array [
+    Array [
+      "Running checkup",
+    ],
+  ],
+  "warn": Array [],
+}
+`
+
+exports[`test/lib/commands/doctor.js TAP discrete checks registry > output 1`] = `
+Check                  [90m  [39mValue [90m  [39mRecommendation/Notes
+npm config get registry[90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
+`
+
+exports[`test/lib/commands/doctor.js TAP discrete checks versions > logs 1`] = `
+Object {
+  "error": Array [],
+  "info": Array [
+    Array [
+      "Running checkup",
+    ],
+    Array [
+      "getLatestNpmVersion",
+      "Getting npm package information",
+    ],
+    Array [
+      "getLatestNodejsVersion",
+      "Getting Node.js release information",
+    ],
+  ],
+  "warn": Array [],
+}
+`
+
+exports[`test/lib/commands/doctor.js TAP discrete checks versions > output 1`] = `
+Check  [90m  [39mValue [90m  [39mRecommendation/Notes
+npm -v [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
+node -v[90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
+`
+
 exports[`test/lib/commands/doctor.js TAP error reading directory > logs 1`] = `
 Object {
   "error": Array [],

--- a/tap-snapshots/test/lib/commands/doctor.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/doctor.js.test.cjs
@@ -49,33 +49,33 @@ Object {
 `
 
 exports[`test/lib/commands/doctor.js TAP all clear > output 1`] = `
-Check                               Value  Recommendation/Notes
-npm ping                            ok
-npm -v                              ok     current: v1.0.0, latest: v1.0.0
-node -v                             ok     current: v1.0.0, recommended: v1.0.0
-npm config get registry             ok     using default registry (https://registry.npmjs.org/)
-which git                           ok     /path/to/git
-Perms check on cached files         ok
-Perms check on local node_modules   ok
-Perms check on global node_modules  ok
-Perms check on local bin folder     ok
-Perms check on global bin folder    ok
-Verify cache contents               ok     verified 0 tarballs
+Check                             [90m  [39mValue [90m  [39mRecommendation/Notes
+npm ping                          [90m  [39mok    [90m  [39m 
+npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
+node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
+npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
+which git                         [90m  [39mok    [90m  [39m/path/to/git
+Perms check on cached files       [90m  [39mok    [90m  [39m 
+Perms check on local node_modules [90m  [39mok    [90m  [39m 
+Perms check on global node_modules[90m  [39mok    [90m  [39m 
+Perms check on local bin folder   [90m  [39mok    [90m  [39m 
+Perms check on global bin folder  [90m  [39mok    [90m  [39m 
+Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
 `
 
 exports[`test/lib/commands/doctor.js TAP all clear in color > everything is ok in color 1`] = `
-[4mCheck[24m                               [4mValue[24m  [4mRecommendation/Notes[24m
-npm ping                            [32mok[39m
-npm -v                              [32mok[39m     current: v1.0.0, latest: v1.0.0
-node -v                             [32mok[39m     current: v1.0.0, recommended: v1.0.0
-npm config get registry             [32mok[39m     using default registry (https://registry.npmjs.org/)
-which git                           [32mok[39m     /path/to/git
-Perms check on cached files         [32mok[39m
-Perms check on local node_modules   [32mok[39m
-Perms check on global node_modules  [32mok[39m
-Perms check on local bin folder     [32mok[39m
-Perms check on global bin folder    [32mok[39m
-Verify cache contents               [32mok[39m     verified 0 tarballs
+[4mCheck[24m                             [90m  [39m[4mValue[24m [90m  [39m[4mRecommendation/Notes[24m
+npm ping                          [90m  [39m[32mok[39m    [90m  [39m 
+npm -v                            [90m  [39m[32mok[39m    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
+node -v                           [90m  [39m[32mok[39m    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
+npm config get registry           [90m  [39m[32mok[39m    [90m  [39musing default registry (https://registry.npmjs.org/)
+which git                         [90m  [39m[32mok[39m    [90m  [39m/path/to/git
+Perms check on cached files       [90m  [39m[32mok[39m    [90m  [39m 
+Perms check on local node_modules [90m  [39m[32mok[39m    [90m  [39m 
+Perms check on global node_modules[90m  [39m[32mok[39m    [90m  [39m 
+Perms check on local bin folder   [90m  [39m[32mok[39m    [90m  [39m 
+Perms check on global bin folder  [90m  [39m[32mok[39m    [90m  [39m 
+Verify cache contents             [90m  [39m[32mok[39m    [90m  [39mverified 0 tarballs
 `
 
 exports[`test/lib/commands/doctor.js TAP all clear in color > logs 1`] = `
@@ -165,33 +165,33 @@ Object {
 `
 
 exports[`test/lib/commands/doctor.js TAP bad proxy > output 1`] = `
-Check                               Value   Recommendation/Notes
-npm ping                            not ok  unsupported proxy protocol: 'ssh:'
-npm -v                              not ok  Error: unsupported proxy protocol: 'ssh:'
-node -v                             not ok  Error: unsupported proxy protocol: 'ssh:'
-npm config get registry             ok      using default registry (https://registry.npmjs.org/)
-which git                           ok      /path/to/git
-Perms check on cached files         ok
-Perms check on local node_modules   ok
-Perms check on global node_modules  ok
-Perms check on local bin folder     ok
-Perms check on global bin folder    ok
-Verify cache contents               ok      verified 0 tarballs
+Check                             [90m  [39mValue [90m  [39mRecommendation/Notes
+npm ping                          [90m  [39mnot ok[90m  [39munsupported proxy protocol: 'ssh:'
+npm -v                            [90m  [39mnot ok[90m  [39mError: unsupported proxy protocol: 'ssh:'
+node -v                           [90m  [39mnot ok[90m  [39mError: unsupported proxy protocol: 'ssh:'
+npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
+which git                         [90m  [39mok    [90m  [39m/path/to/git
+Perms check on cached files       [90m  [39mok    [90m  [39m 
+Perms check on local node_modules [90m  [39mok    [90m  [39m 
+Perms check on global node_modules[90m  [39mok    [90m  [39m 
+Perms check on local bin folder   [90m  [39mok    [90m  [39m 
+Perms check on global bin folder  [90m  [39mok    [90m  [39m 
+Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
 `
 
 exports[`test/lib/commands/doctor.js TAP cacache badContent > corrupted cache content 1`] = `
-Check                               Value  Recommendation/Notes
-npm ping                            ok
-npm -v                              ok     current: v1.0.0, latest: v1.0.0
-node -v                             ok     current: v1.0.0, recommended: v1.0.0
-npm config get registry             ok     using default registry (https://registry.npmjs.org/)
-which git                           ok     /path/to/git
-Perms check on cached files         ok
-Perms check on local node_modules   ok
-Perms check on global node_modules  ok
-Perms check on local bin folder     ok
-Perms check on global bin folder    ok
-Verify cache contents               ok     verified 2 tarballs
+Check                             [90m  [39mValue [90m  [39mRecommendation/Notes
+npm ping                          [90m  [39mok    [90m  [39m 
+npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
+node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
+npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
+which git                         [90m  [39mok    [90m  [39m/path/to/git
+Perms check on cached files       [90m  [39mok    [90m  [39m 
+Perms check on local node_modules [90m  [39mok    [90m  [39m 
+Perms check on global node_modules[90m  [39mok    [90m  [39m 
+Perms check on local bin folder   [90m  [39mok    [90m  [39m 
+Perms check on global bin folder  [90m  [39mok    [90m  [39m 
+Verify cache contents             [90m  [39mok    [90m  [39mverified 2 tarballs
 `
 
 exports[`test/lib/commands/doctor.js TAP cacache badContent > logs 1`] = `
@@ -299,33 +299,33 @@ Object {
 `
 
 exports[`test/lib/commands/doctor.js TAP cacache missingContent > missing content 1`] = `
-Check                               Value  Recommendation/Notes
-npm ping                            ok
-npm -v                              ok     current: v1.0.0, latest: v1.0.0
-node -v                             ok     current: v1.0.0, recommended: v1.0.0
-npm config get registry             ok     using default registry (https://registry.npmjs.org/)
-which git                           ok     /path/to/git
-Perms check on cached files         ok
-Perms check on local node_modules   ok
-Perms check on global node_modules  ok
-Perms check on local bin folder     ok
-Perms check on global bin folder    ok
-Verify cache contents               ok     verified 2 tarballs
+Check                             [90m  [39mValue [90m  [39mRecommendation/Notes
+npm ping                          [90m  [39mok    [90m  [39m 
+npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
+node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
+npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
+which git                         [90m  [39mok    [90m  [39m/path/to/git
+Perms check on cached files       [90m  [39mok    [90m  [39m 
+Perms check on local node_modules [90m  [39mok    [90m  [39m 
+Perms check on global node_modules[90m  [39mok    [90m  [39m 
+Perms check on local bin folder   [90m  [39mok    [90m  [39m 
+Perms check on global bin folder  [90m  [39mok    [90m  [39m 
+Verify cache contents             [90m  [39mok    [90m  [39mverified 2 tarballs
 `
 
 exports[`test/lib/commands/doctor.js TAP cacache reclaimedCount > content garbage collected 1`] = `
-Check                               Value  Recommendation/Notes
-npm ping                            ok
-npm -v                              ok     current: v1.0.0, latest: v1.0.0
-node -v                             ok     current: v1.0.0, recommended: v1.0.0
-npm config get registry             ok     using default registry (https://registry.npmjs.org/)
-which git                           ok     /path/to/git
-Perms check on cached files         ok
-Perms check on local node_modules   ok
-Perms check on global node_modules  ok
-Perms check on local bin folder     ok
-Perms check on global bin folder    ok
-Verify cache contents               ok     verified 2 tarballs
+Check                             [90m  [39mValue [90m  [39mRecommendation/Notes
+npm ping                          [90m  [39mok    [90m  [39m 
+npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
+node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
+npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
+which git                         [90m  [39mok    [90m  [39m/path/to/git
+Perms check on cached files       [90m  [39mok    [90m  [39m 
+Perms check on local node_modules [90m  [39mok    [90m  [39m 
+Perms check on global node_modules[90m  [39mok    [90m  [39m 
+Perms check on local bin folder   [90m  [39mok    [90m  [39m 
+Perms check on global bin folder  [90m  [39mok    [90m  [39m 
+Verify cache contents             [90m  [39mok    [90m  [39mverified 2 tarballs
 `
 
 exports[`test/lib/commands/doctor.js TAP cacache reclaimedCount > logs 1`] = `
@@ -445,33 +445,33 @@ Object {
 `
 
 exports[`test/lib/commands/doctor.js TAP error reading directory > readdir error 1`] = `
-Check                               Value   Recommendation/Notes
-npm ping                            ok
-npm -v                              ok      current: v1.0.0, latest: v1.0.0
-node -v                             ok      current: v1.0.0, recommended: v1.0.0
-npm config get registry             ok      using default registry (https://registry.npmjs.org/)
-which git                           ok      /path/to/git
-Perms check on cached files         not ok  Check the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-error-reading-directory/cache (should be owned by current user)
-Perms check on local node_modules   not ok  Check the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-error-reading-directory/prefix/node_modules (should be owned by current user)
-Perms check on global node_modules  not ok  Check the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-error-reading-directory/global/lib/node_modules
-Perms check on local bin folder     not ok  Check the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-error-reading-directory/prefix/node_modules/.bin
-Perms check on global bin folder    not ok  Check the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-error-reading-directory/global/bin
-Verify cache contents               ok      verified 0 tarballs
+Check                             [90m  [39mValue [90m  [39mRecommendation/Notes
+npm ping                          [90m  [39mok    [90m  [39m 
+npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
+node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
+npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
+which git                         [90m  [39mok    [90m  [39m/path/to/git
+Perms check on cached files       [90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-error-reading-directory/cache (should be owned by current user)
+Perms check on local node_modules [90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-error-reading-directory/prefix/node_modules (should be owned by current user)
+Perms check on global node_modules[90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-error-reading-directory/global/lib/node_modules
+Perms check on local bin folder   [90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-error-reading-directory/prefix/node_modules/.bin
+Perms check on global bin folder  [90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-error-reading-directory/global/bin
+Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
 `
 
 exports[`test/lib/commands/doctor.js TAP incorrect owner > incorrect owner 1`] = `
-Check                               Value   Recommendation/Notes
-npm ping                            ok
-npm -v                              ok      current: v1.0.0, latest: v1.0.0
-node -v                             ok      current: v1.0.0, recommended: v1.0.0
-npm config get registry             ok      using default registry (https://registry.npmjs.org/)
-which git                           ok      /path/to/git
-Perms check on cached files         not ok  Check the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-incorrect-owner/cache (should be owned by current user)
-Perms check on local node_modules   ok
-Perms check on global node_modules  ok
-Perms check on local bin folder     ok
-Perms check on global bin folder    ok
-Verify cache contents               ok      verified 0 tarballs
+Check                             [90m  [39mValue [90m  [39mRecommendation/Notes
+npm ping                          [90m  [39mok    [90m  [39m 
+npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
+node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
+npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
+which git                         [90m  [39mok    [90m  [39m/path/to/git
+Perms check on cached files       [90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-incorrect-owner/cache (should be owned by current user)
+Perms check on local node_modules [90m  [39mok    [90m  [39m 
+Perms check on global node_modules[90m  [39mok    [90m  [39m 
+Perms check on local bin folder   [90m  [39mok    [90m  [39m 
+Perms check on global bin folder  [90m  [39mok    [90m  [39m 
+Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
 `
 
 exports[`test/lib/commands/doctor.js TAP incorrect owner > logs 1`] = `
@@ -523,18 +523,18 @@ Object {
 `
 
 exports[`test/lib/commands/doctor.js TAP incorrect permissions > incorrect owner 1`] = `
-Check                               Value   Recommendation/Notes
-npm ping                            ok
-npm -v                              ok      current: v1.0.0, latest: v1.0.0
-node -v                             ok      current: v1.0.0, recommended: v1.0.0
-npm config get registry             ok      using default registry (https://registry.npmjs.org/)
-which git                           ok      /path/to/git
-Perms check on cached files         not ok  Check the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-incorrect-permissions/cache (should be owned by current user)
-Perms check on local node_modules   not ok  Check the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-incorrect-permissions/prefix/node_modules (should be owned by current user)
-Perms check on global node_modules  not ok  Check the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-incorrect-permissions/global/lib/node_modules
-Perms check on local bin folder     not ok  Check the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-incorrect-permissions/prefix/node_modules/.bin
-Perms check on global bin folder    not ok  Check the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-incorrect-permissions/global/bin
-Verify cache contents               ok      verified 0 tarballs
+Check                             [90m  [39mValue [90m  [39mRecommendation/Notes
+npm ping                          [90m  [39mok    [90m  [39m 
+npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
+node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
+npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
+which git                         [90m  [39mok    [90m  [39m/path/to/git
+Perms check on cached files       [90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-incorrect-permissions/cache (should be owned by current user)
+Perms check on local node_modules [90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-incorrect-permissions/prefix/node_modules (should be owned by current user)
+Perms check on global node_modules[90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-incorrect-permissions/global/lib/node_modules
+Perms check on local bin folder   [90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-incorrect-permissions/prefix/node_modules/.bin
+Perms check on global bin folder  [90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-incorrect-permissions/global/bin
+Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
 `
 
 exports[`test/lib/commands/doctor.js TAP incorrect permissions > logs 1`] = `
@@ -649,18 +649,18 @@ Object {
 `
 
 exports[`test/lib/commands/doctor.js TAP missing git > missing git 1`] = `
-Check                               Value   Recommendation/Notes
-npm ping                            ok
-npm -v                              ok      current: v1.0.0, latest: v1.0.0
-node -v                             ok      current: v1.0.0, recommended: v1.0.0
-npm config get registry             ok      using default registry (https://registry.npmjs.org/)
-which git                           not ok  Install git and ensure it's in your PATH.
-Perms check on cached files         ok
-Perms check on local node_modules   ok
-Perms check on global node_modules  ok
-Perms check on local bin folder     ok
-Perms check on global bin folder    ok
-Verify cache contents               ok      verified 0 tarballs
+Check                             [90m  [39mValue [90m  [39mRecommendation/Notes
+npm ping                          [90m  [39mok    [90m  [39m 
+npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
+node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
+npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
+which git                         [90m  [39mnot ok[90m  [39mInstall git and ensure it's in your PATH.
+Perms check on cached files       [90m  [39mok    [90m  [39m 
+Perms check on local node_modules [90m  [39mok    [90m  [39m 
+Perms check on global node_modules[90m  [39mok    [90m  [39m 
+Perms check on local bin folder   [90m  [39mok    [90m  [39m 
+Perms check on global bin folder  [90m  [39mok    [90m  [39m 
+Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
 `
 
 exports[`test/lib/commands/doctor.js TAP missing global directories > logs 1`] = `
@@ -716,18 +716,18 @@ Object {
 `
 
 exports[`test/lib/commands/doctor.js TAP missing global directories > missing global directories 1`] = `
-Check                               Value   Recommendation/Notes
-npm ping                            ok
-npm -v                              ok      current: v1.0.0, latest: v1.0.0
-node -v                             ok      current: v1.0.0, recommended: v1.0.0
-npm config get registry             ok      using default registry (https://registry.npmjs.org/)
-which git                           ok      /path/to/git
-Perms check on cached files         ok
-Perms check on local node_modules   ok
-Perms check on global node_modules  not ok  Check the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-missing-global-directories/global/lib/node_modules
-Perms check on local bin folder     ok
-Perms check on global bin folder    not ok  Check the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-missing-global-directories/global/bin
-Verify cache contents               ok      verified 0 tarballs
+Check                             [90m  [39mValue [90m  [39mRecommendation/Notes
+npm ping                          [90m  [39mok    [90m  [39m 
+npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
+node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
+npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
+which git                         [90m  [39mok    [90m  [39m/path/to/git
+Perms check on cached files       [90m  [39mok    [90m  [39m 
+Perms check on local node_modules [90m  [39mok    [90m  [39m 
+Perms check on global node_modules[90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-missing-global-directories/global/lib/node_modules
+Perms check on local bin folder   [90m  [39mok    [90m  [39m 
+Perms check on global bin folder  [90m  [39mnot ok[90m  [39mCheck the permissions of files in {CWD}/test/lib/commands/tap-testdir-doctor-missing-global-directories/global/bin
+Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
 `
 
 exports[`test/lib/commands/doctor.js TAP missing local node_modules > logs 1`] = `
@@ -774,18 +774,18 @@ Object {
 `
 
 exports[`test/lib/commands/doctor.js TAP missing local node_modules > missing local node_modules 1`] = `
-Check                               Value  Recommendation/Notes
-npm ping                            ok
-npm -v                              ok     current: v1.0.0, latest: v1.0.0
-node -v                             ok     current: v1.0.0, recommended: v1.0.0
-npm config get registry             ok     using default registry (https://registry.npmjs.org/)
-which git                           ok     /path/to/git
-Perms check on cached files         ok
-Perms check on local node_modules   ok
-Perms check on global node_modules  ok
-Perms check on local bin folder     ok
-Perms check on global bin folder    ok
-Verify cache contents               ok     verified 0 tarballs
+Check                             [90m  [39mValue [90m  [39mRecommendation/Notes
+npm ping                          [90m  [39mok    [90m  [39m 
+npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
+node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
+npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
+which git                         [90m  [39mok    [90m  [39m/path/to/git
+Perms check on cached files       [90m  [39mok    [90m  [39m 
+Perms check on local node_modules [90m  [39mok    [90m  [39m 
+Perms check on global node_modules[90m  [39mok    [90m  [39m 
+Perms check on local bin folder   [90m  [39mok    [90m  [39m 
+Perms check on global bin folder  [90m  [39mok    [90m  [39m 
+Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
 `
 
 exports[`test/lib/commands/doctor.js TAP node out of date - current > logs 1`] = `
@@ -832,18 +832,18 @@ Object {
 `
 
 exports[`test/lib/commands/doctor.js TAP node out of date - current > node is out of date 1`] = `
-Check                               Value   Recommendation/Notes
-npm ping                            ok
-npm -v                              ok      current: v1.0.0, latest: v1.0.0
-node -v                             not ok  Use node v2.0.1 (current: v2.0.0)
-npm config get registry             ok      using default registry (https://registry.npmjs.org/)
-which git                           ok      /path/to/git
-Perms check on cached files         ok
-Perms check on local node_modules   ok
-Perms check on global node_modules  ok
-Perms check on local bin folder     ok
-Perms check on global bin folder    ok
-Verify cache contents               ok      verified 0 tarballs
+Check                             [90m  [39mValue [90m  [39mRecommendation/Notes
+npm ping                          [90m  [39mok    [90m  [39m 
+npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
+node -v                           [90m  [39mnot ok[90m  [39mUse node v2.0.1 (current: v2.0.0)
+npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
+which git                         [90m  [39mok    [90m  [39m/path/to/git
+Perms check on cached files       [90m  [39mok    [90m  [39m 
+Perms check on local node_modules [90m  [39mok    [90m  [39m 
+Perms check on global node_modules[90m  [39mok    [90m  [39m 
+Perms check on local bin folder   [90m  [39mok    [90m  [39m 
+Perms check on global bin folder  [90m  [39mok    [90m  [39m 
+Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
 `
 
 exports[`test/lib/commands/doctor.js TAP node out of date - lts > logs 1`] = `
@@ -890,18 +890,18 @@ Object {
 `
 
 exports[`test/lib/commands/doctor.js TAP node out of date - lts > node is out of date 1`] = `
-Check                               Value   Recommendation/Notes
-npm ping                            ok
-npm -v                              ok      current: v1.0.0, latest: v1.0.0
-node -v                             not ok  Use node v1.0.0 (current: v0.0.1)
-npm config get registry             ok      using default registry (https://registry.npmjs.org/)
-which git                           ok      /path/to/git
-Perms check on cached files         ok
-Perms check on local node_modules   ok
-Perms check on global node_modules  ok
-Perms check on local bin folder     ok
-Perms check on global bin folder    ok
-Verify cache contents               ok      verified 0 tarballs
+Check                             [90m  [39mValue [90m  [39mRecommendation/Notes
+npm ping                          [90m  [39mok    [90m  [39m 
+npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
+node -v                           [90m  [39mnot ok[90m  [39mUse node v1.0.0 (current: v0.0.1)
+npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
+which git                         [90m  [39mok    [90m  [39m/path/to/git
+Perms check on cached files       [90m  [39mok    [90m  [39m 
+Perms check on local node_modules [90m  [39mok    [90m  [39m 
+Perms check on global node_modules[90m  [39mok    [90m  [39m 
+Perms check on local bin folder   [90m  [39mok    [90m  [39m 
+Perms check on global bin folder  [90m  [39mok    [90m  [39m 
+Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
 `
 
 exports[`test/lib/commands/doctor.js TAP non-default registry > logs 1`] = `
@@ -948,18 +948,18 @@ Object {
 `
 
 exports[`test/lib/commands/doctor.js TAP non-default registry > non default registry 1`] = `
-Check                               Value   Recommendation/Notes
-npm ping                            ok
-npm -v                              ok      current: v1.0.0, latest: v1.0.0
-node -v                             ok      current: v1.0.0, recommended: v1.0.0
-npm config get registry             not ok  Try \`npm config set registry=https://registry.npmjs.org/\`
-which git                           ok      /path/to/git
-Perms check on cached files         ok
-Perms check on local node_modules   ok
-Perms check on global node_modules  ok
-Perms check on local bin folder     ok
-Perms check on global bin folder    ok
-Verify cache contents               ok      verified 0 tarballs
+Check                             [90m  [39mValue [90m  [39mRecommendation/Notes
+npm ping                          [90m  [39mok    [90m  [39m 
+npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
+node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
+npm config get registry           [90m  [39mnot ok[90m  [39mTry \`npm config set registry=https://registry.npmjs.org/\`
+which git                         [90m  [39mok    [90m  [39m/path/to/git
+Perms check on cached files       [90m  [39mok    [90m  [39m 
+Perms check on local node_modules [90m  [39mok    [90m  [39m 
+Perms check on global node_modules[90m  [39mok    [90m  [39m 
+Perms check on local bin folder   [90m  [39mok    [90m  [39m 
+Perms check on global bin folder  [90m  [39mok    [90m  [39m 
+Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
 `
 
 exports[`test/lib/commands/doctor.js TAP npm out of date > logs 1`] = `
@@ -1006,18 +1006,18 @@ Object {
 `
 
 exports[`test/lib/commands/doctor.js TAP npm out of date > npm is out of date 1`] = `
-Check                               Value   Recommendation/Notes
-npm ping                            ok
-npm -v                              not ok  Use npm v2.0.0
-node -v                             ok      current: v1.0.0, recommended: v1.0.0
-npm config get registry             ok      using default registry (https://registry.npmjs.org/)
-which git                           ok      /path/to/git
-Perms check on cached files         ok
-Perms check on local node_modules   ok
-Perms check on global node_modules  ok
-Perms check on local bin folder     ok
-Perms check on global bin folder    ok
-Verify cache contents               ok      verified 0 tarballs
+Check                             [90m  [39mValue [90m  [39mRecommendation/Notes
+npm ping                          [90m  [39mok    [90m  [39m 
+npm -v                            [90m  [39mnot ok[90m  [39mUse npm v2.0.0
+node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
+npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
+which git                         [90m  [39mok    [90m  [39m/path/to/git
+Perms check on cached files       [90m  [39mok    [90m  [39m 
+Perms check on local node_modules [90m  [39mok    [90m  [39m 
+Perms check on global node_modules[90m  [39mok    [90m  [39m 
+Perms check on local bin folder   [90m  [39mok    [90m  [39m 
+Perms check on global bin folder  [90m  [39mok    [90m  [39m 
+Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
 `
 
 exports[`test/lib/commands/doctor.js TAP ping 404 > logs 1`] = `
@@ -1064,18 +1064,18 @@ Object {
 `
 
 exports[`test/lib/commands/doctor.js TAP ping 404 > ping 404 1`] = `
-Check                               Value   Recommendation/Notes
-npm ping                            not ok  404 404 Not Found - GET https://registry.npmjs.org/-/ping?write=true
-npm -v                              ok      current: v1.0.0, latest: v1.0.0
-node -v                             ok      current: v1.0.0, recommended: v1.0.0
-npm config get registry             ok      using default registry (https://registry.npmjs.org/)
-which git                           ok      /path/to/git
-Perms check on cached files         ok
-Perms check on local node_modules   ok
-Perms check on global node_modules  ok
-Perms check on local bin folder     ok
-Perms check on global bin folder    ok
-Verify cache contents               ok      verified 0 tarballs
+Check                             [90m  [39mValue [90m  [39mRecommendation/Notes
+npm ping                          [90m  [39mnot ok[90m  [39m404 404 Not Found - GET https://registry.npmjs.org/-/ping?write=true
+npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
+node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
+npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
+which git                         [90m  [39mok    [90m  [39m/path/to/git
+Perms check on cached files       [90m  [39mok    [90m  [39m 
+Perms check on local node_modules [90m  [39mok    [90m  [39m 
+Perms check on global node_modules[90m  [39mok    [90m  [39m 
+Perms check on local bin folder   [90m  [39mok    [90m  [39m 
+Perms check on global bin folder  [90m  [39mok    [90m  [39m 
+Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
 `
 
 exports[`test/lib/commands/doctor.js TAP ping 404 in color > logs 1`] = `
@@ -1122,18 +1122,18 @@ Object {
 `
 
 exports[`test/lib/commands/doctor.js TAP ping 404 in color > ping 404 in color 1`] = `
-[4mCheck[24m                               [4mValue[24m   [4mRecommendation/Notes[24m
-[31mnpm ping[39m                            [31mnot ok[39m  [35m404 404 Not Found - GET https://registry.npmjs.org/-/ping?write=true[39m
-npm -v                              [32mok[39m      current: v1.0.0, latest: v1.0.0
-node -v                             [32mok[39m      current: v1.0.0, recommended: v1.0.0
-npm config get registry             [32mok[39m      using default registry (https://registry.npmjs.org/)
-which git                           [32mok[39m      /path/to/git
-Perms check on cached files         [32mok[39m
-Perms check on local node_modules   [32mok[39m
-Perms check on global node_modules  [32mok[39m
-Perms check on local bin folder     [32mok[39m
-Perms check on global bin folder    [32mok[39m
-Verify cache contents               [32mok[39m      verified 0 tarballs
+[4mCheck[24m                             [90m  [39m[4mValue[24m [90m  [39m[4mRecommendation/Notes[24m
+[31mnpm ping[39m                          [90m  [39m[31mnot ok[39m[90m  [39m[35m404 404 Not Found - GET https://registry.npmjs.org/-/ping?write=true[39m
+npm -v                            [90m  [39m[32mok[39m    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
+node -v                           [90m  [39m[32mok[39m    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
+npm config get registry           [90m  [39m[32mok[39m    [90m  [39musing default registry (https://registry.npmjs.org/)
+which git                         [90m  [39m[32mok[39m    [90m  [39m/path/to/git
+Perms check on cached files       [90m  [39m[32mok[39m    [90m  [39m 
+Perms check on local node_modules [90m  [39m[32mok[39m    [90m  [39m 
+Perms check on global node_modules[90m  [39m[32mok[39m    [90m  [39m 
+Perms check on local bin folder   [90m  [39m[32mok[39m    [90m  [39m 
+Perms check on global bin folder  [90m  [39m[32mok[39m    [90m  [39m 
+Verify cache contents             [90m  [39m[32mok[39m    [90m  [39mverified 0 tarballs
 `
 
 exports[`test/lib/commands/doctor.js TAP ping exception with code > logs 1`] = `
@@ -1180,18 +1180,18 @@ Object {
 `
 
 exports[`test/lib/commands/doctor.js TAP ping exception with code > ping failure 1`] = `
-Check                               Value   Recommendation/Notes
-npm ping                            not ok  request to https://registry.npmjs.org/-/ping?write=true failed, reason: Test Error
-npm -v                              ok      current: v1.0.0, latest: v1.0.0
-node -v                             ok      current: v1.0.0, recommended: v1.0.0
-npm config get registry             ok      using default registry (https://registry.npmjs.org/)
-which git                           ok      /path/to/git
-Perms check on cached files         ok
-Perms check on local node_modules   ok
-Perms check on global node_modules  ok
-Perms check on local bin folder     ok
-Perms check on global bin folder    ok
-Verify cache contents               ok      verified 0 tarballs
+Check                             [90m  [39mValue [90m  [39mRecommendation/Notes
+npm ping                          [90m  [39mnot ok[90m  [39mrequest to https://registry.npmjs.org/-/ping?write=true failed, reason: Test Error
+npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
+node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
+npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
+which git                         [90m  [39mok    [90m  [39m/path/to/git
+Perms check on cached files       [90m  [39mok    [90m  [39m 
+Perms check on local node_modules [90m  [39mok    [90m  [39m 
+Perms check on global node_modules[90m  [39mok    [90m  [39m 
+Perms check on local bin folder   [90m  [39mok    [90m  [39m 
+Perms check on global bin folder  [90m  [39mok    [90m  [39m 
+Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
 `
 
 exports[`test/lib/commands/doctor.js TAP ping exception without code > logs 1`] = `
@@ -1238,18 +1238,18 @@ Object {
 `
 
 exports[`test/lib/commands/doctor.js TAP ping exception without code > ping failure 1`] = `
-Check                               Value   Recommendation/Notes
-npm ping                            not ok  request to https://registry.npmjs.org/-/ping?write=true failed, reason: Test Error
-npm -v                              ok      current: v1.0.0, latest: v1.0.0
-node -v                             ok      current: v1.0.0, recommended: v1.0.0
-npm config get registry             ok      using default registry (https://registry.npmjs.org/)
-which git                           ok      /path/to/git
-Perms check on cached files         ok
-Perms check on local node_modules   ok
-Perms check on global node_modules  ok
-Perms check on local bin folder     ok
-Perms check on global bin folder    ok
-Verify cache contents               ok      verified 0 tarballs
+Check                             [90m  [39mValue [90m  [39mRecommendation/Notes
+npm ping                          [90m  [39mnot ok[90m  [39mrequest to https://registry.npmjs.org/-/ping?write=true failed, reason: Test Error
+npm -v                            [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
+node -v                           [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
+npm config get registry           [90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
+which git                         [90m  [39mok    [90m  [39m/path/to/git
+Perms check on cached files       [90m  [39mok    [90m  [39m 
+Perms check on local node_modules [90m  [39mok    [90m  [39m 
+Perms check on global node_modules[90m  [39mok    [90m  [39m 
+Perms check on local bin folder   [90m  [39mok    [90m  [39m 
+Perms check on global bin folder  [90m  [39mok    [90m  [39m 
+Verify cache contents             [90m  [39mok    [90m  [39mverified 0 tarballs
 `
 
 exports[`test/lib/commands/doctor.js TAP silent > logs 1`] = `
@@ -1343,11 +1343,11 @@ Object {
 `
 
 exports[`test/lib/commands/doctor.js TAP windows skips permissions checks > no permissions checks 1`] = `
-Check                    Value  Recommendation/Notes
-npm ping                 ok
-npm -v                   ok     current: v1.0.0, latest: v1.0.0
-node -v                  ok     current: v1.0.0, recommended: v1.0.0
-npm config get registry  ok     using default registry (https://registry.npmjs.org/)
-which git                ok     /path/to/git
-Verify cache contents    ok     verified 0 tarballs
+Check                  [90m  [39mValue [90m  [39mRecommendation/Notes
+npm ping               [90m  [39mok    [90m  [39m 
+npm -v                 [90m  [39mok    [90m  [39mcurrent: v1.0.0, latest: v1.0.0
+node -v                [90m  [39mok    [90m  [39mcurrent: v1.0.0, recommended: v1.0.0
+npm config get registry[90m  [39mok    [90m  [39musing default registry (https://registry.npmjs.org/)
+which git              [90m  [39mok    [90m  [39m/path/to/git
+Verify cache contents  [90m  [39mok    [90m  [39mverified 0 tarballs
 `

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -2861,7 +2861,7 @@ exports[`test/lib/docs.js TAP usage doctor > must match snapshot 1`] = `
 Check your npm environment
 
 Usage:
-npm doctor
+npm doctor [ping] [registry] [versions] [environment] [permissions] [cache]
 
 Options:
 [--registry <registry>]
@@ -2869,7 +2869,7 @@ Options:
 Run "npm help doctor" for more info
 
 \`\`\`bash
-npm doctor
+npm doctor [ping] [registry] [versions] [environment] [permissions] [cache]
 \`\`\`
 
 #### \`registry\`

--- a/test/lib/commands/doctor.js
+++ b/test/lib/commands/doctor.js
@@ -510,3 +510,97 @@ t.test('bad proxy', async t => {
   t.matchSnapshot(joinedOutput(), 'output')
   t.matchSnapshot({ info: logs.info, warn: logs.warn, error: logs.error }, 'logs')
 })
+
+t.test('discrete checks', t => {
+  t.test('ping', async t => {
+    const { joinedOutput, logs, npm } = await loadMockNpm(t, {
+      mocks,
+      globals,
+      ...dirs,
+    })
+    tnock(t, npm.config.get('registry'))
+      .get('/-/ping?write=true').reply(200, '{}')
+    await npm.exec('doctor', ['ping'])
+    t.matchSnapshot(joinedOutput(), 'output')
+    t.matchSnapshot({ info: logs.info, warn: logs.warn, error: logs.error }, 'logs')
+  })
+
+  t.test('versions', async t => {
+    const { joinedOutput, logs, npm } = await loadMockNpm(t, {
+      mocks,
+      globals,
+      ...dirs,
+    })
+    tnock(t, npm.config.get('registry'))
+      .get('/npm').reply(200, npmManifest(npm.version))
+    tnock(t, 'https://nodejs.org')
+      .get('/dist/index.json').reply(200, nodeVersions)
+    await npm.exec('doctor', ['versions'])
+    t.matchSnapshot(joinedOutput(), 'output')
+    t.matchSnapshot({ info: logs.info, warn: logs.warn, error: logs.error }, 'logs')
+  })
+
+  t.test('registry', async t => {
+    const { joinedOutput, logs, npm } = await loadMockNpm(t, {
+      mocks,
+      globals,
+      ...dirs,
+    })
+    await npm.exec('doctor', ['registry'])
+    t.matchSnapshot(joinedOutput(), 'output')
+    t.matchSnapshot({ info: logs.info, warn: logs.warn, error: logs.error }, 'logs')
+  })
+
+  t.test('git', async t => {
+    const { joinedOutput, logs, npm } = await loadMockNpm(t, {
+      mocks,
+      globals,
+      ...dirs,
+    })
+    await npm.exec('doctor', ['git'])
+    t.matchSnapshot(joinedOutput(), 'output')
+    t.matchSnapshot({ info: logs.info, warn: logs.warn, error: logs.error }, 'logs')
+  })
+
+  t.test('permissions - not windows', async t => {
+    const { joinedOutput, logs, npm } = await loadMockNpm(t, {
+      mocks,
+      globals,
+      ...dirs,
+    })
+    await npm.exec('doctor', ['permissions'])
+    t.matchSnapshot(joinedOutput(), 'output')
+    t.matchSnapshot({ info: logs.info, warn: logs.warn, error: logs.error }, 'logs')
+  })
+
+  t.test('cache', async t => {
+    const { joinedOutput, logs, npm } = await loadMockNpm(t, {
+      mocks,
+      globals,
+      ...dirs,
+    })
+    await npm.exec('doctor', ['cache'])
+    t.matchSnapshot(joinedOutput(), 'output')
+    t.matchSnapshot({ info: logs.info, warn: logs.warn, error: logs.error }, 'logs')
+  })
+
+  t.test('permissions - windows', async t => {
+    const { joinedOutput, logs, npm } = await loadMockNpm(t, {
+      mocks,
+      globals: {
+        ...globals,
+        process: {
+          ...globals.process,
+          platform: 'win32',
+        },
+      },
+      prefixDir: {},
+      globalPrefixDir: {},
+    })
+    await npm.exec('doctor', ['permissions'])
+    t.matchSnapshot(joinedOutput(), 'output')
+    t.matchSnapshot({ info: logs.info, warn: logs.warn, error: logs.error }, 'logs')
+  })
+
+  t.end()
+})


### PR DESCRIPTION
Changed output to display as each check finishes instead of all at once at the end.

Check added: `checkBinPath`. Checks that the global bin is in your path.

Added grouping to commands.