### PR TITLE
fix: do not reset hidden lockfile data before saving

### DIFF
--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -1531,16 +1531,12 @@ module.exports = cls => class Reifier extends cls {
     this.idealTree.meta.filename =
       this.idealTree.realpath + '/node_modules/.package-lock.json'
     this.idealTree.meta.hiddenLockfile = true
-    const resetMeta = this.idealTree.meta && this.idealTree.meta.lockfileVersion !== defaultLockfileVersion
     this.idealTree.meta.lockfileVersion = defaultLockfileVersion
 
     this.actualTree = this.idealTree
     this.idealTree = null
 
     if (!this[_global]) {
-      if (resetMeta) {
-        await this.actualTree.meta.reset()
-      }
       await this.actualTree.meta.save()
       const ignoreScripts = !!this.options.ignoreScripts
       // if we aren't doing a dry run or ignoring scripts and we actually made changes to the dep


### PR DESCRIPTION
this corrects the current behavior where the hidden lockfile is being written, but with the `packages` field being empty. this seems to only happen when `--no-package-lock` is passed
