### PR TITLE
fix: revert `install-links` default back to `false`

### DIFF
--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -1078,7 +1078,7 @@ define('init.version', {
 })
 
 define('install-links', {
-  default: true,
+  default: false,
   type: Boolean,
   description: `
     When set file: protocol dependencies will be packed and installed as

--- a/smoke-tests/tap-snapshots/test/index.js.test.cjs
+++ b/smoke-tests/tap-snapshots/test/index.js.test.cjs
@@ -61,7 +61,7 @@ npm ERR! [--global-style] [--omit <dev|optional|peer> [--omit <dev|optional|peer
 npm ERR! [--strict-peer-deps] [--no-package-lock] [--foreground-scripts]
 npm ERR! [--ignore-scripts] [--no-audit] [--no-bin-links] [--no-fund] [--dry-run]
 npm ERR! [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
-npm ERR! [-ws|--workspaces] [--include-workspace-root] [--no-install-links]
+npm ERR! [-ws|--workspaces] [--include-workspace-root] [--install-links]
 npm ERR! 
 npm ERR! aliases: clean-install, ic, install-clean, isntall-clean
 npm ERR! 

--- a/tap-snapshots/test/lib/commands/config.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/config.js.test.cjs
@@ -81,7 +81,7 @@ exports[`test/lib/commands/config.js TAP config list --json > output matches sna
   "init.license": "ISC",
   "init.module": "{HOME}/.npm-init.js",
   "init.version": "1.0.0",
-  "install-links": true,
+  "install-links": false,
   "install-strategy": "hoisted",
   "key": null,
   "legacy-bundling": false,
@@ -234,7 +234,7 @@ init.author.url = ""
 init.license = "ISC" 
 init.module = "{HOME}/.npm-init.js" 
 init.version = "1.0.0" 
-install-links = true 
+install-links = false 
 install-strategy = "hoisted" 
 json = false 
 key = null 

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -1153,7 +1153,7 @@ number, if not already set in package.json.
 
 #### \`install-links\`
 
-* Default: true
+* Default: false
 * Type: Boolean
 
 When set file: protocol dependencies will be packed and installed as regular
@@ -2537,7 +2537,7 @@ Options:
 [--omit <dev|optional|peer> [--omit <dev|optional|peer> ...]]
 [--foreground-scripts] [--ignore-scripts]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
-[-ws|--workspaces] [--include-workspace-root] [--no-install-links]
+[-ws|--workspaces] [--include-workspace-root] [--install-links]
 
 Run "npm help audit" for more info
 
@@ -2627,7 +2627,7 @@ Options:
 [--strict-peer-deps] [--no-package-lock] [--foreground-scripts]
 [--ignore-scripts] [--no-audit] [--no-bin-links] [--no-fund] [--dry-run]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
-[-ws|--workspaces] [--include-workspace-root] [--no-install-links]
+[-ws|--workspaces] [--include-workspace-root] [--install-links]
 
 aliases: clean-install, ic, install-clean, isntall-clean
 
@@ -2728,7 +2728,7 @@ Options:
 [--omit <dev|optional|peer> [--omit <dev|optional|peer> ...]] [--ignore-scripts]
 [--no-audit] [--no-bin-links] [--no-fund] [--dry-run]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
-[-ws|--workspaces] [--include-workspace-root] [--no-install-links]
+[-ws|--workspaces] [--include-workspace-root] [--install-links]
 
 alias: ddp
 
@@ -2999,7 +2999,7 @@ Options:
 [--omit <dev|optional|peer> [--omit <dev|optional|peer> ...]] [--ignore-scripts]
 [--no-audit] [--no-bin-links] [--no-fund]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
-[-ws|--workspaces] [--include-workspace-root] [--no-install-links]
+[-ws|--workspaces] [--include-workspace-root] [--install-links]
 
 Run "npm help find-dupes" for more info
 
@@ -3181,7 +3181,7 @@ Options:
 [--strict-peer-deps] [--no-package-lock] [--foreground-scripts]
 [--ignore-scripts] [--no-audit] [--no-bin-links] [--no-fund] [--dry-run]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
-[-ws|--workspaces] [--include-workspace-root] [--no-install-links]
+[-ws|--workspaces] [--include-workspace-root] [--install-links]
 
 aliases: add, i, in, ins, inst, insta, instal, isnt, isnta, isntal, isntall
 
@@ -3228,7 +3228,7 @@ Options:
 [--strict-peer-deps] [--no-package-lock] [--foreground-scripts]
 [--ignore-scripts] [--no-audit] [--no-bin-links] [--no-fund] [--dry-run]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
-[-ws|--workspaces] [--include-workspace-root] [--no-install-links]
+[-ws|--workspaces] [--include-workspace-root] [--install-links]
 
 alias: cit
 
@@ -3275,7 +3275,7 @@ Options:
 [--strict-peer-deps] [--no-package-lock] [--foreground-scripts]
 [--ignore-scripts] [--no-audit] [--no-bin-links] [--no-fund] [--dry-run]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
-[-ws|--workspaces] [--include-workspace-root] [--no-install-links]
+[-ws|--workspaces] [--include-workspace-root] [--install-links]
 
 alias: it
 
@@ -3322,7 +3322,7 @@ Options:
 [--omit <dev|optional|peer> [--omit <dev|optional|peer> ...]] [--ignore-scripts]
 [--no-audit] [--no-bin-links] [--no-fund] [--dry-run]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
-[-ws|--workspaces] [--include-workspace-root] [--no-install-links]
+[-ws|--workspaces] [--include-workspace-root] [--install-links]
 
 alias: ln
 
@@ -3365,7 +3365,7 @@ Options:
 [--omit <dev|optional|peer> [--omit <dev|optional|peer> ...]] [--link]
 [--package-lock-only] [--unicode]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
-[-ws|--workspaces] [--include-workspace-root] [--no-install-links]
+[-ws|--workspaces] [--include-workspace-root] [--install-links]
 
 alias: la
 
@@ -3447,7 +3447,7 @@ Options:
 [--omit <dev|optional|peer> [--omit <dev|optional|peer> ...]] [--link]
 [--package-lock-only] [--unicode]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
-[-ws|--workspaces] [--include-workspace-root] [--no-install-links]
+[-ws|--workspaces] [--include-workspace-root] [--install-links]
 
 alias: list
 
@@ -3717,7 +3717,7 @@ Options:
 [--omit <dev|optional|peer> [--omit <dev|optional|peer> ...]] [--dry-run]
 [--json] [--foreground-scripts] [--ignore-scripts]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
-[-ws|--workspaces] [--include-workspace-root] [--no-install-links]
+[-ws|--workspaces] [--include-workspace-root] [--install-links]
 
 Run "npm help prune" for more info
 
@@ -3794,7 +3794,7 @@ npm rebuild [<package-spec>] ...]
 Options:
 [-g|--global] [--no-bin-links] [--foreground-scripts] [--ignore-scripts]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
-[-ws|--workspaces] [--include-workspace-root] [--no-install-links]
+[-ws|--workspaces] [--include-workspace-root] [--install-links]
 
 alias: rb
 
@@ -4150,7 +4150,7 @@ npm uninstall [<@scope>/]<pkg>...
 Options:
 [-S|--save|--no-save|--save-prod|--save-dev|--save-optional|--save-peer|--save-bundle]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
-[-ws|--workspaces] [--include-workspace-root] [--no-install-links]
+[-ws|--workspaces] [--include-workspace-root] [--install-links]
 
 aliases: unlink, remove, rm, r, un
 
@@ -4228,7 +4228,7 @@ Options:
 [--strict-peer-deps] [--no-package-lock] [--foreground-scripts]
 [--ignore-scripts] [--no-audit] [--no-bin-links] [--no-fund] [--dry-run]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
-[-ws|--workspaces] [--include-workspace-root] [--no-install-links]
+[-ws|--workspaces] [--include-workspace-root] [--install-links]
 
 aliases: up, upgrade, udpate
 


### PR DESCRIPTION
this new default was unintentionally breaking so we are reverting it as a bug fix, see https://github.com/nodejs/node/issues/46542

note that this is technically a breaking change. however, since the new default was not delivered appropriately we are reverting this in a patch release as we consider it a bug fix.

if you have already updated to npm@9 and your project includes dependencies using the `file:` protocol, then it is possible that this change will cause the `npm ci` command to fail informing you that your package.json and package-lock.json are out of sync. if this happens, re-running `npm install` will correct the lockfile and cause the `npm ci` command to work again as expected.
