### PR TITLE
fix: don't try to deprecate nonexistant versions

### DIFF
--- a/lib/commands/deprecate.js
+++ b/lib/commands/deprecate.js
@@ -52,19 +52,21 @@ class Deprecate extends BaseCommand {
       query: { write: true },
     })
 
-    Object.keys(packument.versions)
+    const versions = Object.keys(packument.versions)
       .filter(v => semver.satisfies(v, spec, { includePrerelease: true }))
-      .forEach(v => {
-        packument.versions[v].deprecated = msg
-      })
 
-    return otplease(this.npm, this.npm.flatOptions, opts => fetch(uri, {
-      ...opts,
-      spec: p,
-      method: 'PUT',
-      body: packument,
-      ignoreBody: true,
-    }))
+    if (versions.length) {
+      for (const v of versions) {
+        packument.versions[v].deprecated = msg
+      }
+      return otplease(this.npm, this.npm.flatOptions, opts => fetch(uri, {
+        ...opts,
+        spec: p,
+        method: 'PUT',
+        body: packument,
+        ignoreBody: true,
+      }))
+    }
   }
 }
 

--- a/test/lib/commands/deprecate.js
+++ b/test/lib/commands/deprecate.js
@@ -153,3 +153,19 @@ t.test('deprecates all versions when no range is specified', async t => {
   await npm.exec('deprecate', ['foo', message])
   t.match(joinedOutput(), '')
 })
+
+t.test('does nothing if version does not actually exist', async t => {
+  const { npm, joinedOutput } = await loadMockNpm(t, { config: { ...auth } })
+  const registry = new MockRegistry({
+    tap: t,
+    registry: npm.config.get('registry'),
+    authorization: token,
+  })
+  const manifest = registry.manifest({
+    name: 'foo',
+    versions,
+  })
+  await registry.package({ manifest, query: { write: true } })
+  await npm.exec('deprecate', ['foo@1.0.99', 'this should be ignored'])
+  t.match(joinedOutput(), '')
+})


### PR DESCRIPTION
If you pass npm a version that doesn't exist, it still tries to PUT the
packument but with no changes.  This is unneccessary and currently
results in a 422 error from the npm registry
