### PR TITLE
fix: public package check in libnpmpublish

### DIFF
--- a/workspaces/libnpmpublish/lib/publish.js
+++ b/workspaces/libnpmpublish/lib/publish.js
@@ -264,7 +264,7 @@ const ensureProvenanceGeneration = async (registry, spec, opts) => {
   // the package is always private and require `--access public` to publish
   // with provenance.
   let visibility = { public: false }
-  if (true && opts.access !== 'public') {
+  if (opts.access !== 'public') {
     try {
       const res = await npmFetch
         .json(`${registry}/-/package/${spec.escapedName}/visibility`, opts)


### PR DESCRIPTION
Removes a stray "true" in the boolean expression which determines whether the package's access is "public". Result of a bad refactor of the [original implementation](https://github.com/npm/cli/blob/f06469607b80faf72eb897ec3e33deebc6dc10fc/workspaces/libnpmpublish/lib/publish.js#L185)

Does not change behavior.

