### PR TITLE
fix: use npmFetch() instead of npmFetch.json() for team destroy command

### DIFF
--- a/workspaces/libnpmteam/lib/index.js
+++ b/workspaces/libnpmteam/lib/index.js
@@ -20,15 +20,17 @@ cmd.create = (entity, opts = {}) => {
   })
 }
 
-cmd.destroy = (entity, opts = {}) => {
+cmd.destroy = async (entity, opts = {}) => {
   const { scope, team } = splitEntity(entity)
   validate('SSO', [scope, team, opts])
   const uri = `/-/team/${eu(scope)}/${eu(team)}`
-  return npmFetch(uri, {
+  await npmFetch(uri, {
     ...opts,
     method: 'DELETE',
     scope,
-  }).then((res) => res.text())
+    ignoreBody: true,
+  })
+  return true
 }
 
 cmd.add = (user, entity, opts = {}) => {
@@ -43,16 +45,18 @@ cmd.add = (user, entity, opts = {}) => {
   })
 }
 
-cmd.rm = (user, entity, opts = {}) => {
+cmd.rm = async (user, entity, opts = {}) => {
   const { scope, team } = splitEntity(entity)
   validate('SSO', [scope, team, opts])
   const uri = `/-/team/${eu(scope)}/${eu(team)}/user`
-  return npmFetch(uri, {
+  await npmFetch(uri, {
     ...opts,
     method: 'DELETE',
     scope,
     body: { user },
-  }).then(res => res.text())
+    ignoreBody: true,
+  })
+  return true
 }
 
 cmd.lsTeams = (...args) => cmd.lsTeams.stream(...args).collect()

--- a/workspaces/libnpmteam/lib/index.js
+++ b/workspaces/libnpmteam/lib/index.js
@@ -24,7 +24,7 @@ cmd.destroy = (entity, opts = {}) => {
   const { scope, team } = splitEntity(entity)
   validate('SSO', [scope, team, opts])
   const uri = `/-/team/${eu(scope)}/${eu(team)}`
-  return npmFetch.json(uri, {
+  return npmFetch(uri, {
     ...opts,
     method: 'DELETE',
     scope,

--- a/workspaces/libnpmteam/lib/index.js
+++ b/workspaces/libnpmteam/lib/index.js
@@ -28,7 +28,9 @@ cmd.destroy = (entity, opts = {}) => {
     ...opts,
     method: 'DELETE',
     scope,
-  }).then(() => {})
+  }).then(() => {
+    return {}
+  })
 }
 
 cmd.add = (user, entity, opts = {}) => {

--- a/workspaces/libnpmteam/lib/index.js
+++ b/workspaces/libnpmteam/lib/index.js
@@ -28,7 +28,7 @@ cmd.destroy = (entity, opts = {}) => {
     ...opts,
     method: 'DELETE',
     scope,
-  })
+  }).then(() => {})
 }
 
 cmd.add = (user, entity, opts = {}) => {

--- a/workspaces/libnpmteam/lib/index.js
+++ b/workspaces/libnpmteam/lib/index.js
@@ -28,9 +28,7 @@ cmd.destroy = (entity, opts = {}) => {
     ...opts,
     method: 'DELETE',
     scope,
-  }).then(() => {
-    return {}
-  })
+  }).then((res) => res.text())
 }
 
 cmd.add = (user, entity, opts = {}) => {
@@ -49,12 +47,12 @@ cmd.rm = (user, entity, opts = {}) => {
   const { scope, team } = splitEntity(entity)
   validate('SSO', [scope, team, opts])
   const uri = `/-/team/${eu(scope)}/${eu(team)}/user`
-  return npmFetch.json(uri, {
+  return npmFetch(uri, {
     ...opts,
     method: 'DELETE',
     scope,
     body: { user },
-  })
+  }).then(res => res.text())
 }
 
 cmd.lsTeams = (...args) => cmd.lsTeams.stream(...args).collect()

--- a/workspaces/libnpmteam/test/index.js
+++ b/workspaces/libnpmteam/test/index.js
@@ -52,9 +52,9 @@ test('create w/ description', async t => {
 test('destroy', async t => {
   tnock(t, REG).delete(
     '/-/team/foo/cli'
-  ).reply(204, '')
+  ).reply(204, {})
   const ret = await team.destroy('@foo:cli', OPTS)
-  t.same(ret, '', 'request succeeded')
+  t.same(ret, {}, 'request succeeded')
 })
 
 test('destroy - no options', async t => {
@@ -62,10 +62,10 @@ test('destroy - no options', async t => {
   // will be defauled to real registry url in `npm-registry-fetch`
   tnock(t, 'https://registry.npmjs.org')
     .delete('/-/team/foo/cli')
-    .reply(204, '')
+    .reply(204, {})
 
   const ret = await team.destroy('@foo:cli')
-  t.same(ret, '', 'request succeeded')
+  t.same(ret, {}, 'request succeeded')
 })
 
 test('add', async t => {

--- a/workspaces/libnpmteam/test/index.js
+++ b/workspaces/libnpmteam/test/index.js
@@ -52,9 +52,9 @@ test('create w/ description', async t => {
 test('destroy', async t => {
   tnock(t, REG).delete(
     '/-/team/foo/cli'
-  ).reply(204, {})
+  ).reply(204, '')
   const ret = await team.destroy('@foo:cli', OPTS)
-  t.same(ret, {}, 'request succeeded')
+  t.same(ret, '', 'request succeeded')
 })
 
 test('destroy - no options', async t => {
@@ -62,10 +62,10 @@ test('destroy - no options', async t => {
   // will be defauled to real registry url in `npm-registry-fetch`
   tnock(t, 'https://registry.npmjs.org')
     .delete('/-/team/foo/cli')
-    .reply(204, {})
+    .reply(204, '')
 
   const ret = await team.destroy('@foo:cli')
-  t.same(ret, {}, 'request succeeded')
+  t.same(ret, '', 'request succeeded')
 })
 
 test('add', async t => {
@@ -90,9 +90,9 @@ test('add - no options', async t => {
 test('rm', async t => {
   tnock(t, REG).delete(
     '/-/team/foo/cli/user', { user: 'zkat' }
-  ).reply(204, {})
+  ).reply(204, '')
   const ret = await team.rm('zkat', '@foo:cli', OPTS)
-  t.same(ret, {}, 'request succeeded')
+  t.same(ret, '', 'request succeeded')
 })
 
 test('rm - no options', async t => {
@@ -100,10 +100,10 @@ test('rm - no options', async t => {
   // will be defauled to real registry url in `npm-registry-fetch`
   tnock(t, 'https://registry.npmjs.org')
     .delete('/-/team/foo/cli/user', { user: 'zkat' })
-    .reply(204, {})
+    .reply(204, '')
 
   const ret = await team.rm('zkat', '@foo:cli')
-  t.same(ret, {}, 'request succeeded')
+  t.same(ret, '', 'request succeeded')
 })
 
 test('lsTeams', async t => {

--- a/workspaces/libnpmteam/test/index.js
+++ b/workspaces/libnpmteam/test/index.js
@@ -52,9 +52,9 @@ test('create w/ description', async t => {
 test('destroy', async t => {
   tnock(t, REG).delete(
     '/-/team/foo/cli'
-  ).reply(204, {})
+  ).reply(204, '')
   const ret = await team.destroy('@foo:cli', OPTS)
-  t.same(ret, {}, 'request succeeded')
+  t.same(ret, '', 'request succeeded')
 })
 
 test('destroy - no options', async t => {
@@ -62,10 +62,10 @@ test('destroy - no options', async t => {
   // will be defauled to real registry url in `npm-registry-fetch`
   tnock(t, 'https://registry.npmjs.org')
     .delete('/-/team/foo/cli')
-    .reply(204, {})
+    .reply(204, '')
 
   const ret = await team.destroy('@foo:cli')
-  t.same(ret, {}, 'request succeeded')
+  t.same(ret, '', 'request succeeded')
 })
 
 test('add', async t => {

--- a/workspaces/libnpmteam/test/index.js
+++ b/workspaces/libnpmteam/test/index.js
@@ -52,9 +52,11 @@ test('create w/ description', async t => {
 test('destroy', async t => {
   tnock(t, REG).delete(
     '/-/team/foo/cli'
-  ).reply(204, '')
-  const ret = await team.destroy('@foo:cli', OPTS)
-  t.same(ret, '', 'request succeeded')
+  ).reply(204)
+  await t.resolves(
+    team.destroy('@foo:cli', OPTS),
+    'request succeeded'
+  )
 })
 
 test('destroy - no options', async t => {
@@ -62,10 +64,12 @@ test('destroy - no options', async t => {
   // will be defauled to real registry url in `npm-registry-fetch`
   tnock(t, 'https://registry.npmjs.org')
     .delete('/-/team/foo/cli')
-    .reply(204, '')
+    .reply(204)
 
-  const ret = await team.destroy('@foo:cli')
-  t.same(ret, '', 'request succeeded')
+  await t.resolves(
+    team.destroy('@foo:cli'),
+    'request succeeded'
+  )
 })
 
 test('add', async t => {
@@ -73,7 +77,7 @@ test('add', async t => {
     '/-/team/foo/cli/user', { user: 'zkat' }
   ).reply(201, {})
   const ret = await team.add('zkat', '@foo:cli', OPTS)
-  t.same(ret, {}, 'request succeeded')
+  t.ok(ret, 'request succeeded')
 })
 
 test('add - no options', async t => {
@@ -90,9 +94,11 @@ test('add - no options', async t => {
 test('rm', async t => {
   tnock(t, REG).delete(
     '/-/team/foo/cli/user', { user: 'zkat' }
-  ).reply(204, '')
-  const ret = await team.rm('zkat', '@foo:cli', OPTS)
-  t.same(ret, '', 'request succeeded')
+  ).reply(204)
+  await t.resolves(
+    team.rm('zkat', '@foo:cli', OPTS),
+    'request succeeded'
+  )
 })
 
 test('rm - no options', async t => {
@@ -100,10 +106,12 @@ test('rm - no options', async t => {
   // will be defauled to real registry url in `npm-registry-fetch`
   tnock(t, 'https://registry.npmjs.org')
     .delete('/-/team/foo/cli/user', { user: 'zkat' })
-    .reply(204, '')
+    .reply(204)
 
-  const ret = await team.rm('zkat', '@foo:cli')
-  t.same(ret, '', 'request succeeded')
+  await t.resolves(
+    team.rm('zkat', '@foo:cli'),
+    'request succeeded'
+  )
 })
 
 test('lsTeams', async t => {


### PR DESCRIPTION
The registry returns a HTTP 204 status and an empty body on success for the `npm team destroy <org>:<team>` command. Using `npmFetch.json()` makes the CLI error out on completion even though the action was completed successfully in the registry.

Using `npmFetch()` will not attempt to parse the response body as JSON.