### PR TITLE
docs: explain what `ci` in `npm ci` stands for

### DIFF
--- a/docs/content/commands/npm-ci.md
+++ b/docs/content/commands/npm-ci.md
@@ -47,7 +47,7 @@ deployment -- or any situation where you want to make sure you're doing a clean
 install of your dependencies. It can be significantly faster than a regular npm
 install by skipping certain user-oriented features. It is also more strict than
 a regular install, which can help catch errors or inconsistencies caused by the
-incrementally-installed local environments of most npm users.
+incrementally-installed local environments of most npm users. The `ci` in `npm ci` stands for "**C**lean **I**nstall".
 
 In short, the main differences between using `npm install` and `npm ci` are:
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
This change just adds a line explaining what the `ci` in `npm-ci` stands for. I think adding such a line could help readers more easily remember what `npm ci` does.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Closes #6499