### PR TITLE
fix: Do not log warnings about log cleanup when logs_max=0

### DIFF
--- a/lib/utils/log-file.js
+++ b/lib/utils/log-file.js
@@ -223,7 +223,10 @@ class LogFiles {
         }
       }
     } catch (e) {
-      log.warn('logfile', 'error cleaning log files', e)
+      // Disable cleanup failure warnings when log writing is disabled
+      if (this.#logsMax > 0) {
+        log.warn('logfile', 'error cleaning log files', e)
+      }
     } finally {
       log.silly('logfile', 'done cleaning log files')
     }

--- a/test/lib/utils/log-file.js
+++ b/test/lib/utils/log-file.js
@@ -255,6 +255,20 @@ t.test('glob error', async t => {
   t.match(last(logs).content, /error cleaning log files .* bad glob/)
 })
 
+t.test('do not log cleaning errors when logging is disabled', async t => {
+  const { readLogs } = await loadLogFile(t, {
+    logsMax: 0,
+    mocks: {
+      glob: () => {
+        throw new Error('should not be logged')
+      },
+    },
+  })
+
+  const logs = await readLogs()
+  t.equal(logs.length, 0)
+})
+
 t.test('cleans old style logs too', async t => {
   const logsMax = 5
   const oldLogs = 10


### PR DESCRIPTION
This PR disables logging warnings for failures to cleanup log files when log files are disabled.

## References
Fixes #6270 
