### PR TITLE
fix: send options with grant/revoke requests

### DIFF
--- a/lib/commands/access.js
+++ b/lib/commands/access.js
@@ -116,11 +116,11 @@ class Access extends BaseCommand {
   }
 
   async #grant (permissions, scope, pkg) {
-    await libnpmaccess.setPermissions(scope, pkg, permissions)
+    await libnpmaccess.setPermissions(scope, pkg, permissions, this.npm.flatOptions)
   }
 
   async #revoke (scope, pkg) {
-    await libnpmaccess.removePermissions(scope, pkg)
+    await libnpmaccess.removePermissions(scope, pkg, this.npm.flatOptions)
   }
 
   async #listPackages (owner, pkg) {

--- a/test/lib/commands/access.js
+++ b/test/lib/commands/access.js
@@ -70,10 +70,16 @@ t.test('grant', t => {
   })
 
   t.test('read-only', async t => {
-    const { npm } = await loadMockNpm(t)
+    const authToken = 'abcd1234'
+    const { npm } = await loadMockNpm(t, {
+      config: {
+        '//registry.npmjs.org/:_authToken': authToken,
+      },
+    })
     const registry = new MockRegistry({
       tap: t,
       registry: npm.config.get('registry'),
+      authorization: authToken,
     })
     const permissions = 'read-only'
     registry.setPermissions({ spec: '@npmcli/test-package', team: '@npm:test-team', permissions })
@@ -84,10 +90,16 @@ t.test('grant', t => {
 
 t.test('revoke', t => {
   t.test('success', async t => {
-    const { npm } = await loadMockNpm(t)
+    const authToken = 'abcd1234'
+    const { npm } = await loadMockNpm(t, {
+      config: {
+        '//registry.npmjs.org/:_authToken': authToken,
+      },
+    })
     const registry = new MockRegistry({
       tap: t,
       registry: npm.config.get('registry'),
+      authorization: authToken,
     })
     registry.removePermissions({ spec: '@npmcli/test-package', team: '@npm:test-team' })
     await npm.exec('access', ['revoke', '@npm:test-team', '@npmcli/test-package'])


### PR DESCRIPTION
Without the `flatOptions` the npmrc file isn't used to grant permissions, and access can't be changed.


## References
Fixes #6210
