### PR TITLE
fix: npm cache completion

### DIFF
--- a/lib/commands/cache.js
+++ b/lib/commands/cache.js
@@ -76,7 +76,7 @@ class Cache extends BaseCommand {
   async completion (opts) {
     const argv = opts.conf.argv.remain
     if (argv.length === 2) {
-      return ['add', 'clean', 'verify', 'ls', 'delete']
+      return ['add', 'clean', 'verify', 'ls']
     }
 
     // TODO - eventually...
@@ -85,7 +85,6 @@ class Cache extends BaseCommand {
       case 'clean':
       case 'add':
       case 'ls':
-      case 'delete':
         return []
     }
   }


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

the bash completions `npm cache` show an extra command (`npm cache delete`) that does not exist and throws `EUSAGE`. this removes that command.

<!-- ## References -->
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
