### PR TITLE
fix: Remove duplicates in config warnings

### DIFF
--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -1239,7 +1239,7 @@ define('location', {
 
 define('lockfile-version', {
   default: null,
-  type: [null, 1, 2, 3],
+  type: [null, 1, 2, 3, '1', '2', '3'],
   defaultDescription: `
     Version 3 if no lockfile, auto-converting v1 lockfiles to v3, otherwise
     maintain current lockfile version.`,

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -1239,7 +1239,7 @@ define('location', {
 
 define('lockfile-version', {
   default: null,
-  type: [null, 1, 2, 3, '1', '2', '3'],
+  type: [null, 1, 2, 3],
   defaultDescription: `
     Version 3 if no lockfile, auto-converting v1 lockfiles to v3, otherwise
     maintain current lockfile version.`,

--- a/workspaces/config/lib/index.js
+++ b/workspaces/config/lib/index.js
@@ -523,20 +523,32 @@ class Config {
       }
     }
 
-    const typeDesc = typeDescription(type)
-    const oneOrMore = typeDesc.indexOf(Array) !== -1
+    const typeDesc = typeDescription(type);
     const mustBe = typeDesc
-      .filter(m => m !== undefined && m !== Array)
-    const oneOf = mustBe.length === 1 && oneOrMore ? ' one or more'
-      : mustBe.length > 1 && oneOrMore ? ' one or more of:'
-      : mustBe.length > 1 ? ' one of:'
-      : ''
-    const msg = 'Must be' + oneOf
+      .filter(m => m !== undefined && m !== Array);
+    const oneOf = getOneOfKeywords(mustBe,typeDesc);
+    const msg = 'Must be' + oneOf;
     const desc = mustBe.length === 1 ? mustBe[0]
-      : mustBe.filter(m => m !== Array)
-        .map(n => typeof n === 'string' ? n : JSON.stringify(n))
-        .join(', ')
+      : [...new Set(mustBe.map(n => typeof n === 'string' ? n : JSON.stringify(n)))].join(', ');
     log.warn('invalid config', msg, desc)
+  }
+
+  getOneOfKeywords (mustBe, typeDesc) {
+    let keyword;
+    switch (true) {
+      case mustBe.length === 1 && typeDesc.indexOf(Array) !== -1:
+        keyword = " one or more";
+        break;
+      case mustBe.length > 1 && typeDesc.indexOf(Array) !== -1:
+        keyword = " one or more of:";
+        break;
+      case mustBe.length > 1:
+        keyword = " one of:";
+        break;
+      default:
+        keyword = "";
+    }
+    return keyword;
   }
 
   #loadObject (obj, where, source, er = null) {

--- a/workspaces/config/lib/index.js
+++ b/workspaces/config/lib/index.js
@@ -526,8 +526,7 @@ class Config {
     const typeDesc = typeDescription(type);
     const mustBe = typeDesc
       .filter(m => m !== undefined && m !== Array);
-    const oneOf = getOneOfKeywords(mustBe,typeDesc);
-    const msg = 'Must be' + oneOf;
+    const msg = 'Must be' + this.getOneOfKeywords(mustBe,typeDesc);
     const desc = mustBe.length === 1 ? mustBe[0]
       : [...new Set(mustBe.map(n => typeof n === 'string' ? n : JSON.stringify(n)))].join(', ');
     log.warn('invalid config', msg, desc)

--- a/workspaces/config/lib/index.js
+++ b/workspaces/config/lib/index.js
@@ -534,9 +534,9 @@ class Config {
 
   #getOneOfKeywords (mustBe, typeDesc) {
     let keyword
-    if (mustBe.length === 1 && typeDesc.indexOf(Array) !== -1) {
+    if (mustBe.length === 1 && typeDesc.includes(Array)) {
       keyword = ' one or more'
-    } else if (mustBe.length > 1 && typeDesc.indexOf(Array) !== -1) {
+    } else if (mustBe.length > 1 && typeDesc.includes(Array)) {
       keyword = ' one or more of:'
     } else if (mustBe.length > 1) {
       keyword = ' one of:'

--- a/workspaces/config/lib/index.js
+++ b/workspaces/config/lib/index.js
@@ -523,31 +523,27 @@ class Config {
       }
     }
 
-    const typeDesc = typeDescription(type);
+    const typeDesc = typeDescription(type)
     const mustBe = typeDesc
-      .filter(m => m !== undefined && m !== Array);
-    const msg = 'Must be' + this.getOneOfKeywords(mustBe,typeDesc);
+      .filter(m => m !== undefined && m !== Array)
+    const msg = 'Must be' + this.#getOneOfKeywords(mustBe, typeDesc)
     const desc = mustBe.length === 1 ? mustBe[0]
-      : [...new Set(mustBe.map(n => typeof n === 'string' ? n : JSON.stringify(n)))].join(', ');
+      : [...new Set(mustBe.map(n => typeof n === 'string' ? n : JSON.stringify(n)))].join(', ')
     log.warn('invalid config', msg, desc)
   }
 
-  getOneOfKeywords (mustBe, typeDesc) {
-    let keyword;
-    switch (true) {
-      case mustBe.length === 1 && typeDesc.indexOf(Array) !== -1:
-        keyword = " one or more";
-        break;
-      case mustBe.length > 1 && typeDesc.indexOf(Array) !== -1:
-        keyword = " one or more of:";
-        break;
-      case mustBe.length > 1:
-        keyword = " one of:";
-        break;
-      default:
-        keyword = "";
+  #getOneOfKeywords (mustBe, typeDesc) {
+    let keyword
+    if (mustBe.length === 1 && typeDesc.indexOf(Array) !== -1) {
+      keyword = ' one or more'
+    } else if (mustBe.length > 1 && typeDesc.indexOf(Array) !== -1) {
+      keyword = ' one or more of:'
+    } else if (mustBe.length > 1) {
+      keyword = ' one of:'
+    } else {
+      keyword = ''
     }
-    return keyword;
+    return keyword
   }
 
   #loadObject (obj, where, source, er = null) {


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
While updating `lockfileVersion` other than the values `null,1,2,3` it's showing a warning with duplicate lock file versions as below.

![image](https://github.com/npm/cli/assets/30841403/3ed021ca-5245-4760-aa0f-7c994b51d814)

Issue exists in definitions of config utils. I removed the duplicates to fix this issue. Please review and let me know your feedback.
## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Fixes #6404
