### PR TITLE
docs: update outdated file path to definitions.js

### DIFF
--- a/docs/lib/content/commands/npm.md
+++ b/docs/lib/content/commands/npm.md
@@ -130,7 +130,7 @@ npm is extremely configurable.  It reads its configuration options from
   in the cli, env, or user config, then that file is parsed instead.
 * Defaults:
   npm's default configuration options are defined in
-  lib/utils/config-defs.js.  These must not be changed.
+  `lib/utils/config/definitions.js`.  These must not be changed.
 
 See [`config`](/using-npm/config) for much much more information.
 


### PR DESCRIPTION
Looks like npm's default config options were relocated from `lib/utils/config-defs.js` to the current `lib/utils/config/definitions.js` as [can be seen here](https://github.com/npm/cli/blob/latest/lib/utils/config/definitions.js).

