### PR TITLE
fix: make omit flags work properly with workspaces

### DIFF
--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -484,7 +484,7 @@ module.exports = cls => class Reifier extends cls {
     process.emit('time', 'reify:trashOmits')
 
     const filter = node =>
-      node.top.isProjectRoot &&
+      (node.top.isProjectRoot || node.top.isWorkspace) &&
         (
           node.peer && this[_omitPeer] ||
           node.dev && this[_omitDev] ||

--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -483,8 +483,21 @@ module.exports = cls => class Reifier extends cls {
 
     process.emit('time', 'reify:trashOmits')
 
+    const filterTop = node => {
+      // if the top is not the root or workspace filter it out
+      if (!node.isProjectRoot && !node.isWorkspace) {
+        return false
+      }
+      // if we have no filter set, then include it by default
+      if (!this.diff?.filterSet?.size) {
+        return true
+      }
+      // otherwise include based on if the top node is in our filter set
+      return this.diff.filterSet.has(node)
+    }
+
     const filter = node =>
-      (node.top.isProjectRoot || node.top.isWorkspace) &&
+      filterTop(node.top) &&
         (
           node.peer && this[_omitPeer] ||
           node.dev && this[_omitDev] ||

--- a/workspaces/arborist/test/arborist/reify.js
+++ b/workspaces/arborist/test/arborist/reify.js
@@ -1187,15 +1187,53 @@ t.test('workspaces', t => {
   t.test('reify simple-workspaces', t =>
     t.resolveMatchSnapshot(printReified(fixture(t, 'workspaces-simple')), 'should reify simple workspaces'))
 
-  t.test('reify workspaces dev dependencies', async t => {
-    const path = fixture(t, 'workspaces-conflicting-dev-deps')
-    const rootAjv = resolve(path, 'node_modules/ajv/package.json')
-    const ajvOfPkgA = resolve(path, 'a/node_modules/ajv/package.json')
-    t.equal(fs.existsSync(rootAjv), true, 'root ajv exists')
-    t.equal(fs.existsSync(ajvOfPkgA), true, 'ajv under package a node_modules exists')
-    await reify(path, { omit: ['dev'] })
-    t.equal(fs.existsSync(rootAjv), false, 'root ajv no longer exists')
-    t.equal(fs.existsSync(ajvOfPkgA), false, 'ajv under package a node_modules no longer exists')
+  t.test('reify workspaces omit dev dependencies', async t => {
+    const runCase = async (t, opts) => {
+      const path = fixture(t, 'workspaces-conflicting-dev-deps')
+      const rootAjv = resolve(path, 'node_modules/ajv/package.json')
+      const ajvOfPkgA = resolve(path, 'a/node_modules/ajv/package.json')
+      const ajvOfPkgB = resolve(path, 'b/node_modules/ajv/package.json')
+
+      t.equal(fs.existsSync(rootAjv), true, 'root ajv exists')
+      t.equal(fs.existsSync(ajvOfPkgA), true, 'ajv under package a node_modules exists')
+      t.equal(fs.existsSync(ajvOfPkgB), true, 'ajv under package a node_modules exists')
+
+      await reify(path, { omit: ['dev'], ...opts })
+
+      return {
+        root: { exists: () => fs.existsSync(rootAjv) },
+        a: { exists: () => fs.existsSync(ajvOfPkgA) },
+        b: { exists: () => fs.existsSync(ajvOfPkgB) },
+      }
+    }
+
+    await t.test('default', async t => {
+      const { root, a, b } = await runCase(t)
+      t.equal(root.exists(), false, 'root')
+      t.equal(a.exists(), false, 'a')
+      t.equal(b.exists(), false, 'b')
+    })
+
+    await t.test('workspaces only', async t => {
+      const { root, a, b } = await runCase(t, { workspaces: ['a'] })
+      t.equal(root.exists(), false, 'root')
+      t.equal(a.exists(), false, 'a')
+      t.equal(b.exists(), true, 'b')
+    })
+
+    await t.test('workspaces + root', async t => {
+      const { root, a, b } = await runCase(t, { workspaces: ['a'], includeWorkspaceRoot: true })
+      t.equal(root.exists(), false, 'root')
+      t.equal(a.exists(), false, 'a')
+      t.equal(b.exists(), true, 'b')
+    })
+
+    await t.test('disable workspaces', async t => {
+      const { root, a, b } = await runCase(t, { workspacesEnabled: false })
+      t.equal(root.exists(), false, 'root')
+      t.equal(a.exists(), true, 'a')
+      t.equal(b.exists(), true, 'b')
+    })
   })
 
   t.test('reify workspaces lockfile', async t => {

--- a/workspaces/arborist/test/arborist/reify.js
+++ b/workspaces/arborist/test/arborist/reify.js
@@ -1187,6 +1187,17 @@ t.test('workspaces', t => {
   t.test('reify simple-workspaces', t =>
     t.resolveMatchSnapshot(printReified(fixture(t, 'workspaces-simple')), 'should reify simple workspaces'))
 
+  t.test('reify workspaces dev dependencies', async t => {
+    const path = fixture(t, 'workspaces-conflicting-dev-deps')
+    const rootAjv = resolve(path, 'node_modules/ajv/package.json')
+    const ajvOfPkgA = resolve(path, 'a/node_modules/ajv/package.json')
+    t.equal(fs.existsSync(rootAjv), true, 'root ajv exists')
+    t.equal(fs.existsSync(ajvOfPkgA), true, 'ajv under package a node_modules exists')
+    await reify(path, { omit: ['dev'] })
+    t.equal(fs.existsSync(rootAjv), false, 'root ajv no longer exists')
+    t.equal(fs.existsSync(ajvOfPkgA), false, 'ajv under package a node_modules no longer exists')
+  })
+
   t.test('reify workspaces lockfile', async t => {
     const path = fixture(t, 'workspaces-simple')
     await reify(path)

--- a/workspaces/arborist/test/fixtures/reify-cases/workspaces-conflicting-dev-deps.js
+++ b/workspaces/arborist/test/fixtures/reify-cases/workspaces-conflicting-dev-deps.js
@@ -26,13 +26,31 @@ module.exports = t => {
       }  
     },
   },
+  "b": {
+    "package.json": JSON.stringify({
+      "name": "b",
+      "version": "1.0.0",
+      "devDependencies": {
+        "ajv": "5.11.2"
+      }
+    }),
+    "node_modules": {
+      ajv: {
+        'package.json': JSON.stringify({
+          name: 'ajv',
+          version: '5.11.2',
+        }),
+      }  
+    },
+  },
   "package.json": JSON.stringify({
     "name": "workspace-conflicting-dev-deps",
     "devDependencies": {
       "ajv": "6.10.2"
     },
     "workspaces": [
-      "a"
+      "a",
+      "b"
     ]
   })
 })

--- a/workspaces/arborist/test/fixtures/reify-cases/workspaces-conflicting-dev-deps.js
+++ b/workspaces/arborist/test/fixtures/reify-cases/workspaces-conflicting-dev-deps.js
@@ -1,0 +1,40 @@
+// generated from test/fixtures/workspaces-simple
+module.exports = t => {
+  const path = t.testdir({
+  "node_modules": {
+    ajv: {
+      'package.json': JSON.stringify({
+        name: 'ajv',
+        version: '6.10.2',
+      }),
+    }
+  },
+  "a": {
+    "package.json": JSON.stringify({
+      "name": "a",
+      "version": "1.0.0",
+      "devDependencies": {
+        "ajv": "4.11.2"
+      }
+    }),
+    "node_modules": {
+      ajv: {
+        'package.json': JSON.stringify({
+          name: 'ajv',
+          version: '4.11.2',
+        }),
+      }  
+    },
+  },
+  "package.json": JSON.stringify({
+    "name": "workspace-conflicting-dev-deps",
+    "devDependencies": {
+      "ajv": "6.10.2"
+    },
+    "workspaces": [
+      "a"
+    ]
+  })
+})
+  return path
+}


### PR DESCRIPTION
I am encountering an issue in using work-spaces whereby if i have a dev dependency at the root of my project with some version v1 and the same dependency inside one of the work-spaces which is a sub-folder in the project root with version v2 also as dev dependency that conflicts with v1 and try to do `npm ci --omit=dev` it skips installing the v1 dependency which was at project root but still installs the v2 dependency that was in the child workspace. I would expect that v2 should also not be installed. I have raised an issue for it here https://github.com/npm/cli/issues/6441 which also includes a link to minimum reproducible example.

In reify under arborist I found a filter condition which runs through the idealTree inventory to see which packages needed to be filtered out when omit dev or omit peer options etc are passed. Along with checking which flag is enabled and which packages is which type it also includes a condition of `node.top.isProjectRoot`. I don't fully understand the purpose of the last condition but am guessing, it is there so that the package is only filtered out if it is going to be directly under the root node_modules folder and not if it is going to be under the node_modules of some package which is under the actual root node_modules folder. I have extended the condition so that it is also filtered out if its top is a workspace which i think would translate to, that it should also be filtered out if its directly under the node_modules of a workspace folder.

## References
  Fixes #6441 

PS: It is my first time contributing to open source please excuse me if i have not followed proper procedure or otherwise missed something,