### PR TITLE
fix: only add directories we made to _sparseTreeRoots

### DIFF
--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -535,9 +535,14 @@ module.exports = cls => class Reifier extends cls {
           await this[_renamePath](d, retired)
         }
       }
-      const made = await mkdir(node.path, { recursive: true })
       this[_sparseTreeDirs].add(node.path)
-      this[_sparseTreeRoots].add(made)
+      const made = await mkdir(node.path, { recursive: true })
+      // if the directory already exists, made will be undefined. if that's the case
+      // we don't want to remove it because we aren't the ones who created it so we
+      // omit it from the _sparseTreeRoots
+      if (made) {
+        this[_sparseTreeRoots].add(made)
+      }
     }))
       .then(() => process.emit('timeEnd', 'reify:createSparse'))
   }


### PR DESCRIPTION
when we changed from `mkdirp` to `fs.mkdir` we missed a breaking change in the underlying behavior. `mkdirp` returns the path it was asked to make, even if it doesn't create any directories. `fs.mkdir` on the other hand will return `undefined` if the directory already exists.

in order to not delete directories that we didn't create, we only add paths that we've created to the `_sparseTreeRoots`
