### PR TITLE
docs: add flag `package-lock-only` for `npm install`

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -27,6 +27,7 @@ class Install extends ArboristWorkspaceCmd {
     'strict-peer-deps',
     'prefer-dedupe',
     'package-lock',
+    'package-lock-only',
     'foreground-scripts',
     'ignore-scripts',
     'audit',

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -3202,8 +3202,9 @@ Options:
 [-E|--save-exact] [-g|--global]
 [--install-strategy <hoisted|nested|shallow|linked>] [--legacy-bundling]
 [--global-style] [--omit <dev|optional|peer> [--omit <dev|optional|peer> ...]]
-[--strict-peer-deps] [--prefer-dedupe] [--no-package-lock] [--foreground-scripts]
-[--ignore-scripts] [--no-audit] [--no-bin-links] [--no-fund] [--dry-run]
+[--strict-peer-deps] [--prefer-dedupe] [--no-package-lock] [--package-lock-only]
+[--foreground-scripts] [--ignore-scripts] [--no-audit] [--no-bin-links]
+[--no-fund] [--dry-run]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [-ws|--workspaces] [--include-workspace-root] [--install-links]
 
@@ -3227,6 +3228,7 @@ aliases: add, i, in, ins, inst, insta, instal, isnt, isnta, isntal, isntall
 #### \`strict-peer-deps\`
 #### \`prefer-dedupe\`
 #### \`package-lock\`
+#### \`package-lock-only\`
 #### \`foreground-scripts\`
 #### \`ignore-scripts\`
 #### \`audit\`
@@ -3291,8 +3293,9 @@ Options:
 [-E|--save-exact] [-g|--global]
 [--install-strategy <hoisted|nested|shallow|linked>] [--legacy-bundling]
 [--global-style] [--omit <dev|optional|peer> [--omit <dev|optional|peer> ...]]
-[--strict-peer-deps] [--prefer-dedupe] [--no-package-lock] [--foreground-scripts]
-[--ignore-scripts] [--no-audit] [--no-bin-links] [--no-fund] [--dry-run]
+[--strict-peer-deps] [--prefer-dedupe] [--no-package-lock] [--package-lock-only]
+[--foreground-scripts] [--ignore-scripts] [--no-audit] [--no-bin-links]
+[--no-fund] [--dry-run]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [-ws|--workspaces] [--include-workspace-root] [--install-links]
 
@@ -3316,6 +3319,7 @@ alias: it
 #### \`strict-peer-deps\`
 #### \`prefer-dedupe\`
 #### \`package-lock\`
+#### \`package-lock-only\`
 #### \`foreground-scripts\`
 #### \`ignore-scripts\`
 #### \`audit\`


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

the flag is described in

https://github.com/npm/cli/blob/03aaa78eb5d3122d991c4bc057aa6de829c83139/docs/lib/content/commands/npm-install.md?plain=1#L389-L391

and in `params` for `npm ls` and `npm audit`

https://github.com/npm/cli/blob/03aaa78eb5d3122d991c4bc057aa6de829c83139/lib/commands/ls.js#L36

https://github.com/npm/cli/blob/03aaa78eb5d3122d991c4bc057aa6de829c83139/lib/commands/audit.js#L406

but wasn't actually added to `params` for `npm install`

<!-- ## References -->
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
