### PR TITLE
docs: fix typos in definitions.js

### DIFF
--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -163,7 +163,7 @@ define('access', {
   `,
   type: [null, 'restricted', 'public'],
   description: `
-    If do not want your scoped package to be publicly viewable (and
+    If you do not want your scoped package to be publicly viewable (and
     installable) set \`--access=restricted\`.
 
     Unscoped packages can not be set to \`restricted\`.

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -848,7 +848,7 @@ define('global-style', {
   type: Boolean,
   description: `
     Only install direct dependencies in the top level \`node_modules\`,
-    but hoist on deeper dependendencies.
+    but hoist on deeper dependencies.
     Sets \`--install-strategy=shallow\`.
   `,
   deprecated: `

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -2021,7 +2021,7 @@ define('strict-peer-deps', {
     even if doing so will result in some packages receiving a peer dependency
     outside the range set in their package's \`peerDependencies\` object.
 
-    When such and override is performed, a warning is printed, explaining the
+    When such an override is performed, a warning is printed, explaining the
     conflict and the packages involved.  If \`--strict-peer-deps\` is set,
     then this warning is treated as a failure.
   `,


### PR DESCRIPTION
Fix a typo in the docs for the `--access` flag which shows up like this on the site:

![image](https://user-images.githubusercontent.com/20465797/209483484-62303dae-9feb-43b3-b137-b204cc207dc8.png)

The sentence *"If do not want..."* should read *"If **you** do not want..."*.

---
Fix a typo in the docs for the `--strict-peer-deps` flag which shows up like this on the site:

![image](https://user-images.githubusercontent.com/20465797/210121589-3ff081ff-fadf-422a-91ec-442cdf24ec18.png)

The sentence *"When such and override is performed"* should read *"When such **an** override is performed"*.

---
Fix a typo in the docs for the `--global-style` flag which shows up like this on the site:

![image](https://user-images.githubusercontent.com/20465797/210122105-c9a60d74-8982-499b-919a-a85fbf5376f5.png)

The sentence *"...hoist on deeper dependendencies"* should read *"...hoist on deeper **dependencies**"*.