### PR TITLE
feat: expose provenance transparency url

### DIFF
--- a/workspaces/libnpmpublish/lib/publish.js
+++ b/workspaces/libnpmpublish/lib/publish.js
@@ -74,12 +74,16 @@ Remove the 'private' field from the package.json to publish it.`),
       query: { write: true },
     })
     const newMetadata = patchMetadata(current, metadata)
-    return npmFetch(spec.escapedName, {
+    const res = await npmFetch(spec.escapedName, {
       ...opts,
       method: 'PUT',
       body: newMetadata,
       ignoreBody: true,
     })
+    if (transparencyLogUrl) {
+      res.transparencyLogUrl = transparencyLogUrl
+    }
+    return res
   }
 }
 

--- a/workspaces/libnpmpublish/lib/publish.js
+++ b/workspaces/libnpmpublish/lib/publish.js
@@ -80,6 +80,7 @@ Remove the 'private' field from the package.json to publish it.`),
       body: newMetadata,
       ignoreBody: true,
     })
+    /* istanbul ignore next */
     if (transparencyLogUrl) {
       res.transparencyLogUrl = transparencyLogUrl
     }

--- a/workspaces/libnpmpublish/test/publish.js
+++ b/workspaces/libnpmpublish/test/publish.js
@@ -511,6 +511,7 @@ t.test('publish includes access', async t => {
   })
 
   t.ok(ret, 'publish succeeded')
+  t.notOk(ret.transparencyLogUrl, 'no transparencyLogUrl for non-provenance publish')
 })
 
 t.test('refuse if package is unscoped plus `restricted` access', async t => {
@@ -804,6 +805,11 @@ t.test('publish existing package with provenance in gha', async t => {
     rekorURL: rekorURL,
   })
   t.ok(ret, 'publish succeeded')
+  t.equal(
+    ret.transparencyLogUrl,
+    'https://search.sigstore.dev/?logIndex=2513258',
+    'has appropriate transparencyLogUrl property'
+  )
   t.match(log, [
     ['notice', 'publish',
       'Signed provenance statement with source and build information from GitHub Actions'],


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
I was able to add support for provenance in `lerna` yesterday (now available in v6.6.2) but `libnpmpublish` currently only emits a log with the transparency log URL, it does not expose it as data for us to use.

This is a particularly a problem for lerna, because we often deal with publishing many packages concurrently. These publish requests are kicked off eagerly in parallel, and so it is currently not possible to reconcile the logs to their originating package.

The presence of this URL data would allow me to easily differentiate between packages which were published with provenance and those which weren't, as well as recreate the log on the lerna side.

For now the best I can do via log interception is gather up the unique URLs and print them at the very end:

<img width="688" alt="image" src="https://user-images.githubusercontent.com/900523/236454696-c15859dd-d918-4509-acf9-c40405e4cd99.png">

I have gone for a rather rudimentary "bolt it on the npmFetch response" approach here, but it would definitely get me what I need. Let me know if you want to rename the property or apply it within some other existing structure on the response in some way.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
