### PR TITLE
docs: Added steps for using npm/npx locally to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,11 +66,11 @@ node . exec
 
 For example instead of:
 ```bash 
-npm exec --yes false -- esbuild
+npm exec -- <package>
 ```  
 Use:
 ```bash
-node . exec --yes false -- esbuild
+node . exec -- <package>
 ```
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,34 @@ We use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).  
 
 We use [`tap`](https://node-tap.org/) for testing & expect that every new feature or bug fix comes with corresponding tests that validate the solutions. Tap also reports on code coverage and it will fail if that drops below 100%.
 
+## Run npm/npx Locally
+
+If a specific command is not covered by tap, try the following:
+
+To run your repository's version of the npm cli on your local machine use the following commands:
+
+**npm commands:**
+```bash
+alias localnpm="node /filepath/npm"
+```
+
+**npx commands:**
+```bash
+alias localnpx="node /filepath/npm/bin/npx-cli.js"
+```
+
+After running the above commands, use localnpx and localnpm instead of npx and npm respectively.
+
+For example instead of:
+```bash 
+npx --no-install esbuild
+```  
+Use:
+```bash
+localnpx --no-install esbuild
+```
+
+
 ## Performance & Benchmarks
 
 We've set up an automated [benchmark](https://github.com/npm/benchmarks) integration that will run against all Pull Requests; Posting back a comment with the results of the run.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,10 +48,6 @@ We use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).  
 
 We use [`tap`](https://node-tap.org/) for testing & expect that every new feature or bug fix comes with corresponding tests that validate the solutions. Tap also reports on code coverage and it will fail if that drops below 100%.
 
-## Run npm/npx Locally
-
-If a specific command is not covered by tap, try the following:
-
 To run your repository's version of the npm cli on your local machine use the following commands:
 
 **npm commands:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,23 +56,21 @@ To run your repository's version of the npm cli on your local machine use the fo
 
 **npm commands:**
 ```bash
-alias localnpm="node /filepath/npm"
+node . <command>
 ```
 
 **npx commands:**
 ```bash
-alias localnpx="node /filepath/npm/bin/npx-cli.js"
+node . exec
 ```
-
-After running the above commands, use localnpx and localnpm instead of npx and npm respectively.
 
 For example instead of:
 ```bash 
-npx --no-install esbuild
+npm install esbuild
 ```  
 Use:
 ```bash
-localnpx --no-install esbuild
+node . install esbuild
 ```
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,11 +66,11 @@ node . exec
 
 For example instead of:
 ```bash 
-npm install esbuild
+npm exec --yes false -- esbuild
 ```  
 Use:
 ```bash
-node . install esbuild
+node . exec --yes false -- esbuild
 ```
 
 


### PR DESCRIPTION
## Summary
We noticed there were no steps for using npm/npx locally on the CONTIBUTING.md file so we decided to add a new section that explained how to do this.
