### PR TITLE
chore: fix tests for node 19

### DIFF
--- a/test/lib/cli.js
+++ b/test/lib/cli.js
@@ -30,7 +30,7 @@ const cliMock = async (t, opts) => {
 }
 
 t.afterEach(() => {
-  delete process.exitCode
+  process.exitCode = undefined
 })
 
 t.test('print the version, and treat npm_g as npm -g', async t => {


### PR DESCRIPTION
node 19 appears to have made it so that we can't delete the `process.exitCode` property. overwriting it with `undefined` will have to do moving forward
