### PR TITLE
Fix deprecated message

### DIFF
--- a/lib/utils/update-notifier.js
+++ b/lib/utils/update-notifier.js
@@ -107,7 +107,7 @@ const updateNotifier = async (npm, spec = 'latest') => {
   const latestc = !useColor ? latest : chalk.green(latest)
   const changelog = `https://github.com/npm/cli/releases/tag/v${latest}`
   const changelogc = !useColor ? `<${changelog}>` : chalk.cyan(changelog)
-  const cmd = `npm install -g npm@${latest}`
+  const cmd = `npm install --location=global npm@${latest}`
   const cmdc = !useColor ? `\`${cmd}\`` : chalk.green(cmd)
   const message = `\nNew ${typec} version of npm available! ` +
     `${oldc} -> ${latestc}\n` +


### PR DESCRIPTION
-g option is deprecated. Instead use `--location=global`

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
