### PR TITLE
docs: remove npm bin link

### DIFF
--- a/docs/lib/content/commands/npm-prefix.md
+++ b/docs/lib/content/commands/npm-prefix.md
@@ -36,7 +36,6 @@ npm prefix -g
 ### See Also
 
 * [npm root](/commands/npm-root)
-* [npm bin](/commands/npm-bin)
 * [npm folders](/configuring-npm/folders)
 * [npm config](/commands/npm-config)
 * [npmrc](/configuring-npm/npmrc)

--- a/docs/lib/content/commands/npm-root.md
+++ b/docs/lib/content/commands/npm-root.md
@@ -28,7 +28,6 @@ echo "Global packages installed in: ${global_node_modules}"
 ### See Also
 
 * [npm prefix](/commands/npm-prefix)
-* [npm bin](/commands/npm-bin)
 * [npm folders](/configuring-npm/folders)
 * [npm config](/commands/npm-config)
 * [npmrc](/configuring-npm/npmrc)


### PR DESCRIPTION
Since v9 `npm bin` no longer exists.

## References
* https://github.com/npm/cli/pull/5459
* https://github.com/npm/cli/commit/2e9280072f9852466fa0944d3a0fdb0c8af156a9