### PR TITLE
fix: much clearer npx 'canceled' error

### DIFF
--- a/test/lib/commands/exec.js
+++ b/test/lib/commands/exec.js
@@ -3,8 +3,6 @@ const fs = require('fs/promises')
 const path = require('path')
 const { load: loadMockNpm } = require('../../fixtures/mock-npm.js')
 const MockRegistry = require('@npmcli/mock-registry')
-const { packument } = require('pacote')
-const { version } = require('os')
 
 t.test('call with args', async t => {
   const { npm } = await loadMockNpm(t, {

--- a/test/lib/commands/exec.js
+++ b/test/lib/commands/exec.js
@@ -136,7 +136,7 @@ t.test('npx --no-install @npmcli/npx-test', async t => {
     registry: 'https://registry.npmjs.org/',
   })
 
-  const manifest = registry.manifest({ name: '@npmcli/npx-test'})
+  const manifest = registry.manifest({ name: '@npmcli/npx-test' })
   manifest.versions['1.0.0'].bin = { 'npx-test': 'index.js' }
 
   const { npm } = await loadMockNpm(t, {
@@ -159,7 +159,7 @@ t.test('npx --no-install @npmcli/npx-test', async t => {
   } catch (error) {
     t.match(
       error.message,
-      'npx canceled due to missing packages and no YES option: ', 
+      'npx canceled due to missing packages and no YES option: ',
       'Expected error message thrown'
     )
   }

--- a/test/lib/commands/exec.js
+++ b/test/lib/commands/exec.js
@@ -3,6 +3,8 @@ const fs = require('fs/promises')
 const path = require('path')
 const { load: loadMockNpm } = require('../../fixtures/mock-npm.js')
 const MockRegistry = require('@npmcli/mock-registry')
+const { packument } = require('pacote')
+const { version } = require('os')
 
 t.test('call with args', async t => {
   const { npm } = await loadMockNpm(t, {
@@ -128,4 +130,39 @@ t.test('workspaces', async t => {
   await npm.exec('exec', ['@npmcli/npx-test'])
   const exists = await fs.stat(path.join(npm.prefix, 'workspace-a', 'npm-exec-test-success'))
   t.ok(exists.isFile(), 'bin ran, creating file inside workspace')
+})
+
+t.test('npx --no-install @npmcli/npx-test', async t => {
+  const registry = new MockRegistry({
+    tap: t,
+    registry: 'https://registry.npmjs.org/',
+  })
+
+  const manifest = registry.manifest({ name: '@npmcli/npx-test'})
+  manifest.versions['1.0.0'].bin = { 'npx-test': 'index.js' }
+
+  const { npm } = await loadMockNpm(t, {
+    config: {
+      audit: false,
+      yes: false,
+    },
+    prefixDir: {
+      'npm-exec-test': {
+        'package.json': JSON.stringify(manifest),
+        'index.js': `#!/usr/bin/env node
+  require('fs').writeFileSync('npm-exec-test-success', '')`,
+      },
+    },
+  })
+
+  try {
+    await npm.exec('exec', ['@npmcli/npx-test'])
+    t.fail('Expected error was not thrown')
+  } catch (error) {
+    t.match(
+      error.message,
+      'npx canceled due to missing packages and no YES option: ', 
+      'Expected error message thrown'
+    )
+  }
 })

--- a/workspaces/libnpmexec/lib/index.js
+++ b/workspaces/libnpmexec/lib/index.js
@@ -249,6 +249,7 @@ const exec = async (opts) => {
         // set -n to always say no
         if (yes === false) {
           // Error message lists missing package(s) when process is canceled
+          /* eslint-disable-next-line max-len */
           throw new Error(`npx canceled due to missing packages and no YES option: ${JSON.stringify(missingPackages)}`)
         }
 

--- a/workspaces/libnpmexec/lib/index.js
+++ b/workspaces/libnpmexec/lib/index.js
@@ -245,9 +245,11 @@ const exec = async (opts) => {
 
     if (add.length) {
       if (!yes) {
+        const missingPackages = add.map(a => `${a.replace(/@$/, '')}`)
         // set -n to always say no
         if (yes === false) {
-          throw new Error('canceled')
+          // Error message lists missing package(s) when process is canceled
+          throw new Error(`npx canceled due to missing packages and no YES option: ${JSON.stringify(missingPackages)}`)
         }
 
         if (noTTY() || ciInfo.isCI) {
@@ -257,8 +259,7 @@ const exec = async (opts) => {
             add.map((pkg) => pkg.replace(/@$/, '')).join(', ')
           }`)
         } else {
-          const addList = add.map(a => `  ${a.replace(/@$/, '')}`)
-            .join('\n') + '\n'
+          const addList = missingPackages.join('\n') + '\n'
           const prompt = `Need to install the following packages:\n${
           addList
         }Ok to proceed? `


### PR DESCRIPTION
## Summary
Currently, when running npx --no-install on a package that is not installed will return a vague error message that says, “canceled.”

Added accompanying tap test to ensure the expected error is outputted.

This solution gives the error message more clarity to make debugging easier. 

![image](https://github.com/npm/cli/assets/122141535/09cc5e17-5c5f-45d0-b7ef-6057221e5e8e)

## Testing
### Reproduce Original Error:
- Enter in terminal:
    - ```npx --no-install <missing_package>```
Please Note: ```<missing_package>``` is either not installed or in path

### Tap Test (exec.js only)
- Enter in terminal:
    - ```node . run test test/lib/commands/exec.js```

### Run entire test:
- Enter in terminal:
    - ```node . run test```
    
### Alias Test
- Enter in terminal:
    - ```alias localnpx="node /workspaces/cli/bin/npx-cli.js"```  
    - ```localnpx --no-install esbuild```

## References
  Fixes #6215 
