### PR TITLE
fix: Better support boolean or string flags

### DIFF
--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -98,6 +98,7 @@ const {
     Umask: { type: Umask },
     url: { type: url },
     path: { type: path },
+    BooleanOrString: { type: BooleanOrString },
   },
 } = Config
 
@@ -279,7 +280,7 @@ define('browser', {
   defaultDescription: `
     OS X: \`"open"\`, Windows: \`"start"\`, Others: \`"xdg-open"\`
   `,
-  type: [null, Boolean, String],
+  type: [null, BooleanOrString],
   description: `
     The browser that is called by npm commands to open websites.
 

--- a/workspaces/config/lib/type-defs.js
+++ b/workspaces/config/lib/type-defs.js
@@ -68,7 +68,7 @@ module.exports = {
   BooleanOrString: {
     type: BooleanOrString,
     validate: validateBooleanOrString,
-    description: 'boolean value (true or false) or a string',
+    description: 'boolean value (true or false or "true" or "false") or a string',
   },
 }
 

--- a/workspaces/config/lib/type-defs.js
+++ b/workspaces/config/lib/type-defs.js
@@ -19,6 +19,18 @@ const validatePath = (data, k, val) => {
   return noptValidatePath(data, k, val)
 }
 
+class BooleanOrString {}
+
+const validateBooleanOrString = (data, k, val) => {
+  if (typeof val === 'boolean' || val === 'true' || val === 'false') {
+    return nopt.typeDefs.Boolean.validate(data, k, val)
+  }
+  if (typeof val === 'string') {
+    return nopt.typeDefs.String.validate(data, k, val)
+  }
+  return false
+}
+
 // add descriptions so we can validate more usefully
 module.exports = {
   ...nopt.typeDefs,
@@ -52,6 +64,11 @@ module.exports = {
   Date: {
     ...nopt.typeDefs.Date,
     description: 'valid Date string',
+  },
+  BooleanOrString: {
+    type: BooleanOrString,
+    validate: validateBooleanOrString,
+    description: 'boolean value (true or false) or a string',
   },
 }
 

--- a/workspaces/config/test/type-defs.js
+++ b/workspaces/config/test/type-defs.js
@@ -7,10 +7,13 @@ const {
   path: {
     validate: validatePath,
   },
+  BooleanOrString: {
+    validate: validateBooleanOrString,
+  },
 } = typeDefs
 const { resolve } = require('path')
 
-const d = { semver: 'foobar', somePath: true }
+const d = { semver: 'foobar', somePath: true, boolOrString: 'true' }
 t.equal(validateSemver(d, 'semver', 'foobar'), false)
 t.equal(validateSemver(d, 'semver', 'v1.2.3'), undefined)
 t.equal(d.semver, '1.2.3')
@@ -20,3 +23,11 @@ t.equal(validatePath(d, 'somePath', null), false)
 t.equal(validatePath(d, 'somePath', 1234), false)
 t.equal(validatePath(d, 'somePath', 'false'), true)
 t.equal(d.somePath, resolve('false'))
+
+t.equal(validateBooleanOrString(d, 'boolOrString', 'true'), undefined)
+t.equal(validateBooleanOrString(d, 'boolOrString', 'false'), undefined)
+t.equal(validateBooleanOrString(d, 'boolOrString', true), undefined)
+t.equal(validateBooleanOrString(d, 'boolOrString', false), undefined)
+t.equal(validateBooleanOrString(d, 'boolOrString', 'foobar'), undefined)
+t.equal(validateBooleanOrString(d, 'boolOrString', ''), undefined)
+t.equal(validateBooleanOrString(d, 'boolOrString', null), false)


### PR DESCRIPTION
Adds a `BooleanOrString` CLI flag validation type that better evaluates if a CLI flag argument is a boolean or a string.
1. If the flag has no argument it is treated as having a boolean value.
2. If the flag's string argument is "true" or "false" then it is evaluated as a boolean value.
3. Otherwise the argument is evaluated as a string.

Previously all strings were treated as boolean values.

The `--browser` flag is updated to use this new validation type.

## References
Related to #6313

/cc @wraithgar @lukekarrys 