### PR TITLE
feat: Add `--cpu` and `--os` option to override platform specific install 

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -34,6 +34,7 @@ class Install extends ArboristWorkspaceCmd {
     'bin-links',
     'fund',
     'dry-run',
+    'cpu',
     ...super.params,
   ]
 

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -35,6 +35,7 @@ class Install extends ArboristWorkspaceCmd {
     'fund',
     'dry-run',
     'cpu',
+    'os',
     ...super.params,
   ]
 

--- a/tap-snapshots/test/lib/commands/config.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/config.js.test.cjs
@@ -33,6 +33,7 @@ exports[`test/lib/commands/config.js TAP config list --json > output matches sna
   "cidr": null,
   "color": true,
   "commit-hooks": true,
+  "cpu": null,
   "depth": null,
   "description": true,
   "dev": false,
@@ -187,6 +188,7 @@ cert = null
 cidr = null 
 color = true 
 commit-hooks = true 
+cpu = null 
 depth = null 
 description = true 
 dev = false 

--- a/tap-snapshots/test/lib/commands/config.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/config.js.test.cjs
@@ -34,6 +34,7 @@ exports[`test/lib/commands/config.js TAP config list --json > output matches sna
   "color": true,
   "commit-hooks": true,
   "cpu": null,
+  "os": null,
   "depth": null,
   "description": true,
   "dev": false,
@@ -260,6 +261,7 @@ omit = []
 omit-lockfile-registry-resolved = false 
 only = null 
 optional = null 
+os = null 
 otp = null 
 pack-destination = "." 
 package = [] 

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -392,6 +392,16 @@ Run git commit hooks when using the \`npm version\` command.
 
 
 
+#### \`cpu\`
+
+* Default: null
+* Type: null or String
+
+Override CPU architecture of native modules to install. Acceptable values
+are same as \`cpu\` field of package.json, which comes from \`process.arch\`.
+
+
+
 #### \`depth\`
 
 * Default: \`Infinity\` if \`--all\` is set, otherwise \`1\`
@@ -2006,6 +2016,7 @@ Array [
   "cidr",
   "color",
   "commit-hooks",
+  "cpu",
   "depth",
   "description",
   "dev",
@@ -2159,6 +2170,7 @@ Array [
   "cidr",
   "color",
   "commit-hooks",
+  "cpu",
   "depth",
   "description",
   "dev",
@@ -2313,6 +2325,7 @@ Object {
   "cidr": null,
   "color": false,
   "commitHooks": true,
+  "cpu": null,
   "defaultTag": "latest",
   "depth": null,
   "diff": Array [],
@@ -3170,7 +3183,7 @@ Options:
 [--global-style] [--omit <dev|optional|peer> [--omit <dev|optional|peer> ...]]
 [--strict-peer-deps] [--prefer-dedupe] [--no-package-lock] [--package-lock-only]
 [--foreground-scripts] [--ignore-scripts] [--no-audit] [--no-bin-links]
-[--no-fund] [--dry-run]
+[--no-fund] [--dry-run] [--cpu <cpu>]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [-ws|--workspaces] [--include-workspace-root] [--install-links]
 
@@ -3201,6 +3214,7 @@ aliases: add, i, in, ins, inst, insta, instal, isnt, isnta, isntal, isntall
 #### \`bin-links\`
 #### \`fund\`
 #### \`dry-run\`
+#### \`cpu\`
 #### \`workspace\`
 #### \`workspaces\`
 #### \`include-workspace-root\`
@@ -3261,7 +3275,7 @@ Options:
 [--global-style] [--omit <dev|optional|peer> [--omit <dev|optional|peer> ...]]
 [--strict-peer-deps] [--prefer-dedupe] [--no-package-lock] [--package-lock-only]
 [--foreground-scripts] [--ignore-scripts] [--no-audit] [--no-bin-links]
-[--no-fund] [--dry-run]
+[--no-fund] [--dry-run] [--cpu <cpu>]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [-ws|--workspaces] [--include-workspace-root] [--install-links]
 
@@ -3292,6 +3306,7 @@ alias: it
 #### \`bin-links\`
 #### \`fund\`
 #### \`dry-run\`
+#### \`cpu\`
 #### \`workspace\`
 #### \`workspaces\`
 #### \`include-workspace-root\`

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -1095,6 +1095,16 @@ time.
 
 
 
+#### \`os\`
+
+* Default: null
+* Type: null or String
+
+Override OS of native modules to install. Acceptable values are same as \`os\`
+field of package.json, which comes from \`process.platform\`.
+
+
+
 #### \`otp\`
 
 * Default: null
@@ -2017,6 +2027,7 @@ Array [
   "color",
   "commit-hooks",
   "cpu",
+  "os",
   "depth",
   "description",
   "dev",
@@ -2171,6 +2182,7 @@ Array [
   "color",
   "commit-hooks",
   "cpu",
+  "os",
   "depth",
   "description",
   "dev",
@@ -2374,6 +2386,7 @@ Object {
   "offline": false,
   "omit": Array [],
   "omitLockfileRegistryResolved": false,
+  "os": null,
   "otp": null,
   "package": Array [],
   "packageLock": true,
@@ -3183,7 +3196,7 @@ Options:
 [--global-style] [--omit <dev|optional|peer> [--omit <dev|optional|peer> ...]]
 [--strict-peer-deps] [--prefer-dedupe] [--no-package-lock] [--package-lock-only]
 [--foreground-scripts] [--ignore-scripts] [--no-audit] [--no-bin-links]
-[--no-fund] [--dry-run] [--cpu <cpu>]
+[--no-fund] [--dry-run] [--cpu <cpu>] [--os <os>]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [-ws|--workspaces] [--include-workspace-root] [--install-links]
 
@@ -3215,6 +3228,7 @@ aliases: add, i, in, ins, inst, insta, instal, isnt, isnta, isntal, isntall
 #### \`fund\`
 #### \`dry-run\`
 #### \`cpu\`
+#### \`os\`
 #### \`workspace\`
 #### \`workspaces\`
 #### \`include-workspace-root\`
@@ -3275,7 +3289,7 @@ Options:
 [--global-style] [--omit <dev|optional|peer> [--omit <dev|optional|peer> ...]]
 [--strict-peer-deps] [--prefer-dedupe] [--no-package-lock] [--package-lock-only]
 [--foreground-scripts] [--ignore-scripts] [--no-audit] [--no-bin-links]
-[--no-fund] [--dry-run] [--cpu <cpu>]
+[--no-fund] [--dry-run] [--cpu <cpu>] [--os <os>]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [-ws|--workspaces] [--include-workspace-root] [--install-links]
 
@@ -3307,6 +3321,7 @@ alias: it
 #### \`fund\`
 #### \`dry-run\`
 #### \`cpu\`
+#### \`os\`
 #### \`workspace\`
 #### \`workspaces\`
 #### \`include-workspace-root\`

--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -628,7 +628,7 @@ module.exports = cls => class Reifier extends cls {
     process.emit('time', timer)
     this.addTracker('reify', node.name, node.location)
 
-    const { npmVersion, nodeVersion } = this.options
+    const { npmVersion, nodeVersion, cpu, os } = this.options
     const p = Promise.resolve().then(async () => {
       // when we reify an optional node, check the engine and platform
       // first. be sure to ignore the --force and --engine-strict flags,
@@ -638,7 +638,7 @@ module.exports = cls => class Reifier extends cls {
       // eslint-disable-next-line promise/always-return
       if (node.optional) {
         checkEngine(node.package, npmVersion, nodeVersion, false)
-        checkPlatform(node.package, false)
+        checkPlatform(node.package, false, { cpu, os })
       }
       await this[_checkBins](node)
       await this[_extractOrLink](node)

--- a/workspaces/arborist/tap-snapshots/test/arborist/reify.js.test.cjs
+++ b/workspaces/arborist/tap-snapshots/test/arborist/reify.js.test.cjs
@@ -3161,6 +3161,44 @@ ArboristNode {
 }
 `
 
+exports[`test/arborist/reify.js TAP fail to install optional deps with matched os and mismatched cpu with os and cpu options > expect resolving Promise 1`] = `
+ArboristNode {
+  "edgesOut": Map {
+    "platform-specifying-test-package" => EdgeOut {
+      "name": "platform-specifying-test-package",
+      "spec": "1.0.0",
+      "to": null,
+      "type": "optional",
+    },
+  },
+  "isProjectRoot": true,
+  "location": "",
+  "name": "tap-testdir-reify-fail-to-install-optional-deps-with-matched-os-and-mismatched-cpu-with-os-and-cpu-options",
+  "packageName": "platform-test",
+  "path": "{CWD}/test/arborist/tap-testdir-reify-fail-to-install-optional-deps-with-matched-os-and-mismatched-cpu-with-os-and-cpu-options",
+  "version": "1.0.0",
+}
+`
+
+exports[`test/arborist/reify.js TAP fail to install optional deps with mismatched os and matched cpu with os and cpu options > expect resolving Promise 1`] = `
+ArboristNode {
+  "edgesOut": Map {
+    "platform-specifying-test-package" => EdgeOut {
+      "name": "platform-specifying-test-package",
+      "spec": "1.0.0",
+      "to": null,
+      "type": "optional",
+    },
+  },
+  "isProjectRoot": true,
+  "location": "",
+  "name": "tap-testdir-reify-fail-to-install-optional-deps-with-mismatched-os-and-matched-cpu-with-os-and-cpu-options",
+  "packageName": "platform-test",
+  "path": "{CWD}/test/arborist/tap-testdir-reify-fail-to-install-optional-deps-with-mismatched-os-and-matched-cpu-with-os-and-cpu-options",
+  "version": "1.0.0",
+}
+`
+
 exports[`test/arborist/reify.js TAP failing script means install failure, unless ignoreScripts prod-dep-allinstall-fail --ignore-scripts > expect resolving Promise 1`] = `
 ArboristNode {
   "children": Map {
@@ -32991,6 +33029,43 @@ exports[`test/arborist/reify.js TAP store files with a custom indenting > must m
 	}
 }
 
