### PR TITLE
fix: use recursive rm in ci command

### DIFF
--- a/lib/commands/ci.js
+++ b/lib/commands/ci.js
@@ -67,7 +67,7 @@ class CI extends ArboristWorkspaceCmd {
       const path = `${where}/node_modules`
       // get the list of entries so we can skip the glob for performance
       const entries = await fs.readdir(path, null).catch(er => [])
-      return Promise.all(entries.map(f => fs.rm(`${path}/${f}`, { force: true })))
+      return Promise.all(entries.map(f => fs.rm(`${path}/${f}`, { force: true, recursive: true })))
     })
 
     await arb.reify(opts)


### PR DESCRIPTION
<!-- What / Why -->
Adds recursive flag to the `fs.rm` call used in the `npm ci` command

<!-- Describe the request in detail. What it does and why it's being changed. -->
The CI command attempts to delete everything in the `node_modules` directory but is missing a recursive flag, leading to command failure

## References
Fixes #6051