### PR TITLE
docs: broken fragment links

### DIFF
--- a/docs/lib/content/configuring-npm/install.md
+++ b/docs/lib/content/configuring-npm/install.md
@@ -17,11 +17,11 @@ run npm packages globally.
 ### Overview
 
 - [Checking your version of npm and
-  Node.js](#checking-your-version-of-npm-and-node-js)
+  Node.js](#checking-your-version-of-npm-and-nodejs)
 - [Using a Node version manager to install Node.js and
-  npm](#using-a-node-version-manager-to-install-node-js-and-npm)
+  npm](#using-a-node-version-manager-to-install-nodejs-and-npm)
 - [Using a Node installer to install Node.js and
-  npm](#using-a-node-installer-to-install-node-js-and-npm)
+  npm](#using-a-node-installer-to-install-nodejs-and-npm)
 
 ### Checking your version of npm and Node.js
 


### PR DESCRIPTION
In links with fragments like `#checking-your-version-of-npm-and-node-js` the `node-js` portion doesn't work and should be `nodejs`. So for example, the following link currently on the site does NOT work (i.e. it won't scroll to the relevant section):

> https://docs.npmjs.com/cli/v9/configuring-npm/install#checking-your-version-of-npm-and-node-js

...but this one (as implemented by this fix) DOES work:

> https://docs.npmjs.com/cli/v9/configuring-npm/install#checking-your-version-of-npm-and-nodejs

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
