### PR TITLE
chore(smoke-test): dont mock tarball for update request

### DIFF
--- a/smoke-tests/test/fixtures/setup.js
+++ b/smoke-tests/test/fixtures/setup.js
@@ -140,6 +140,7 @@ module.exports = async (t, { testdir = {}, debug } = {}) => {
     '--no-audit',
     '--no-update-notifier',
     '--loglevel=silly',
+    '--fetch-retries=0',
     ]
     const [positionals, flags] = args.reduce((acc, arg) => {
       if (arg.startsWith('-')) {

--- a/smoke-tests/test/index.js
+++ b/smoke-tests/test/index.js
@@ -267,9 +267,6 @@ t.test('basic', async t => {
     const manifest = abbrevManifest()
     await registry.package({
       manifest: manifest,
-      tarballs: {
-        '1.1.1': join(paths.root, 'packages', 'abbrev-1.1.1'),
-      },
     })
 
     await npm('update', '--no-save')


### PR DESCRIPTION
After 80c6c4a5111ab1779256a779a2cba41eb2c8675f the hidden lockfile is no
longer reset, so the `update` request in the smoke test only has to mock
the manifest and not the tarball.
