### PR TITLE
fix: use recursive rm in ci command and add test case

### DIFF
--- a/lib/commands/ci.js
+++ b/lib/commands/ci.js
@@ -67,7 +67,7 @@ class CI extends ArboristWorkspaceCmd {
       const path = `${where}/node_modules`
       // get the list of entries so we can skip the glob for performance
       const entries = await fs.readdir(path, null).catch(er => [])
-      return Promise.all(entries.map(f => fs.rm(`${path}/${f}`, { force: true })))
+      return Promise.all(entries.map(f => fs.rm(`${path}/${f}`, { force: true, recursive: true })))
     })
 
     await arb.reify(opts)


### PR DESCRIPTION
Adds a test to the PR (#6052) that fixes the referenced issue covering repeat uses of the ci command.


## References

Fixes #6051
