### PR TITLE
docs: update OSI link

### DIFF
--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -120,7 +120,7 @@ SPDX license identifier for the license you're using, like this:
 
 You can check [the full list of SPDX license
 IDs](https://spdx.org/licenses/).  Ideally you should pick one that is
-[OSI](https://opensource.org/licenses/alphabetical) approved.
+[OSI](https://opensource.org/licenses/) approved.
 
 If your package is licensed under multiple common licenses, use an [SPDX
 license expression syntax version 2.0


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

The current link for OSI-approved licenses (https://opensource.org/licenses/alphabetical) leads to a 404 page. Updated it to redirect to a valid page (https://opensource.org/licenses/).

<!-- ## References -->
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
