### PR TITLE
docs: fix typos in definitions.js

### DIFF
--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -163,7 +163,7 @@ define('access', {
   `,
   type: [null, 'restricted', 'public'],
   description: `
-    If do not want your scoped package to be publicly viewable (and
+    If you do not want your scoped package to be publicly viewable (and
     installable) set \`--access=restricted\`.
 
     Unscoped packages can not be set to \`restricted\`.

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -848,7 +848,7 @@ define('global-style', {
   type: Boolean,
   description: `
     Only install direct dependencies in the top level \`node_modules\`,
-    but hoist on deeper dependendencies.
+    but hoist on deeper dependencies.
     Sets \`--install-strategy=shallow\`.
   `,
   deprecated: `

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -2021,7 +2021,7 @@ define('strict-peer-deps', {
     even if doing so will result in some packages receiving a peer dependency
     outside the range set in their package's \`peerDependencies\` object.
 
-    When such and override is performed, a warning is printed, explaining the
+    When such an override is performed, a warning is printed, explaining the
     conflict and the packages involved.  If \`--strict-peer-deps\` is set,
     then this warning is treated as a failure.
   `,

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -604,8 +604,8 @@ safer to use a registry-provided authentication bearer token stored in the
   current level
 * Type: null, "restricted", or "public"
 
-If do not want your scoped package to be publicly viewable (and installable)
-set \`--access=restricted\`.
+If you do not want your scoped package to be publicly viewable (and
+installable) set \`--access=restricted\`.
 
 Unscoped packages can not be set to \`restricted\`.
 
@@ -1702,7 +1702,7 @@ be resolved using the nearest non-peer dependency specification, even if
 doing so will result in some packages receiving a peer dependency outside
 the range set in their package's \`peerDependencies\` object.
 
-When such and override is performed, a warning is printed, explaining the
+When such an override is performed, a warning is printed, explaining the
 conflict and the packages involved. If \`--strict-peer-deps\` is set, then
 this warning is treated as a failure.
 
@@ -1983,7 +1983,7 @@ Alias for \`--include=dev\`.
   \`--install-strategy=shallow\`
 
 Only install direct dependencies in the top level \`node_modules\`, but hoist
-on deeper dependendencies. Sets \`--install-strategy=shallow\`.
+on deeper dependencies. Sets \`--install-strategy=shallow\`.
 
 #### \`init.author.email\`
 


### PR DESCRIPTION
- Fix typo in definitions.js
- Fix another typo in definitions.js
- Fix yet another typo in definitions.js
- update snapshots
