### PR TITLE
chore: check node version using includePrerelease option

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -13,7 +13,7 @@ module.exports = async process => {
     process.argv.splice(1, 1, 'npm', '-g')
   }
 
-  const nodeVersion = process.version.replace(/-.*$/, '')
+  const nodeVersion = process.version
   const pkg = require('../package.json')
   const engines = pkg.engines.node
   const npmVersion = `v${pkg.version}`
@@ -57,7 +57,7 @@ module.exports = async process => {
   process.on('unhandledRejection', exitHandler)
 
   // It is now safe to log a warning if they are using a version of node that is not going to fail on syntax errors but is still unsupported and untested and might not work reliably. This is safe to use the logger now which we want since this will show up in the error log too.
-  if (!satisfies(nodeVersion, engines)) {
+  if (!satisfies(nodeVersion, engines, { includePrerelease: true })) {
     log.warn('cli', unsupportedMessage)
   }
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
I think it's better to use the `includePrerelease ` option for pre-release checks.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
