### PR TITLE
feat: add --provenance-file flag for publish command

### DIFF
--- a/docs/lib/index.js
+++ b/docs/lib/index.js
@@ -42,6 +42,17 @@ const getCommandByDoc = (docFile, docExt) => {
   const srcName = name === 'npx' ? 'exec' : name
   const { params, usage = [''], workspaces } = require(`../../lib/commands/${srcName}`)
   const usagePrefix = name === 'npx' ? 'npx' : `npm ${name}`
+  if (params) {
+    for (const param of params) {
+      if (definitions[param].exclusive) {
+        for (const e of definitions[param].exclusive) {
+          if (!params.includes(e)) {
+            params.splice(params.indexOf(param) + 1, 0, e)
+          }
+        }
+      }
+    }
+  }
 
   return {
     name,

--- a/lib/base-command.js
+++ b/lib/base-command.js
@@ -18,6 +18,7 @@ class BaseCommand {
   // this is a static so that we can read from it without instantiating a command
   // which would require loading the config
   static get describeUsage () {
+    const seenExclusive = new Set()
     const wrapWidth = 80
     const { description, usage = [''], name, params } = this
 
@@ -32,7 +33,22 @@ class BaseCommand {
       let results = ''
       let line = ''
       for (const param of params) {
-        const paramUsage = `[${definitions[param].usage}]`
+        /* istanbul ignore next */
+        if (seenExclusive.has(param)) {
+          continue
+        }
+        const { exclusive } = definitions[param]
+        let paramUsage = `${definitions[param].usage}`
+        if (exclusive) {
+          const exclusiveParams = [paramUsage]
+          seenExclusive.add(param)
+          for (const e of exclusive) {
+            seenExclusive.add(e)
+            exclusiveParams.push(definitions[e].usage)
+          }
+          paramUsage = `${exclusiveParams.join('|')}`
+        }
+        paramUsage = `[${paramUsage}]`
         if (line.length + paramUsage.length > wrapWidth) {
           results = [results, line].filter(Boolean).join('\n')
           line = ''

--- a/lib/utils/config/definition.js
+++ b/lib/utils/config/definition.js
@@ -13,6 +13,7 @@ const allowed = [
   'defaultDescription',
   'deprecated',
   'description',
+  'exclusive',
   'flatten',
   'hint',
   'key',
@@ -83,12 +84,15 @@ class Definition {
 This value is not exported to the environment for child processes.
 `
     const deprecated = !this.deprecated ? '' : `* DEPRECATED: ${unindent(this.deprecated)}\n`
+    /* eslint-disable-next-line max-len */
+    const exclusive = !this.exclusive ? '' : `\nThis config can not be used with: \`${this.exclusive.join('`, `')}\``
     return wrapAll(`#### \`${this.key}\`
 
 * Default: ${unindent(this.defaultDescription)}
 * Type: ${unindent(this.typeDescription)}
 ${deprecated}
 ${description}
+${exclusive}
 ${noEnvExport}`)
   }
 }

--- a/lib/utils/config/definitions.js
+++ b/lib/utils/config/definitions.js
@@ -1635,9 +1635,21 @@ define('progress', {
 define('provenance', {
   default: false,
   type: Boolean,
+  exclusive: ['provenance-file'],
   description: `
     When publishing from a supported cloud CI/CD system, the package will be
     publicly linked to where it was built and published from.
+  `,
+  flatten,
+})
+
+define('provenance-file', {
+  default: null,
+  type: path,
+  hint: '<file>',
+  exclusive: ['provenance'],
+  description: `
+    When publishing, the provenance bundle at the given path will be used.
   `,
   flatten,
 })

--- a/tap-snapshots/test/lib/commands/config.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/config.js.test.cjs
@@ -118,6 +118,7 @@ exports[`test/lib/commands/config.js TAP config list --json > output matches sna
   "production": null,
   "progress": true,
   "provenance": false,
+  "provenance-file": null,
   "proxy": null,
   "read-only": false,
   "rebuild-bundle": true,
@@ -274,6 +275,7 @@ preid = ""
 production = null 
 progress = true 
 provenance = false 
+provenance-file = null 
 proxy = null 
 read-only = false 
 rebuild-bundle = true 

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -183,6 +183,8 @@ Warning: This should generally not be set via a command-line option. It is
 safer to use a registry-provided authentication bearer token stored in the
 ~/.npmrc file by running \`npm login\`.
 
+
+
 #### \`access\`
 
 * Default: 'public' for new packages, existing packages it will not change the
@@ -199,6 +201,8 @@ packages. Specifying a value of \`restricted\` or \`public\` during publish will
 change the access for an existing package the same way that \`npm access set
 status\` would.
 
+
+
 #### \`all\`
 
 * Default: false
@@ -208,6 +212,8 @@ When running \`npm outdated\` and \`npm ls\`, setting \`--all\` will show all
 outdated or installed packages, rather than only those directly depended
 upon by the current project.
 
+
+
 #### \`allow-same-version\`
 
 * Default: false
@@ -215,6 +221,8 @@ upon by the current project.
 
 Prevents throwing an error when \`npm version\` is used to set the new version
 to the same value as the current version.
+
+
 
 #### \`audit\`
 
@@ -226,6 +234,8 @@ default registry and all registries configured for scopes. See the
 documentation for [\`npm audit\`](/commands/npm-audit) for details on what is
 submitted.
 
+
+
 #### \`audit-level\`
 
 * Default: null
@@ -234,6 +244,8 @@ submitted.
 The minimum level of vulnerability for \`npm audit\` to exit with a non-zero
 exit code.
 
+
+
 #### \`auth-type\`
 
 * Default: "web"
@@ -241,6 +253,8 @@ exit code.
 
 What authentication strategy to use with \`login\`. Note that if an \`otp\`
 config is given, this value will always be set to \`legacy\`.
+
+
 
 #### \`before\`
 
@@ -257,6 +271,8 @@ If the requested version is a \`dist-tag\` and the given tag does not pass the
 will be used. For example, \`foo@latest\` might install \`foo@1.2\` even though
 \`latest\` is \`2.0\`.
 
+
+
 #### \`bin-links\`
 
 * Default: true
@@ -269,6 +285,8 @@ Set to false to have it not do this. This can be used to work around the
 fact that some file systems don't support symlinks, even on ostensibly Unix
 systems.
 
+
+
 #### \`browser\`
 
 * Default: OS X: \`"open"\`, Windows: \`"start"\`, Others: \`"xdg-open"\`
@@ -280,6 +298,8 @@ Set to \`false\` to suppress browser behavior and instead print urls to
 terminal.
 
 Set to \`true\` to use default system URL opener.
+
+
 
 #### \`ca\`
 
@@ -307,12 +327,16 @@ ca[]="..."
 
 See also the \`strict-ssl\` config.
 
+
+
 #### \`cache\`
 
 * Default: Windows: \`%LocalAppData%\\npm-cache\`, Posix: \`~/.npm\`
 * Type: Path
 
 The location of npm's cache directory.
+
+
 
 #### \`cafile\`
 
@@ -322,6 +346,8 @@ The location of npm's cache directory.
 A path to a file containing one or multiple Certificate Authority signing
 certificates. Similar to the \`ca\` setting, but allows for multiple CA's, as
 well as for the CA information to be stored in a file on disk.
+
+
 
 #### \`call\`
 
@@ -336,6 +362,7 @@ npm exec --package yo --package generator-node --call "yo node"
 \`\`\`
 
 
+
 #### \`cidr\`
 
 * Default: null
@@ -343,6 +370,8 @@ npm exec --package yo --package generator-node --call "yo node"
 
 This is a list of CIDR address to be used when configuring limited access
 tokens with the \`npm token create\` command.
+
+
 
 #### \`color\`
 
@@ -352,12 +381,16 @@ tokens with the \`npm token create\` command.
 If false, never shows colors. If \`"always"\` then always shows colors. If
 true, then only prints color codes for tty file descriptors.
 
+
+
 #### \`commit-hooks\`
 
 * Default: true
 * Type: Boolean
 
 Run git commit hooks when using the \`npm version\` command.
+
+
 
 #### \`depth\`
 
@@ -369,12 +402,16 @@ The depth to go when recursing packages for \`npm ls\`.
 If not set, \`npm ls\` will show only the immediate dependencies of the root
 project. If \`--all\` is set, then npm will show all dependencies by default.
 
+
+
 #### \`description\`
 
 * Default: true
 * Type: Boolean
 
 Show the description in \`npm search\`
+
+
 
 #### \`diff\`
 
@@ -383,12 +420,16 @@ Show the description in \`npm search\`
 
 Define arguments to compare in \`npm diff\`.
 
+
+
 #### \`diff-dst-prefix\`
 
 * Default: "b/"
 * Type: String
 
 Destination prefix to be used in \`npm diff\` output.
+
+
 
 #### \`diff-ignore-all-space\`
 
@@ -397,12 +438,16 @@ Destination prefix to be used in \`npm diff\` output.
 
 Ignore whitespace when comparing lines in \`npm diff\`.
 
+
+
 #### \`diff-name-only\`
 
 * Default: false
 * Type: Boolean
 
 Prints only filenames when using \`npm diff\`.
+
+
 
 #### \`diff-no-prefix\`
 
@@ -414,12 +459,16 @@ Do not show any source or destination prefix in \`npm diff\` output.
 Note: this causes \`npm diff\` to ignore the \`--diff-src-prefix\` and
 \`--diff-dst-prefix\` configs.
 
+
+
 #### \`diff-src-prefix\`
 
 * Default: "a/"
 * Type: String
 
 Source prefix to be used in \`npm diff\` output.
+
+
 
 #### \`diff-text\`
 
@@ -428,12 +477,16 @@ Source prefix to be used in \`npm diff\` output.
 
 Treat all files as text in \`npm diff\`.
 
+
+
 #### \`diff-unified\`
 
 * Default: 3
 * Type: Number
 
 The number of lines of context to print in \`npm diff\`.
+
+
 
 #### \`dry-run\`
 
@@ -448,6 +501,8 @@ commands that modify your local installation, eg, \`install\`, \`update\`,
 Note: This is NOT honored by other network related commands, eg \`dist-tags\`,
 \`owner\`, etc.
 
+
+
 #### \`editor\`
 
 * Default: The EDITOR or VISUAL environment variables, or
@@ -455,6 +510,8 @@ Note: This is NOT honored by other network related commands, eg \`dist-tags\`,
 * Type: String
 
 The command to run for \`npm edit\` and \`npm config edit\`.
+
+
 
 #### \`engine-strict\`
 
@@ -467,6 +524,8 @@ Node.js version.
 
 This can be overridden by setting the \`--force\` flag.
 
+
+
 #### \`fetch-retries\`
 
 * Default: 2
@@ -478,12 +537,16 @@ from the registry.
 npm will retry idempotent read requests to the registry in the case of
 network failures or 5xx HTTP errors.
 
+
+
 #### \`fetch-retry-factor\`
 
 * Default: 10
 * Type: Number
 
 The "factor" config for the \`retry\` module to use when fetching packages.
+
+
 
 #### \`fetch-retry-maxtimeout\`
 
@@ -493,6 +556,8 @@ The "factor" config for the \`retry\` module to use when fetching packages.
 The "maxTimeout" config for the \`retry\` module to use when fetching
 packages.
 
+
+
 #### \`fetch-retry-mintimeout\`
 
 * Default: 10000 (10 seconds)
@@ -501,12 +566,16 @@ packages.
 The "minTimeout" config for the \`retry\` module to use when fetching
 packages.
 
+
+
 #### \`fetch-timeout\`
 
 * Default: 300000 (5 minutes)
 * Type: Number
 
 The maximum amount of time to wait for HTTP requests to complete.
+
+
 
 #### \`force\`
 
@@ -534,6 +603,8 @@ mistakes, unnecessary performance degradation, and malicious input.
 If you don't have a clear idea of what you want to do, it is strongly
 recommended that you do not use this option!
 
+
+
 #### \`foreground-scripts\`
 
 * Default: false
@@ -546,6 +617,8 @@ input, output, and error with the main npm process.
 Note that this will generally make installs run slower, and be much noisier,
 but can be useful for debugging.
 
+
+
 #### \`format-package-lock\`
 
 * Default: true
@@ -553,6 +626,8 @@ but can be useful for debugging.
 
 Format \`package-lock.json\` or \`npm-shrinkwrap.json\` as a human readable
 file.
+
+
 
 #### \`fund\`
 
@@ -563,6 +638,8 @@ When "true" displays the message at the end of each \`npm install\`
 acknowledging the number of dependencies looking for funding. See [\`npm
 fund\`](/commands/npm-fund) for details.
 
+
+
 #### \`git\`
 
 * Default: "git"
@@ -571,6 +648,8 @@ fund\`](/commands/npm-fund) for details.
 The command to use for git commands. If git is installed on the computer,
 but is not in the \`PATH\`, then set this to the full path to the git binary.
 
+
+
 #### \`git-tag-version\`
 
 * Default: true
@@ -578,6 +657,8 @@ but is not in the \`PATH\`, then set this to the full path to the git binary.
 
 Tag the commit when using the \`npm version\` command. Setting this to false
 results in no commit being made at all.
+
+
 
 #### \`global\`
 
@@ -593,6 +674,8 @@ folder instead of the current working directory. See
 * bin files are linked to \`{prefix}/bin\`
 * man pages are linked to \`{prefix}/share/man\`
 
+
+
 #### \`globalconfig\`
 
 * Default: The global --prefix setting plus 'etc/npmrc'. For example,
@@ -601,12 +684,16 @@ folder instead of the current working directory. See
 
 The config file to read for global config options.
 
+
+
 #### \`heading\`
 
 * Default: "npm"
 * Type: String
 
 The string that starts all the debugging log output.
+
+
 
 #### \`https-proxy\`
 
@@ -617,6 +704,8 @@ A proxy to use for outgoing https requests. If the \`HTTPS_PROXY\` or
 \`https_proxy\` or \`HTTP_PROXY\` or \`http_proxy\` environment variables are set,
 proxy settings will be honored by the underlying \`make-fetch-happen\`
 library.
+
+
 
 #### \`if-present\`
 
@@ -644,6 +733,8 @@ Note that commands explicitly intended to run a particular script, such as
 will still run their intended script if \`ignore-scripts\` is set, but they
 will *not* run any pre- or post-scripts.
 
+
+
 #### \`include\`
 
 * Default:
@@ -656,6 +747,8 @@ This is the inverse of \`--omit=<type>\`.
 Dependency types specified in \`--include\` will not be omitted, regardless of
 the order in which omit/include are specified on the command-line.
 
+
+
 #### \`include-staged\`
 
 * Default: false
@@ -665,6 +758,8 @@ Allow installing "staged" published packages, as defined by [npm RFC PR
 #92](https://github.com/npm/rfcs/pull/92).
 
 This is experimental, and not implemented by the npm public registry.
+
+
 
 #### \`include-workspace-root\`
 
@@ -686,12 +781,16 @@ This value is not exported to the environment for child processes.
 
 The value \`npm init\` should use by default for the package author's email.
 
+
+
 #### \`init-author-name\`
 
 * Default: ""
 * Type: String
 
 The value \`npm init\` should use by default for the package author's name.
+
+
 
 #### \`init-author-url\`
 
@@ -701,12 +800,16 @@ The value \`npm init\` should use by default for the package author's name.
 The value \`npm init\` should use by default for the package author's
 homepage.
 
+
+
 #### \`init-license\`
 
 * Default: "ISC"
 * Type: String
 
 The value \`npm init\` should use by default for the package license.
+
+
 
 #### \`init-module\`
 
@@ -718,6 +821,8 @@ documentation for the
 [init-package-json](https://github.com/npm/init-package-json) module for
 more information, or [npm init](/commands/npm-init).
 
+
+
 #### \`init-version\`
 
 * Default: "1.0.0"
@@ -725,6 +830,8 @@ more information, or [npm init](/commands/npm-init).
 
 The value that \`npm init\` should use by default for the package version
 number, if not already set in package.json.
+
+
 
 #### \`install-links\`
 
@@ -734,6 +841,8 @@ number, if not already set in package.json.
 When set file: protocol dependencies will be packed and installed as regular
 dependencies instead of creating a symlink. This option has no effect on
 workspaces.
+
+
 
 #### \`install-strategy\`
 
@@ -747,6 +856,8 @@ place, no hoisting. shallow (formerly --global-style) only install direct
 deps at top-level. linked: (experimental) install in node_modules/.store,
 link in place, unhoisted.
 
+
+
 #### \`json\`
 
 * Default: false
@@ -758,6 +869,8 @@ Whether or not to output JSON data, rather than the normal output.
   saving them to your \`package.json\`.
 
 Not supported by all npm commands.
+
+
 
 #### \`legacy-peer-deps\`
 
@@ -777,12 +890,16 @@ This differs from \`--omit=peer\`, in that \`--omit=peer\` will avoid unpacking
 Use of \`legacy-peer-deps\` is not recommended, as it will not enforce the
 \`peerDependencies\` contract that meta-dependencies may rely on.
 
+
+
 #### \`link\`
 
 * Default: false
 * Type: Boolean
 
 Used with \`npm ls\`, limiting output to only those packages that are linked.
+
+
 
 #### \`local-address\`
 
@@ -791,6 +908,8 @@ Used with \`npm ls\`, limiting output to only those packages that are linked.
 
 The IP address of the local interface to use when making connections to the
 npm registry. Must be IPv4 in versions of Node prior to 0.12.
+
+
 
 #### \`location\`
 
@@ -808,6 +927,8 @@ instead of the current working directory. See
   of the current working directory.
 * bin files are linked to \`{prefix}/bin\`
 * man pages are linked to \`{prefix}/share/man\`
+
+
 
 #### \`lockfile-version\`
 
@@ -831,6 +952,8 @@ determinism and interoperability, at the expense of more bytes on disk.
 disk than lockfile version 2, but not interoperable with older npm versions.
 Ideal if all users are on npm version 7 and higher.
 
+
+
 #### \`loglevel\`
 
 * Default: "notice"
@@ -845,6 +968,8 @@ Any logs of a higher level than the setting are shown. The default is
 
 See also the \`foreground-scripts\` config.
 
+
+
 #### \`logs-dir\`
 
 * Default: A directory named \`_logs\` inside the cache
@@ -852,6 +977,8 @@ See also the \`foreground-scripts\` config.
 
 The location of npm's log directory. See [\`npm logging\`](/using-npm/logging)
 for more information.
+
+
 
 #### \`logs-max\`
 
@@ -862,12 +989,16 @@ The maximum number of log files to store.
 
 If set to 0, no log files will be written for the current run.
 
+
+
 #### \`long\`
 
 * Default: false
 * Type: Boolean
 
 Show extended information in \`ls\`, \`search\`, and \`help-search\`.
+
+
 
 #### \`maxsockets\`
 
@@ -876,6 +1007,8 @@ Show extended information in \`ls\`, \`search\`, and \`help-search\`.
 
 The maximum number of connections to use per origin (protocol/host/port
 combination).
+
+
 
 #### \`message\`
 
@@ -886,6 +1019,8 @@ Commit message which is used by \`npm version\` when creating version commit.
 
 Any "%s" in the message will be replaced with the version number.
 
+
+
 #### \`node-options\`
 
 * Default: null
@@ -894,6 +1029,8 @@ Any "%s" in the message will be replaced with the version number.
 Options to pass through to Node.js via the \`NODE_OPTIONS\` environment
 variable. This does not impact how npm itself is executed but it does impact
 how lifecycle scripts are called.
+
+
 
 #### \`noproxy\`
 
@@ -904,6 +1041,8 @@ Domain extensions that should bypass any proxies.
 
 Also accepts a comma-delimited string.
 
+
+
 #### \`offline\`
 
 * Default: false
@@ -911,6 +1050,8 @@ Also accepts a comma-delimited string.
 
 Force offline mode: no network requests will be done during install. To
 allow the CLI to fill in missing cache data, see \`--prefer-offline\`.
+
+
 
 #### \`omit\`
 
@@ -930,6 +1071,8 @@ it will be included.
 If the resulting omit list includes \`'dev'\`, then the \`NODE_ENV\` environment
 variable will be set to \`'production'\` for all lifecycle scripts.
 
+
+
 #### \`omit-lockfile-registry-resolved\`
 
 * Default: false
@@ -939,6 +1082,8 @@ This option causes npm to create lock files without a \`resolved\` key for
 registry dependencies. Subsequent installs will need to resolve tarball
 endpoints with the configured registry, likely resulting in a longer install
 time.
+
+
 
 #### \`otp\`
 
@@ -951,12 +1096,16 @@ when publishing or changing package permissions with \`npm access\`.
 If not set, and a registry response fails with a challenge for a one-time
 password, npm will prompt on the command line for one.
 
+
+
 #### \`pack-destination\`
 
 * Default: "."
 * Type: String
 
 Directory in which \`npm pack\` will save tarballs.
+
+
 
 #### \`package\`
 
@@ -965,6 +1114,8 @@ Directory in which \`npm pack\` will save tarballs.
 
 The package or packages to install for [\`npm exec\`](/commands/npm-exec)
 
+
+
 #### \`package-lock\`
 
 * Default: true
@@ -972,6 +1123,8 @@ The package or packages to install for [\`npm exec\`](/commands/npm-exec)
 
 If set to false, then ignore \`package-lock.json\` files when installing. This
 will also prevent _writing_ \`package-lock.json\` if \`save\` is true.
+
+
 
 #### \`package-lock-only\`
 
@@ -987,6 +1140,8 @@ instead of checking \`node_modules\` and downloading dependencies.
 For \`list\` this means the output will be based on the tree described by the
 \`package-lock.json\`, rather than the contents of \`node_modules\`.
 
+
+
 #### \`parseable\`
 
 * Default: false
@@ -995,6 +1150,8 @@ For \`list\` this means the output will be based on the tree described by the
 Output parseable results from commands that write to standard output. For
 \`npm search\`, this will be tab-separated table format.
 
+
+
 #### \`prefer-dedupe\`
 
 * Default: false
@@ -1002,6 +1159,8 @@ Output parseable results from commands that write to standard output. For
 
 Prefer to deduplicate packages if possible, rather than choosing a newer
 version of a dependency.
+
+
 
 #### \`prefer-offline\`
 
@@ -1012,6 +1171,8 @@ If true, staleness checks for cached data will be bypassed, but missing data
 will be requested from the server. To force full offline mode, use
 \`--offline\`.
 
+
+
 #### \`prefer-online\`
 
 * Default: false
@@ -1019,6 +1180,8 @@ will be requested from the server. To force full offline mode, use
 
 If true, staleness checks for cached data will be forced, making the CLI
 look for updates immediately even for fresh package data.
+
+
 
 #### \`prefix\`
 
@@ -1030,6 +1193,8 @@ look for updates immediately even for fresh package data.
 The location to install global items. If set on the command line, then it
 forces non-global commands to run in the specified folder.
 
+
+
 #### \`preid\`
 
 * Default: ""
@@ -1037,6 +1202,8 @@ forces non-global commands to run in the specified folder.
 
 The "prerelease identifier" to use as a prefix for the "prerelease" part of
 a semver. Like the \`rc\` in \`1.2.0-rc.8\`.
+
+
 
 #### \`progress\`
 
@@ -1048,6 +1215,8 @@ operations, if \`process.stderr\` is a TTY.
 
 Set to \`false\` to suppress the progress bar.
 
+
+
 #### \`provenance\`
 
 * Default: false
@@ -1055,6 +1224,17 @@ Set to \`false\` to suppress the progress bar.
 
 When publishing from a supported cloud CI/CD system, the package will be
 publicly linked to where it was built and published from.
+
+This config can not be used with: \`provenance-file\`
+
+#### \`provenance-file\`
+
+* Default: null
+* Type: Path
+
+When publishing, the provenance bundle at the given path will be used.
+
+This config can not be used with: \`provenance\`
 
 #### \`proxy\`
 
@@ -1065,6 +1245,8 @@ A proxy to use for outgoing http requests. If the \`HTTP_PROXY\` or
 \`http_proxy\` environment variables are set, proxy settings will be honored
 by the underlying \`request\` library.
 
+
+
 #### \`read-only\`
 
 * Default: false
@@ -1073,6 +1255,8 @@ by the underlying \`request\` library.
 This is used to mark a token as unable to publish when configuring limited
 access tokens with the \`npm token create\` command.
 
+
+
 #### \`rebuild-bundle\`
 
 * Default: true
@@ -1080,12 +1264,16 @@ access tokens with the \`npm token create\` command.
 
 Rebuild bundled dependencies after installation.
 
+
+
 #### \`registry\`
 
 * Default: "https://registry.npmjs.org/"
 * Type: URL
 
 The base URL of the npm registry.
+
+
 
 #### \`replace-registry-host\`
 
@@ -1102,6 +1290,8 @@ registry host with the configured host every time.
 
 You may also specify a bare hostname (e.g., "registry.npmjs.org").
 
+
+
 #### \`save\`
 
 * Default: \`true\` unless when using \`npm update\` where it defaults to \`false\`
@@ -1114,6 +1304,8 @@ When used with the \`npm rm\` command, removes the dependency from
 
 Will also prevent writing to \`package-lock.json\` if set to \`false\`.
 
+
+
 #### \`save-bundle\`
 
 * Default: false
@@ -1125,12 +1317,16 @@ If a package would be saved at install time by the use of \`--save\`,
 
 Ignored if \`--save-peer\` is set, since peerDependencies cannot be bundled.
 
+
+
 #### \`save-dev\`
 
 * Default: false
 * Type: Boolean
 
 Save installed packages to a package.json file as \`devDependencies\`.
+
+
 
 #### \`save-exact\`
 
@@ -1140,6 +1336,8 @@ Save installed packages to a package.json file as \`devDependencies\`.
 Dependencies saved to package.json will be configured with an exact version
 rather than using npm's default semver range operator.
 
+
+
 #### \`save-optional\`
 
 * Default: false
@@ -1147,12 +1345,16 @@ rather than using npm's default semver range operator.
 
 Save installed packages to a package.json file as \`optionalDependencies\`.
 
+
+
 #### \`save-peer\`
 
 * Default: false
 * Type: Boolean
 
 Save installed packages to a package.json file as \`peerDependencies\`
+
+
 
 #### \`save-prefix\`
 
@@ -1167,6 +1369,8 @@ to \`^1.2.3\` which allows minor upgrades for that package, but after \`npm
 config set save-prefix='~'\` it would be set to \`~1.2.3\` which only allows
 patch upgrades.
 
+
+
 #### \`save-prod\`
 
 * Default: false
@@ -1178,6 +1382,8 @@ you want to move it to be a non-optional production dependency.
 
 This is the default behavior if \`--save\` is true, and neither \`--save-dev\`
 or \`--save-optional\` are true.
+
+
 
 #### \`scope\`
 
@@ -1209,6 +1415,7 @@ npm init --scope=@foo --yes
 \`\`\`
 
 
+
 #### \`script-shell\`
 
 * Default: '/bin/sh' on POSIX systems, 'cmd.exe' on Windows
@@ -1217,12 +1424,16 @@ npm init --scope=@foo --yes
 The shell to use for scripts run with the \`npm exec\`, \`npm run\` and \`npm
 init <package-spec>\` commands.
 
+
+
 #### \`searchexclude\`
 
 * Default: ""
 * Type: String
 
 Space-separated options that limit the results from search.
+
+
 
 #### \`searchlimit\`
 
@@ -1232,12 +1443,16 @@ Space-separated options that limit the results from search.
 Number of items to limit search results to. Will not apply at all to legacy
 searches.
 
+
+
 #### \`searchopts\`
 
 * Default: ""
 * Type: String
 
 Space-separated options that are always passed to search.
+
+
 
 #### \`searchstaleness\`
 
@@ -1247,6 +1462,8 @@ Space-separated options that are always passed to search.
 The age of the cache, in seconds, before another registry request is made if
 using legacy search endpoint.
 
+
+
 #### \`shell\`
 
 * Default: SHELL environment variable, or "bash" on Posix, or "cmd.exe" on
@@ -1254,6 +1471,8 @@ using legacy search endpoint.
 * Type: String
 
 The shell to run for the \`npm explore\` command.
+
+
 
 #### \`sign-git-commit\`
 
@@ -1266,6 +1485,8 @@ version using \`-S\` to add a signature.
 Note that git requires you to have set up GPG keys in your git configs for
 this to work properly.
 
+
+
 #### \`sign-git-tag\`
 
 * Default: false
@@ -1276,6 +1497,8 @@ If set to true, then the \`npm version\` command will tag the version using
 
 Note that git requires you to have set up GPG keys in your git configs for
 this to work properly.
+
+
 
 #### \`strict-peer-deps\`
 
@@ -1296,6 +1519,8 @@ When such an override is performed, a warning is printed, explaining the
 conflict and the packages involved. If \`--strict-peer-deps\` is set, then
 this warning is treated as a failure.
 
+
+
 #### \`strict-ssl\`
 
 * Default: true
@@ -1305,6 +1530,8 @@ Whether or not to do SSL key validation when making requests to the registry
 via https.
 
 See also the \`ca\` config.
+
+
 
 #### \`tag\`
 
@@ -1320,6 +1547,8 @@ command, if no explicit tag is given.
 When used by the \`npm diff\` command, this is the tag used to fetch the
 tarball that will be compared with the local files by default.
 
+
+
 #### \`tag-version-prefix\`
 
 * Default: "v"
@@ -1332,6 +1561,8 @@ it to the empty string: \`""\`.
 Because other tools may rely on the convention that npm version tags look
 like \`v1.0.0\`, _only use this property if it is absolutely necessary_. In
 particular, use care when overriding this setting for public packages.
+
+
 
 #### \`timing\`
 
@@ -1346,6 +1577,8 @@ You can quickly view it with this [json](https://npm.im/json) command line:
 
 Timing information will also be reported in the terminal. To suppress this
 while still writing the timing file, use \`--silent\`.
+
+
 
 #### \`umask\`
 
@@ -1367,6 +1600,8 @@ Thus, the effective default umask value on most POSIX systems is 0o22,
 meaning that folders and executables are created with a mode of 0o755 and
 other files are created with a mode of 0o644.
 
+
+
 #### \`unicode\`
 
 * Default: false on windows, true on mac/unix systems with a unicode locale,
@@ -1376,6 +1611,8 @@ other files are created with a mode of 0o644.
 When set to true, npm uses unicode characters in the tree output. When
 false, it uses ascii characters instead of unicode glyphs.
 
+
+
 #### \`update-notifier\`
 
 * Default: true
@@ -1384,12 +1621,16 @@ false, it uses ascii characters instead of unicode glyphs.
 Set to false to suppress the update notification when using an older version
 of npm than the latest.
 
+
+
 #### \`usage\`
 
 * Default: false
 * Type: Boolean
 
 Show short usage output about the command specified.
+
+
 
 #### \`user-agent\`
 
@@ -1409,6 +1650,8 @@ their actual counterparts:
 * \`{ci}\` - The value of the \`ci-name\` config, if set, prefixed with \`ci/\`, or
   an empty string if \`ci-name\` is empty.
 
+
+
 #### \`userconfig\`
 
 * Default: "~/.npmrc"
@@ -1420,6 +1663,8 @@ This may be overridden by the \`npm_config_userconfig\` environment variable
 or the \`--userconfig\` command line option, but may _not_ be overridden by
 settings in the \`globalconfig\` file.
 
+
+
 #### \`version\`
 
 * Default: false
@@ -1428,6 +1673,8 @@ settings in the \`globalconfig\` file.
 If true, output the npm version and exit successfully.
 
 Only relevant when specified explicitly on the command line.
+
+
 
 #### \`versions\`
 
@@ -1440,6 +1687,8 @@ exists, and exit successfully.
 
 Only relevant when specified explicitly on the command line.
 
+
+
 #### \`viewer\`
 
 * Default: "man" on Posix, "browser" on Windows
@@ -1449,12 +1698,16 @@ The program to use to view help content.
 
 Set to \`"browser"\` to view html help content in the default web browser.
 
+
+
 #### \`which\`
 
 * Default: null
 * Type: null or Number
 
 If there are multiple funding sources, which 1-indexed source URL to open.
+
+
 
 #### \`workspace\`
 
@@ -1504,6 +1757,8 @@ This value is not exported to the environment for child processes.
 If set to true, the npm cli will run an update after operations that may
 possibly change the workspaces installed to the \`node_modules\` folder.
 
+
+
 #### \`yes\`
 
 * Default: null
@@ -1511,6 +1766,8 @@ possibly change the workspaces installed to the \`node_modules\` folder.
 
 Automatically answer "yes" to any prompts that npm might print on the
 command line.
+
+
 
 #### \`also\`
 
@@ -1520,6 +1777,8 @@ command line.
 
 When set to \`dev\` or \`development\`, this is an alias for \`--include=dev\`.
 
+
+
 #### \`cache-max\`
 
 * Default: Infinity
@@ -1528,6 +1787,8 @@ When set to \`dev\` or \`development\`, this is an alias for \`--include=dev\`.
 
 \`--cache-max=0\` is an alias for \`--prefer-online\`
 
+
+
 #### \`cache-min\`
 
 * Default: 0
@@ -1535,6 +1796,8 @@ When set to \`dev\` or \`development\`, this is an alias for \`--include=dev\`.
 * DEPRECATED: This option has been deprecated in favor of \`--prefer-offline\`.
 
 \`--cache-min=9999 (or bigger)\` is an alias for \`--prefer-offline\`.
+
+
 
 #### \`cert\`
 
@@ -1557,6 +1820,8 @@ It is _not_ the path to a certificate file, though you can set a
 registry-scoped "certfile" path like
 "//other-registry.tld/:certfile=/path/to/cert.pem".
 
+
+
 #### \`ci-name\`
 
 * Default: The name of the current CI system, or \`null\` when not on a known CI
@@ -1569,6 +1834,8 @@ The name of a continuous integration system. If not set explicitly, npm will
 detect the current CI environment using the
 [\`ci-info\`](http://npm.im/ci-info) module.
 
+
+
 #### \`dev\`
 
 * Default: false
@@ -1576,6 +1843,8 @@ detect the current CI environment using the
 * DEPRECATED: Please use --include=dev instead.
 
 Alias for \`--include=dev\`.
+
+
 
 #### \`global-style\`
 
@@ -1587,6 +1856,8 @@ Alias for \`--include=dev\`.
 Only install direct dependencies in the top level \`node_modules\`, but hoist
 on deeper dependencies. Sets \`--install-strategy=shallow\`.
 
+
+
 #### \`init.author.email\`
 
 * Default: ""
@@ -1594,6 +1865,8 @@ on deeper dependencies. Sets \`--install-strategy=shallow\`.
 * DEPRECATED: Use \`--init-author-email\` instead.
 
 Alias for \`--init-author-email\`
+
+
 
 #### \`init.author.name\`
 
@@ -1603,6 +1876,8 @@ Alias for \`--init-author-email\`
 
 Alias for \`--init-author-name\`
 
+
+
 #### \`init.author.url\`
 
 * Default: ""
@@ -1610,6 +1885,8 @@ Alias for \`--init-author-name\`
 * DEPRECATED: Use \`--init-author-url\` instead.
 
 Alias for \`--init-author-url\`
+
+
 
 #### \`init.license\`
 
@@ -1619,6 +1896,8 @@ Alias for \`--init-author-url\`
 
 Alias for \`--init-license\`
 
+
+
 #### \`init.module\`
 
 * Default: "~/.npm-init.js"
@@ -1627,6 +1906,8 @@ Alias for \`--init-license\`
 
 Alias for \`--init-module\`
 
+
+
 #### \`init.version\`
 
 * Default: "1.0.0"
@@ -1634,6 +1915,8 @@ Alias for \`--init-module\`
 * DEPRECATED: Use \`--init-version\` instead.
 
 Alias for \`--init-version\`
+
+
 
 #### \`key\`
 
@@ -1654,6 +1937,8 @@ key="-----BEGIN PRIVATE KEY-----\\nXXXX\\nXXXX\\n-----END PRIVATE KEY-----"
 It is _not_ the path to a key file, though you can set a registry-scoped
 "keyfile" path like "//other-registry.tld/:keyfile=/path/to/key.pem".
 
+
+
 #### \`legacy-bundling\`
 
 * Default: false
@@ -1666,6 +1951,8 @@ the same manner that they are depended on. This may cause very deep
 directory structures and duplicate package installs as there is no
 de-duplicating. Sets \`--install-strategy=nested\`.
 
+
+
 #### \`only\`
 
 * Default: null
@@ -1673,6 +1960,8 @@ de-duplicating. Sets \`--install-strategy=nested\`.
 * DEPRECATED: Use \`--omit=dev\` to omit dev dependencies from the install.
 
 When set to \`prod\` or \`production\`, this is an alias for \`--omit=dev\`.
+
+
 
 #### \`optional\`
 
@@ -1685,6 +1974,8 @@ Default value does install optional deps unless otherwise omitted.
 
 Alias for --include=optional or --omit=optional
 
+
+
 #### \`production\`
 
 * Default: null
@@ -1693,6 +1984,8 @@ Alias for --include=optional or --omit=optional
 
 Alias for \`--omit=dev\`
 
+
+
 #### \`shrinkwrap\`
 
 * Default: true
@@ -1700,6 +1993,8 @@ Alias for \`--omit=dev\`
 * DEPRECATED: Use the --package-lock setting instead.
 
 Alias for --package-lock
+
+
 
 #### \`tmp\`
 
@@ -1712,6 +2007,8 @@ Alias for --package-lock
 
 Historically, the location where temporary files were stored. No longer
 relevant.
+
+
 `
 
 exports[`test/lib/docs.js TAP config > all keys 1`] = `
@@ -1822,6 +2119,7 @@ Array [
   "production",
   "progress",
   "provenance",
+  "provenance-file",
   "proxy",
   "read-only",
   "rebuild-bundle",
@@ -1958,6 +2256,7 @@ Array [
   "production",
   "progress",
   "provenance",
+  "provenance-file",
   "proxy",
   "read-only",
   "rebuild-bundle",
@@ -3343,7 +3642,8 @@ npm publish <package-spec>
 Options:
 [--tag <tag>] [--access <restricted|public>] [--dry-run] [--otp <otp>]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
-[-ws|--workspaces] [--include-workspace-root] [--provenance]
+[-ws|--workspaces] [--include-workspace-root]
+[--provenance|--provenance-file <file>]
 
 Run "npm help publish" for more info
 
@@ -3359,6 +3659,7 @@ npm publish <package-spec>
 #### \`workspaces\`
 #### \`include-workspace-root\`
 #### \`provenance\`
+#### \`provenance-file\`
 `
 
 exports[`test/lib/docs.js TAP usage query > must match snapshot 1`] = `

--- a/tap-snapshots/test/lib/utils/config/definition.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/config/definition.js.test.cjs
@@ -15,6 +15,8 @@ exports[`test/lib/utils/config/definition.js TAP basic definition > description 
 it should not be used ever
 
 not even once.
+
+
 `
 
 exports[`test/lib/utils/config/definition.js TAP basic definition > human-readable description 1`] = `
@@ -24,6 +26,8 @@ exports[`test/lib/utils/config/definition.js TAP basic definition > human-readab
 * Type: Number or String
 
 just a test thingie
+
+
 `
 
 exports[`test/lib/utils/config/definition.js TAP long description > cols=-1 1`] = `
@@ -92,6 +96,7 @@ with (multiple) {
   blocks()
 }
 \`\`\`
+
 
 `
 
@@ -162,6 +167,7 @@ with (multiple) {
 }
 \`\`\`
 
+
 `
 
 exports[`test/lib/utils/config/definition.js TAP long description > cols=40 1`] = `
@@ -201,6 +207,7 @@ with (multiple) {
 }
 \`\`\`
 
+
 `
 
 exports[`test/lib/utils/config/definition.js TAP long description > cols=9000 1`] = `
@@ -231,6 +238,7 @@ with (multiple) {
 }
 \`\`\`
 
+
 `
 
 exports[`test/lib/utils/config/definition.js TAP long description > cols=NaN 1`] = `
@@ -260,5 +268,6 @@ with (multiple) {
   blocks()
 }
 \`\`\`
+
 
 `

--- a/workspaces/config/lib/index.js
+++ b/workspaces/config/lib/index.js
@@ -575,6 +575,13 @@ class Config {
         const v = this.parseField(value, k)
         if (where !== 'default') {
           this.#checkDeprecated(k, where, obj, [key, value])
+          if (this.definitions[key]?.exclusive) {
+            for (const exclusive of this.definitions[key].exclusive) {
+              if (!this.isDefault(exclusive)) {
+                throw new TypeError(`--${key} can not be provided when using --${exclusive}`)
+              }
+            }
+          }
         }
         conf.data[k] = v
       }

--- a/workspaces/config/test/fixtures/definitions.js
+++ b/workspaces/config/test/fixtures/definitions.js
@@ -2606,4 +2606,18 @@ const definitions = module.exports = {
     defaultDescription: 'false',
     typeDescription: 'Boolean',
   },
+  truth: {
+    key: 'truth',
+    default: false,
+    type: Boolean,
+    description: 'The Truth',
+    exclusive: ['lie'],
+  },
+  lie: {
+    key: 'lie',
+    default: false,
+    type: Boolean,
+    description: 'A Lie',
+    exclusive: ['truth'],
+  },
 }

--- a/workspaces/config/test/index.js
+++ b/workspaces/config/test/index.js
@@ -239,7 +239,6 @@ loglevel = yolo
       env,
       argv,
       cwd: join(`${path}/project`),
-
       shorthands,
       definitions,
     })
@@ -1318,6 +1317,27 @@ t.test('workspaces', async (t) => {
   })
 })
 
+t.test('exclusive options conflict', async t => {
+  const path = t.testdir()
+  const config = new Config({
+    env: {},
+    npmPath: __dirname,
+    argv: [
+      process.execPath,
+      __filename,
+      '--truth=true',
+      '--lie=true',
+    ],
+    cwd: join(`${path}/project`),
+    shorthands,
+    definitions,
+    flatten,
+  })
+  await t.rejects(config.load(), {
+    name: 'TypeError',
+    message: '--lie can not be provided when using --truth',
+  })
+})
 t.test('env-replaced config from files is not clobbered when saving', async (t) => {
   const path = t.testdir()
   const opts = {

--- a/workspaces/libnpmpublish/README.md
+++ b/workspaces/libnpmpublish/README.md
@@ -51,6 +51,17 @@ A couple of options of note:
   token for the registry. For other ways to pass in auth details, see the
   n-r-f docs.
 
+* `opts.provenance` - when running in a supported CI environment, will trigger
+  the generation of a signed provenance statement to be published alongside
+  the package. Mutually exclusive with the `provenanceFile` option.
+
+* `opts.provenanceFile` - specifies the path to an externally-generated
+  provenance statement to be published alongside the package. Mutually
+  exclusive with the `provenance` option. The specified file should be a
+  [Sigstore Bundle](https://github.com/sigstore/protobuf-specs/blob/main/protos/sigstore_bundle.proto)
+  containing a [DSSE](https://github.com/secure-systems-lab/dsse)-packaged
+  provenance statement.
+
 #### <a name="publish"></a> `> libpub.publish(manifest, tarData, [opts]) -> Promise`
 
 Sends the package represented by the `manifest` and `tarData` to the

--- a/workspaces/libnpmpublish/lib/publish.js
+++ b/workspaces/libnpmpublish/lib/publish.js
@@ -7,7 +7,7 @@ const { URL } = require('url')
 const ssri = require('ssri')
 const ciInfo = require('ci-info')
 
-const { generateProvenance } = require('./provenance')
+const { generateProvenance, verifyProvenance } = require('./provenance')
 
 const TLOG_BASE_URL = 'https://search.sigstore.dev/'
 
@@ -111,7 +111,7 @@ const patchManifest = (_manifest, opts) => {
 }
 
 const buildMetadata = async (registry, manifest, tarballData, spec, opts) => {
-  const { access, defaultTag, algorithms, provenance } = opts
+  const { access, defaultTag, algorithms, provenance, provenanceFile } = opts
   const root = {
     _id: manifest.name,
     name: manifest.name,
@@ -154,66 +154,31 @@ const buildMetadata = async (registry, manifest, tarballData, spec, opts) => {
 
   // Handle case where --provenance flag was set to true
   let transparencyLogUrl
-  if (provenance === true) {
+  if (provenance === true || provenanceFile) {
+    let provenanceBundle
     const subject = {
       name: npa.toPurl(spec),
       digest: { sha512: integrity.sha512[0].hexDigest() },
     }
 
-    // Ensure that we're running in GHA, currently the only supported build environment
-    if (ciInfo.name !== 'GitHub Actions') {
-      throw Object.assign(
-        new Error('Automatic provenance generation not supported outside of GitHub Actions'),
-        { code: 'EUSAGE' }
-      )
-    }
+    if (provenance === true) {
+      await ensureProvenanceGeneration(registry, spec, opts)
+      provenanceBundle = await generateProvenance([subject], opts)
 
-    // Ensure that the GHA OIDC token is available
-    if (!process.env.ACTIONS_ID_TOKEN_REQUEST_URL) {
-      throw Object.assign(
-        /* eslint-disable-next-line max-len */
-        new Error('Provenance generation in GitHub Actions requires "write" access to the "id-token" permission'),
-        { code: 'EUSAGE' }
-      )
-    }
+      /* eslint-disable-next-line max-len */
+      log.notice('publish', 'Signed provenance statement with source and build information from GitHub Actions')
 
-    // Some registries (e.g. GH packages) require auth to check visibility,
-    // and always return 404 when no auth is supplied. In this case we assume
-    // the package is always private and require `--access public` to publish
-    // with provenance.
-    let visibility = { public: false }
-    if (opts.provenance === true && opts.access !== 'public') {
-      try {
-        const res = await npmFetch
-          .json(`${registry}/-/package/${spec.escapedName}/visibility`, opts)
-        visibility = res
-      } catch (err) {
-        if (err.code !== 'E404') {
-          throw err
-        }
+      const tlogEntry = provenanceBundle?.verificationMaterial?.tlogEntries[0]
+      /* istanbul ignore else */
+      if (tlogEntry) {
+        transparencyLogUrl = `${TLOG_BASE_URL}?logIndex=${tlogEntry.logIndex}`
+        log.notice(
+          'publish',
+          `Provenance statement published to transparency log: ${transparencyLogUrl}`
+        )
       }
-    }
-
-    if (!visibility.public && opts.provenance === true && opts.access !== 'public') {
-      throw Object.assign(
-        /* eslint-disable-next-line max-len */
-        new Error("Can't generate provenance for new or private package, you must set `access` to public."),
-        { code: 'EUSAGE' }
-      )
-    }
-    const provenanceBundle = await generateProvenance([subject], opts)
-
-    /* eslint-disable-next-line max-len */
-    log.notice('publish', 'Signed provenance statement with source and build information from GitHub Actions')
-
-    const tlogEntry = provenanceBundle?.verificationMaterial?.tlogEntries[0]
-    /* istanbul ignore else */
-    if (tlogEntry) {
-      transparencyLogUrl = `${TLOG_BASE_URL}?logIndex=${tlogEntry.logIndex}`
-      log.notice(
-        'publish',
-        `Provenance statement published to transparency log: ${transparencyLogUrl}`
-      )
+    } else {
+      provenanceBundle = await verifyProvenance(subject, provenanceFile)
     }
 
     const serializedBundle = JSON.stringify(provenanceBundle)
@@ -273,6 +238,51 @@ const patchMetadata = (current, newData) => {
   }
 
   return current
+}
+
+// Check that all the prereqs are met for provenance generation
+const ensureProvenanceGeneration = async (registry, spec, opts) => {
+  // Ensure that we're running in GHA, currently the only supported build environment
+  if (ciInfo.name !== 'GitHub Actions') {
+    throw Object.assign(
+      new Error('Automatic provenance generation not supported outside of GitHub Actions'),
+      { code: 'EUSAGE' }
+    )
+  }
+
+  // Ensure that the GHA OIDC token is available
+  if (!process.env.ACTIONS_ID_TOKEN_REQUEST_URL) {
+    throw Object.assign(
+      /* eslint-disable-next-line max-len */
+      new Error('Provenance generation in GitHub Actions requires "write" access to the "id-token" permission'),
+      { code: 'EUSAGE' }
+    )
+  }
+
+  // Some registries (e.g. GH packages) require auth to check visibility,
+  // and always return 404 when no auth is supplied. In this case we assume
+  // the package is always private and require `--access public` to publish
+  // with provenance.
+  let visibility = { public: false }
+  if (true && opts.access !== 'public') {
+    try {
+      const res = await npmFetch
+        .json(`${registry}/-/package/${spec.escapedName}/visibility`, opts)
+      visibility = res
+    } catch (err) {
+      if (err.code !== 'E404') {
+        throw err
+      }
+    }
+  }
+
+  if (!visibility.public && opts.provenance === true && opts.access !== 'public') {
+    throw Object.assign(
+      /* eslint-disable-next-line max-len */
+      new Error("Can't generate provenance for new or private package, you must set `access` to public."),
+      { code: 'EUSAGE' }
+    )
+  }
 }
 
 module.exports = publish


### PR DESCRIPTION
Updates the `publish` command to accept a new `--provenance-file` option which points to an externally-generated provenance statement. If specified, the provenance statement will be read, verified and published as an attachment to the package.

Before the provenance is passed to the registry, there are some basic sanity checks like ensuring that the subject name/digest present in the provenance statement match the package being published. The signature in the provenance bundle is also verified to ensure it matches the package. More thorough verification checks are performed by the registry before it accepts the package for publishing. 

This PR also introduces a mechanism to configure sets of flags whose use is mutually exclusive. This is currently applied to the `--provenance` and `--provenance-file` flags, but can be generally used for any flag sets with similar semantics.

Mutually-exclusive flags will appear like this in the help output:
```
Publish a package

Usage:
npm publish <package-spec>

Options:
[--tag <tag>] [--access <restricted|public>] [--dry-run] [--otp <otp>]
[-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
[-ws|--workspaces] [--include-workspace-root]
[--provenance|--provenance-file <file>]
```

An attempt to use exclusive flags at the same time will result in an error which looks like this:
```
$ node . publish --provenance --provenance-file ./foo
TypeError: --provenance-file can not be provided when using --provenance
```