### PR TITLE
fix: lazy loading of arborist and pacote

### DIFF
--- a/lib/commands/audit.js
+++ b/lib/commands/audit.js
@@ -412,15 +412,17 @@ class Audit extends ArboristWorkspaceCmd {
 
   async auditAdvisories (args) {
     const reporter = this.npm.config.get('json') ? 'json' : 'detail'
+    const Arborist = require('@npmcli/arborist')
     const opts = {
       ...this.npm.flatOptions,
+      Arborist,
       audit: true,
       path: this.npm.prefix,
       reporter,
       workspaces: this.workspaceNames,
     }
 
-    const arb = new opts.Arborist(opts)
+    const arb = new Arborist(opts)
     const fix = args[0] === 'fix'
     await arb.audit({ fix })
     if (fix) {
@@ -444,13 +446,15 @@ class Audit extends ArboristWorkspaceCmd {
     }
 
     log.verbose('loading installed dependencies')
+    const Arborist = require('@npmcli/arborist')
     const opts = {
       ...this.npm.flatOptions,
+      Arborist,
       path: this.npm.prefix,
       workspaces: this.workspaceNames,
     }
 
-    const arb = new opts.Arborist(opts)
+    const arb = new Arborist(opts)
     const tree = await arb.loadActual()
     let filterSet = new Set()
     if (opts.workspaces && opts.workspaces.length) {

--- a/lib/commands/audit.js
+++ b/lib/commands/audit.js
@@ -1,4 +1,3 @@
-const Arborist = require('@npmcli/arborist')
 const auditReport = require('npm-audit-report')
 const fetch = require('npm-registry-fetch')
 const localeCompare = require('@isaacs/string-locale-compare')('en')
@@ -421,7 +420,7 @@ class Audit extends ArboristWorkspaceCmd {
       workspaces: this.workspaceNames,
     }
 
-    const arb = new Arborist(opts)
+    const arb = new opts.Arborist(opts)
     const fix = args[0] === 'fix'
     await arb.audit({ fix })
     if (fix) {
@@ -451,7 +450,7 @@ class Audit extends ArboristWorkspaceCmd {
       workspaces: this.workspaceNames,
     }
 
-    const arb = new Arborist(opts)
+    const arb = new opts.Arborist(opts)
     const tree = await arb.loadActual()
     let filterSet = new Set()
     if (opts.workspaces && opts.workspaces.length) {

--- a/lib/commands/audit.js
+++ b/lib/commands/audit.js
@@ -415,7 +415,6 @@ class Audit extends ArboristWorkspaceCmd {
     const Arborist = require('@npmcli/arborist')
     const opts = {
       ...this.npm.flatOptions,
-      Arborist,
       audit: true,
       path: this.npm.prefix,
       reporter,
@@ -449,7 +448,6 @@ class Audit extends ArboristWorkspaceCmd {
     const Arborist = require('@npmcli/arborist')
     const opts = {
       ...this.npm.flatOptions,
-      Arborist,
       path: this.npm.prefix,
       workspaces: this.workspaceNames,
     }

--- a/lib/commands/cache.js
+++ b/lib/commands/cache.js
@@ -1,5 +1,4 @@
 const cacache = require('cacache')
-const Arborist = require('@npmcli/arborist')
 const pacote = require('pacote')
 const fs = require('fs/promises')
 const { join } = require('path')
@@ -162,7 +161,7 @@ class Cache extends BaseCommand {
       return pacote.tarball.stream(spec, stream => {
         stream.resume()
         return stream.promise()
-      }, { ...this.npm.flatOptions, Arborist })
+      }, { ...this.npm.flatOptions })
     }))
   }
 

--- a/lib/commands/ci.js
+++ b/lib/commands/ci.js
@@ -21,15 +21,17 @@ class CI extends ArboristWorkspaceCmd {
     }
 
     const where = this.npm.prefix
+    const Arborist = require('@npmcli/arborist')
     const opts = {
       ...this.npm.flatOptions,
+      Arborist,
       packageLock: true, // npm ci should never skip lock files
       path: where,
       save: false, // npm ci should never modify the lockfile or package.json
       workspaces: this.workspaceNames,
     }
 
-    const arb = new opts.Arborist(opts)
+    const arb = new Arborist(opts)
     await arb.loadVirtual().catch(er => {
       log.verbose('loadVirtual', er.stack)
       const msg =

--- a/lib/commands/ci.js
+++ b/lib/commands/ci.js
@@ -1,4 +1,3 @@
-const Arborist = require('@npmcli/arborist')
 const reifyFinish = require('../utils/reify-finish.js')
 const runScript = require('@npmcli/run-script')
 const fs = require('fs/promises')
@@ -30,7 +29,7 @@ class CI extends ArboristWorkspaceCmd {
       workspaces: this.workspaceNames,
     }
 
-    const arb = new Arborist(opts)
+    const arb = new opts.Arborist(opts)
     await arb.loadVirtual().catch(er => {
       log.verbose('loadVirtual', er.stack)
       const msg =

--- a/lib/commands/ci.js
+++ b/lib/commands/ci.js
@@ -24,7 +24,6 @@ class CI extends ArboristWorkspaceCmd {
     const Arborist = require('@npmcli/arborist')
     const opts = {
       ...this.npm.flatOptions,
-      Arborist,
       packageLock: true, // npm ci should never skip lock files
       path: where,
       save: false, // npm ci should never modify the lockfile or package.json

--- a/lib/commands/dedupe.js
+++ b/lib/commands/dedupe.js
@@ -1,5 +1,4 @@
 // dedupe duplicated packages, or find them in the tree
-const Arborist = require('@npmcli/arborist')
 const reifyFinish = require('../utils/reify-finish.js')
 
 const ArboristWorkspaceCmd = require('../arborist-cmd.js')
@@ -42,7 +41,7 @@ class Dedupe extends ArboristWorkspaceCmd {
       save: false,
       workspaces: this.workspaceNames,
     }
-    const arb = new Arborist(opts)
+    const arb = new opts.Arborist(opts)
     await arb.dedupe(opts)
     await reifyFinish(this.npm, arb)
   }

--- a/lib/commands/dedupe.js
+++ b/lib/commands/dedupe.js
@@ -33,7 +33,6 @@ class Dedupe extends ArboristWorkspaceCmd {
     const Arborist = require('@npmcli/arborist')
     const opts = {
       ...this.npm.flatOptions,
-      Arborist,
       path: where,
       dryRun,
       // Saving during dedupe would only update if one of your direct

--- a/lib/commands/dedupe.js
+++ b/lib/commands/dedupe.js
@@ -30,8 +30,10 @@ class Dedupe extends ArboristWorkspaceCmd {
 
     const dryRun = this.npm.config.get('dry-run')
     const where = this.npm.prefix
+    const Arborist = require('@npmcli/arborist')
     const opts = {
       ...this.npm.flatOptions,
+      Arborist,
       path: where,
       dryRun,
       // Saving during dedupe would only update if one of your direct
@@ -41,7 +43,7 @@ class Dedupe extends ArboristWorkspaceCmd {
       save: false,
       workspaces: this.workspaceNames,
     }
-    const arb = new opts.Arborist(opts)
+    const arb = new Arborist(opts)
     await arb.dedupe(opts)
     await reifyFinish(this.npm, arb)
   }

--- a/lib/commands/diff.js
+++ b/lib/commands/diff.js
@@ -145,12 +145,14 @@ class Diff extends BaseCommand {
     if (spec.registry) {
       let actualTree
       let node
+      const Arborist = require('@npmcli/arborist')
       try {
         const opts = {
           ...this.npm.flatOptions,
+          Arborist,
           path: this.top,
         }
-        const arb = new opts.Arborist(opts)
+        const arb = new Arborist(opts)
         actualTree = await arb.loadActual(opts)
         node = actualTree &&
           actualTree.inventory.query('name', spec.name)
@@ -256,12 +258,14 @@ class Diff extends BaseCommand {
 
   async findVersionsByPackageName (specs) {
     let actualTree
+    const Arborist = require('@npmcli/arborist')
     try {
       const opts = {
         ...this.npm.flatOptions,
+        Arborist,
         path: this.top,
       }
-      const arb = new opts.Arborist(opts)
+      const arb = new Arborist(opts)
       actualTree = await arb.loadActual(opts)
     } catch (e) {
       log.verbose('diff', 'failed to load actual install tree')

--- a/lib/commands/diff.js
+++ b/lib/commands/diff.js
@@ -2,7 +2,6 @@ const { resolve } = require('path')
 const semver = require('semver')
 const libnpmdiff = require('libnpmdiff')
 const npa = require('npm-package-arg')
-const Arborist = require('@npmcli/arborist')
 const pacote = require('pacote')
 const pickManifest = require('npm-pick-manifest')
 const log = require('../utils/log-shim')
@@ -151,7 +150,7 @@ class Diff extends BaseCommand {
           ...this.npm.flatOptions,
           path: this.top,
         }
-        const arb = new Arborist(opts)
+        const arb = new opts.Arborist(opts)
         actualTree = await arb.loadActual(opts)
         node = actualTree &&
           actualTree.inventory.query('name', spec.name)
@@ -262,7 +261,7 @@ class Diff extends BaseCommand {
         ...this.npm.flatOptions,
         path: this.top,
       }
-      const arb = new Arborist(opts)
+      const arb = new opts.Arborist(opts)
       actualTree = await arb.loadActual(opts)
     } catch (e) {
       log.verbose('diff', 'failed to load actual install tree')

--- a/lib/commands/diff.js
+++ b/lib/commands/diff.js
@@ -149,7 +149,6 @@ class Diff extends BaseCommand {
       try {
         const opts = {
           ...this.npm.flatOptions,
-          Arborist,
           path: this.top,
         }
         const arb = new Arborist(opts)
@@ -262,7 +261,6 @@ class Diff extends BaseCommand {
     try {
       const opts = {
         ...this.npm.flatOptions,
-        Arborist,
         path: this.top,
       }
       const arb = new Arborist(opts)

--- a/lib/commands/explain.js
+++ b/lib/commands/explain.js
@@ -28,7 +28,8 @@ class Explain extends ArboristWorkspaceCmd {
       throw this.usageError()
     }
 
-    const arb = new this.npm.flatOptions.Arborist({ path: this.npm.prefix, ...this.npm.flatOptions })
+    const Arborist = require('@npmcli/arborist')
+    const arb = new Arborist({ path: this.npm.prefix, ...this.npm.flatOptions, Arborist })
     const tree = await arb.loadActual()
 
     if (this.npm.flatOptions.workspacesEnabled

--- a/lib/commands/explain.js
+++ b/lib/commands/explain.js
@@ -29,7 +29,7 @@ class Explain extends ArboristWorkspaceCmd {
     }
 
     const Arborist = require('@npmcli/arborist')
-    const arb = new Arborist({ path: this.npm.prefix, ...this.npm.flatOptions, Arborist })
+    const arb = new Arborist({ path: this.npm.prefix, ...this.npm.flatOptions })
     const tree = await arb.loadActual()
 
     if (this.npm.flatOptions.workspacesEnabled

--- a/lib/commands/explain.js
+++ b/lib/commands/explain.js
@@ -1,6 +1,4 @@
 const { explainNode } = require('../utils/explain-dep.js')
-const completion = require('../utils/completion/installed-deep.js')
-const Arborist = require('@npmcli/arborist')
 const npa = require('npm-package-arg')
 const semver = require('semver')
 const { relative, resolve } = require('path')
@@ -21,6 +19,7 @@ class Explain extends ArboristWorkspaceCmd {
   // TODO
   /* istanbul ignore next */
   async completion (opts) {
+    const completion = require('../utils/completion/installed-deep.js')
     return completion(this.npm, opts)
   }
 
@@ -29,7 +28,7 @@ class Explain extends ArboristWorkspaceCmd {
       throw this.usageError()
     }
 
-    const arb = new Arborist({ path: this.npm.prefix, ...this.npm.flatOptions })
+    const arb = new this.npm.flatOptions.Arborist({ path: this.npm.prefix, ...this.npm.flatOptions })
     const tree = await arb.loadActual()
 
     if (this.npm.flatOptions.workspacesEnabled

--- a/lib/commands/fund.js
+++ b/lib/commands/fund.js
@@ -64,12 +64,11 @@ class Fund extends ArboristWorkspaceCmd {
 
     const where = this.npm.prefix
     const Arborist = require('@npmcli/arborist')
-    const arb = new Arborist({ ...this.npm.flatOptions, Arborist, path: where })
+    const arb = new Arborist({ ...this.npm.flatOptions, path: where })
     const tree = await arb.loadActual()
 
     if (spec) {
       await this.openFundingUrl({
-        Arborist,
         path: where,
         tree,
         spec,
@@ -157,7 +156,7 @@ class Fund extends ArboristWorkspaceCmd {
     return this.npm.chalk.reset(res)
   }
 
-  async openFundingUrl ({ path, tree, spec, fundingSourceNumber, Arborist }) {
+  async openFundingUrl ({ path, tree, spec, fundingSourceNumber }) {
     const arg = npa(spec, path)
 
     const retrievePackageMetadata = () => {
@@ -188,7 +187,7 @@ class Fund extends ArboristWorkspaceCmd {
 
     const { funding } =
       retrievePackageMetadata() ||
-      (await pacote.manifest(arg, { ...this.npm.flatOptions, Arborist }).catch(() => ({})))
+      (await pacote.manifest(arg, this.npm.flatOptions).catch(() => ({})))
 
     const validSources = [].concat(normalizeFunding(funding)).filter(isValidFunding)
 

--- a/lib/commands/fund.js
+++ b/lib/commands/fund.js
@@ -1,12 +1,10 @@
 const archy = require('archy')
-const Arborist = require('@npmcli/arborist')
 const pacote = require('pacote')
 const semver = require('semver')
 const npa = require('npm-package-arg')
 const { depth } = require('treeverse')
 const { readTree: getFundingInfo, normalizeFunding, isValidFunding } = require('libnpmfund')
 
-const completion = require('../utils/completion/installed-deep.js')
 const openUrl = require('../utils/open-url.js')
 const ArboristWorkspaceCmd = require('../arborist-cmd.js')
 
@@ -39,6 +37,7 @@ class Fund extends ArboristWorkspaceCmd {
   // TODO
   /* istanbul ignore next */
   async completion (opts) {
+    const completion = require('../utils/completion/installed-deep.js')
     return completion(this.npm, opts)
   }
 
@@ -64,6 +63,7 @@ class Fund extends ArboristWorkspaceCmd {
     }
 
     const where = this.npm.prefix
+    const Arborist = this.npm.flatOptions.Arborist
     const arb = new Arborist({ ...this.npm.flatOptions, path: where })
     const tree = await arb.loadActual()
 

--- a/lib/commands/fund.js
+++ b/lib/commands/fund.js
@@ -63,12 +63,13 @@ class Fund extends ArboristWorkspaceCmd {
     }
 
     const where = this.npm.prefix
-    const Arborist = this.npm.flatOptions.Arborist
-    const arb = new Arborist({ ...this.npm.flatOptions, path: where })
+    const Arborist = require('@npmcli/arborist')
+    const arb = new Arborist({ ...this.npm.flatOptions, Arborist, path: where })
     const tree = await arb.loadActual()
 
     if (spec) {
       await this.openFundingUrl({
+        Arborist,
         path: where,
         tree,
         spec,
@@ -80,6 +81,7 @@ class Fund extends ArboristWorkspaceCmd {
     // TODO: add !workspacesEnabled option handling to libnpmfund
     const fundingInfo = getFundingInfo(tree, {
       ...this.flatOptions,
+      Arborist,
       workspaces: this.workspaceNames,
     })
 
@@ -155,7 +157,7 @@ class Fund extends ArboristWorkspaceCmd {
     return this.npm.chalk.reset(res)
   }
 
-  async openFundingUrl ({ path, tree, spec, fundingSourceNumber }) {
+  async openFundingUrl ({ path, tree, spec, fundingSourceNumber, Arborist }) {
     const arg = npa(spec, path)
 
     const retrievePackageMetadata = () => {
@@ -186,7 +188,7 @@ class Fund extends ArboristWorkspaceCmd {
 
     const { funding } =
       retrievePackageMetadata() ||
-      (await pacote.manifest(arg, this.npm.flatOptions).catch(() => ({})))
+      (await pacote.manifest(arg, { ...this.npm.flatOptions, Arborist }).catch(() => ({})))
 
     const validSources = [].concat(normalizeFunding(funding)).filter(isValidFunding)
 

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -137,7 +137,6 @@ class Install extends ArboristWorkspaceCmd {
     const Arborist = require('@npmcli/arborist')
     const opts = {
       ...this.npm.flatOptions,
-      Arborist,
       auditLevel: null,
       path: where,
       add: args,

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -134,14 +134,16 @@ class Install extends ArboristWorkspaceCmd {
       throw this.usageError()
     }
 
+    const Arborist = require('@npmcli/arborist')
     const opts = {
       ...this.npm.flatOptions,
+      Arborist,
       auditLevel: null,
       path: where,
       add: args,
       workspaces: this.workspaceNames,
     }
-    const arb = new opts.Arborist(opts)
+    const arb = new Arborist(opts)
     await arb.reify(opts)
 
     if (!args.length && !isGlobalInstall && !ignoreScripts) {

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -5,7 +5,6 @@ const readdir = util.promisify(fs.readdir)
 const reifyFinish = require('../utils/reify-finish.js')
 const log = require('../utils/log-shim.js')
 const { resolve, join } = require('path')
-const Arborist = require('@npmcli/arborist')
 const runScript = require('@npmcli/run-script')
 const pacote = require('pacote')
 const checks = require('npm-install-checks')
@@ -142,7 +141,7 @@ class Install extends ArboristWorkspaceCmd {
       add: args,
       workspaces: this.workspaceNames,
     }
-    const arb = new Arborist(opts)
+    const arb = new opts.Arborist(opts)
     await arb.reify(opts)
 
     if (!args.length && !isGlobalInstall && !ignoreScripts) {

--- a/lib/commands/link.js
+++ b/lib/commands/link.js
@@ -3,7 +3,6 @@ const util = require('util')
 const readdir = util.promisify(fs.readdir)
 const { resolve } = require('path')
 
-const Arborist = require('@npmcli/arborist')
 const npa = require('npm-package-arg')
 const rpj = require('read-package-json-fast')
 const semver = require('semver')
@@ -73,6 +72,7 @@ class Link extends ArboristWorkspaceCmd {
       global: true,
       prune: false,
     }
+    const Arborist = this.npm.flatOptions.Arborist
     const globalArb = new Arborist(globalOpts)
 
     // get only current top-level packages from the global space
@@ -138,6 +138,7 @@ class Link extends ArboristWorkspaceCmd {
     const paths = wsp && wsp.length ? wsp : [this.npm.prefix]
     const add = paths.map(path => `file:${path.replace(/#/g, '%23')}`)
     const globalTop = resolve(this.npm.globalDir, '..')
+    const Arborist = this.npm.flatOptions.Arborist
     const arb = new Arborist({
       ...this.npm.flatOptions,
       path: globalTop,

--- a/lib/commands/link.js
+++ b/lib/commands/link.js
@@ -118,14 +118,12 @@ class Link extends ArboristWorkspaceCmd {
     // reify all the pending names as symlinks there
     const localArb = new Arborist({
       ...this.npm.flatOptions,
-      Arborist,
       prune: false,
       path: this.npm.prefix,
       save,
     })
     await localArb.reify({
       ...this.npm.flatOptions,
-      Arborist,
       prune: false,
       path: this.npm.prefix,
       add: names.map(l => `file:${resolve(globalTop, 'node_modules', l).replace(/#/g, '%23')}`),

--- a/lib/commands/link.js
+++ b/lib/commands/link.js
@@ -66,13 +66,14 @@ class Link extends ArboristWorkspaceCmd {
     // load current packages from the global space,
     // and then add symlinks installs locally
     const globalTop = resolve(this.npm.globalDir, '..')
+    const Arborist = require('@npmcli/arborist')
     const globalOpts = {
       ...this.npm.flatOptions,
+      Arborist,
       path: globalTop,
       global: true,
       prune: false,
     }
-    const Arborist = this.npm.flatOptions.Arborist
     const globalArb = new Arborist(globalOpts)
 
     // get only current top-level packages from the global space
@@ -117,12 +118,14 @@ class Link extends ArboristWorkspaceCmd {
     // reify all the pending names as symlinks there
     const localArb = new Arborist({
       ...this.npm.flatOptions,
+      Arborist,
       prune: false,
       path: this.npm.prefix,
       save,
     })
     await localArb.reify({
       ...this.npm.flatOptions,
+      Arborist,
       prune: false,
       path: this.npm.prefix,
       add: names.map(l => `file:${resolve(globalTop, 'node_modules', l).replace(/#/g, '%23')}`),
@@ -138,9 +141,10 @@ class Link extends ArboristWorkspaceCmd {
     const paths = wsp && wsp.length ? wsp : [this.npm.prefix]
     const add = paths.map(path => `file:${path.replace(/#/g, '%23')}`)
     const globalTop = resolve(this.npm.globalDir, '..')
-    const Arborist = this.npm.flatOptions.Arborist
+    const Arborist = require('@npmcli/arborist')
     const arb = new Arborist({
       ...this.npm.flatOptions,
+      Arborist,
       path: globalTop,
       global: true,
     })

--- a/lib/commands/ls.js
+++ b/lib/commands/ls.js
@@ -61,11 +61,12 @@ class LS extends ArboristWorkspaceCmd {
 
     const path = global ? resolve(this.npm.globalDir, '..') : this.npm.prefix
 
-    const Arborist = this.npm.flatOptions.Arborist
+    const Arborist = require('@npmcli/arborist')
 
     const arb = new Arborist({
       global,
       ...this.npm.flatOptions,
+      Arborist,
       legacyPeerDeps: false,
       path,
     })

--- a/lib/commands/ls.js
+++ b/lib/commands/ls.js
@@ -3,11 +3,8 @@ const relativePrefix = `.${sep}`
 const { EOL } = require('os')
 
 const archy = require('archy')
-const Arborist = require('@npmcli/arborist')
 const { breadth } = require('treeverse')
 const npa = require('npm-package-arg')
-
-const completion = require('../utils/completion/installed-deep.js')
 
 const _depth = Symbol('depth')
 const _dedupe = Symbol('dedupe')
@@ -44,6 +41,7 @@ class LS extends ArboristWorkspaceCmd {
   // TODO
   /* istanbul ignore next */
   async completion (opts) {
+    const completion = require('../utils/completion/installed-deep.js')
     return completion(this.npm, opts)
   }
 
@@ -62,6 +60,8 @@ class LS extends ArboristWorkspaceCmd {
     const workspacesEnabled = this.npm.flatOptions.workspacesEnabled
 
     const path = global ? resolve(this.npm.globalDir, '..') : this.npm.prefix
+
+    const Arborist = this.npm.flatOptions.Arborist
 
     const arb = new Arborist({
       global,

--- a/lib/commands/ls.js
+++ b/lib/commands/ls.js
@@ -66,7 +66,6 @@ class LS extends ArboristWorkspaceCmd {
     const arb = new Arborist({
       global,
       ...this.npm.flatOptions,
-      Arborist,
       legacyPeerDeps: false,
       path,
     })

--- a/lib/commands/outdated.js
+++ b/lib/commands/outdated.js
@@ -6,8 +6,6 @@ const npa = require('npm-package-arg')
 const pickManifest = require('npm-pick-manifest')
 const localeCompare = require('@isaacs/string-locale-compare')('en')
 
-const Arborist = require('@npmcli/arborist')
-
 const ansiTrim = require('../utils/ansi-trim.js')
 const ArboristWorkspaceCmd = require('../arborist-cmd.js')
 
@@ -30,7 +28,7 @@ class Outdated extends ArboristWorkspaceCmd {
       ? global
       : this.npm.prefix
 
-    const arb = new Arborist({
+    const arb = new this.npm.flatOptions.Arborist({
       ...this.npm.flatOptions,
       path: where,
     })

--- a/lib/commands/outdated.js
+++ b/lib/commands/outdated.js
@@ -28,8 +28,10 @@ class Outdated extends ArboristWorkspaceCmd {
       ? global
       : this.npm.prefix
 
-    const arb = new this.npm.flatOptions.Arborist({
+    const Arborist = require('@npmcli/arborist')
+    const arb = new Arborist({
       ...this.npm.flatOptions,
+      Arborist,
       path: where,
     })
 

--- a/lib/commands/outdated.js
+++ b/lib/commands/outdated.js
@@ -31,7 +31,6 @@ class Outdated extends ArboristWorkspaceCmd {
     const Arborist = require('@npmcli/arborist')
     const arb = new Arborist({
       ...this.npm.flatOptions,
-      Arborist,
       path: where,
     })
 

--- a/lib/commands/prune.js
+++ b/lib/commands/prune.js
@@ -18,12 +18,14 @@ class Prune extends ArboristWorkspaceCmd {
 
   async exec () {
     const where = this.npm.prefix
+    const Arborist = require('@npmcli/arborist')
     const opts = {
       ...this.npm.flatOptions,
+      Arborist,
       path: where,
       workspaces: this.workspaceNames,
     }
-    const arb = new opts.Arborist(opts)
+    const arb = new Arborist(opts)
     await arb.prune(opts)
     await reifyFinish(this.npm, arb)
   }

--- a/lib/commands/prune.js
+++ b/lib/commands/prune.js
@@ -21,7 +21,6 @@ class Prune extends ArboristWorkspaceCmd {
     const Arborist = require('@npmcli/arborist')
     const opts = {
       ...this.npm.flatOptions,
-      Arborist,
       path: where,
       workspaces: this.workspaceNames,
     }

--- a/lib/commands/prune.js
+++ b/lib/commands/prune.js
@@ -1,5 +1,4 @@
 // prune extraneous packages
-const Arborist = require('@npmcli/arborist')
 const reifyFinish = require('../utils/reify-finish.js')
 
 const ArboristWorkspaceCmd = require('../arborist-cmd.js')
@@ -24,7 +23,7 @@ class Prune extends ArboristWorkspaceCmd {
       path: where,
       workspaces: this.workspaceNames,
     }
-    const arb = new Arborist(opts)
+    const arb = new opts.Arborist(opts)
     await arb.prune(opts)
     await reifyFinish(this.npm, arb)
   }

--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { resolve } = require('path')
-const Arborist = require('@npmcli/arborist')
 const BaseCommand = require('../base-command.js')
 
 class QuerySelectorItem {
@@ -63,7 +62,7 @@ class Query extends BaseCommand {
       path: where,
       forceActual: true,
     }
-    const arb = new Arborist(opts)
+    const arb = new opts.Arborist(opts)
     const tree = await arb.loadActual(opts)
     const items = await tree.querySelectorAll(args[0], this.npm.flatOptions)
     this.buildResponse(items)
@@ -77,7 +76,7 @@ class Query extends BaseCommand {
       ...this.npm.flatOptions,
       path: this.npm.prefix,
     }
-    const arb = new Arborist(opts)
+    const arb = new opts.Arborist(opts)
     const tree = await arb.loadActual(opts)
     for (const workspacePath of this.workspacePaths) {
       let items

--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -60,7 +60,6 @@ class Query extends BaseCommand {
     const Arborist = require('@npmcli/arborist')
     const opts = {
       ...this.npm.flatOptions,
-      Arborist,
       path: where,
       forceActual: true,
     }
@@ -77,7 +76,6 @@ class Query extends BaseCommand {
     const Arborist = require('@npmcli/arborist')
     const opts = {
       ...this.npm.flatOptions,
-      Arborist,
       path: this.npm.prefix,
     }
     const arb = new Arborist(opts)

--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -57,12 +57,14 @@ class Query extends BaseCommand {
   async exec (args) {
     // one dir up from wherever node_modules lives
     const where = resolve(this.npm.dir, '..')
+    const Arborist = require('@npmcli/arborist')
     const opts = {
       ...this.npm.flatOptions,
+      Arborist,
       path: where,
       forceActual: true,
     }
-    const arb = new opts.Arborist(opts)
+    const arb = new Arborist(opts)
     const tree = await arb.loadActual(opts)
     const items = await tree.querySelectorAll(args[0], this.npm.flatOptions)
     this.buildResponse(items)
@@ -72,11 +74,13 @@ class Query extends BaseCommand {
 
   async execWorkspaces (args) {
     await this.setWorkspaces()
+    const Arborist = require('@npmcli/arborist')
     const opts = {
       ...this.npm.flatOptions,
+      Arborist,
       path: this.npm.prefix,
     }
-    const arb = new opts.Arborist(opts)
+    const arb = new Arborist(opts)
     const tree = await arb.loadActual(opts)
     for (const workspacePath of this.workspacePaths) {
       let items

--- a/lib/commands/rebuild.js
+++ b/lib/commands/rebuild.js
@@ -1,8 +1,6 @@
 const { resolve } = require('path')
-const Arborist = require('@npmcli/arborist')
 const npa = require('npm-package-arg')
 const semver = require('semver')
-const completion = require('../utils/completion/installed-deep.js')
 
 const ArboristWorkspaceCmd = require('../arborist-cmd.js')
 class Rebuild extends ArboristWorkspaceCmd {
@@ -21,13 +19,14 @@ class Rebuild extends ArboristWorkspaceCmd {
   // TODO
   /* istanbul ignore next */
   async completion (opts) {
+    const completion = require('../utils/completion/installed-deep.js')
     return completion(this.npm, opts)
   }
 
   async exec (args) {
     const globalTop = resolve(this.npm.globalDir, '..')
     const where = this.npm.global ? globalTop : this.npm.prefix
-    const arb = new Arborist({
+    const arb = new this.npm.flatOptions.Arborist({
       ...this.npm.flatOptions,
       path: where,
       // TODO when extending ReifyCmd

--- a/lib/commands/rebuild.js
+++ b/lib/commands/rebuild.js
@@ -29,7 +29,6 @@ class Rebuild extends ArboristWorkspaceCmd {
     const Arborist = require('@npmcli/arborist')
     const arb = new Arborist({
       ...this.npm.flatOptions,
-      Arborist,
       path: where,
       // TODO when extending ReifyCmd
       // workspaces: this.workspaceNames,

--- a/lib/commands/rebuild.js
+++ b/lib/commands/rebuild.js
@@ -26,8 +26,10 @@ class Rebuild extends ArboristWorkspaceCmd {
   async exec (args) {
     const globalTop = resolve(this.npm.globalDir, '..')
     const where = this.npm.global ? globalTop : this.npm.prefix
-    const arb = new this.npm.flatOptions.Arborist({
+    const Arborist = require('@npmcli/arborist')
+    const arb = new Arborist({
       ...this.npm.flatOptions,
+      Arborist,
       path: where,
       // TODO when extending ReifyCmd
       // workspaces: this.workspaceNames,

--- a/lib/commands/shrinkwrap.js
+++ b/lib/commands/shrinkwrap.js
@@ -1,6 +1,5 @@
 const { resolve, basename } = require('path')
 const { unlink } = require('fs').promises
-const Arborist = require('@npmcli/arborist')
 const log = require('../utils/log-shim')
 const BaseCommand = require('../base-command.js')
 class Shrinkwrap extends BaseCommand {
@@ -23,7 +22,7 @@ class Shrinkwrap extends BaseCommand {
 
     const path = this.npm.prefix
     const sw = resolve(path, 'npm-shrinkwrap.json')
-    const arb = new Arborist({ ...this.npm.flatOptions, path })
+    const arb = new this.npm.flatOptions.Arborist({ ...this.npm.flatOptions, path })
     const tree = await arb.loadVirtual().catch(() => arb.loadActual())
     const { meta } = tree
     const newFile = meta.hiddenLockfile || !meta.loadedFromDisk

--- a/lib/commands/shrinkwrap.js
+++ b/lib/commands/shrinkwrap.js
@@ -20,9 +20,10 @@ class Shrinkwrap extends BaseCommand {
       throw er
     }
 
+    const Arborist = require('@npmcli/arborist')
     const path = this.npm.prefix
     const sw = resolve(path, 'npm-shrinkwrap.json')
-    const arb = new this.npm.flatOptions.Arborist({ ...this.npm.flatOptions, path })
+    const arb = new Arborist({ ...this.npm.flatOptions, Arborist, path })
     const tree = await arb.loadVirtual().catch(() => arb.loadActual())
     const { meta } = tree
     const newFile = meta.hiddenLockfile || !meta.loadedFromDisk

--- a/lib/commands/shrinkwrap.js
+++ b/lib/commands/shrinkwrap.js
@@ -23,7 +23,7 @@ class Shrinkwrap extends BaseCommand {
     const Arborist = require('@npmcli/arborist')
     const path = this.npm.prefix
     const sw = resolve(path, 'npm-shrinkwrap.json')
-    const arb = new Arborist({ ...this.npm.flatOptions, Arborist, path })
+    const arb = new Arborist({ ...this.npm.flatOptions, path })
     const tree = await arb.loadVirtual().catch(() => arb.loadActual())
     const { meta } = tree
     const newFile = meta.hiddenLockfile || !meta.loadedFromDisk

--- a/lib/commands/uninstall.js
+++ b/lib/commands/uninstall.js
@@ -44,7 +44,6 @@ class Uninstall extends ArboristWorkspaceCmd {
     const Arborist = require('@npmcli/arborist')
     const opts = {
       ...this.npm.flatOptions,
-      Arborist,
       path,
       rm: args,
       workspaces: this.workspaceNames,

--- a/lib/commands/uninstall.js
+++ b/lib/commands/uninstall.js
@@ -1,5 +1,4 @@
 const { resolve } = require('path')
-const Arborist = require('@npmcli/arborist')
 const rpj = require('read-package-json-fast')
 
 const reifyFinish = require('../utils/reify-finish.js')
@@ -48,7 +47,7 @@ class Uninstall extends ArboristWorkspaceCmd {
       rm: args,
       workspaces: this.workspaceNames,
     }
-    const arb = new Arborist(opts)
+    const arb = new opts.Arborist(opts)
     await arb.reify(opts)
     await reifyFinish(this.npm, arb)
   }

--- a/lib/commands/uninstall.js
+++ b/lib/commands/uninstall.js
@@ -41,13 +41,15 @@ class Uninstall extends ArboristWorkspaceCmd {
       ? resolve(this.npm.globalDir, '..')
       : this.npm.localPrefix
 
+    const Arborist = require('@npmcli/arborist')
     const opts = {
       ...this.npm.flatOptions,
+      Arborist,
       path,
       rm: args,
       workspaces: this.workspaceNames,
     }
-    const arb = new opts.Arborist(opts)
+    const arb = new Arborist(opts)
     await arb.reify(opts)
     await reifyFinish(this.npm, arb)
   }

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -55,7 +55,6 @@ class Update extends ArboristWorkspaceCmd {
     const Arborist = require('@npmcli/arborist')
     const opts = {
       ...this.npm.flatOptions,
-      Arborist,
       path: where,
       save,
       workspaces: this.workspaceNames,

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -1,10 +1,8 @@
 const path = require('path')
 
-const Arborist = require('@npmcli/arborist')
 const log = require('../utils/log-shim.js')
 
 const reifyFinish = require('../utils/reify-finish.js')
-const completion = require('../utils/completion/installed-deep.js')
 
 const ArboristWorkspaceCmd = require('../arborist-cmd.js')
 class Update extends ArboristWorkspaceCmd {
@@ -34,6 +32,7 @@ class Update extends ArboristWorkspaceCmd {
   // TODO
   /* istanbul ignore next */
   async completion (opts) {
+    const completion = require('../utils/completion/installed-deep.js')
     return completion(this.npm, opts)
   }
 
@@ -59,7 +58,7 @@ class Update extends ArboristWorkspaceCmd {
       save,
       workspaces: this.workspaceNames,
     }
-    const arb = new Arborist(opts)
+    const arb = new opts.Arborist(opts)
 
     await arb.reify({ ...opts, update })
     await reifyFinish(this.npm, arb)

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -52,13 +52,15 @@ class Update extends ArboristWorkspaceCmd {
         'https://github.com/npm/rfcs/blob/latest/implemented/0019-remove-update-depth-option.md')
     }
 
+    const Arborist = require('@npmcli/arborist')
     const opts = {
       ...this.npm.flatOptions,
+      Arborist,
       path: where,
       save,
       workspaces: this.workspaceNames,
     }
-    const arb = new opts.Arborist(opts)
+    const arb = new Arborist(opts)
 
     await arb.reify({ ...opts, update })
     await reifyFinish(this.npm, arb)

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -1,4 +1,3 @@
-const Arborist = require('@npmcli/arborist')
 const EventEmitter = require('events')
 const { resolve, dirname, join } = require('path')
 const Config = require('@npmcli/config')
@@ -310,10 +309,6 @@ class Npm extends EventEmitter {
 
   get flatOptions () {
     const { flat } = this.config
-    // the Arborist constructor is used almost everywhere we call pacote, it's
-    // easiest to attach it to flatOptions so it goes everywhere without having
-    // to touch every call
-    flat.Arborist = Arborist
     flat.nodeVersion = process.version
     flat.npmVersion = pkg.version
     if (this.command) {

--- a/lib/package-url-cmd.js
+++ b/lib/package-url-cmd.js
@@ -2,7 +2,6 @@
 
 const pacote = require('pacote')
 const hostedGitInfo = require('hosted-git-info')
-const Arborist = require('@npmcli/arborist')
 
 const openUrl = require('./utils/open-url.js')
 const log = require('./utils/log-shim')
@@ -33,7 +32,6 @@ class PackageUrlCommand extends BaseCommand {
         ...this.npm.flatOptions,
         where: this.npm.localPrefix,
         fullMetadata: true,
-        Arborist,
       }
       const mani = await pacote.manifest(arg, opts)
       const url = this.getUrl(arg, mani)

--- a/lib/utils/completion/installed-deep.js
+++ b/lib/utils/completion/installed-deep.js
@@ -2,6 +2,7 @@ const { resolve } = require('path')
 const localeCompare = require('@isaacs/string-locale-compare')('en')
 
 const installedDeep = async (npm) => {
+  const Arborist = require('@npmcli/arborist')
   const {
     depth,
     global,
@@ -19,7 +20,7 @@ const installedDeep = async (npm) => {
       .sort((a, b) => (a.depth - b.depth) || localeCompare(a.name, b.name))
 
   const res = new Set()
-  const gArb = new npm.flatOptions.Arborist({
+  const gArb = new Arborist({
     global: true,
     path: resolve(npm.globalDir, '..'),
     workspacesEnabled,
@@ -31,7 +32,7 @@ const installedDeep = async (npm) => {
   }
 
   if (!global) {
-    const arb = new npm.flatOptions.Arborist({ global: false, path: prefix, workspacesEnabled })
+    const arb = new Arborist({ global: false, path: prefix, workspacesEnabled })
     const tree = await arb.loadActual()
     for (const node of getValues(tree)) {
       res.add(node.name)

--- a/lib/utils/completion/installed-deep.js
+++ b/lib/utils/completion/installed-deep.js
@@ -1,5 +1,4 @@
 const { resolve } = require('path')
-const Arborist = require('@npmcli/arborist')
 const localeCompare = require('@isaacs/string-locale-compare')('en')
 
 const installedDeep = async (npm) => {
@@ -20,7 +19,7 @@ const installedDeep = async (npm) => {
       .sort((a, b) => (a.depth - b.depth) || localeCompare(a.name, b.name))
 
   const res = new Set()
-  const gArb = new Arborist({
+  const gArb = new npm.flatOptions.Arborist({
     global: true,
     path: resolve(npm.globalDir, '..'),
     workspacesEnabled,
@@ -32,7 +31,7 @@ const installedDeep = async (npm) => {
   }
 
   if (!global) {
-    const arb = new Arborist({ global: false, path: prefix, workspacesEnabled })
+    const arb = new npm.flatOptions.Arborist({ global: false, path: prefix, workspacesEnabled })
     const tree = await arb.loadActual()
     for (const node of getValues(tree)) {
       res.add(node.name)

--- a/lib/utils/update-notifier.js
+++ b/lib/utils/update-notifier.js
@@ -2,19 +2,10 @@
 // but not in CI, and not if we're doing that already.
 // Check daily for betas, and weekly otherwise.
 
-const pacote = require('pacote')
 const ciInfo = require('ci-info')
 const semver = require('semver')
 const { stat, writeFile } = require('fs/promises')
 const { resolve } = require('path')
-
-const SKIP = Symbol('SKIP')
-
-const isGlobalNpmUpdate = npm => {
-  return npm.flatOptions.global &&
-    ['install', 'update'].includes(npm.command) &&
-    npm.argv.some(arg => /^npm(@|$)/.test(arg))
-}
 
 // update check frequency
 const DAILY = 1000 * 60 * 60 * 24
@@ -24,39 +15,10 @@ const WEEKLY = DAILY * 7
 const lastCheckedFile = npm =>
   resolve(npm.flatOptions.cache, '../_update-notifier-last-checked')
 
-const checkTimeout = async (npm, duration) => {
-  const t = new Date(Date.now() - duration)
-  const f = lastCheckedFile(npm)
-  // if we don't have a file, then definitely check it.
-  const st = await stat(f).catch(() => ({ mtime: t - 1 }))
-  return t > st.mtime
-}
-
-const updateNotifier = async (npm, spec = 'latest') => {
-  // never check for updates in CI, when updating npm already, or opted out
-  if (!npm.config.get('update-notifier') ||
-      isGlobalNpmUpdate(npm) ||
-      ciInfo.isCI) {
-    return SKIP
-  }
-
-  // if we're on a prerelease train, then updates are coming fast
-  // check for a new one daily.  otherwise, weekly.
-  const { version } = npm
-  const current = semver.parse(version)
-
-  // if we're on a beta train, always get the next beta
-  if (current.prerelease.length) {
-    spec = `^${version}`
-  }
-
-  // while on a beta train, get updates daily
-  const duration = spec !== 'latest' ? DAILY : WEEKLY
-
-  // if we've already checked within the specified duration, don't check again
-  if (!(await checkTimeout(npm, duration))) {
-    return null
-  }
+// Actual check for updates. This is a separate function so that we only load
+// this if we are doing the actual update
+const updateCheck = async (npm, spec, version, current) => {
+  const pacote = require('pacote')
 
   const mani = await pacote.manifest(`npm@${spec}`, {
     // always prefer latest, even if doing --tag=whatever on the cmd
@@ -112,14 +74,48 @@ const updateNotifier = async (npm, spec = 'latest') => {
   return message
 }
 
-// only update the notification timeout if we actually finished checking
-module.exports = async npm => {
-  const notification = await updateNotifier(npm)
+const updateNotifier = async (npm, spec = 'latest') => {
+  // if we're on a prerelease train, then updates are coming fast
+  // check for a new one daily.  otherwise, weekly.
+  const { version } = npm
+  const current = semver.parse(version)
 
-  // dont write the file if we skipped checking altogether
-  if (notification === SKIP) {
+  // if we're on a beta train, always get the next beta
+  if (current.prerelease.length) {
+    spec = `^${version}`
+  }
+
+  // while on a beta train, get updates daily
+  const duration = spec !== 'latest' ? DAILY : WEEKLY
+
+  const t = new Date(Date.now() - duration)
+  // if we don't have a file, then definitely check it.
+  const st = await stat(lastCheckedFile(npm)).catch(() => ({ mtime: t - 1 }))
+
+  // if we've already checked within the specified duration, don't check again
+  if (!(t > st.mtime)) {
     return null
   }
+
+  return updateCheck(npm, spec, version, current)
+}
+
+// only update the notification timeout if we actually finished checking
+module.exports = async npm => {
+  if (
+    // opted out
+    !npm.config.get('update-notifier')
+    // global npm update
+    || (npm.flatOptions.global &&
+      ['install', 'update'].includes(npm.command) &&
+      npm.argv.some(arg => /^npm(@|$)/.test(arg)))
+    // CI
+    || ciInfo.isCI
+  ) {
+    return null
+  }
+
+  const notification = await updateNotifier(npm)
 
   // intentional.  do not await this.  it's a best-effort update.  if this
   // fails, it's ok.  might be using /dev/null as the cache or something weird

--- a/lib/workspaces/update-workspaces.js
+++ b/lib/workspaces/update-workspaces.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const Arborist = require('@npmcli/arborist')
 const reifyFinish = require('../utils/reify-finish.js')
 
 async function updateWorkspaces ({
@@ -31,7 +30,7 @@ async function updateWorkspaces ({
     path: localPrefix,
     save,
   }
-  const arb = new Arborist(opts)
+  const arb = new flatOptions.Arborist(opts)
 
   await arb.reify({ ...opts, update: workspaces })
   await reifyFinish(npm, arb)

--- a/lib/workspaces/update-workspaces.js
+++ b/lib/workspaces/update-workspaces.js
@@ -30,7 +30,8 @@ async function updateWorkspaces ({
     path: localPrefix,
     save,
   }
-  const arb = new flatOptions.Arborist(opts)
+  const Arborist = require('@npmcli/arborist')
+  const arb = new Arborist(opts)
 
   await arb.reify({ ...opts, update: workspaces })
   await reifyFinish(npm, arb)

--- a/test/lib/utils/completion/installed-deep.js
+++ b/test/lib/utils/completion/installed-deep.js
@@ -8,6 +8,7 @@ const _flatOptions = {
   depth: Infinity,
   global: false,
   workspacesEnabled: true,
+  Arborist: require('@npmcli/arborist'),
   get prefix () {
     return prefix
   },

--- a/workspaces/arborist/lib/arborist/index.js
+++ b/workspaces/arborist/lib/arborist/index.js
@@ -71,6 +71,7 @@ class Arborist extends Base {
     this.options = {
       nodeVersion: process.version,
       ...options,
+      Arborist: this.constructor,
       path: options.path || '.',
       cache: options.cache || `${homedir()}/.npm/_cacache`,
       packumentCache: options.packumentCache || new Map(),

--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -702,7 +702,6 @@ module.exports = cls => class Reifier extends cls {
       })
       await pacote.extract(res, node.path, {
         ...this.options,
-        Arborist: this.constructor,
         resolved: node.resolved,
         integrity: node.integrity,
       })


### PR DESCRIPTION
This is a test to try some very limited intentional lazy loading.
Please squash this when and if it comes time to land.

- fix: shuffle arborist requires around
- fix: continue shuffling arborist requires
- fix: decouple arborist from flatoptions
- fix: stop passing arborist to itself
- fix: add self to options passed downstream
- fix: lazy load pacote/chalk during updateNotifier
