### PR TITLE
docs: add cli params to `npm set`, `npm get`

### DIFF
--- a/lib/commands/get.js
+++ b/lib/commands/get.js
@@ -4,6 +4,7 @@ class Get extends BaseCommand {
   static description = 'Get a value from the npm configuration'
   static name = 'get'
   static usage = ['[<key> ...] (See `npm config`)']
+  static params = ['long']
   static ignoreImplicitWorkspace = false
 
   // TODO

--- a/lib/commands/set.js
+++ b/lib/commands/set.js
@@ -4,6 +4,7 @@ class Set extends BaseCommand {
   static description = 'Set a value in the npm configuration'
   static name = 'set'
   static usage = ['<key>=<value> [<key>=<value> ...] (See `npm config`)']
+  static params = ['global', 'location']
   static ignoreImplicitWorkspace = false
 
   // TODO

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -3531,6 +3531,9 @@ Set a value in the npm configuration
 Usage:
 npm set <key>=<value> [<key>=<value> ...] (See \`npm config\`)
 
+Options:
+[-g|--global] [-L|--location <global|user|project>]
+
 Run "npm help set" for more info
 
 \`\`\`bash
@@ -3539,7 +3542,8 @@ npm set <key>=<value> [<key>=<value> ...] (See \`npm config\`)
 
 Note: This command is unaware of workspaces.
 
-NO PARAMS
+#### \`global\`
+#### \`location\`
 `
 
 exports[`test/lib/docs.js TAP usage shrinkwrap > must match snapshot 1`] = `

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -2638,6 +2638,9 @@ Get a value from the npm configuration
 Usage:
 npm get [<key> ...] (See \`npm config\`)
 
+Options:
+[-l|--long]
+
 Run "npm help get" for more info
 
 \`\`\`bash
@@ -2646,7 +2649,7 @@ npm get [<key> ...] (See \`npm config\`)
 
 Note: This command is unaware of workspaces.
 
-NO PARAMS
+#### \`long\`
 `
 
 exports[`test/lib/docs.js TAP usage help > must match snapshot 1`] = `


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

running `npm set --help` or `npm help set` does not show cli parameters that you are able to specify (`--global` and `--location`).  
this adds those params.

`npm get` has the same issue with `--long`, adding that too.

<!-- ## References -->
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
