### PR TITLE
docs: patch separated commands

### DIFF
--- a/docs/content/commands/npm-completion.md
+++ b/docs/content/commands/npm-completion.md
@@ -23,6 +23,12 @@ everywhere:
 
 ```bash
 npm completion >> ~/.bashrc
+
+```
+
+OR
+
+```bash
 npm completion >> ~/.zshrc
 ```
 

--- a/docs/content/commands/npm-completion.md
+++ b/docs/content/commands/npm-completion.md
@@ -23,7 +23,6 @@ everywhere:
 
 ```bash
 npm completion >> ~/.bashrc
-
 ```
 
 OR


### PR DESCRIPTION
# What / Why
Separated Completion code sections because they are pointing at different terminals. 
