### PR TITLE
docs: add global option for uninstall

### DIFF
--- a/lib/commands/uninstall.js
+++ b/lib/commands/uninstall.js
@@ -8,7 +8,7 @@ const ArboristWorkspaceCmd = require('../arborist-cmd.js')
 class Uninstall extends ArboristWorkspaceCmd {
   static description = 'Remove a package'
   static name = 'uninstall'
-  static params = ['save', ...super.params]
+  static params = ['save', 'global', ...super.params]
   static usage = ['[<@scope>/]<pkg>...']
   static ignoreImplicitWorkspace = false
 

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -3729,6 +3729,7 @@ npm uninstall [<@scope>/]<pkg>...
 
 Options:
 [-S|--save|--no-save|--save-prod|--save-dev|--save-optional|--save-peer|--save-bundle]
+[-g|--global]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [-ws|--workspaces] [--include-workspace-root] [--install-links]
 
@@ -3743,6 +3744,7 @@ aliases: unlink, remove, rm, r, un
 \`\`\`
 
 #### \`save\`
+#### \`global\`
 #### \`workspace\`
 #### \`workspaces\`
 #### \`include-workspace-root\`


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

running `npm uninstall --help` or `npm help uninstall` does not list `[-g|--global]` as an option, even though it is an option and is mentioned as a possibility in
https://github.com/npm/cli/blob/173bc89b986ae208effe87cea6ed041c77a57bb5/docs/lib/content/commands/npm-uninstall.md?plain=1#L30-L34
this pr adds that option to the docs

<!-- ## References -->
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
