### PR TITLE
docs: missing backtick in synopsis of npm init (#5837)

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -28,7 +28,7 @@ class Init extends BaseCommand {
 
   static name = 'init'
   static usage = [
-    '<package-spec> (same as `npx <package-spec>)',
+    '<package-spec> (same as `npx <package-spec>`)',
     '<@scope> (same as `npx <@scope>/create`)',
   ]
 

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -3139,7 +3139,7 @@ exports[`test/lib/docs.js TAP usage init > must match snapshot 1`] = `
 Create a package.json file
 
 Usage:
-npm init <package-spec> (same as \`npx <package-spec>)
+npm init <package-spec> (same as \`npx <package-spec>\`)
 npm init <@scope> (same as \`npx <@scope>/create\`)
 
 Options:
@@ -3152,7 +3152,7 @@ aliases: create, innit
 Run "npm help init" for more info
 
 \`\`\`bash
-npm init <package-spec> (same as \`npx <package-spec>)
+npm init <package-spec> (same as \`npx <package-spec>\`)
 npm init <@scope> (same as \`npx <@scope>/create\`)
 
 aliases: create, innit


### PR DESCRIPTION
Resolving the issue #5837.

Adding backticks to init.js :
[lib/commands/init.js](https://github.com/npm/cli/compare/latest...Peallyz:cli:latest#diff-80ba150a44f479df765994a9d4725d0c3717382f804fb4fedcb30d50af7d2535) 
line 31

Adding " \`  to docs.js.test.cjs to pass test : 
[tap-snapshots/test/lib/docs.js.test.cjs](https://github.com/npm/cli/compare/latest...Peallyz:cli:latest#diff-6f21b9547f08121788002c1b5494afcd450c3d6a9a6f4e1f452d71d2764515b4)
line 3142
line 3155

Hope it helped, do not hesitate to tell me if i did wrong.

