### PR TITLE
fix: Cannot read properties of undefined (reading 'description')

### DIFF
--- a/lib/commands/ls.js
+++ b/lib/commands/ls.js
@@ -336,7 +336,7 @@ const getHumanOutputItem = (node, { args, color, global, long }) => {
     ) +
     (isGitNode(node) ? ` (${node.resolved})` : '') +
     (node.isLink ? ` -> ${relativePrefix}${targetLocation}` : '') +
-    (long ? `${EOL}${node.package.description || ''}` : '')
+    (long ? `${EOL}${node.package ? node.package.description || '' : ''}` : '')
 
   return augmentItemWithIncludeMetadata(node, { label, nodes: [] })
 }


### PR DESCRIPTION
A check for not defined `node.package` value is added to `getHumanOutputItem`

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #5961
  Closes #0
-->
Fixes: #5961
