### PR TITLE
fix: unpublish with scoped registry

### DIFF
--- a/lib/commands/unpublish.js
+++ b/lib/commands/unpublish.js
@@ -26,7 +26,10 @@ class Unpublish extends BaseCommand {
 
   async getKeysOfVersions (name, opts) {
     const pkgUri = npa(name).escapedName
-    const json = await npmFetch.json(`${pkgUri}?write=true`, opts)
+    const json = await npmFetch.json(`${pkgUri}?write=true`, {
+      ...opts,
+      spec: name,
+    })
     return Object.keys(json.versions)
   }
 

--- a/test/fixtures/mock-npm.js
+++ b/test/fixtures/mock-npm.js
@@ -206,7 +206,7 @@ const setupMockNpm = async (t, {
         acc.env[`process.env."npm_config_${key}"`] = value
       } else {
         const values = [].concat(value)
-        acc.argv.push(...values.flatMap(v => [`--${key}`, v.toString()]))
+        acc.argv.push(...values.flatMap(v => `--${key}=${v.toString()}`))
       }
       acc.config[key] = value
       return acc


### PR DESCRIPTION
Unpublish now works if you have a scoped registry config

Closes https://github.com/npm/cli/issues/5685