### PR TITLE
Fix issue where documentation is shown raw

### DIFF
--- a/docs/content/commands/npm-install.md
+++ b/docs/content/commands/npm-install.md
@@ -122,11 +122,12 @@ after packing it up into a tarball (b).
 
     Examples:
 
-          npm install my-react@npm:react
-          npm install jquery2@npm:jquery@2
-          npm install jquery3@npm:jquery@3
-          npm install npa@npm:npm-package-arg
-
+    ```bash
+    npm install my-react@npm:react
+    npm install jquery2@npm:jquery@2
+    npm install jquery3@npm:jquery@3
+    npm install npa@npm:npm-package-arg
+    ```
 
     `npm install` saves any specified packages into `dependencies` by default.
     Additionally, you can control where and how they get saved with some


### PR DESCRIPTION
Some of the markdown is shown raw on https://docs.npmjs.com/cli/v6/commands/npm-install

The majority of the `npm install <alias>@npm:<name>:` bullet point was shown as a raw text block rather than the markdown. This made it difficult to read and impossible to select text out of.

Note, that Github's markdown preview does not have this problem.

Before:
![image](https://user-images.githubusercontent.com/241046/227787575-c874e990-83e8-4fd2-8a27-56b9283b9d94.png)

After:
![image](https://user-images.githubusercontent.com/241046/227787515-2ee5e358-c65e-4ad1-8b35-0b3eb2527f2c.png)

Note that whilst version 6 is the oldest legacy version, it is the default version shown when searching for `npm install`.

![image](https://user-images.githubusercontent.com/241046/227787729-4c9137dc-a142-40e6-a6cb-6be2b287de21.png)