### PR TITLE
fix: rethrow error when script failed

### DIFF
--- a/lib/commands/run-script.js
+++ b/lib/commands/run-script.js
@@ -213,6 +213,7 @@ class RunScript extends BaseCommand {
         // in some workspaces since other scripts might have succeeded
         if (!scriptMissing) {
           process.exitCode = 1
+          throw err
         }
 
         return scriptMissing


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

Fixes #6399

It rethrows the error after being catched and printed.

This allows the exit-handler: https://github.com/npm/cli/blob/829503b804f31b63a405ece48ea265b641b43392/lib/utils/exit-handler.js#L220-L223 to catch the error and propagate the error

