### PR TITLE
chore: convert tests to use mock-npm options

### DIFF
--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -24,7 +24,7 @@ All commands:
     
 
 Specify configs in the ini-formatted file:
-    /some/config/file/.npmrc
+    {USERCONFIG}
 or on the command line via: npm <command> --key=value
 
 More configuration info: npm help config

--- a/test/fixtures/mock-npm.js
+++ b/test/fixtures/mock-npm.js
@@ -212,7 +212,7 @@ const setupMockNpm = async (t, {
       return acc
     }, { argv: [...rawArgv], env: {}, config: {} })
 
-  mockGlobals(t, {
+  const mockedGlobals = mockGlobals(t, {
     'process.env.HOME': dirs.home,
     // global prefix cannot be (easily) set via argv so this is the easiest way
     // to set it that also closely mimics the behavior a user would see since it
@@ -269,6 +269,7 @@ const setupMockNpm = async (t, {
 
   return {
     npm,
+    mockedGlobals,
     ...mockNpm,
     ...dirs,
     ...mockCommand,

--- a/test/lib/commands/adduser.js
+++ b/test/lib/commands/adduser.js
@@ -8,6 +8,34 @@ const mockGlobals = require('@npmcli/mock-globals')
 const MockRegistry = require('@npmcli/mock-registry')
 const stream = require('stream')
 
+const mockAddUser = async (t, { stdin: stdinLines, registry: registryUrl, ...options } = {}) => {
+  let stdin
+  if (stdinLines) {
+    stdin = new stream.PassThrough()
+    for (const l of stdinLines) {
+      stdin.write(l + '\n')
+    }
+    mockGlobals(t, {
+      'process.stdin': stdin,
+      'process.stdout': new stream.PassThrough(), // to quiet readline
+    }, { replace: true })
+  }
+  const mock = await loadMockNpm(t, {
+    ...options,
+    command: 'adduser',
+  })
+  const registry = new MockRegistry({
+    tap: t,
+    registry: registryUrl ?? mock.npm.config.get('registry'),
+  })
+  return {
+    registry,
+    stdin,
+    rc: () => ini.parse(fs.readFileSync(path.join(mock.home, '.npmrc'), 'utf8')),
+    ...mock,
+  }
+}
+
 t.test('usage', async t => {
   const { npm } = await loadMockNpm(t)
   const adduser = await npm.cmd('adduser')
@@ -16,15 +44,8 @@ t.test('usage', async t => {
 
 t.test('legacy', async t => {
   t.test('simple adduser', async t => {
-    const stdin = new stream.PassThrough()
-    stdin.write('test-user\n')
-    stdin.write('test-password\n')
-    stdin.write('test-email@npmjs.org\n')
-    mockGlobals(t, {
-      'process.stdin': stdin,
-      'process.stdout': new stream.PassThrough(), // to quiet readline
-    }, { replace: true })
-    const { npm, home } = await loadMockNpm(t, {
+    const { npm, rc, registry, adduser } = await mockAddUser(t, {
+      stdin: ['test-user', 'test-password', 'test-email@npmjs.org'],
       config: { 'auth-type': 'legacy' },
       homeDir: {
         '.npmrc': [
@@ -34,44 +55,28 @@ t.test('legacy', async t => {
         ].join('\n'),
       },
     })
-    const registry = new MockRegistry({
-      tap: t,
-      registry: npm.config.get('registry'),
-    })
     registry.couchadduser({
       username: 'test-user',
       password: 'test-password',
       email: 'test-email@npmjs.org',
       token: 'npm_test-token',
     })
-    await npm.exec('adduser', [])
+    await adduser.exec([])
     t.same(npm.config.get('email'), 'test-email-old@npmjs.org')
     t.same(npm.config.get('//registry.npmjs.org/:_authToken'), 'npm_test-token')
-    const rc = ini.parse(fs.readFileSync(path.join(home, '.npmrc'), 'utf8'))
-    t.same(rc, {
+    t.same(rc(), {
       '//registry.npmjs.org/:_authToken': 'npm_test-token',
       email: 'test-email-old@npmjs.org',
     }, 'should only have token and un-nerfed old email')
   })
 
   t.test('scoped adduser', async t => {
-    const stdin = new stream.PassThrough()
-    stdin.write('test-user\n')
-    stdin.write('test-password\n')
-    stdin.write('test-email@npmjs.org\n')
-    mockGlobals(t, {
-      'process.stdin': stdin,
-      'process.stdout': new stream.PassThrough(), // to quiet readline
-    }, { replace: true })
-    const { npm, home } = await loadMockNpm(t, {
+    const { npm, rc, registry, adduser } = await mockAddUser(t, {
+      stdin: ['test-user', 'test-password', 'test-email@npmjs.org'],
       config: {
         'auth-type': 'legacy',
         scope: '@myscope',
       },
-    })
-    const registry = new MockRegistry({
-      tap: t,
-      registry: npm.config.get('registry'),
     })
     registry.couchadduser({
       username: 'test-user',
@@ -79,26 +84,19 @@ t.test('legacy', async t => {
       email: 'test-email@npmjs.org',
       token: 'npm_test-token',
     })
-    await npm.exec('adduser', [])
+    await adduser.exec([])
     t.same(npm.config.get('//registry.npmjs.org/:_authToken'), 'npm_test-token')
     t.same(npm.config.get('@myscope:registry'), 'https://registry.npmjs.org/')
-    const rc = ini.parse(fs.readFileSync(path.join(home, '.npmrc'), 'utf8'))
-    t.same(rc, {
+    t.same(rc(), {
       '//registry.npmjs.org/:_authToken': 'npm_test-token',
       '@myscope:registry': 'https://registry.npmjs.org/',
     }, 'should only have token and scope:registry')
   })
 
   t.test('scoped adduser with valid scoped registry config', async t => {
-    const stdin = new stream.PassThrough()
-    stdin.write('test-user\n')
-    stdin.write('test-password\n')
-    stdin.write('test-email@npmjs.org\n')
-    mockGlobals(t, {
-      'process.stdin': stdin,
-      'process.stdout': new stream.PassThrough(), // to quiet readline
-    }, { replace: true })
-    const { npm, home } = await loadMockNpm(t, {
+    const { npm, rc, registry, adduser } = await mockAddUser(t, {
+      stdin: ['test-user', 'test-password', 'test-email@npmjs.org'],
+      registry: 'https://diff-registry.npmjs.org',
       homeDir: {
         '.npmrc': '@myscope:registry=https://diff-registry.npmjs.org',
       },
@@ -107,44 +105,28 @@ t.test('legacy', async t => {
         scope: '@myscope',
       },
     })
-    const registry = new MockRegistry({
-      tap: t,
-      registry: 'https://diff-registry.npmjs.org',
-    })
     registry.couchadduser({
       username: 'test-user',
       password: 'test-password',
       email: 'test-email@npmjs.org',
       token: 'npm_test-token',
     })
-    await npm.exec('adduser', [])
+    await adduser.exec([])
     t.same(npm.config.get('//diff-registry.npmjs.org/:_authToken'), 'npm_test-token')
     t.same(npm.config.get('@myscope:registry'), 'https://diff-registry.npmjs.org')
-    const rc = ini.parse(fs.readFileSync(path.join(home, '.npmrc'), 'utf8'))
-    t.same(rc, {
+    t.same(rc(), {
       '@myscope:registry': 'https://diff-registry.npmjs.org',
       '//diff-registry.npmjs.org/:_authToken': 'npm_test-token',
     }, 'should only have token and scope:registry')
   })
 
   t.test('save config failure', async t => {
-    const stdin = new stream.PassThrough()
-    stdin.write('test-user\n')
-    stdin.write('test-password\n')
-    stdin.write('test-email@npmjs.org\n')
-    mockGlobals(t, {
-      'process.stdin': stdin,
-      'process.stdout': new stream.PassThrough(), // to quiet readline
-    }, { replace: true })
-    const { npm } = await loadMockNpm(t, {
+    const { registry, adduser } = await mockAddUser(t, {
+      stdin: ['test-user', 'test-password', 'test-email@npmjs.org'],
       config: { 'auth-type': 'legacy' },
       homeDir: {
         '.npmrc': {},
       },
-    })
-    const registry = new MockRegistry({
-      tap: t,
-      registry: npm.config.get('registry'),
     })
     registry.couchadduser({
       username: 'test-user',
@@ -152,60 +134,40 @@ t.test('legacy', async t => {
       email: 'test-email@npmjs.org',
       token: 'npm_test-token',
     })
-    await t.rejects(npm.exec('adduser', []))
+    await t.rejects(adduser.exec([]))
   })
   t.end()
 })
 
 t.test('web', t => {
   t.test('basic adduser', async t => {
-    const { npm, home } = await loadMockNpm(t, {
+    const { npm, rc, registry, adduser } = await mockAddUser(t, {
       config: { 'auth-type': 'web' },
     })
-    const registry = new MockRegistry({
-      tap: t,
-      registry: npm.config.get('registry'),
-    })
     registry.webadduser({ token: 'npm_test-token' })
-    await npm.exec('adduser', [])
+    await adduser.exec([])
     t.same(npm.config.get('//registry.npmjs.org/:_authToken'), 'npm_test-token')
-    const rc = ini.parse(fs.readFileSync(path.join(home, '.npmrc'), 'utf8'))
-    t.same(rc, {
+    t.same(rc(), {
       '//registry.npmjs.org/:_authToken': 'npm_test-token',
     })
   })
 
   t.test('server error', async t => {
-    const { npm } = await loadMockNpm(t, {
+    const { adduser, registry } = await mockAddUser(t, {
       config: { 'auth-type': 'web' },
-    })
-    const registry = new MockRegistry({
-      tap: t,
-      registry: npm.config.get('registry'),
     })
     registry.nock.post(registry.fullPath('/-/v1/login'))
       .reply(503, {})
     await t.rejects(
-      npm.exec('adduser', []),
+      adduser.exec([]),
       { message: /503/ }
     )
   })
 
   t.test('fallback', async t => {
-    const stdin = new stream.PassThrough()
-    stdin.write('test-user\n')
-    stdin.write('test-password\n')
-    stdin.write('test-email@npmjs.org\n')
-    mockGlobals(t, {
-      'process.stdin': stdin,
-      'process.stdout': new stream.PassThrough(), // to quiet readline
-    }, { replace: true })
-    const { npm } = await loadMockNpm(t, {
+    const { npm, registry, adduser } = await mockAddUser(t, {
+      stdin: ['test-user', 'test-password', 'test-email@npmjs.org'],
       config: { 'auth-type': 'web' },
-    })
-    const registry = new MockRegistry({
-      tap: t,
-      registry: npm.config.get('registry'),
     })
     registry.nock.post(registry.fullPath('/-/v1/login'))
       .reply(404, {})
@@ -215,7 +177,7 @@ t.test('web', t => {
       email: 'test-email@npmjs.org',
       token: 'npm_test-token',
     })
-    await npm.exec('adduser', [])
+    await adduser.exec([])
     t.same(npm.config.get('//registry.npmjs.org/:_authToken'), 'npm_test-token')
   })
   t.end()

--- a/test/lib/commands/cache.js
+++ b/test/lib/commands/cache.js
@@ -1,7 +1,6 @@
 const t = require('tap')
 const { load: loadMockNpm } = require('../../fixtures/mock-npm.js')
 const MockRegistry = require('@npmcli/mock-registry')
-const mockGlobals = require('@npmcli/mock-globals')
 
 const cacache = require('cacache')
 const fs = require('fs')
@@ -267,8 +266,9 @@ t.test('cache verify', async t => {
 })
 
 t.test('cache verify as part of home', async t => {
-  const { npm, joinedOutput, prefix } = await loadMockNpm(t)
-  mockGlobals(t, { 'process.env.HOME': path.dirname(prefix) })
+  const { npm, joinedOutput } = await loadMockNpm(t, {
+    globals: ({ prefix }) => ({ 'process.env.HOME': path.dirname(prefix) }),
+  })
   await npm.exec('cache', ['verify'])
   t.match(joinedOutput(), 'Cache verified and compressed (~', 'contains ~ shorthand')
 })

--- a/test/lib/commands/get.js
+++ b/test/lib/commands/get.js
@@ -2,10 +2,11 @@ const t = require('tap')
 const { load: loadMockNpm } = require('../../fixtures/mock-npm')
 
 t.test('should retrieve values from config', async t => {
-  const { joinedOutput, npm } = await loadMockNpm(t)
   const name = 'editor'
   const value = 'vigor'
-  npm.config.set(name, value)
+  const { joinedOutput, npm } = await loadMockNpm(t, {
+    config: { [name]: value },
+  })
   await npm.exec('get', [name])
   t.equal(
     joinedOutput(),

--- a/test/lib/commands/login.js
+++ b/test/lib/commands/login.js
@@ -8,6 +8,34 @@ const mockGlobals = require('@npmcli/mock-globals')
 const MockRegistry = require('@npmcli/mock-registry')
 const stream = require('stream')
 
+const mockLogin = async (t, { stdin: stdinLines, registry: registryUrl, ...options } = {}) => {
+  let stdin
+  if (stdinLines) {
+    stdin = new stream.PassThrough()
+    for (const l of stdinLines) {
+      stdin.write(l + '\n')
+    }
+    mockGlobals(t, {
+      'process.stdin': stdin,
+      'process.stdout': new stream.PassThrough(), // to quiet readline
+    }, { replace: true })
+  }
+  const mock = await loadMockNpm(t, {
+    ...options,
+    command: 'login',
+  })
+  const registry = new MockRegistry({
+    tap: t,
+    registry: registryUrl ?? mock.npm.config.get('registry'),
+  })
+  return {
+    registry,
+    stdin,
+    rc: () => ini.parse(fs.readFileSync(path.join(mock.home, '.npmrc'), 'utf8')),
+    ...mock,
+  }
+}
+
 t.test('usage', async t => {
   const { npm } = await loadMockNpm(t)
   const login = await npm.cmd('login')
@@ -16,14 +44,8 @@ t.test('usage', async t => {
 
 t.test('legacy', t => {
   t.test('basic login', async t => {
-    const stdin = new stream.PassThrough()
-    stdin.write('test-user\n')
-    stdin.write('test-password\n')
-    mockGlobals(t, {
-      'process.stdin': stdin,
-      'process.stdout': new stream.PassThrough(), // to quiet readline
-    }, { replace: true })
-    const { npm, home } = await loadMockNpm(t, {
+    const { npm, registry, login, rc } = await mockLogin(t, {
+      stdin: ['test-user', 'test-password'],
       config: { 'auth-type': 'legacy' },
       homeDir: {
         '.npmrc': [
@@ -33,66 +55,45 @@ t.test('legacy', t => {
         ].join('\n'),
       },
     })
-    const registry = new MockRegistry({
-      tap: t,
-      registry: npm.config.get('registry'),
-    })
     registry.couchlogin({
       username: 'test-user',
       password: 'test-password',
       token: 'npm_test-token',
     })
-    await npm.exec('login', [])
+    await login.exec([])
     t.same(npm.config.get('//registry.npmjs.org/:_authToken'), 'npm_test-token')
-    const rc = ini.parse(fs.readFileSync(path.join(home, '.npmrc'), 'utf8'))
-    t.same(rc, {
+    t.same(rc(), {
       '//registry.npmjs.org/:_authToken': 'npm_test-token',
       email: 'test-email-old@npmjs.org',
     }, 'should only have token and un-nerfed old email')
   })
 
   t.test('scoped login default registry', async t => {
-    const stdin = new stream.PassThrough()
-    stdin.write('test-user\n')
-    stdin.write('test-password\n')
-    mockGlobals(t, {
-      'process.stdin': stdin,
-      'process.stdout': new stream.PassThrough(), // to quiet readline
-    }, { replace: true })
-    const { npm, home } = await loadMockNpm(t, {
+    const { npm, registry, login, rc } = await mockLogin(t, {
+      stdin: ['test-user', 'test-password'],
       config: {
         'auth-type': 'legacy',
         scope: '@npmcli',
       },
-    })
-    const registry = new MockRegistry({
-      tap: t,
-      registry: npm.config.get('registry'),
     })
     registry.couchlogin({
       username: 'test-user',
       password: 'test-password',
       token: 'npm_test-token',
     })
-    await npm.exec('login', [])
+    await login.exec([])
     t.same(npm.config.get('//registry.npmjs.org/:_authToken'), 'npm_test-token')
     t.same(npm.config.get('@npmcli:registry'), 'https://registry.npmjs.org/')
-    const rc = ini.parse(fs.readFileSync(path.join(home, '.npmrc'), 'utf8'))
-    t.same(rc, {
+    t.same(rc(), {
       '//registry.npmjs.org/:_authToken': 'npm_test-token',
       '@npmcli:registry': 'https://registry.npmjs.org/',
     }, 'should only have token and scope:registry')
   })
 
   t.test('scoped login scoped registry', async t => {
-    const stdin = new stream.PassThrough()
-    stdin.write('test-user\n')
-    stdin.write('test-password\n')
-    mockGlobals(t, {
-      'process.stdin': stdin,
-      'process.stdout': new stream.PassThrough(), // to quiet readline
-    }, { replace: true })
-    const { npm, home } = await loadMockNpm(t, {
+    const { npm, registry, login, rc } = await mockLogin(t, {
+      stdin: ['test-user', 'test-password'],
+      registry: 'https://diff-registry.npmjs.org',
       config: {
         'auth-type': 'legacy',
         scope: '@npmcli',
@@ -101,20 +102,15 @@ t.test('legacy', t => {
         '.npmrc': '@npmcli:registry=https://diff-registry.npmjs.org',
       },
     })
-    const registry = new MockRegistry({
-      tap: t,
-      registry: 'https://diff-registry.npmjs.org',
-    })
     registry.couchlogin({
       username: 'test-user',
       password: 'test-password',
       token: 'npm_test-token',
     })
-    await npm.exec('login', [])
+    await login.exec([])
     t.same(npm.config.get('//diff-registry.npmjs.org/:_authToken'), 'npm_test-token')
     t.same(npm.config.get('@npmcli:registry'), 'https://diff-registry.npmjs.org')
-    const rc = ini.parse(fs.readFileSync(path.join(home, '.npmrc'), 'utf8'))
-    t.same(rc, {
+    t.same(rc(), {
       '@npmcli:registry': 'https://diff-registry.npmjs.org',
       '//diff-registry.npmjs.org/:_authToken': 'npm_test-token',
     }, 'should only have token and scope:registry')
@@ -124,50 +120,31 @@ t.test('legacy', t => {
 
 t.test('web', t => {
   t.test('basic login', async t => {
-    const { npm, home } = await loadMockNpm(t, {
+    const { npm, registry, login, rc } = await mockLogin(t, {
       config: { 'auth-type': 'web' },
     })
-    const registry = new MockRegistry({
-      tap: t,
-      registry: npm.config.get('registry'),
-    })
     registry.weblogin({ token: 'npm_test-token' })
-    await npm.exec('login', [])
+    await login.exec([])
     t.same(npm.config.get('//registry.npmjs.org/:_authToken'), 'npm_test-token')
-    const rc = ini.parse(fs.readFileSync(path.join(home, '.npmrc'), 'utf8'))
-    t.same(rc, {
+    t.same(rc(), {
       '//registry.npmjs.org/:_authToken': 'npm_test-token',
     })
   })
   t.test('server error', async t => {
-    const { npm } = await loadMockNpm(t, {
+    const { registry, login } = await mockLogin(t, {
       config: { 'auth-type': 'web' },
-    })
-    const registry = new MockRegistry({
-      tap: t,
-      registry: npm.config.get('registry'),
     })
     registry.nock.post(registry.fullPath('/-/v1/login'))
       .reply(503, {})
     await t.rejects(
-      npm.exec('login', []),
+      login.exec([]),
       { message: /503/ }
     )
   })
   t.test('fallback', async t => {
-    const stdin = new stream.PassThrough()
-    stdin.write('test-user\n')
-    stdin.write('test-password\n')
-    mockGlobals(t, {
-      'process.stdin': stdin,
-      'process.stdout': new stream.PassThrough(), // to quiet readline
-    }, { replace: true })
-    const { npm } = await loadMockNpm(t, {
+    const { npm, registry, login } = await mockLogin(t, {
+      stdin: ['test-user', 'test-password'],
       config: { 'auth-type': 'web' },
-    })
-    const registry = new MockRegistry({
-      tap: t,
-      registry: npm.config.get('registry'),
     })
     registry.nock.post(registry.fullPath('/-/v1/login'))
       .reply(404, {})
@@ -176,7 +153,7 @@ t.test('web', t => {
       password: 'test-password',
       token: 'npm_test-token',
     })
-    await npm.exec('login', [])
+    await login.exec([])
     t.same(npm.config.get('//registry.npmjs.org/:_authToken'), 'npm_test-token')
   })
   t.end()

--- a/test/lib/commands/pack.js
+++ b/test/lib/commands/pack.js
@@ -28,8 +28,8 @@ t.test('follows pack-destination config', async t => {
       }),
       'tar-destination': {},
     },
+    config: ({ prefix }) => ({ 'pack-destination': path.join(prefix, 'tar-destination') }),
   })
-  npm.config.set('pack-destination', path.join(npm.prefix, 'tar-destination'))
   await npm.exec('pack', [])
   const filename = 'test-package-1.0.0.tgz'
   t.strictSame(outputs, [[filename]])
@@ -59,8 +59,8 @@ t.test('should log output as valid json', async t => {
         version: '1.0.0',
       }),
     },
+    config: { json: true },
   })
-  npm.config.set('json', true)
   await npm.exec('pack', [])
   const filename = 'test-package-1.0.0.tgz'
   t.matchSnapshot(outputs.map(JSON.parse), 'outputs as json')
@@ -76,8 +76,8 @@ t.test('should log scoped package output as valid json', async t => {
         version: '1.0.0',
       }),
     },
+    config: { json: true },
   })
-  npm.config.set('json', true)
   await npm.exec('pack', [])
   const filename = 'myscope-test-package-1.0.0.tgz'
   t.matchSnapshot(outputs.map(JSON.parse), 'outputs as json')
@@ -93,8 +93,8 @@ t.test('dry run', async t => {
         version: '1.0.0',
       }),
     },
+    config: { 'dry-run': true },
   })
-  npm.config.set('dry-run', true)
   await npm.exec('pack', [])
   const filename = 'test-package-1.0.0.tgz'
   t.strictSame(outputs, [[filename]])

--- a/test/lib/npm.js
+++ b/test/lib/npm.js
@@ -663,8 +663,7 @@ t.test('implicit workspace accept', async t => {
 
 t.test('usage', async t => {
   t.test('with browser', async t => {
-    mockGlobals(t, { process: { platform: 'posix' } })
-    const { npm } = await loadMockNpm(t)
+    const { npm } = await loadMockNpm(t, { globals: { process: { platform: 'posix' } } })
     const usage = await npm.usage
     npm.config.set('viewer', 'browser')
     const browserUsage = await npm.usage
@@ -673,8 +672,7 @@ t.test('usage', async t => {
   })
 
   t.test('windows always uses browser', async t => {
-    mockGlobals(t, { process: { platform: 'win32' } })
-    const { npm } = await loadMockNpm(t)
+    const { npm } = await loadMockNpm(t, { globals: { process: { platform: 'win32' } } })
     const usage = await npm.usage
     npm.config.set('viewer', 'browser')
     const browserUsage = await npm.usage


### PR DESCRIPTION
This converts some tests to use the available mock-npm options
in favor of manually calling mockGlobals and npm.config.set.