+`
+
+exports[`test/arborist/reify.js TAP success to install optional deps with matched platform specifications with os and cpu options > expect resolving Promise 1`] = `
+ArboristNode {
+  "children": Map {
+    "platform-specifying-test-package" => ArboristNode {
+      "edgesIn": Set {
+        EdgeIn {
+          "from": "",
+          "name": "platform-specifying-test-package",
+          "spec": "1.0.0",
+          "type": "optional",
+        },
+      },
+      "location": "node_modules/platform-specifying-test-package",
+      "name": "platform-specifying-test-package",
+      "optional": true,
+      "path": "{CWD}/test/arborist/tap-testdir-reify-success-to-install-optional-deps-with-matched-platform-specifications-with-os-and-cpu-options/node_modules/platform-specifying-test-package",
+      "resolved": "https://registry.npmjs.org/platform-specifying-test-package/-/platform-specifying-test-package-1.0.0.tgz",
+      "version": "1.0.0",
+    },
+  },
+  "edgesOut": Map {
+    "platform-specifying-test-package" => EdgeOut {
+      "name": "platform-specifying-test-package",
+      "spec": "1.0.0",
+      "to": "node_modules/platform-specifying-test-package",
+      "type": "optional",
+    },
+  },
+  "isProjectRoot": true,
+  "location": "",
+  "name": "tap-testdir-reify-success-to-install-optional-deps-with-matched-platform-specifications-with-os-and-cpu-options",
+  "packageName": "platform-test",
+  "path": "{CWD}/test/arborist/tap-testdir-reify-success-to-install-optional-deps-with-matched-platform-specifications-with-os-and-cpu-options",
+  "version": "1.0.0",
+}
 `
 
 exports[`test/arborist/reify.js TAP tarball deps with transitive tarball deps > expect resolving Promise 1`] = `

