### PR TITLE
chore(release): call release-integration workflow from release

### DIFF
--- a/.github/workflows/node-integration.yml
+++ b/.github/workflows/node-integration.yml
@@ -82,12 +82,16 @@ jobs:
           echo "::endgroup::"
 
           if [[ "${{ inputs.npmVersion }}" != "git" ]]; then
-            echo "::group::checking out npm@${{ inputs.npmVersion }}"
+            npmVersion="${{ inputs.npmVersion }}"
+            npmVersion="${npmVersion#v}"
+            echo "::group::checking out npm@${npmVersion}"
             pushd "$npmDir" >/dev/null
-            npmVersion=$(curl -sSL https://registry.npmjs.org/npm |\
-              jq -r '.time | to_entries | map(select(.key | test("^${{ inputs.npmVersion }}"))) | sort_by(.value | split(".") | "\(.[0])Z" | fromdate) | .[-1].key')
-            npmGitHead=$(git show-ref --tags "v${npmVersion}" | cut -d' ' -f1)
-            git reset --hard "$npmGitHead"
+            taggedSha=$(git show-ref --tags "v${npmVersion}" | cut -d' ' -f1)
+            git reset --hard "$taggedSha"
+            publishedSha=$(curl -sSL https://registry.npmjs.org/npm | jq -r --arg ver "$npmVersion" '.versions[$ver].gitHead')
+            if [[ "$taggedSha" != "$publishedSha" ]]; then
+              echo "::warning ::git tag ($taggedSha) differs from published tag ($publishedSha)"
+            fi
             popd >/dev/null
             echo "::endgroup::"
           fi

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -1,9 +1,12 @@
 name: release integration
 
 on:
-  release:
-    types:
-      - published
+  workflow_call:
+    inputs:
+      npmVersion:
+        description: npm version to test
+        type: string
+        required: true
   workflow_dispatch:
     inputs:
       npmVersion:
@@ -12,21 +15,6 @@ on:
         required: true
 
 jobs:
-  npm-version:
-    env:
-      npmVersion: ${{ inputs.npmVersion || github.ref_name }}
-    name: determine npm version
-    if: ${{ inputs.npmVersion || startsWith(github.ref_name, 'v') }}
-    runs-on: ubuntu-latest
-    outputs:
-      npmVersion: ${{ steps.version.outputs.npmVersion }}
-    steps:
-      - name: clean npm version
-        id: version
-        run: |
-          npmVersion="${{ env.npmVersion }}"
-          npmVersion="${npmVersion/#v}"
-          echo "npmVersion=${npmVersion}" >> $GITHUB_OUTPUT
   node-integration:
     name: nodejs@${{ matrix.nodeVersion }} integration
     strategy:
@@ -36,10 +24,7 @@ jobs:
           - 18
           - 19
           - nightly
-    needs:
-      - npm-version
     uses: ./.github/workflows/node-integration.yml
     with:
       nodeVersion: ${{ matrix.nodeVersion }}
-      npmVersion: ${{ needs.npm-version.outputs.npmVersion }}
-
+      npmVersion: ${{ inputs.npmVersion }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,8 @@ jobs:
   release:
     outputs:
       pr: ${{ steps.release.outputs.pr }}
+      release: ${{ steps.release.outputs.release }}
       releases: ${{ steps.release.outputs.releases }}
-      release-flags: ${{ steps.release.outputs.release-flags }}
       branch: ${{ steps.release.outputs.pr-branch }}
       pr-number: ${{ steps.release.outputs.pr-number }}
       comment-id: ${{ steps.pr-comment.outputs.result }}
@@ -60,26 +60,25 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         with:
           script: |
-            const { REF_NAME, PR_NUMBER } = process.env
-            const repo = { owner: context.repo.owner, repo: context.repo.repo }
-            const issue = { ...repo, issue_number: PR_NUMBER }
+            const { REF_NAME, PR_NUMBER: issue_number } = process.env
+            const { runId, repo: { owner, repo } } = context
 
-            const { data: workflow } = await github.rest.actions.getWorkflowRun({ ...repo, run_id: context.runId })
+            const { data: workflow } = await github.rest.actions.getWorkflowRun({ owner, repo, run_id: runId })
 
             let body = '## Release Manager\n\n'
 
-            const comments = await github.paginate(github.rest.issues.listComments, issue)
-            let commentId = comments?.find(c => c.user.login === 'github-actions[bot]' && c.body.startsWith(body))?.id
+            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number })
+            let commentId = comments.find(c => c.user.login === 'github-actions[bot]' && c.body.startsWith(body))?.id
 
             body += `Release workflow run: ${workflow.html_url}\n\n#### Force CI to Update This Release\n\n`
             body += `This PR will be updated and CI will run for every non-\`chore:\` commit that is pushed to \`latest\`. `
             body += `To force CI to update this PR, run this command:\n\n`
