### PR TITLE
fix(arborist): dependencies from registries with a peerDependency on a workspace

### DIFF
--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -1243,7 +1243,7 @@ This is a one-time fix-up, please be patient...
     if (isWorkspace) {
       const existingNode = this.idealTree.edgesOut.get(spec.name).to
       if (existingNode && existingNode.isWorkspace && existingNode.satisfies(edge)) {
-        return edge.to
+        return existingNode
       }
     }
 

--- a/workspaces/arborist/test/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/test/arborist/build-ideal-tree.js
@@ -877,6 +877,52 @@ t.test('workspaces', t => {
     t.matchSnapshot(printTree(await tree))
   })
 
+  t.test('should allow cyclic peer dependencies between workspaces and packages from a repository', async t => {
+    generateNocks(t, {
+      foo: {
+        versions: ['1.0.0'],
+        peerDependencies: ['workspace-a'],
+      },
+    })
+    const path = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'root',
+        dependencies: {
+          'workspace-a': '*',
+        },
+        workspaces: ['workspace-a'],
+      }),
+      'workspace-a': {
+        'package.json': JSON.stringify({
+          name: 'workspace-a',
+          version: '1.0.0',
+          dependencies: {
+            'foo': '>=1.0.0',
+          },
+        }),
+      },
+    })
+
+    const arb = new Arborist({
+      ...OPT,
+      path,
+      workspaces: ['workspace-a'],
+    })
+
+    const tree = arb.buildIdealTree({
+      path,
+      add: [
+        'foo',
+      ],
+    })
+
+    // just assert that the buildIdealTree call resolves, if there's a
+    // problem here it will reject because of nock disabling requests
+    await t.resolves(tree)
+
+    t.matchSnapshot(printTree(await tree))
+  })
+
   t.test('workspace nodes are used instead of fetching manifests when they are valid', async t => {
     // turn off networking, this should never make a registry request
     nock.disableNetConnect()

--- a/workspaces/arborist/test/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/test/arborist/build-ideal-tree.js
@@ -897,7 +897,7 @@ t.test('workspaces', t => {
           name: 'workspace-a',
           version: '1.0.0',
           dependencies: {
-            'foo': '>=1.0.0',
+            foo: '>=1.0.0',
           },
         }),
       },


### PR DESCRIPTION
Currently if you attempt to install a package from a registry that has a peer dependency on a package published from a workspace in your local project, you are presented with the error (even if all specs match and there are no version conflicts):

```
44 verbose stack TypeError: Cannot set property 'parent' of null
44 verbose stack     at Arborist.[nodeFromEdge] (/Users/chris/.nvm/versions/node/v14.18.3/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/build-ideal-tree.js:1129:17)
44 verbose stack     at async Arborist.[loadPeerSet] (/Users/chris/.nvm/versions/node/v14.18.3/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/build-ideal-tree.js:1373:23)
44 verbose stack     at async Arborist.[buildDepStep] (/Users/chris/.nvm/versions/node/v14.18.3/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/build-ideal-tree.js:976:11)
44 verbose stack     at async Arborist.buildIdealTree (/Users/chris/.nvm/versions/node/v14.18.3/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/build-ideal-tree.js:218:7)
44 verbose stack     at async Promise.all (index 1)
44 verbose stack     at async Arborist.reify (/Users/chris/.nvm/versions/node/v14.18.3/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/reify.js:153:5)
44 verbose stack     at async Install.exec (/Users/chris/.nvm/versions/node/v14.18.3/lib/node_modules/npm/lib/commands/install.js:156:5)
44 verbose stack     at async module.exports (/Users/chris/.nvm/versions/node/v14.18.3/lib/node_modules/npm/lib/cli.js:78:5)
```

This is an edge case, but something we've come across frequently due to having multiple repos publishing packages (e.g. strongly typed clients) where occasionally a cyclic dependency exists within the type system (which TypeScript can handle once we have the packages installed).

This does not affect packages referred to by path as these are handled by: https://github.com/npm/cli/blob/latest/workspaces/arborist/lib/arborist/build-ideal-tree.js#L1236-L1238

The issue appears to be https://github.com/npm/cli/blob/latest/workspaces/arborist/lib/arborist/build-ideal-tree.js#L1245-L1247 where we find a suitable existing node, but then immediately throw it away, returning the unresolved `edge.to`.

I believe this is a typo and returning `existingNode` is the desired behaviour? I've added a test case that fails without this change.