### PR TITLE
fix: Update publish /w provenance to ignore pkg vis 404

### DIFF
--- a/workspaces/libnpmpublish/test/publish.js
+++ b/workspaces/libnpmpublish/test/publish.js
@@ -776,7 +776,6 @@ t.test('publish existing package with provenance in gha', async t => {
     .post('/api/v1/log/entries')
     .reply(201, rekorEntry)
 
-  registry.getVisibility({ spec, visibility: { public: true } })
   registry.nock.put(`/${spec.escapedName}`, body => {
     const bundleAttachment = body._attachments['@npmcli/libnpmpublish-test-1.0.0.sigstore']
     const bundle = JSON.parse(bundleAttachment.data)
@@ -925,7 +924,7 @@ t.test('publish new package with provenance in gha when visibility 500s - no acc
       access: null,
       provenance: true,
     }),
-    { code: 'EUSAGE' }
+    { code: 'E500' }
   )
 })
 

--- a/workspaces/libnpmpublish/test/publish.js
+++ b/workspaces/libnpmpublish/test/publish.js
@@ -855,7 +855,7 @@ t.test('publish new/private package with provenance in gha - no access', async t
   )
 })
 
-t.test('publish new package with provenance in gha to gh packages - no access', async t => {
+t.test('publish new package with provenance in gha when visibility 404s - no access', async t => {
   const oidcURL = 'https://mock.oidc'
   const requestToken = 'decafbad'
   mockGlobals(t, {
@@ -882,6 +882,44 @@ t.test('publish new package with provenance in gha to gh packages - no access', 
   registry.nock.get(
     this.fullPath(`/-/package/${npa(spec).escapedName}/visibility`))
     .reply(404)
+
+  await t.rejects(
+    publish(manifest, Buffer.from(''), {
+      ...opts,
+      access: null,
+      provenance: true,
+    }),
+    { code: 'EUSAGE' }
+  )
+})
+
+t.test('publish new package with provenance in gha when visibility 500s - no access', async t => {
+  const oidcURL = 'https://mock.oidc'
+  const requestToken = 'decafbad'
+  mockGlobals(t, {
+    'process.env': {
+      CI: true,
+      GITHUB_ACTIONS: true,
+      ACTIONS_ID_TOKEN_REQUEST_URL: oidcURL,
+      ACTIONS_ID_TOKEN_REQUEST_TOKEN: requestToken,
+    },
+  })
+  const { publish } = t.mock('..', { 'ci-info': t.mock('ci-info') })
+  const registry = new MockRegistry({
+    tap: t,
+    registry: opts.registry,
+    authorization: token,
+    strict: true,
+  })
+  const manifest = {
+    name: '@npmcli/libnpmpublish-test',
+    version: '1.0.0',
+    description: 'test libnpmpublish package',
+  }
+  const spec = npa(manifest.name)
+  registry.nock.get(
+    this.fullPath(`/-/package/${npa(spec).escapedName}/visibility`))
+    .reply(500)
 
   await t.rejects(
     publish(manifest, Buffer.from(''), {

--- a/workspaces/libnpmpublish/test/publish.js
+++ b/workspaces/libnpmpublish/test/publish.js
@@ -879,8 +879,7 @@ t.test('publish new package with provenance in gha when visibility 404s - no acc
     description: 'test libnpmpublish package',
   }
   const spec = npa(manifest.name)
-  registry.nock.get(
-    this.fullPath(`/-/package/${npa(spec).escapedName}/visibility`))
+  registry.nock.get(`/-/package/${npa(spec).escapedName}/visibility`)
     .reply(404)
 
   await t.rejects(
@@ -917,8 +916,7 @@ t.test('publish new package with provenance in gha when visibility 500s - no acc
     description: 'test libnpmpublish package',
   }
   const spec = npa(manifest.name)
-  registry.nock.get(
-    this.fullPath(`/-/package/${npa(spec).escapedName}/visibility`))
+  registry.nock.get(`/-/package/${npa(spec).escapedName}/visibility`)
     .reply(500)
 
   await t.rejects(


### PR DESCRIPTION
Some registries (e.g. GH packages) require auth to check visibility, and always return 404 when no auth is supplied. In this case we assume the package is always private and require `--access public` to publish.

I've also updated this to only perform a visibility check when this is actually needed (i.e. when `provenance` is true and `access` is not `public`).

Fixes https://github.com/npm/cli/issues/6436

