### PR TITLE
docs: fix npm cache folder location for windows

### DIFF
--- a/docs/lib/content/configuring-npm/folders.md
+++ b/docs/lib/content/configuring-npm/folders.md
@@ -72,7 +72,7 @@ Man pages are not installed on Windows systems.
 #### Cache
 
 See [`npm cache`](/commands/npm-cache).  Cache files are stored in `~/.npm` on Posix, or
-`%AppData%/npm-cache` on Windows.
+`%LocalAppData%/npm-cache` on Windows.
 
 This is controlled by the [`cache` config](/using-npm/config#cache) param.
 


### PR DESCRIPTION
The default npm install folder for windows is located at %AppData%\npm 
The default npm cache folder for windows is located at %LocalAppData%\npm-cache