### PR TITLE
fix: default auth-type to legacy if otp is configured

### DIFF
--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -238,6 +238,7 @@ define('auth-type', {
   type: ['legacy', 'web'],
   description: `
     What authentication strategy to use with \`login\`.
+    Note that if an \`otp\` config is given, this value will always be set to \`legacy\`.
   `,
   flatten,
 })
@@ -1465,7 +1466,13 @@ define('otp', {
     If not set, and a registry response fails with a challenge for a one-time
     password, npm will prompt on the command line for one.
   `,
-  flatten,
+  flatten (key, obj, flatOptions) {
+    flatten(key, obj, flatOptions)
+    if (obj.otp) {
+      obj['auth-type'] = 'legacy'
+      flatten('auth-type', obj, flatOptions)
+    }
+  },
 })
 
 define('package', {

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -654,7 +654,8 @@ exit code.
 * Default: "web"
 * Type: "legacy" or "web"
 
-What authentication strategy to use with \`login\`.
+What authentication strategy to use with \`login\`. Note that if an \`otp\`
+config is given, this value will always be set to \`legacy\`.
 
 #### \`before\`
 

--- a/test/lib/utils/config/definitions.js
+++ b/test/lib/utils/config/definitions.js
@@ -931,3 +931,12 @@ t.test('remap global-style', t => {
   t.strictSame(flat, { installStrategy: 'shallow' })
   t.end()
 })
+
+t.test('otp changes auth-type', t => {
+  const obj = { 'auth-type': 'web', otp: 123456 }
+  const flat = {}
+  mockDefs().otp.flatten('otp', obj, flat)
+  t.strictSame(flat, { authType: 'legacy', otp: 123456 })
+  t.strictSame(obj, { 'auth-type': 'legacy', otp: 123456 })
+  t.end()
+})


### PR DESCRIPTION
Closes https://github.com/npm/statusboard/issues/624