### PR TITLE
fix: prefix in .npmrc error log

### DIFF
--- a/workspaces/config/lib/index.js
+++ b/workspaces/config/lib/index.js
@@ -619,7 +619,7 @@ class Config {
             log.error(`prefix=${parsedConfigPrefix} cannot be changed from project config: ${file}`)
           }
         }
-        this.#loadObject(parsedConfig, type, file)
+        return this.#loadObject(parsedConfig, type, file)
       },
       er => this.#loadObject(null, type, file, er)
     )

--- a/workspaces/config/lib/index.js
+++ b/workspaces/config/lib/index.js
@@ -610,7 +610,17 @@ class Config {
     process.emit('time', 'config:load:file:' + file)
     // only catch the error from readFile, not from the loadObject call
     await readFile(file, 'utf8').then(
-      data => this.#loadObject(ini.parse(data), type, file),
+      data => {
+        const parsedConfig = ini.parse(data)
+        if (type === 'project') {
+          const parsedConfigPrefix = parsedConfig.prefix
+          // Log error if prefix is mentioned in project .npmrc
+          if (parsedConfigPrefix) {
+            log.error(`prefix=${parsedConfigPrefix} cannot be changed from project config: ${file}`)
+          }
+        }
+        this.#loadObject(parsedConfig, type, file)
+      },
       er => this.#loadObject(null, type, file, er)
     )
     process.emit('timeEnd', 'config:load:file:' + file)

--- a/workspaces/config/lib/index.js
+++ b/workspaces/config/lib/index.js
@@ -612,12 +612,10 @@ class Config {
     await readFile(file, 'utf8').then(
       data => {
         const parsedConfig = ini.parse(data)
-        if (type === 'project') {
-          const parsedConfigPrefix = parsedConfig.prefix
+        if (type === 'project' && parsedConfig.prefix) {
           // Log error if prefix is mentioned in project .npmrc
-          if (parsedConfigPrefix) {
-            log.error(`prefix=${parsedConfigPrefix} cannot be changed from project config: ${file}`)
-          }
+          /* eslint-disable-next-line max-len */
+          log.error('config', `prefix cannot be changed from project config: ${file}.`)
         }
         return this.#loadObject(parsedConfig, type, file)
       },

--- a/workspaces/config/test/index.js
+++ b/workspaces/config/test/index.js
@@ -1475,6 +1475,6 @@ t.test('catch project config prefix error', async t => {
   // config.load() triggers the error to be logged
   await config.load()
   t.match(logs, [[
-    'error', `prefix=./lib cannot be changed from project config: ${path}`,
+    'error', 'config', `prefix cannot be changed from project config: ${path}`,
   ]], 'Expected error logged')
 })

--- a/workspaces/config/test/index.js
+++ b/workspaces/config/test/index.js
@@ -1447,3 +1447,35 @@ t.test('umask', async t => {
     t.equal(umask, 0)
   })
 })
+
+t.test('catch project config prefix error', async t=> {
+  const path = t.testdir()
+  t.testdir({
+    project: {
+      node_modules: {},
+      '.npmrc': `
+      project-config = true
+      foo = from-project-config
+      prefix=./lib
+      `,
+    },
+  })
+  const config = new Config({
+    npmPath: `${path}/npm`,
+    argv: [process.execPath, __filename, '--projectconfig', `${path}/project/.npmrc`],
+    cwd: join(`${path}/project`),
+    shorthands,
+    definitions,
+  })
+  const logs = []
+  const logHandler = (...args) => logs.push(args)
+  process.on('log', logHandler)
+  t.teardown(() => process.off('log', logHandler));
+  logs.length = 0
+  
+  // config.load() triggers the error to be logged
+  await config.load()
+  t.match(logs, [[
+    'error', `prefix=./lib cannot be changed from project config: ${path}/project/.npmrc`
+  ]], 'Expected error logged')
+})

--- a/workspaces/config/test/index.js
+++ b/workspaces/config/test/index.js
@@ -1448,7 +1448,7 @@ t.test('umask', async t => {
   })
 })
 
-t.test('catch project config prefix error', async t=> {
+t.test('catch project config prefix error', async t => {
   const path = t.testdir()
   t.testdir({
     project: {
@@ -1470,12 +1470,11 @@ t.test('catch project config prefix error', async t=> {
   const logs = []
   const logHandler = (...args) => logs.push(args)
   process.on('log', logHandler)
-  t.teardown(() => process.off('log', logHandler));
+  t.teardown(() => process.off('log', logHandler))
   logs.length = 0
-  
   // config.load() triggers the error to be logged
   await config.load()
   t.match(logs, [[
-    'error', `prefix=./lib cannot be changed from project config: ${path}/project/.npmrc`
+    'error', `prefix=./lib cannot be changed from project config: ${path}/project/.npmrc`,
   ]], 'Expected error logged')
 })

--- a/workspaces/config/test/index.js
+++ b/workspaces/config/test/index.js
@@ -1475,6 +1475,6 @@ t.test('catch project config prefix error', async t => {
   // config.load() triggers the error to be logged
   await config.load()
   t.match(logs, [[
-    'error', `prefix=./lib cannot be changed from project config: ${path}/project/.npmrc`,
+    'error', `prefix=./lib cannot be changed from project config: ${path}`,
   ]], 'Expected error logged')
 })


### PR DESCRIPTION
## Summary
The original issue (#6081) wanted the project's .npmrc to set a prefix value for npm to use in both ```npm prefix``` and ```npm install <package>``` However, we made the changes according to wraithgar's comment.

Currently, when running ```npm prefix``` or ```npm install```, there is no error logged communicating to the user that prefix cannot be changed in the project config.

This solution gives the error message more clarity to make debugging easier and lets the user know that prefix cannot be changed from the project level.

![Screenshot](https://github.com/npm/cli/assets/122141535/065b9e64-b4b9-4420-aa7b-6938651f5dd0)

Also added the accompanying tap test to ensure the expected error is outputted.

### PLEASE NOTE: 
**If prefix is set to a value, the error will be logged anytime a user enters in a npm or npx command, which means that the logging is not specific to just ```npm prefix``` or ```npm install <package>```, but also applies to commands such as ```npm exec```.**

## Testing

### Reproduce Original Issue:

1. Add .npmrc file into your project’s directory
2. Set prefix to some location e.g. prefix=./vendor
3. Run ```npm prefix``` or ```npm install <package>```
4. ```npm prefix``` will give the current directory’s prefix, and ```npm install <package>``` will install the package in the current directory.
5. No error would be logged to tell user that prefix cannot be changed from project level

### File tap test:
- Enter in terminal:
- ```TAP_SNAPSHOT=1 node . run test workspaces/config/test/index.js```

### Run the entire tap test:
- Enter in terminal:
- ```node . run test```

### Dummy Project Test:

- Made a dummy project with a vendor folder and a .npmrc file with prefix=./vendor
- Used aliasing to see if the error is being logged:
- Enter in terminal: 
- ```alias localnpm="node /workspaces/cli/"```
- ```localnpm prefix```
- ```localnpm install <package>```


## References
  Fixes #6081 
