### PR TITLE
feat: add ps1 scripts

### DIFF
--- a/bin/npm.ps1
+++ b/bin/npm.ps1
@@ -9,18 +9,27 @@ if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
 }
 $ret=0
 
-$nodebin = $(Get-Command "node$exe" -ErrorAction SilentlyContinue -ErrorVariable F).Source
+$nodeexe = "node$exe"
+$nodebin = $(Get-Command $nodeexe -ErrorAction SilentlyContinue -ErrorVariable F).Source
 if ($nodebin -eq $null) {
-  Write-Host "node$exe not found."
+  Write-Host "$nodeexe not found."
   exit 1
 }
 $nodedir = $(New-Object -ComObject Scripting.FileSystemObject).GetFile("$nodebin").ParentFolder.Path
 
+$npmclijs="$nodedir/node_modules/npm/bin/npm-cli.js"
+$npmprefix=(& $nodeexe $npmclijs prefix -g)
+if ($LASTEXITCODE -ne 0) {
+  Write-Host "Could not determine Node.js install directory"
+  exit 1
+}
+$npmprefixclijs="$npmprefix/node_modules/npm/bin/npm-cli.js"
+
 # Support pipeline input
 if ($MyInvocation.ExpectingInput) {
-  $input | & "node$exe" "$nodedir/node_modules/npm/bin/npm-cli.js" $args
+  $input | & $nodeexe $npmprefixclijs $args
 } else {
-  & "node$exe" "$nodedir/node_modules/npm/bin/npm-cli.js" $args
+  & $nodeexe $npmprefixclijs $args
 }
 $ret=$LASTEXITCODE
 exit $ret

--- a/bin/npm.ps1
+++ b/bin/npm.ps1
@@ -1,0 +1,26 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+
+$nodebin = $(Get-Command "node$exe" -ErrorAction SilentlyContinue -ErrorVariable F).Source
+if ($nodebin -eq $null) {
+  Write-Host "node$exe not found."
+  exit 1
+}
+$nodedir = $(New-Object -ComObject Scripting.FileSystemObject).GetFile("$nodebin").ParentFolder.Path
+
+# Support pipeline input
+if ($MyInvocation.ExpectingInput) {
+  $input | & "node$exe" "$nodedir/node_modules/npm/bin/npm-cli.js" $args
+} else {
+  & "node$exe" "$nodedir/node_modules/npm/bin/npm-cli.js" $args
+}
+$ret=$LASTEXITCODE
+exit $ret

--- a/bin/npx.ps1
+++ b/bin/npx.ps1
@@ -1,0 +1,26 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+
+$nodebin = $(Get-Command "node$exe" -ErrorAction SilentlyContinue -ErrorVariable F).Source
+if ($nodebin -eq $null) {
+  Write-Host "node$exe not found."
+  exit 1
+}
+$nodedir = $(New-Object -ComObject Scripting.FileSystemObject).GetFile("$nodebin").ParentFolder.Path
+
+# Support pipeline input
+if ($MyInvocation.ExpectingInput) {
+  $input | & "node$exe" "$nodedir/node_modules/npm/bin/npx-cli.js" $args
+} else {
+  & "node$exe" "$nodedir/node_modules/npm/bin/npx-cli.js" $args
+}
+$ret=$LASTEXITCODE
+exit $ret

--- a/bin/npx.ps1
+++ b/bin/npx.ps1
@@ -9,18 +9,27 @@ if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
 }
 $ret=0
 
-$nodebin = $(Get-Command "node$exe" -ErrorAction SilentlyContinue -ErrorVariable F).Source
+$nodeexe = "node$exe"
+$nodebin = $(Get-Command $nodeexe -ErrorAction SilentlyContinue -ErrorVariable F).Source
 if ($nodebin -eq $null) {
-  Write-Host "node$exe not found."
+  Write-Host "$nodeexe not found."
   exit 1
 }
 $nodedir = $(New-Object -ComObject Scripting.FileSystemObject).GetFile("$nodebin").ParentFolder.Path
 
+$npmclijs="$nodedir/node_modules/npm/bin/npm-cli.js"
+$npmprefix=(& $nodeexe $npmclijs prefix -g)
+if ($LASTEXITCODE -ne 0) {
+  Write-Host "Could not determine Node.js install directory"
+  exit 1
+}
+$npmprefixclijs="$npmprefix/node_modules/npm/bin/npx-cli.js"
+
 # Support pipeline input
 if ($MyInvocation.ExpectingInput) {
-  $input | & "node$exe" "$nodedir/node_modules/npm/bin/npx-cli.js" $args
+  $input | & $nodeexe $npmprefixclijs $args
 } else {
-  & "node$exe" "$nodedir/node_modules/npm/bin/npx-cli.js" $args
+  & $nodeexe $npmprefixclijs $args
 }
 $ret=$LASTEXITCODE
 exit $ret


### PR DESCRIPTION
Resolves UNC path issues because powershell.exe
supports UNC, while cmd.exe doesn't.
(Which is why npm.cmd doesn't work within
UNC paths, even under powershell)

Added ps1 versions of npm and npx

Closes https://github.com/npm/cli/issues/6280
