### PR TITLE
docs: replace version manager list with a github search

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,17 +27,7 @@ curl -qL https://www.npmjs.com/install.sh | sh
 
 #### Node Version Managers
 
-If you're looking to manage multiple versions of **`node`** &/or **`npm`**, consider using a "Node Version Manager" such as:
-
-* [**`nvm`**](https://github.com/nvm-sh/nvm)
-* [**`nvs`**](https://github.com/jasongin/nvs)
-* [**`nave`**](https://github.com/isaacs/nave)
-* [**`n`**](https://github.com/tj/n)
-* [**`volta`**](https://github.com/volta-cli/volta)
-* [**`nodenv`**](https://github.com/nodenv/nodenv)
-* [**`asdf-nodejs`**](https://github.com/asdf-vm/asdf-nodejs)
-* [**`nvm-windows`**](https://github.com/coreybutler/nvm-windows)
-* [**`fnm`**](https://github.com/Schniz/fnm)
+If you're looking to manage multiple versions of **`Node.js`** &/or **`npm`**, consider using a [node version manager](https://github.com/search?q=node%20version%20manager&type=repositories)
 
 ### Usage
 

--- a/docs/lib/content/configuring-npm/install.md
+++ b/docs/lib/content/configuring-npm/install.md
@@ -39,7 +39,7 @@ Node version managers allow you to install and switch between multiple
 versions of Node.js and npm on your system so you can test your
 applications on multiple versions of npm to ensure they work for users on
 different versions.  You can
-[search for them on github](https://github.com/search?q=node%20version%20manager&type=repositories).
+[search for them on GitHub](https://github.com/search?q=node%20version%20manager&type=repositories).
 
 ### Using a Node installer to install Node.js and npm
 

--- a/docs/lib/content/configuring-npm/install.md
+++ b/docs/lib/content/configuring-npm/install.md
@@ -38,17 +38,8 @@ npm -v
 Node version managers allow you to install and switch between multiple
 versions of Node.js and npm on your system so you can test your
 applications on multiple versions of npm to ensure they work for users on
-different versions.
-
-#### OSX or Linux Node version managers
-
-* [nvm](https://github.com/creationix/nvm)
-* [n](https://github.com/tj/n)
-
-#### Windows Node version managers
-
-* [nodist](https://github.com/marcelklehr/nodist)
-* [nvm-windows](https://github.com/coreybutler/nvm-windows)
+different versions.  You can
+[search for them on github](https://github.com/search?q=node%20version%20manager&type=repositories).
 
 ### Using a Node installer to install Node.js and npm
 


### PR DESCRIPTION
We are not really in the business of curating external tools and github search returns very good results
