### PR TITLE
fix: audit package mismatch in special case

### DIFF
--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -619,14 +619,16 @@ module.exports = cls => class IdealTreeBuilder extends cls {
             continue
           }
 
-          const { isSemVerMajor, version } = fixAvailable
+          // name may be different if parent fixes the dep
+          // see Vuln fixAvailable setter
+          const { isSemVerMajor, version, name: fixName } = fixAvailable
           const breakingMessage = isSemVerMajor
             ? 'a SemVer major change'
             : 'outside your stated dependency range'
-          log.warn('audit', `Updating ${name} to ${version}, ` +
+          log.warn('audit', `Updating ${fixName} to ${version}, ` +
             `which is ${breakingMessage}.`)
 
-          await this[_add](node, { add: [`${name}@${version}`] })
+          await this[_add](node, { add: [`${fixName}@${version}`] })
           nodesTouched.add(node)
         }
       }

--- a/workspaces/arborist/lib/vuln.js
+++ b/workspaces/arborist/lib/vuln.js
@@ -65,6 +65,9 @@ class Vuln {
     // - {name, version, isSemVerMajor} fix requires -f, is semver major
     // - {name, version} fix requires -f, not semver major
     // - true: fix does not require -f
+    // TODO: duped entries may require different fixes but the current
+    // structure does not support this, so the case were a top level fix
+    // corrects a duped entry may mean you have to run fix more than once
     for (const v of this.via) {
       // don't blow up on loops
       if (v.fixAvailable === f) {


### PR DESCRIPTION
`npm audit fix --force` might get and Audit Report where the fix was different from the package that was vulnerable if a parent package update resolved the vulnerability, but the command assumed that the package would be the same.

There's still an issue where the the solution might be different for duped packages in this case, so `audit fix --force` would have to be run twice since the AuditReport object doesn't duplicate vulnerable packages at multiple locations.

Closes #5750