### PR TITLE
fix:Replacing only the host of the resolved package when `replaceRegistryHost` is set

### DIFF
--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -11,7 +11,7 @@ const log = require('proc-log')
 const hgi = require('hosted-git-info')
 const rpj = require('read-package-json-fast')
 
-const { dirname, resolve, relative, join, parse } = require('path')
+const { dirname, resolve, relative, join } = require('path')
 const { depth: dfwalk } = require('treeverse')
 const {
   lstat,

--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -11,7 +11,7 @@ const log = require('proc-log')
 const hgi = require('hosted-git-info')
 const rpj = require('read-package-json-fast')
 
-const { dirname, resolve, relative, join } = require('path')
+const { dirname, resolve, relative, join, parse } = require('path')
 const { depth: dfwalk } = require('treeverse')
 const {
   lstat,
@@ -752,6 +752,7 @@ module.exports = cls => class Reifier extends cls {
     // Shrinkwrap and Node classes carefully, so for now, just treat
     // the default reg as the magical animal that it has been.
     const resolvedURL = hgi.parseUrl(resolved)
+    const parsedHostName = hgi.parseUrl(this.registry)
 
     if (!resolvedURL) {
       // if we could not parse the url at all then returning nothing
@@ -759,10 +760,10 @@ module.exports = cls => class Reifier extends cls {
       return
     }
 
-    if ((this.options.replaceRegistryHost === resolvedURL.hostname)
+    if (this.options.replaceRegistryHost === resolvedURL.hostname
       || this.options.replaceRegistryHost === 'always') {
-      // this.registry always has a trailing slash
-      return `${this.registry.slice(0, -1)}${resolvedURL.pathname}${resolvedURL.searchParams}`
+      const newRegistryHost = resolved.replace(resolvedURL.hostname, parsedHostName.hostname)
+      return newRegistryHost
     }
 
     return resolved

--- a/workspaces/arborist/test/arborist/reify.js
+++ b/workspaces/arborist/test/arborist/reify.js
@@ -2997,6 +2997,22 @@ t.only('should preserve exact ranges, missing actual tree', async (t) => {
     },
   })
 
+  const abbrevPackument3 = JSON.stringify({
+    _id: 'abbrev',
+    _rev: 'lkjadflkjasdf',
+    name: 'abbrev',
+    'dist-tags': { latest: '1.1.1' },
+    versions: {
+      '1.1.1': {
+        name: 'abbrev',
+        version: '1.1.1',
+        dist: {
+          tarball: 'https://registry2.com/a/b/abbrev/-/abbrev-1.1.1.tgz',
+        },
+      },
+    },
+  })
+
   const gitSshPackument = JSON.stringify({
     _id: 'gitssh',
     _rev: 'lkjadflkjasdf',
@@ -3145,6 +3161,34 @@ t.only('should preserve exact ranges, missing actual tree', async (t) => {
     const arb = new Arborist({
       path: resolve(testdir, 'project'),
       registry: 'https://registry.github.com',
+      cache: resolve(testdir, 'cache'),
+      replaceRegistryHost: 'always',
+    })
+    await arb.reify()
+  })
+
+  t.only('host should be always replaceRegistryHost=customRegistry', async (t) => {
+    const testdir = t.testdir({
+      project: {
+        'package.json': JSON.stringify({
+          name: 'myproject',
+          version: '1.0.0',
+          dependencies: {
+            abbrev: '1.1.1',
+          },
+        }),
+      },
+    })
+    tnock(t, 'https://registry1.com/a/b')
+      .get('/abbrev')
+      .reply(200, abbrevPackument3)
+    tnock(t, 'https://registry1.com/a/b')
+      .get('/abbrev/-/abbrev-1.1.1.tgz')
+      .reply(200, abbrevTGZ)
+
+    const arb = new Arborist({
+      path: resolve(testdir, 'project'),
+      registry: 'https://registry1.com/a/b',
       cache: resolve(testdir, 'cache'),
       replaceRegistryHost: 'always',
     })


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Attempt to address https://github.com/npm/cli/issues/6110

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
