### PR TITLE
docs: don't redirect "npm config' to itself

### DIFF
--- a/docs/lib/content/commands/npm-config.md
+++ b/docs/lib/content/commands/npm-config.md
@@ -90,7 +90,6 @@ global config.
 ### See Also
 
 * [npm folders](/configuring-npm/folders)
-* [npm config](/commands/npm-config)
 * [package.json](/configuring-npm/package-json)
 * [npmrc](/configuring-npm/npmrc)
 * [npm](/commands/npm)


### PR DESCRIPTION
The `npm config` page redirects to itself in the "See also" section.