-            body += `\`\`\`\ngh workflow run release.yml -r ${REF_NAME}\n\`\`\``
+            body += `\`\`\`\ngh workflow run release.yml -r ${REF_NAME} -R ${owner}/${repo}\n\`\`\``
 
             if (commentId) {
-              await github.rest.issues.updateComment({ ...repo, comment_id: commentId, body })
+              await github.rest.issues.updateComment({ owner, repo, comment_id: commentId, body })
             } else {
-              const { data: comment } = await github.rest.issues.createComment({ ...issue, body })
+              const { data: comment } = await github.rest.issues.createComment({ owner, repo, issue_number, body })
               commentId = comment?.id
             }
 
@@ -270,21 +269,86 @@ jobs:
       run:
         shell: bash
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Setup Git User
-        run: |
-          git config --global user.email "npm-cli+bot@github.com"
-          git config --global user.name "npm CLI robot"
-      - name: Setup Node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18.x
-          cache: npm
-      - name: Reset Deps
-        run: node . run resetdeps
-      - name: Run Post Release Actions
+      - name: Create Release PR Comment
+        uses: actions/github-script@v6
         env:
           RELEASES: ${{ needs.release.outputs.releases }}
+        with:
+          script: |
+            const releases = JSON.parse(process.env.RELEASES)
+            const { runId, repo: { owner, repo } } = context
+            const issue_number = releases[0].prNumber
+
+            let body = '## Release Workflow\n\n'
+            for (const { pkgName, version, url } of releases) {
+              body += `- \`${pkgName}@${version}\` ${url}\n`
+            }
+
+            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number })
+            const releaseComments = comments.filter(c => c.user.login === 'github-actions[bot]' && c.body.includes('Release is at'))
+
+            for (const comment of releaseComments) {
+              await github.rest.issues.deleteComment({ owner, repo, comment_id: comment.id })
+            }
+
+            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${runId}`
+            await github.rest.issues.createComment({ 
+              owner,
+              repo,
+              issue_number,
+              body: `${body}- Workflow run: :arrows_counterclockwise: ${runUrl}`,
+            })
+
+  release-integration:
+    needs: release
+    name: Release Integration
+    if: needs.release.outputs.release
+    uses: ./.github/workflows/release-integration.yml
+    with:
+      npmVersion: ${{ fromJSON(needs.release.outputs.release).version }}
+
+  post-release-integration:
+    needs: [ release, release-integration ]
+    name: Post Release Integration - Release
+    if: github.repository_owner == 'npm' && needs.release.outputs.release && always()
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Get Needs Result
+        id: needs-result
         run: |
-          node . run rp-release --ignore-scripts --if-present ${{ join(fromJSON(needs.release.outputs.release-flags), ' ') }}
+          result=""
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            result="x"
+          elif [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            result="heavy_multiplication_x"
+          else
+            result="white_check_mark"
+          fi
+          echo "::set-output name=result::$result"
+      - name: Update Release PR Comment
+        uses: actions/github-script@v6
+        env:
+          PR_NUMBER: ${{ fromJSON(needs.release.outputs.release).prNumber }}
+          RESULT: ${{ steps.needs-result.outputs.result }}
+        with:
+          script: |
+            const { PR_NUMBER: issue_number, RESULT } = process.env
+            const { repo: { owner, repo } } = context
+
+            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number })
+            const updateComment = comments.find(c => c.user.login === 'github-actions[bot]' && c.body.startsWith('## Release Workflow\n\n'))
+
+            if (updateComment) {
+              console.log('Found comment to update:', JSON.stringify(updateComment, null, 2))
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: updateComment.id,
+                body: updateComment.body.replace(/Workflow run: :[a-z_]+:/, `Workflow run: :${RESULT}:`),
+              })
+            } else {
+              console.log('No matching comments found:', JSON.stringify(comments, null, 2))
+            }

--- a/docs/package.json
+++ b/docs/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@isaacs/string-locale-compare": "^1.1.0",
     "@npmcli/eslint-config": "^4.0.0",
-    "@npmcli/template-oss": "4.11.0",
+    "@npmcli/template-oss": "4.11.1",
     "front-matter": "^4.0.2",
     "ignore-walk": "^6.0.0",
     "jsdom": "^20.0.3",
@@ -56,7 +56,7 @@
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
     "ciVersions": "latest",
     "engines": "^14.17.0 || ^16.13.0 || >=18.0.0",
-    "version": "4.11.0",
+    "version": "4.11.1",
     "content": "../scripts/template-oss/index.js",
     "workspaceRepo": {
       "add": {

--- a/mock-registry/package.json
+++ b/mock-registry/package.json
@@ -34,7 +34,7 @@
   },
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
-    "version": "4.11.0"
+    "version": "4.11.1"
   },
   "tap": {
     "no-coverage": true,
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@npmcli/arborist": "^6.1.1",
     "@npmcli/eslint-config": "^4.0.1",
-    "@npmcli/template-oss": "4.11.0",
+    "@npmcli/template-oss": "4.11.1",
     "nock": "^13.2.9",
     "npm-package-arg": "^10.1.0",
     "pacote": "^15.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -163,7 +163,7 @@
         "@npmcli/git": "^4.0.1",
         "@npmcli/mock-registry": "^1.0.0",
         "@npmcli/promise-spawn": "^6.0.1",
-        "@npmcli/template-oss": "4.11.0",
+        "@npmcli/template-oss": "4.11.1",
         "licensee": "^10.0.0",
         "nock": "^13.2.4",
         "npm-packlist": "^7.0.4",
@@ -184,7 +184,7 @@
       "devDependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
         "@npmcli/eslint-config": "^4.0.0",
-        "@npmcli/template-oss": "4.11.0",
+        "@npmcli/template-oss": "4.11.1",
         "front-matter": "^4.0.2",
         "ignore-walk": "^6.0.0",
         "jsdom": "^20.0.3",
@@ -209,7 +209,7 @@
       "devDependencies": {
         "@npmcli/arborist": "^6.1.1",
         "@npmcli/eslint-config": "^4.0.1",
-        "@npmcli/template-oss": "4.11.0",
+        "@npmcli/template-oss": "4.11.1",
         "nock": "^13.2.9",
         "npm-package-arg": "^10.1.0",
         "pacote": "^15.0.7",
@@ -2258,9 +2258,9 @@
       "link": true
     },
     "node_modules/@npmcli/template-oss": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/template-oss/-/template-oss-4.11.0.tgz",
-      "integrity": "sha512-nvZqRxT9AFf56Fj07v1yG9AQVOTNn82ysMVI67IzpktunKFHmZ5Tp8P/al5pPik/nYQ4AieEyh7XC2dMro4moA==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/template-oss/-/template-oss-4.11.1.tgz",
+      "integrity": "sha512-Rs0sYcHhbcLA9mfQz/ojdNjKIMqyPG9kA/Ie2W4OxuBeVR/rhDf7yL4iqTK4Rum9dRVz9jWXex5PDNyDyiQnHw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -14290,7 +14290,7 @@
         "@npmcli/eslint-config": "^4.0.0",
         "@npmcli/mock-registry": "^1.0.0",
         "@npmcli/promise-spawn": "^6.0.1",
-        "@npmcli/template-oss": "4.11.0",
+        "@npmcli/template-oss": "4.11.1",
         "http-proxy": "^1.18.1",
         "just-extend": "^6.1.1",
         "just-safe-set": "^4.1.1",
@@ -14345,7 +14345,7 @@
       },
       "devDependencies": {
         "@npmcli/eslint-config": "^4.0.0",
-        "@npmcli/template-oss": "4.11.0",
+        "@npmcli/template-oss": "4.11.1",
         "benchmark": "^2.1.4",
         "chalk": "^4.1.0",
         "minify-registry-metadata": "^3.0.0",
@@ -14372,7 +14372,7 @@
       },
       "devDependencies": {
         "@npmcli/eslint-config": "^4.0.0",
-        "@npmcli/template-oss": "4.11.0",
+        "@npmcli/template-oss": "4.11.1",
         "tap": "^16.3.2"
       },
       "engines": {
@@ -14389,7 +14389,7 @@
       "devDependencies": {
         "@npmcli/eslint-config": "^4.0.0",
         "@npmcli/mock-registry": "^1.0.0",
-        "@npmcli/template-oss": "4.11.0",
+        "@npmcli/template-oss": "4.11.1",
         "nock": "^13.2.4",
         "tap": "^16.3.2"
       },
@@ -14413,7 +14413,7 @@
       },
       "devDependencies": {
         "@npmcli/eslint-config": "^4.0.0",
-        "@npmcli/template-oss": "4.11.0",
+        "@npmcli/template-oss": "4.11.1",
         "tap": "^16.3.2"
       },
       "engines": {
@@ -14440,7 +14440,7 @@
       "devDependencies": {
         "@npmcli/eslint-config": "^4.0.0",
         "@npmcli/mock-registry": "^1.0.0",
-        "@npmcli/template-oss": "4.11.0",
+        "@npmcli/template-oss": "4.11.1",
         "bin-links": "^4.0.1",
         "just-extend": "^6.1.1",
         "just-safe-set": "^4.1.1",
@@ -14460,7 +14460,7 @@
       },
       "devDependencies": {
         "@npmcli/eslint-config": "^4.0.0",
-        "@npmcli/template-oss": "4.11.0",
+        "@npmcli/template-oss": "4.11.1",
         "tap": "^16.3.2"
       },
       "engines": {
@@ -14476,7 +14476,7 @@
       },
       "devDependencies": {
         "@npmcli/eslint-config": "^4.0.0",
-        "@npmcli/template-oss": "4.11.0",
+        "@npmcli/template-oss": "4.11.1",
         "nock": "^13.2.4",
         "tap": "^16.3.2"
       },
@@ -14493,7 +14493,7 @@
       },
       "devDependencies": {
         "@npmcli/eslint-config": "^4.0.0",
-        "@npmcli/template-oss": "4.11.0",
+        "@npmcli/template-oss": "4.11.1",
         "minipass": "^4.0.0",
         "nock": "^13.2.4",
         "tap": "^16.3.2"
@@ -14513,7 +14513,7 @@
       },
       "devDependencies": {
         "@npmcli/eslint-config": "^4.0.0",
-        "@npmcli/template-oss": "4.11.0",
+        "@npmcli/template-oss": "4.11.1",
         "nock": "^13.0.7",
         "spawk": "^1.7.1",
         "tap": "^16.3.2"
@@ -14535,7 +14535,7 @@
       "devDependencies": {
         "@npmcli/eslint-config": "^4.0.0",
         "@npmcli/mock-registry": "^1.0.0",
-        "@npmcli/template-oss": "4.11.0",
+        "@npmcli/template-oss": "4.11.1",
         "lodash.clonedeep": "^4.5.0",
         "nock": "^13.2.4",
         "tap": "^16.3.2"
@@ -14552,7 +14552,7 @@
       },
       "devDependencies": {
         "@npmcli/eslint-config": "^4.0.0",
-        "@npmcli/template-oss": "4.11.0",
+        "@npmcli/template-oss": "4.11.1",
         "nock": "^13.2.4",
         "tap": "^16.3.2"
       },
@@ -14569,7 +14569,7 @@
       },
       "devDependencies": {
         "@npmcli/eslint-config": "^4.0.0",
-        "@npmcli/template-oss": "4.11.0",
+        "@npmcli/template-oss": "4.11.1",
         "nock": "^13.2.4",
         "tap": "^16.3.2"
       },
@@ -14589,7 +14589,7 @@
       },
       "devDependencies": {
         "@npmcli/eslint-config": "^4.0.0",
-        "@npmcli/template-oss": "4.11.0",
+        "@npmcli/template-oss": "4.11.1",
         "require-inject": "^1.4.4",
         "tap": "^16.3.2"
       },

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "@npmcli/git": "^4.0.1",
     "@npmcli/mock-registry": "^1.0.0",
     "@npmcli/promise-spawn": "^6.0.1",
-    "@npmcli/template-oss": "4.11.0",
+    "@npmcli/template-oss": "4.11.1",
     "licensee": "^10.0.0",
     "nock": "^13.2.4",
     "npm-packlist": "^7.0.4",
@@ -250,7 +250,7 @@
   },
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
-    "version": "4.11.0",
+    "version": "4.11.1",
     "content": "./scripts/template-oss/root.js"
   },
   "license": "Artistic-2.0",

--- a/scripts/template-oss/_job-release-integration.yml
+++ b/scripts/template-oss/_job-release-integration.yml
@@ -1,0 +1,3 @@
+uses: ./.github/workflows/release-integration.yml
+with:
+  npmVersion: $\{{ fromJSON(needs.release.outputs.release).version }}

--- a/smoke-tests/package.json
+++ b/smoke-tests/package.json
@@ -21,7 +21,7 @@
     "@npmcli/eslint-config": "^4.0.0",
     "@npmcli/mock-registry": "^1.0.0",
     "@npmcli/promise-spawn": "^6.0.1",
-    "@npmcli/template-oss": "4.11.0",
+    "@npmcli/template-oss": "4.11.1",
     "http-proxy": "^1.18.1",
     "just-extend": "^6.1.1",
     "just-safe-set": "^4.1.1",
@@ -32,7 +32,7 @@
   "license": "ISC",
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
-    "version": "4.11.0",
+    "version": "4.11.1",
     "content": "../scripts/template-oss/index.js"
   },
   "tap": {

--- a/workspaces/arborist/package.json
+++ b/workspaces/arborist/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@npmcli/eslint-config": "^4.0.0",
-    "@npmcli/template-oss": "4.11.0",
+    "@npmcli/template-oss": "4.11.1",
     "benchmark": "^2.1.4",
     "chalk": "^4.1.0",
     "minify-registry-metadata": "^3.0.0",
@@ -100,7 +100,7 @@
   },
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
-    "version": "4.11.0",
+    "version": "4.11.1",
     "content": "../../scripts/template-oss/index.js"
   }
 }

--- a/workspaces/config/package.json
+++ b/workspaces/config/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@npmcli/eslint-config": "^4.0.0",
-    "@npmcli/template-oss": "4.11.0",
+    "@npmcli/template-oss": "4.11.1",
     "tap": "^16.3.2"
   },
   "dependencies": {
@@ -50,6 +50,6 @@
   },
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
-    "version": "4.11.0"
+    "version": "4.11.1"
   }
 }

--- a/workspaces/libnpmaccess/package.json
+++ b/workspaces/libnpmaccess/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@npmcli/eslint-config": "^4.0.0",
     "@npmcli/mock-registry": "^1.0.0",
-    "@npmcli/template-oss": "4.11.0",
+    "@npmcli/template-oss": "4.11.1",
     "nock": "^13.2.4",
     "tap": "^16.3.2"
   },
@@ -41,7 +41,7 @@
   ],
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
-    "version": "4.11.0",
+    "version": "4.11.1",
     "content": "../../scripts/template-oss/index.js"
   },
   "tap": {

--- a/workspaces/libnpmdiff/package.json
+++ b/workspaces/libnpmdiff/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@npmcli/eslint-config": "^4.0.0",
-    "@npmcli/template-oss": "4.11.0",
+    "@npmcli/template-oss": "4.11.1",
     "tap": "^16.3.2"
   },
   "dependencies": {
@@ -59,7 +59,7 @@
   },
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
-    "version": "4.11.0",
+    "version": "4.11.1",
     "content": "../../scripts/template-oss/index.js"
   },
   "tap": {

--- a/workspaces/libnpmexec/package.json
+++ b/workspaces/libnpmexec/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@npmcli/eslint-config": "^4.0.0",
     "@npmcli/mock-registry": "^1.0.0",
-    "@npmcli/template-oss": "4.11.0",
+    "@npmcli/template-oss": "4.11.1",
     "bin-links": "^4.0.1",
     "just-extend": "^6.1.1",
     "just-safe-set": "^4.1.1",
@@ -76,7 +76,7 @@
   },
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
-    "version": "4.11.0",
+    "version": "4.11.1",
     "content": "../../scripts/template-oss/index.js"
   }
 }

--- a/workspaces/libnpmfund/package.json
+++ b/workspaces/libnpmfund/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@npmcli/eslint-config": "^4.0.0",
-    "@npmcli/template-oss": "4.11.0",
+    "@npmcli/template-oss": "4.11.1",
     "tap": "^16.3.2"
   },
   "dependencies": {
@@ -53,7 +53,7 @@
   },
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
-    "version": "4.11.0",
+    "version": "4.11.1",
     "content": "../../scripts/template-oss/index.js"
   },
   "tap": {

--- a/workspaces/libnpmhook/package.json
+++ b/workspaces/libnpmhook/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@npmcli/eslint-config": "^4.0.0",
-    "@npmcli/template-oss": "4.11.0",
+    "@npmcli/template-oss": "4.11.1",
     "nock": "^13.2.4",
     "tap": "^16.3.2"
   },
@@ -46,7 +46,7 @@
   },
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
-    "version": "4.11.0",
+    "version": "4.11.1",
     "content": "../../scripts/template-oss/index.js"
   },
   "tap": {

--- a/workspaces/libnpmorg/package.json
+++ b/workspaces/libnpmorg/package.json
@@ -28,7 +28,7 @@
   ],
   "devDependencies": {
     "@npmcli/eslint-config": "^4.0.0",
-    "@npmcli/template-oss": "4.11.0",
+    "@npmcli/template-oss": "4.11.1",
     "minipass": "^4.0.0",
     "nock": "^13.2.4",
     "tap": "^16.3.2"
@@ -49,7 +49,7 @@
   },
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
-    "version": "4.11.0",
+    "version": "4.11.1",
     "content": "../../scripts/template-oss/index.js"
   },
   "tap": {

--- a/workspaces/libnpmpack/package.json
+++ b/workspaces/libnpmpack/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@npmcli/eslint-config": "^4.0.0",
-    "@npmcli/template-oss": "4.11.0",
+    "@npmcli/template-oss": "4.11.1",
     "nock": "^13.0.7",
     "spawk": "^1.7.1",
     "tap": "^16.3.2"
@@ -46,7 +46,7 @@
   },
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
-    "version": "4.11.0",
+    "version": "4.11.1",
     "content": "../../scripts/template-oss/index.js"
   },
   "tap": {

--- a/workspaces/libnpmpublish/package.json
+++ b/workspaces/libnpmpublish/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@npmcli/eslint-config": "^4.0.0",
     "@npmcli/mock-registry": "^1.0.0",
-    "@npmcli/template-oss": "4.11.0",
+    "@npmcli/template-oss": "4.11.1",
     "lodash.clonedeep": "^4.5.0",
     "nock": "^13.2.4",
     "tap": "^16.3.2"
@@ -50,7 +50,7 @@
   },
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
-    "version": "4.11.0",
+    "version": "4.11.1",
     "content": "../../scripts/template-oss/index.js"
   },
   "tap": {

--- a/workspaces/libnpmsearch/package.json
+++ b/workspaces/libnpmsearch/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@npmcli/eslint-config": "^4.0.0",
-    "@npmcli/template-oss": "4.11.0",
+    "@npmcli/template-oss": "4.11.1",
     "nock": "^13.2.4",
     "tap": "^16.3.2"
   },
@@ -45,7 +45,7 @@
   },
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
-    "version": "4.11.0",
+    "version": "4.11.1",
     "content": "../../scripts/template-oss/index.js"
   },
   "tap": {

--- a/workspaces/libnpmteam/package.json
+++ b/workspaces/libnpmteam/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@npmcli/eslint-config": "^4.0.0",
-    "@npmcli/template-oss": "4.11.0",
+    "@npmcli/template-oss": "4.11.1",
     "nock": "^13.2.4",
     "tap": "^16.3.2"
   },
@@ -39,7 +39,7 @@
   },
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
-    "version": "4.11.0",
+    "version": "4.11.1",
     "content": "../../scripts/template-oss/index.js"
   },
   "tap": {

--- a/workspaces/libnpmversion/package.json
+++ b/workspaces/libnpmversion/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@npmcli/eslint-config": "^4.0.0",
-    "@npmcli/template-oss": "4.11.0",
+    "@npmcli/template-oss": "4.11.1",
     "require-inject": "^1.4.4",
     "tap": "^16.3.2"
   },
@@ -48,7 +48,7 @@
   },
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
-    "version": "4.11.0",
+    "version": "4.11.1",
     "content": "../../scripts/template-oss/index.js"
   }
 }


### PR DESCRIPTION
since our releases are created from within an action by release-please the release-integration workflow doesn't get triggered. in order to make it work, we instead use `workflow_call` from within the release.yml

~draft as this depends on https://github.com/npm/template-oss/pull/269 being merged and published before it will work~

this pr now updates @npmcli/template-oss and is ready for review