### PR TITLE
[DOCS] `description` field section anchor in invalid

### DIFF
--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -63,7 +63,7 @@ Version must be parseable by
 [node-semver](https://github.com/npm/node-semver), which is bundled with
 npm as a dependency.  (`npm install semver` to use it yourself.)
 
-### description
+### description&nbsp;
 
 Put a description in it.  It's a string.  This helps people discover your
 package, as it's listed in `npm search`.


### PR DESCRIPTION
## Issue

The table of contents on [this page](https://docs.npmjs.com/cli/v9/configuring-npm/package-json) contains a link to the `description` field, and its url links to the anchor `#description-1`, but for some reason there's no such anchor on the page itself.

## Investigation

1. There's a heading `Description` for the page contents description
1. There's a heading `description` for the corresponding `package.json` field
1. Markdown implies that the auto-generated section links for sections with identical names (`Description` and `description`) become `<name>-1`, `<name>-2` etc.
1. The table of contents (ToC) seems to be auto-generated based upon the contents of this `md` file
1. ToC contains correct section links: `#description` redirects to the page contents description, `#description-1` – to the `description` field
1. The `Description` heading is rendered correctly: `h3#description`, anchor with `id="description"`
1. The `description` heading is rendered incorrectly: `h3#description`, anchor with `id="description"`, which is the root of the issue

## Fix?

Even GitHub's preview rendered the original code correctly (with `#description-1` as the anchor for `description` section), and thus I'm unable to reproduce the issue.
So, I can't fix it.

I'm not sure if that's 

This PR is not an attempt to fix anything, because even  The PR is just there to pinpoint the problem.
