### PR TITLE
fix: improve permission error for provenance

### DIFF
--- a/workspaces/libnpmpublish/lib/publish.js
+++ b/workspaces/libnpmpublish/lib/publish.js
@@ -141,11 +141,19 @@ const buildMetadata = async (registry, manifest, tarballData, spec, opts) => {
       digest: { sha512: integrity.sha512[0].hexDigest() },
     }
 
-    // Ensure that we're running in GHA and an OIDC token is available,
-    // currently the only supported build environment
-    if (ciInfo.name !== 'GitHub Actions' || !process.env.ACTIONS_ID_TOKEN_REQUEST_URL) {
+    // Ensure that we're running in GHA, currently the only supported build environment
+    if (ciInfo.name !== 'GitHub Actions') {
       throw Object.assign(
         new Error('Automatic provenance generation not supported outside of GitHub Actions'),
+        { code: 'EUSAGE' }
+      )
+    }
+
+    // Ensure that the GHA OIDC token is available
+    if (!process.env.ACTIONS_ID_TOKEN_REQUEST_URL) {
+      throw Object.assign(
+        /* eslint-disable-next-line max-len */
+        new Error('Provenance generation in GitHub Actions requires "write" access to the "id-token" permission'),
         { code: 'EUSAGE' }
       )
     }

--- a/workspaces/libnpmpublish/test/publish.js
+++ b/workspaces/libnpmpublish/test/publish.js
@@ -784,7 +784,7 @@ t.test('automatic provenance in unsupported environment', async t => {
   mockGlobals(t, {
     'process.env': {
       CI: false,
-      GITHUB_ACTIONS: false,
+      GITHUB_ACTIONS: undefined,
     },
   })
   const { publish } = t.mock('..', { 'ci-info': t.mock('ci-info') })
@@ -802,6 +802,34 @@ t.test('automatic provenance in unsupported environment', async t => {
     }),
     {
       message: /not supported/,
+      code: 'EUSAGE',
+    }
+  )
+})
+
+t.test('automatic provenance with incorrect permissions', async t => {
+  mockGlobals(t, {
+    'process.env': {
+      CI: false,
+      GITHUB_ACTIONS: true,
+      ACTIONS_ID_TOKEN_REQUEST_URL: undefined,
+    },
+  })
+  const { publish } = t.mock('..', { 'ci-info': t.mock('ci-info') })
+  const manifest = {
+    name: '@npmcli/libnpmpublish-test',
+    version: '1.0.0',
+    description: 'test libnpmpublish package',
+  }
+
+  await t.rejects(
+    publish(manifest, Buffer.from(''), {
+      ...opts,
+      access: null,
+      provenance: true,
+    }),
+    {
+      message: /requires "write" access/,
       code: 'EUSAGE',
     }
   )


### PR DESCRIPTION
Improves the error message returned when a user attempts to generate a provenance statement on publish but has not set the correct perissions in the GitHub Actions workflow.

<!-- What / Why -->
Improves the error messaging if the user attempts to publish a package w/ provenance but has NOT set the necessary token permissions to create an OIDC token.

Currently, if the user omits the `id-token: write` permission, the error message reads:
```
Automatic provenance generation not supported outside of GitHub Actions
```
This is potentially confusing given that it may actually be running in GitHub Actions, just with incorrect permissions.

This change separates the `CI == 'GitHub Actions'` check from the `ACTIONS_ID_TOKEN_REQUEST_URL` check so we can provide more specific error messages in the two cases.

The new error message reads:
```
Provenance generation in GitHub Actions requires "write" access to the "id-token" permission
```

