### PR TITLE
chore(release): drop actions permission from node-integration workflow

### DIFF
--- a/.github/workflows/node-integration.yml
+++ b/.github/workflows/node-integration.yml
@@ -27,10 +27,6 @@ on:
         type: string
         default: git
 
-# used by setup-ccache-action's post hook to cleanup old caches
-permissions:
-  actions: write
-
 jobs:
   build-nodejs:
     name: build nodejs@${{ inputs.nodeVersion }} npm@${{ inputs.npmVersion }}


### PR DESCRIPTION
this action is failing due to asking for permissions it's not allowed to have, so i removed them. the consequence of this is that our ccache action will not be able to clean up old stale caches for us. we'll want to determine a way to do that ourselves elsewhere at some point.
