### PR TITLE
Fix cannot read undefined prop `edgesOut`

### DIFF
--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -1300,6 +1300,8 @@ This is a one-time fix-up, please be patient...
       }
 
       const parentEdge = node.parent.edgesOut.get(edge.name)
+      if (!parentEdge) continue
+
       const { isProjectRoot, isWorkspace } = node.parent.sourceReference
       const isMine = isProjectRoot || isWorkspace
       const conflictOK = this[_force] || !isMine && !this.#strictPeerDeps


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Fixed error when installing packages like `styled-components`. It was caused by the `edgesOut` part of the `node`.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

Fixes #4787 