### PR TITLE
feat: try to make npm create sorted `package.json`

### DIFF
--- a/lib/utils/sort-package.js
+++ b/lib/utils/sort-package.js
@@ -1,0 +1,18 @@
+/**
+ * This is a pure function that creates a new object with keys from
+ * the parameter, in sorted order.
+ * @param {object} originalObject The keys are pulled from this object.
+ * @returns a new object with the same keys as the parameter,
+ * except in sorted order
+ */
+const createObjectjWithSortedKeys = (originalObject) => {
+  const keys = Object.keys(originalObject)
+  keys.sort()
+  const objectWithSortedKeys = {}
+  for (const key of keys) {
+    objectWithSortedKeys[key] = originalObject[key]
+  }
+  return objectWithSortedKeys
+}
+
+module.exports = createObjectjWithSortedKeys

--- a/test/lib/utils/sort-package.js
+++ b/test/lib/utils/sort-package.js
@@ -1,0 +1,34 @@
+const t = require('tap')
+const createObjectjWithSortedKeys = require('../../../lib/utils/sort-package.js')
+
+t.test('package.json has sorted keys on init', async (t) => {
+  const unsortedPkg = {
+    version: '9.4.1',
+    name: 'npm',
+    description: 'a package manager for JavaScript',
+    workspaces: ['docs', 'smoke-tests', 'mock-registry', 'workspaces/*'],
+    keywords: ['install', 'modules', 'package manager', 'package.json'],
+    homepage: 'https://docs.npmjs.com/',
+    author: 'GitHub Inc.',
+    main: './index.js',
+    license: 'Artistic-2.0',
+  }
+  const actual = createObjectjWithSortedKeys(unsortedPkg)
+
+  const expected = {
+    author: 'GitHub Inc.',
+    description: 'a package manager for JavaScript',
+    homepage: 'https://docs.npmjs.com/',
+    keywords: ['install', 'modules', 'package manager', 'package.json'],
+    license: 'Artistic-2.0',
+    main: './index.js',
+    name: 'npm',
+    version: '9.4.1',
+    workspaces: ['docs', 'smoke-tests', 'mock-registry', 'workspaces/*'],
+  }
+  t.strictSame(
+    actual,
+    expected,
+    'should create package.json with keys in sorted order'
+  )
+})

--- a/workspaces/libnpmversion/lib/write-json.js
+++ b/workspaces/libnpmversion/lib/write-json.js
@@ -1,5 +1,6 @@
 // write the json back, preserving the line breaks and indent
 const { promisify } = require('util')
+const createObjectjWithSortedKeys = require('../../../lib/utils/sort-package.js');
 const writeFile = promisify(require('fs').writeFile)
 const kIndent = Symbol.for('indent')
 const kNewline = Symbol.for('newline')
@@ -10,7 +11,8 @@ module.exports = async (path, pkg) => {
     [kNewline]: newline = '\n',
   } = pkg
   delete pkg._id
-  const raw = JSON.stringify(pkg, null, indent) + '\n'
+  const pkgWithSortedKeys = createObjectjWithSortedKeys(pkg)
+  const raw = JSON.stringify(pkgWithSortedKeys, null, indent) + '\n'
   const data = newline === '\n' ? raw : raw.split('\n').join(newline)
   return writeFile(path, data)
 }


### PR DESCRIPTION
<!-- What / Why -->
I think it would be kind of neat if `npm init -y` created a `package.json` with sorted keys. This pull request tries to add that functionality.

<!-- Describe the request in detail. What it does and why it's being changed. -->
It creates a new object, with the keys in `pkg`, except in sorted order, and uses that for `raw` in `workspaces/libnpmversion/lib/write-json.js`.

`test/lib/utils/sort-package.js` is the unit test I added for this.

`lib/utils/sort-package.js` is the helper function, with documentation.