### PR TITLE
docs: remove reference to npm-packlist

### DIFF
--- a/docs/lib/content/commands/npm-publish.md
+++ b/docs/lib/content/commands/npm-publish.md
@@ -50,7 +50,7 @@ to the registry.
 
 ### Files included in package
 
-To see what will be included in your package, run `npx npm-packlist@6`.  All
+To see what will be included in your package, run `npm pack --dry-run`.  All
 files are included by default, with the following exceptions:
 
 - Certain files that are relevant to package installation and distribution

--- a/docs/lib/content/commands/npm-publish.md
+++ b/docs/lib/content/commands/npm-publish.md
@@ -50,7 +50,7 @@ to the registry.
 
 ### Files included in package
 
-To see what will be included in your package, run `npx npm-packlist`.  All
+To see what will be included in your package, run `npx npm-packlist@6`.  All
 files are included by default, with the following exceptions:
 
 - Certain files that are relevant to package installation and distribution


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
`npm-packlist` (appears to intentionally) no longer ship a binary as of v7.

## References
Related to https://github.com/npm/npm-packlist/issues/164
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
