### PR TITLE
feat: implement flag --prefer-dedupe for `npm install`

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -25,6 +25,7 @@ class Install extends ArboristWorkspaceCmd {
     'global-style',
     'omit',
     'strict-peer-deps',
+    'prefer-dedupe',
     'package-lock',
     'foreground-scripts',
     'ignore-scripts',

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -1546,6 +1546,16 @@ define('parseable', {
   flatten,
 })
 
+define('prefer-dedupe', {
+  default: false,
+  type: Boolean,
+  description: `
+    Prefer to deduplicate packages if possible., rather than
+    choosing a newer version of a dependency.
+  `,
+  flatten,
+})
+
 define('prefer-offline', {
   default: false,
   type: Boolean,

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -1550,7 +1550,7 @@ define('prefer-dedupe', {
   default: false,
   type: Boolean,
   description: `
-    Prefer to deduplicate packages if possible., rather than
+    Prefer to deduplicate packages if possible, rather than
     choosing a newer version of a dependency.
   `,
   flatten,

--- a/tap-snapshots/test/lib/commands/config.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/config.js.test.cjs
@@ -111,6 +111,7 @@ exports[`test/lib/commands/config.js TAP config list --json > output matches sna
   "package-lock-only": false,
   "pack-destination": ".",
   "parseable": false,
+  "prefer-dedupe": false,
   "prefer-offline": false,
   "prefer-online": false,
   "preid": "",
@@ -265,6 +266,7 @@ package = []
 package-lock = true 
 package-lock-only = false 
 parseable = false 
+prefer-dedupe = false 
 prefer-offline = false 
 prefer-online = false 
 ; prefix = "{REALGLOBALREFIX}" ; overridden by cli

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -991,6 +991,14 @@ For \`list\` this means the output will be based on the tree described by the
 Output parseable results from commands that write to standard output. For
 \`npm search\`, this will be tab-separated table format.
 
+#### \`prefer-dedupe\`
+
+* Default: false
+* Type: Boolean
+
+Prefer to deduplicate packages if possible., rather than choosing a newer
+version of a dependency.
+
 #### \`prefer-offline\`
 
 * Default: false
@@ -1802,6 +1810,7 @@ Array [
   "package-lock-only",
   "pack-destination",
   "parseable",
+  "prefer-dedupe",
   "prefer-offline",
   "prefer-online",
   "prefix",
@@ -1938,6 +1947,7 @@ Array [
   "package-lock-only",
   "pack-destination",
   "parseable",
+  "prefer-dedupe",
   "prefer-offline",
   "prefer-online",
   "preid",
@@ -2763,7 +2773,7 @@ Options:
 [-E|--save-exact] [-g|--global]
 [--install-strategy <hoisted|nested|shallow|linked>] [--legacy-bundling]
 [--global-style] [--omit <dev|optional|peer> [--omit <dev|optional|peer> ...]]
-[--strict-peer-deps] [--no-package-lock] [--foreground-scripts]
+[--strict-peer-deps] [--prefer-dedupe] [--no-package-lock] [--foreground-scripts]
 [--ignore-scripts] [--no-audit] [--no-bin-links] [--no-fund] [--dry-run]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [-ws|--workspaces] [--include-workspace-root] [--install-links]
@@ -2786,6 +2796,7 @@ aliases: add, i, in, ins, inst, insta, instal, isnt, isnta, isntal, isntall
 #### \`global-style\`
 #### \`omit\`
 #### \`strict-peer-deps\`
+#### \`prefer-dedupe\`
 #### \`package-lock\`
 #### \`foreground-scripts\`
 #### \`ignore-scripts\`
@@ -2851,7 +2862,7 @@ Options:
 [-E|--save-exact] [-g|--global]
 [--install-strategy <hoisted|nested|shallow|linked>] [--legacy-bundling]
 [--global-style] [--omit <dev|optional|peer> [--omit <dev|optional|peer> ...]]
-[--strict-peer-deps] [--no-package-lock] [--foreground-scripts]
+[--strict-peer-deps] [--prefer-dedupe] [--no-package-lock] [--foreground-scripts]
 [--ignore-scripts] [--no-audit] [--no-bin-links] [--no-fund] [--dry-run]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [-ws|--workspaces] [--include-workspace-root] [--install-links]
@@ -2874,6 +2885,7 @@ alias: it
 #### \`global-style\`
 #### \`omit\`
 #### \`strict-peer-deps\`
+#### \`prefer-dedupe\`
 #### \`package-lock\`
 #### \`foreground-scripts\`
 #### \`ignore-scripts\`

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -996,7 +996,7 @@ Output parseable results from commands that write to standard output. For
 * Default: false
 * Type: Boolean
 
-Prefer to deduplicate packages if possible., rather than choosing a newer
+Prefer to deduplicate packages if possible, rather than choosing a newer
 version of a dependency.
 
 #### \`prefer-offline\`


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

defining the `--prefer-dedupe` flag for `npm install` (and `npm install-test`) to let `@npmcli/arborist` handle it.

## References
fix #6473 

<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