--- a/workspaces/arborist/test/arborist/reify.js
+++ b/workspaces/arborist/test/arborist/reify.js
@@ -465,6 +465,18 @@ t.test('still do not install optional deps with mismatched platform specificatio
 t.test('fail to install deps with mismatched platform specifications', t =>
   t.rejects(printReified(fixture(t, 'platform-specification')), { code: 'EBADPLATFORM' }))
 
+t.test('success to install optional deps with matched platform specifications with os and cpu options', t =>
+  t.resolveMatchSnapshot(printReified(
+    fixture(t, 'optional-platform-specification'), { os: 'not-your-os', cpu: 'not-your-cpu' })))
+
+t.test('fail to install optional deps with matched os and mismatched cpu with os and cpu options', t =>
+  t.resolveMatchSnapshot(printReified(
+    fixture(t, 'optional-platform-specification'), { os: 'not-your-os', cpu: 'another-cpu' })))
+
+t.test('fail to install optional deps with mismatched os and matched cpu with os and cpu options', t =>
+  t.resolveMatchSnapshot(printReified(
+    fixture(t, 'optional-platform-specification'), { os: 'another-os', cpu: 'not-your-cpu' })))
+
 t.test('dry run, do not get anything wet', async t => {
   const cases = [
     'shrinkwrapped-dep-with-lock-empty',

--- a/workspaces/arborist/test/fixtures/registry-mocks/content/platform-specifying-test-package.json
+++ b/workspaces/arborist/test/fixtures/registry-mocks/content/platform-specifying-test-package.json
@@ -21,6 +21,9 @@
       "os": [
         "not-your-os"
       ],
+      "cpu": [
+        "not-your-cpu"
+      ],
       "_id": "platform-specifying-test-package@1.0.0",
       "_nodeVersion": "12.18.4",
       "_npmVersion": "6.14.6",

--- a/workspaces/arborist/test/fixtures/registry-mocks/content/platform-specifying-test-package.min.json
+++ b/workspaces/arborist/test/fixtures/registry-mocks/content/platform-specifying-test-package.min.json
@@ -15,6 +15,9 @@
       },
       "os": [
         "not-your-os"
+      ],
+      "cpu": [
+        "not-your-cpu"
       ]
     }
   },

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -483,6 +483,17 @@ define('cpu', {
   flatten,
 })
 
+define('os', {
+  default: null,
+  type: [null, String],
+  description: `
+    Override OS of native modules to install.
+    Acceptable values are same as \`os\` field of package.json,
+    which comes from \`process.platform\`.
+  `,
+  flatten,
+})
+
 define('depth', {
   default: null,
   defaultDescription: `

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -472,6 +472,17 @@ define('commit-hooks', {
   flatten,
 })
 
+define('cpu', {
+  default: null,
+  type: [null, String],
+  description: `
+    Override CPU architecture of native modules to install.
+    Acceptable values are same as \`cpu\` field of package.json,
+    which comes from \`process.arch\`.
+  `,
+  flatten,
+})
+
 define('depth', {
   default: null,
   defaultDescription: `

--- a/workspaces/config/tap-snapshots/test/type-description.js.test.cjs
+++ b/workspaces/config/tap-snapshots/test/type-description.js.test.cjs
@@ -339,6 +339,10 @@ Object {
     null,
     "boolean value (true or false)",
   ],
+  "os": Array [
+    null,
+    Function String(),
+  ],
   "otp": Array [
     null,
     Function String(),

--- a/workspaces/config/tap-snapshots/test/type-description.js.test.cjs
+++ b/workspaces/config/tap-snapshots/test/type-description.js.test.cjs
@@ -91,6 +91,10 @@ Object {
   "commit-hooks": Array [
     "boolean value (true or false)",
   ],
+  "cpu": Array [
+    null,
+    Function String(),
+  ],
   "depth": Array [
     null,
     "numeric value",


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

Add `--cpu` option and `---os` option which is proposed in https://github.com/npm/rfcs/issues/612.

The change of npm-install-checks package is here: https://github.com/npm/npm-install-checks/pull/65

## Real Example

Let's think about the package.json below:

```json
{
  "name": "demo",
  "version": "1.0.0",
  "dependencies": {
    "@node-rs/xxhash": "latest"
  }
}
```

Running `npm i` on my M1 mac machine will install two package `@node-rs/xxhash` and `@node-rs/xxhash-darwin-arm64`.

Running `npm i  --cpu x64 --os freebsd` will install `@node-rs/xxhash-freebsd-x64` instead of `@node-rs/xxhash-darwin-arm64`.


## References

Closes https://github.com/npm/rfcs/issues/612
