### PR TITLE
fix: remove unused lib/npm relics

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -1,4 +1,3 @@
-const EventEmitter = require('events')
 const { resolve, dirname, join } = require('path')
 const Config = require('@npmcli/config')
 const chalk = require('chalk')
@@ -20,7 +19,7 @@ const updateNotifier = require('./utils/update-notifier.js')
 const pkg = require('../package.json')
 const { commands, aliases } = require('./utils/cmd-list.js')
 
-class Npm extends EventEmitter {
+class Npm {
   static get version () {
     return pkg.version
   }
@@ -32,7 +31,6 @@ class Npm extends EventEmitter {
   #command = null
   #runId = new Date().toISOString().replace(/[.:]/g, '_')
   #loadPromise = null
-  #tmpFolder = null
   #title = 'npm'
   #argvClean = []
   #chalk = null
@@ -66,7 +64,6 @@ class Npm extends EventEmitter {
   //     prefix to `npmRoot` since that is the first dir it would encounter when
   //     doing implicit detection
   constructor ({ npmRoot = dirname(__dirname), argv = [], excludeNpmCwd = false } = {}) {
-    super()
     this.#npmRoot = npmRoot
     this.config = new Config({
       npmPath: this.#npmRoot,
@@ -460,15 +457,6 @@ class Npm extends EventEmitter {
 
   get usage () {
     return usage(this)
-  }
-
-  // XXX add logging to see if we actually use this
-  get tmp () {
-    if (!this.#tmpFolder) {
-      const rand = require('crypto').randomBytes(4).toString('hex')
-      this.#tmpFolder = `npm-${process.pid}-${rand}`
-    }
-    return resolve(this.config.get('tmp'), this.#tmpFolder)
   }
 
   // output to stdout in a progress bar compatible way

--- a/test/lib/npm.js
+++ b/test/lib/npm.js
@@ -105,10 +105,6 @@ t.test('npm.load', async t => {
     mockGlobals(t, { process: { platform: 'win32' } })
     t.equal(npm.bin, npm.globalBin, 'bin is global bin in windows mode')
     t.equal(npm.dir, npm.globalDir, 'dir is global dir in windows mode')
-
-    const tmp = npm.tmp
-    t.match(tmp, String, 'npm.tmp is a string')
-    t.equal(tmp, npm.tmp, 'getter only generates it once')
   })
 
   await t.test('forceful loading', async t => {


### PR DESCRIPTION
npm being an instance of EventEmitter and have a tmp public getter
were both unused. Since we do not have a public API we can make these
changes without it being a breaking change.
