### PR TITLE
chore: add is-core-module to known failures for node integration test

### DIFF
--- a/.github/workflows/node-integration.yml
+++ b/.github/workflows/node-integration.yml
@@ -296,6 +296,8 @@ jobs:
               knownFailures.push('fastify')
               // esbuild barfs on node 20.0.0-pre
               knownFailures.push('serialport')
+              // is-core-module fails on test/reporters
+              knownFailures.push('is-core-module')
             }
 
             // this is a manually updated list of packages that are flaky

--- a/scripts/template-oss/node-integration.yml
+++ b/scripts/template-oss/node-integration.yml
@@ -294,6 +294,8 @@ jobs:
               knownFailures.push('fastify')
               // esbuild barfs on node 20.0.0-pre
               knownFailures.push('serialport')
+              // is-core-module fails on test/reporters
+              knownFailures.push('is-core-module')
             }
 
             // this is a manually updated list of packages that are flaky


### PR DESCRIPTION
this gets our integration tests back to green
