### PR TITLE
Replaced SHA1 with SHA512

### DIFF
--- a/lib/utils/config/index.js
+++ b/lib/utils/config/index.js
@@ -25,8 +25,8 @@ const flatten = (obj, flat = {}) => {
     : /* istanbul ignore next - not configurable property */ undefined
   flat.nodeBin = process.env.NODE || process.execPath
 
-  // XXX should this be sha512?  is it even relevant?
-  flat.hashAlgorithm = 'sha1'
+  // Replaced SHA1 with SHA512
+  flat.hashAlgorithm = 'sha512'
 
   return flat
 }


### PR DESCRIPTION
As we know that SHA1 is vulnerable and deprecated, SHA-512 is more realible and secure.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
