### PR TITLE
docs: remove `package-lock` option for `npm ci`

### DIFF
--- a/lib/commands/ci.js
+++ b/lib/commands/ci.js
@@ -17,7 +17,6 @@ class CI extends ArboristWorkspaceCmd {
     'global-style',
     'omit',
     'strict-peer-deps',
-    'package-lock',
     'foreground-scripts',
     'ignore-scripts',
     'audit',

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -1495,8 +1495,6 @@ define('package-lock', {
     If set to false, then ignore \`package-lock.json\` files when installing.
     This will also prevent _writing_ \`package-lock.json\` if \`save\` is
     true.
-
-    This configuration does not affect \`npm ci\`.
   `,
   flatten: (key, obj, flatOptions) => {
     flatten(key, obj, flatOptions)

--- a/smoke-tests/tap-snapshots/test/index.js.test.cjs
+++ b/smoke-tests/tap-snapshots/test/index.js.test.cjs
@@ -57,8 +57,8 @@ npm ERR!
 npm ERR! Options:
 npm ERR! [--install-strategy <hoisted|nested|shallow|linked>] [--legacy-bundling]
 npm ERR! [--global-style] [--omit <dev|optional|peer> [--omit <dev|optional|peer> ...]]
-npm ERR! [--strict-peer-deps] [--no-package-lock] [--foreground-scripts]
-npm ERR! [--ignore-scripts] [--no-audit] [--no-bin-links] [--no-fund] [--dry-run]
+npm ERR! [--strict-peer-deps] [--foreground-scripts] [--ignore-scripts] [--no-audit]
+npm ERR! [--no-bin-links] [--no-fund] [--dry-run]
 npm ERR! [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 npm ERR! [-ws|--workspaces] [--include-workspace-root] [--install-links]
 npm ERR! 

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -969,8 +969,6 @@ The package or packages to install for [\`npm exec\`](/commands/npm-exec)
 If set to false, then ignore \`package-lock.json\` files when installing. This
 will also prevent _writing_ \`package-lock.json\` if \`save\` is true.
 
-This configuration does not affect \`npm ci\`.
-
 #### \`package-lock-only\`
 
 * Default: false

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -2215,8 +2215,8 @@ npm ci
 Options:
 [--install-strategy <hoisted|nested|shallow|linked>] [--legacy-bundling]
 [--global-style] [--omit <dev|optional|peer> [--omit <dev|optional|peer> ...]]
-[--strict-peer-deps] [--no-package-lock] [--foreground-scripts]
-[--ignore-scripts] [--no-audit] [--no-bin-links] [--no-fund] [--dry-run]
+[--strict-peer-deps] [--foreground-scripts] [--ignore-scripts] [--no-audit]
+[--no-bin-links] [--no-fund] [--dry-run]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [-ws|--workspaces] [--include-workspace-root] [--install-links]
 
@@ -2235,7 +2235,6 @@ aliases: clean-install, ic, install-clean, isntall-clean
 #### \`global-style\`
 #### \`omit\`
 #### \`strict-peer-deps\`
-#### \`package-lock\`
 #### \`foreground-scripts\`
 #### \`ignore-scripts\`
 #### \`audit\`
@@ -2811,8 +2810,8 @@ npm install-ci-test
 Options:
 [--install-strategy <hoisted|nested|shallow|linked>] [--legacy-bundling]
 [--global-style] [--omit <dev|optional|peer> [--omit <dev|optional|peer> ...]]
-[--strict-peer-deps] [--no-package-lock] [--foreground-scripts]
-[--ignore-scripts] [--no-audit] [--no-bin-links] [--no-fund] [--dry-run]
+[--strict-peer-deps] [--foreground-scripts] [--ignore-scripts] [--no-audit]
+[--no-bin-links] [--no-fund] [--dry-run]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [-ws|--workspaces] [--include-workspace-root] [--install-links]
 
@@ -2831,7 +2830,6 @@ aliases: cit, clean-install-test, sit
 #### \`global-style\`
 #### \`omit\`
 #### \`strict-peer-deps\`
-#### \`package-lock\`
 #### \`foreground-scripts\`
 #### \`ignore-scripts\`
 #### \`audit\`


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

running `npm help ci` and `npm ci --help` suggests the option `package-lock` and `--no-package-lock` respectively, even though the `npm help ci` explicitly states that this has no effect on `npm ci`.  
 this also applies to `npm help install-ci-test` and `npm install-ci-test --help`.

this pr would remove that unnecessary option suggestion.

<!-- ## References -->
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
