### PR TITLE
Double Quote Symbolic Path Links for Windows to Work

### DIFF
--- a/node_modules/libnpmaccess
+++ b/node_modules/libnpmaccess
@@ -1,1 +1,1 @@
-../workspaces/libnpmaccess
+"../workspaces/libnpmaccess"

--- a/node_modules/libnpmdiff
+++ b/node_modules/libnpmdiff
@@ -1,1 +1,1 @@
-../workspaces/libnpmdiff
+"../workspaces/libnpmdiff"

--- a/node_modules/libnpmexec
+++ b/node_modules/libnpmexec
@@ -1,1 +1,1 @@
-../workspaces/libnpmexec
+"../workspaces/libnpmexec"

--- a/node_modules/libnpmfund
+++ b/node_modules/libnpmfund
@@ -1,1 +1,1 @@
-../workspaces/libnpmfund
+"../workspaces/libnpmfund"

--- a/node_modules/libnpmhook
+++ b/node_modules/libnpmhook
@@ -1,1 +1,1 @@
-../workspaces/libnpmhook
+"../workspaces/libnpmhook"

--- a/node_modules/libnpmorg
+++ b/node_modules/libnpmorg
@@ -1,1 +1,1 @@
-../workspaces/libnpmorg
+"../workspaces/libnpmorg"

--- a/node_modules/libnpmpack
+++ b/node_modules/libnpmpack
@@ -1,1 +1,1 @@
-../workspaces/libnpmpack
+"../workspaces/libnpmpack"

--- a/node_modules/libnpmpublish
+++ b/node_modules/libnpmpublish
@@ -1,1 +1,1 @@
-../workspaces/libnpmpublish
+"../workspaces/libnpmpublish"

--- a/node_modules/libnpmsearch
+++ b/node_modules/libnpmsearch
@@ -1,1 +1,1 @@
-../workspaces/libnpmsearch
+"../workspaces/libnpmsearch"

--- a/node_modules/libnpmteam
+++ b/node_modules/libnpmteam
@@ -1,1 +1,1 @@
-../workspaces/libnpmteam
+"../workspaces/libnpmteam"

--- a/node_modules/libnpmversion
+++ b/node_modules/libnpmversion
@@ -1,1 +1,1 @@
-../workspaces/libnpmversion
+"../workspaces/libnpmversion"


### PR DESCRIPTION
I had to double quote these regular expressions to work on Windows. Can we use Windows Symbolic Links instead of these files that contain directory paths?

![Screenshot 2023-06-22 201219](https://github.com/npm/cli/assets/4573756/610e635b-ec1e-434e-8fd0-45fb16279913)

![Screenshot 2023-06-22 201504](https://github.com/npm/cli/assets/4573756/e9e07c7b-ac44-4ab9-8c59-398366773e08)

https://github.com/npm/cli/issues/4234

@fritzy 
