### PR TITLE
docs: add path usage for view command

### DIFF
--- a/docs/lib/content/commands/npm-view.md
+++ b/docs/lib/content/commands/npm-view.md
@@ -28,6 +28,13 @@ For example, to show the dependencies of the `ronn` package at version
 npm view ronn@0.3.5 dependencies
 ```
 
+By default, `npm view` shows data about the current project context (by looking for a `package.json`).
+To show field data for the current project use a file path (i.e. `.`):
+
+```bash
+npm view . dependencies
+```
+
 You can view child fields by separating them with a period.
 To view the git repository URL for the latest version of `npm`, you would run the following command:
 


### PR DESCRIPTION
Document how to target the current project context using the path `.`, so that field data about a local project can be viewed.

## References
Relates (in part) to #6390 