### PR TITLE
docs: update references to OTP to be accurate

### DIFF
--- a/docs/lib/content/commands/npm-access.md
+++ b/docs/lib/content/commands/npm-access.md
@@ -57,8 +57,7 @@ You must have privileges to set the access of a package:
 * You have been given read-write privileges for a package, either as a member
   of a team or directly as an owner.
 
-If you have two-factor authentication enabled then you'll be prompted to
-provide an otp token, or may use the `--otp=...` option to specify it on
+If you have two-factor authentication enabled then you'll be prompted to provide a second factor, or may use the `--otp=...` option to specify it on
 the command line.
 
 If your account is not paid, then attempts to publish scoped packages will

--- a/docs/lib/content/commands/npm-dist-tag.md
+++ b/docs/lib/content/commands/npm-dist-tag.md
@@ -16,12 +16,12 @@ Add, remove, and enumerate distribution tags on a package:
   or the [`--tag` config](/using-npm/config#tag) if not specified. If you have
   two-factor authentication on auth-and-writes then you’ll need to include a
   one-time password on the command line with
-  `--otp <one-time password>`, or at the OTP prompt.
+  `--otp <one-time password>`, or go through a second factor flow based on your `authtype`.
 
 * rm: Clear a tag that is no longer in use from the package. If you have
   two-factor authentication on auth-and-writes then you’ll need to include
   a one-time password on the command line with `--otp <one-time password>`,
-  or at the OTP prompt.
+  or go through a second factor flow based on your `authtype`
 
 * ls: Show all of the dist-tags for a package, defaulting to the package in
   the current prefix. This is the default action if none is specified.

--- a/docs/lib/content/commands/npm-owner.md
+++ b/docs/lib/content/commands/npm-owner.md
@@ -24,8 +24,8 @@ or you can't.  Future versions may contain more fine-grained access levels, but
 that is not implemented at this time.
 
 If you have two-factor authentication enabled with `auth-and-writes` (see
-[`npm-profile`](/commands/npm-profile)) then you'll need to include an otp
-on the command line when changing ownership with `--otp`.
+[`npm-profile`](/commands/npm-profile)) then you'll need to go through a second factor
+flow when changing ownership or include an otp on the command line with `--otp`.
 
 ### Configuration
 

--- a/docs/lib/content/commands/npm-team.md
+++ b/docs/lib/content/commands/npm-team.md
@@ -20,7 +20,8 @@ as `@org:newteam` in these commands.
 
 If you have two-factor authentication enabled in `auth-and-writes` mode, then
 you can provide a code from your authenticator with `[--otp <otpcode>]`.
-If you don't include this then you will be prompted.
+If you don't include this then you will be taken through a second factor flow based
+on your `authtype`.
 
 * create / destroy:
   Create a new team, or destroy an existing one. Note: You cannot remove the


### PR DESCRIPTION
With `--authtype` default now being `web` some of the references to 2FA in the docs are no longer accurate.

We might want to just remove the documentation about 2FA related to commands as it has risk of going stale with registry changes over time or alternatively centralize it.

I'm not 100% I found everything, but did the best I could with some small greps