### PR TITLE
chore: replace deprecated command with environment file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,7 +174,7 @@ jobs:
         run: |
           git commit --all --amend --no-edit || true
           git push --force-with-lease
-          echo "::set-output  name=sha::$(git rev-parse HEAD)"
+          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
       - name: Get Workflow Job
         uses: actions/github-script@v6
         if: steps.commit.outputs.sha
@@ -255,7 +255,7 @@ jobs:
           else
             result="success"
           fi
-          echo "::set-output name=result::$result"
+          echo "result=$result" >> $GITHUB_OUTPUT
       - name: Conclude Check
         uses: LouisBrunner/checks-action@v1.3.1
         if: needs.update.outputs.check-id && always()
@@ -342,7 +342,7 @@ jobs:
           else
             result="white_check_mark"
           fi
-          echo "::set-output name=result::$result"
+          echo "result=$result" >> $GITHUB_OUTPUT
       - name: Update Release PR Comment
         uses: actions/github-script@v6
         env:


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

## Description

Update `.github/workflows/release.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
echo "::set-output name=sha::$(git rev-parse HEAD)"
```

```yml
echo "::set-output name=result::$result"
```

**TO-BE**

```yml
echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
```

```yml
echo "result=$result" >> $GITHUB_OUTPUT
```


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

Closes #6201 