### PR TITLE
deps: http-cache-semantics@4.1.1 for v8 release

### DIFF
--- a/node_modules/http-cache-semantics/index.js
+++ b/node_modules/http-cache-semantics/index.js
@@ -7,6 +7,7 @@ const statusCodeCacheableByDefault = new Set([
     206,
     300,
     301,
+    308,
     404,
     405,
     410,
@@ -79,10 +80,10 @@ function parseCacheControl(header) {
 
     // TODO: When there is more than one value present for a given directive (e.g., two Expires header fields, multiple Cache-Control: max-age directives),
     // the directive's value is considered invalid. Caches are encouraged to consider responses that have invalid freshness information to be stale
-    const parts = header.trim().split(/\s*,\s*/); // TODO: lame parsing
+    const parts = header.trim().split(/,/);
     for (const part of parts) {
-        const [k, v] = part.split(/\s*=\s*/, 2);
-        cc[k] = v === undefined ? true : v.replace(/^"|"$/g, ''); // TODO: lame unquoting
+        const [k, v] = part.split(/=/, 2);
+        cc[k.trim()] = v === undefined ? true : v.trim().replace(/^"|"$/g, '');
     }
 
     return cc;

--- a/node_modules/http-cache-semantics/package.json
+++ b/node_modules/http-cache-semantics/package.json
@@ -1,6 +1,6 @@
 {
     "name": "http-cache-semantics",
-    "version": "4.1.0",
+    "version": "4.1.1",
     "description": "Parses Cache-Control and other headers. Helps building correct HTTP caches and proxies",
     "repository": "https://github.com/kornelski/http-cache-semantics.git",
     "main": "index.js",
@@ -13,12 +13,6 @@
     "author": "Kornel Lesiński <kornel@geekhood.net> (https://kornel.ski/)",
     "license": "BSD-2-Clause",
     "devDependencies": {
-        "eslint": "^5.13.0",
-        "eslint-plugin-prettier": "^3.0.1",
-        "husky": "^0.14.3",
-        "lint-staged": "^8.1.3",
-        "mocha": "^5.1.0",
-        "prettier": "^1.14.3",
-        "prettier-eslint-cli": "^4.7.1"
+        "mocha": "^10.0"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6442,9 +6442,10 @@
       "license": "MIT"
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "inBundle": true,
-      "license": "BSD-2-Clause"
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
+      "inBundle": true
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",


### PR DESCRIPTION
https://www.cve.org/CVERecord?id=CVE-2022-25881

Replicated the changes made by https://github.com/npm/cli/pull/6115 for the v8 release branch