### PR TITLE
chore: allow publishing new major of workspace without prerelease

### DIFF
--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -8,12 +8,12 @@ const resetdeps = () => npm('run', 'resetdeps')
 const op = () => spawn('op', 'item', 'get', 'npm', '--otp', { out: true, ok: true })
 
 const getVersion = async (s) => {
-  const mani = await pacote.manifest(s, { preferOnline: true })
-  return mani.version
+  const mani = await pacote.manifest(s, { preferOnline: true }).catch(() => null)
+  return mani?.version
 }
-const getLatest = async (s) => {
-  const pack = await pacote.packument(s, { preferOnline: true })
-  return pack['dist-tags'].latest
+const getLatestMajor = async (s) => {
+  const pack = await pacote.packument(s, { preferOnline: true }).catch(() => null)
+  return pack?.['dist-tags']?.latest ? semver.major(pack['dist-tags'].latest) : 0
 }
 
 const TAG = {
@@ -23,7 +23,7 @@ const TAG = {
     if (prerelease.length) {
       return 'prerelease'
     }
-    if (major === await getLatest(name).then(v => semver.major(v))) {
+    if (major >= await getLatestMajor(name)) {
       return 'latest'
     }
     return 'backport'


### PR DESCRIPTION
Previously the publish script assumed that a new major version of a
workspace would always be preceeded by a prerelease. This updates the
script so that a workspace will be published to the `latest` tag if it
is greater than the current latest major version.

This also fixes an issue where getting a version of a workspace could
fail if it is the first time being published to a new tag. The script
now catches this error and treats it like a workspace that needs
publishing.
