### PR TITLE
chore: fix bundle version in libnpmpublish tests

### DIFF
--- a/workspaces/libnpmpublish/test/fixtures/valid-bundle.json
+++ b/workspaces/libnpmpublish/test/fixtures/valid-bundle.json
@@ -1,5 +1,5 @@
 {
-  "mediaType": "application/vnd.dev.sigstore.bundle+json;version=0.1",
+  "mediaType": "application/vnd.dev.sigstore.bundle+json;version=0.2",
   "verificationData": {
     "tlogEntries": [
       {

--- a/workspaces/libnpmpublish/test/publish.js
+++ b/workspaces/libnpmpublish/test/publish.js
@@ -486,7 +486,7 @@ t.test('publish existing package with provenance in gha', async t => {
         // Can't match length because in github actions certain environment
         // variables are present that are not present when running locally,
         // changing the payload size.
-        content_type: 'application/vnd.dev.sigstore.bundle+json;version=0.1',
+        content_type: 'application/vnd.dev.sigstore.bundle+json;version=0.2',
       },
     },
   }
@@ -768,7 +768,7 @@ t.test('user-supplied provenance - success', async t => {
         length: tarData.length,
       },
       '@npmcli/libnpmpublish-test-1.0.0.sigstore': {
-        content_type: 'application/vnd.dev.sigstore.bundle+json;version=0.1',
+        content_type: 'application/vnd.dev.sigstore.bundle+json;version=0.2',
         data: /.*/, // Can't match against static value as signature is always different
         length: 7927,
       },
@@ -1035,7 +1035,7 @@ t.test('publish existing package with provenance in gitlab', async t => {
         // Can't match length because in github actions certain environment
         // variables are present that are not present when running locally,
         // changing the payload size.
-        content_type: 'application/vnd.dev.sigstore.bundle+json;version=0.1',
+        content_type: 'application/vnd.dev.sigstore.bundle+json;version=0.2',
       },
     },
   }


### PR DESCRIPTION
Update sigstore bundle version number in `libnpmpublish` tests to match the bundle version string generated by `sigstore@2.1.0`
