### PR TITLE
docs: Package-json.md - Updated example for monorepo and json to jsonc

### DIFF
--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -144,7 +144,7 @@ Then include a file named `<filename>` at the top level of the package.
 Some old packages used license objects or a "licenses" property containing
 an array of license objects:
 
-```json
+```jsonc
 // Not valid metadata
 {
   "license" : {
@@ -985,7 +985,7 @@ this limitation easier to deal with, overrides may also be defined as a
 reference to a spec for a direct dependency by prefixing the name of the
 package you wish the version to match with a `$`.
 
-```json
+```jsonc
 {
   "dependencies": {
     "foo": "^1.0.0"

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -516,11 +516,9 @@ same shortcut syntax you use for `npm install`:
 }
 ```
 
-If the `package.json` for your package is not in the root directory (for
-example if it is part of a monorepo), you can specify the directory in
-which it lives:
-
-```json
+If your `package.json` isn't in the root directory, common with monorepos like Facebook's React, you can specify its location. i.e. `react-dom`:
+```jsonc
+/* @/packages/react-dom/package.json */
 {
   "repository": {
     "type": "git",
@@ -528,6 +526,12 @@ which it lives:
     "directory": "packages/react-dom"
   }
 }
+```
+```txt
+react.git/
+└── packages/
+    └── react-dom/
+        └── package.json
 ```
 
 ### scripts


### PR DESCRIPTION
<!-- What / Why -->
Added folder tree to visualize example. 

<!-- Describe the request in detail. What it does and why it's being changed. -->
1. Added folder tree to help visualize the package.json Monorepo react example. 
2. json to jsonc (json blocks with comments)

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
