### PR TITLE
docs: remove link to deprecated `npm set-script` command

### DIFF
--- a/docs/lib/content/commands/npm-pkg.md
+++ b/docs/lib/content/commands/npm-pkg.md
@@ -182,5 +182,4 @@ npm pkg get name version --ws
 * [npm install](/commands/npm-install)
 * [npm init](/commands/npm-init)
 * [npm config](/commands/npm-config)
-* [npm set-script](/commands/npm-set-script)
 * [workspaces](/using-npm/workspaces)


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

PR simply removes link to the `set-script` command in the docs. In PR #5456 `npm set-script` was removed so this PR updates the docs by removing any recourses that are still pointing to `set-script`. See change log [here](https://github.com/npm/cli/blob/4689ae4d2167712d893b6193a4347b26779acf9e/CHANGELOG.md?plain=1#L889).

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
