### PR TITLE
fix: `$npm_execpath` always points to npm, even when running npx

### DIFF
--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -2354,6 +2354,7 @@ Object {
   "nodeBin": "{NODE}",
   "nodeVersion": "2.2.2",
   "noProxy": "",
+  "npmBin": "{CWD}/other/bin/npm-cli.js",
   "npmCommand": "version",
   "npmVersion": "3.3.3",
   "npxCache": "{CWD}/cache/_npx",

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -2354,7 +2354,6 @@ Object {
   "nodeBin": "{NODE}",
   "nodeVersion": "2.2.2",
   "noProxy": "",
-  "npmBin": "{CWD}/{TESTDIR}/docs.js",
   "npmCommand": "version",
   "npmVersion": "3.3.3",
   "npxCache": "{CWD}/cache/_npx",

--- a/workspaces/config/lib/definitions/index.js
+++ b/workspaces/config/lib/definitions/index.js
@@ -18,9 +18,6 @@ const flatten = (obj, flat = {}) => {
       flat[key] = val
     }
   }
-
-  flat.nodeBin = process.env.NODE || process.execPath
-
   return flat
 }
 

--- a/workspaces/config/lib/definitions/index.js
+++ b/workspaces/config/lib/definitions/index.js
@@ -19,10 +19,6 @@ const flatten = (obj, flat = {}) => {
     }
   }
 
-  // XXX make this the bin/npm-cli.js file explicitly instead
-  // otherwise using npm programmatically is a bit of a pain.
-  flat.npmBin = require.main ? require.main.filename
-    : /* istanbul ignore next - not configurable property */ undefined
   flat.nodeBin = process.env.NODE || process.execPath
 
   return flat

--- a/workspaces/config/lib/index.js
+++ b/workspaces/config/lib/index.js
@@ -115,6 +115,7 @@ class Config {
     this.defaults = defaults
 
     this.npmPath = npmPath
+    this.npmBin = join(this.npmPath, 'bin/npm-cli.js')
     this.argv = argv
     this.env = env
     this.execPath = execPath

--- a/workspaces/config/lib/index.js
+++ b/workspaces/config/lib/index.js
@@ -232,6 +232,8 @@ class Config {
     for (const { data } of this.data.values()) {
       this.#flatten(data, this.#flatOptions)
     }
+    this.#flatOptions.nodeBin = process.env.NODE || this.execPath
+    this.#flatOptions.npmBin = this.npmBin
     process.emit('timeEnd', 'config:load:flatten')
 
     return this.#flatOptions

--- a/workspaces/config/lib/index.js
+++ b/workspaces/config/lib/index.js
@@ -232,7 +232,7 @@ class Config {
     for (const { data } of this.data.values()) {
       this.#flatten(data, this.#flatOptions)
     }
-    this.#flatOptions.nodeBin = process.env.NODE || this.execPath
+    this.#flatOptions.nodeBin = this.execPath
     this.#flatOptions.npmBin = this.npmBin
     process.emit('timeEnd', 'config:load:flatten')
 

--- a/workspaces/config/lib/set-envs.js
+++ b/workspaces/config/lib/set-envs.js
@@ -101,10 +101,7 @@ const setEnvs = (config) => {
   if (cliConf['node-options']) {
     env.NODE_OPTIONS = cliConf['node-options']
   }
-
-  if (require.main && require.main.filename) {
-    env.npm_execpath = require.main.filename
-  }
+  env.npm_execpath = config.npmBin
   env.NODE = env.npm_node_execpath = config.execPath
 }
 

--- a/workspaces/config/test/definitions/index.js
+++ b/workspaces/config/test/definitions/index.js
@@ -1,7 +1,6 @@
 const t = require('tap')
 const config = require('../../lib/definitions/index.js')
 const definitions = require('../../lib/definitions/definitions.js')
-const mockGlobals = require('@npmcli/mock-globals')
 
 t.test('defaults', t => {
   // just spot check a few of these to show that we got defaults assembled
@@ -14,10 +13,6 @@ t.test('defaults', t => {
 })
 
 t.test('flatten', t => {
-  // cant use mockGlobals since its not a configurable property
-  require.main.filename = '/path/to/npm'
-  mockGlobals(t, { process: { execPath: '/path/to/node', 'env.NODE': undefined } })
-
   const obj = {
     'save-exact': true,
     'save-prefix': 'ignored',
@@ -34,10 +29,6 @@ t.test('flatten', t => {
     savePrefix: '',
     '@foobar:registry': 'https://foo.bar.com/',
     '//foo.bar.com:_authToken': 'foobarbazquuxasdf',
-  })
-
-  mockGlobals(t, {
-    'process.env.NODE': '/usr/local/bin/node.exe',
   })
 
   // now flatten something else on top of it.

--- a/workspaces/config/test/definitions/index.js
+++ b/workspaces/config/test/definitions/index.js
@@ -34,8 +34,6 @@ t.test('flatten', t => {
     savePrefix: '',
     '@foobar:registry': 'https://foo.bar.com/',
     '//foo.bar.com:_authToken': 'foobarbazquuxasdf',
-    npmBin: '/path/to/npm',
-    nodeBin: '/path/to/node',
   })
 
   mockGlobals(t, {
@@ -49,8 +47,6 @@ t.test('flatten', t => {
     savePrefix: '',
     '@foobar:registry': 'https://foo.bar.com/',
     '//foo.bar.com:_authToken': 'foobarbazquuxasdf',
-    npmBin: '/path/to/npm',
-    nodeBin: '/usr/local/bin/node.exe',
   })
 
   t.end()

--- a/workspaces/config/test/set-envs.js
+++ b/workspaces/config/test/set-envs.js
@@ -9,6 +9,9 @@ const globalPrefix = join(cwd, 'global')
 const localPrefix = join(cwd, 'local')
 const NODE = execPath
 
+const npmPath = '{path}'
+const npmBin = join(npmPath, 'bin/npm-cli.js')
+
 const mockDefinitions = (t) => {
   mockGlobals(t, { 'process.env': { EDITOR: 'vim' } })
   const { definitions, defaults } = t.mock('../lib/definitions/index.js')
@@ -24,7 +27,7 @@ t.test('set envs that are not defaults and not already in env', t => {
     INIT_CWD: cwd,
     EDITOR: 'vim',
     HOME: undefined,
-    npm_execpath: require.main.filename,
+    npm_execpath: npmBin,
     npm_node_execpath: execPath,
     npm_config_global_prefix: globalPrefix,
     npm_config_local_prefix: localPrefix,
@@ -39,6 +42,8 @@ t.test('set envs that are not defaults and not already in env', t => {
     execPath,
     globalPrefix,
     localPrefix,
+    npmPath,
+    npmBin,
   }
 
   setEnvs(config)
@@ -75,7 +80,7 @@ t.test('set envs that are not defaults and not already in env, array style', t =
     INIT_CWD: cwd,
     EDITOR: 'vim',
     HOME: undefined,
-    npm_execpath: require.main.filename,
+    npm_execpath: npmBin,
     npm_node_execpath: execPath,
     npm_config_global_prefix: globalPrefix,
     npm_config_local_prefix: localPrefix,
@@ -90,6 +95,8 @@ t.test('set envs that are not defaults and not already in env, array style', t =
     execPath,
     globalPrefix,
     localPrefix,
+    npmPath,
+    npmBin,
   }
   setEnvs(config)
   t.strictSame(env, { ...extras }, 'no new environment vars to create')
@@ -123,7 +130,7 @@ t.test('set envs that are not defaults and not already in env, boolean edition',
     INIT_CWD: cwd,
     EDITOR: 'vim',
     HOME: undefined,
-    npm_execpath: require.main.filename,
+    npm_execpath: npmBin,
     npm_node_execpath: execPath,
     npm_config_global_prefix: globalPrefix,
     npm_config_local_prefix: localPrefix,
@@ -138,6 +145,8 @@ t.test('set envs that are not defaults and not already in env, boolean edition',
     execPath,
     globalPrefix,
     localPrefix,
+    npmPath,
+    npmBin,
   }
   setEnvs(config)
   t.strictSame(env, { ...extras }, 'no new environment vars to create')
@@ -164,7 +173,7 @@ t.test('set envs that are not defaults and not already in env, boolean edition',
   t.end()
 })
 
-t.test('dont set npm_execpath if require.main.filename is not set', t => {
+t.test('set npm_execpath even if require.main.filename is not set', t => {
   const { definitions, defaults } = mockDefinitions(t)
   const { filename } = require.main
   t.teardown(() => require.main.filename = filename)
@@ -182,9 +191,10 @@ t.test('dont set npm_execpath if require.main.filename is not set', t => {
     execPath,
     globalPrefix,
     localPrefix,
+    npmBin,
   }
   setEnvs(config)
-  t.equal(env.npm_execpath, undefined, 'did not set npm_execpath')
+  t.equal(env.npm_execpath, npmBin, 'did not set npm_execpath')
   t.end()
 })
 
@@ -197,7 +207,7 @@ t.test('dont set configs marked as envExport:false', t => {
     INIT_CWD: cwd,
     EDITOR: 'vim',
     HOME: undefined,
-    npm_execpath: require.main.filename,
+    npm_execpath: npmBin,
     npm_node_execpath: execPath,
     npm_config_global_prefix: globalPrefix,
     npm_config_local_prefix: localPrefix,
@@ -212,6 +222,8 @@ t.test('dont set configs marked as envExport:false', t => {
     execPath,
     globalPrefix,
     localPrefix,
+    npmPath,
+    npmBin,
   }
   setEnvs(config)
   t.strictSame(env, { ...extras }, 'no new environment vars to create')


### PR DESCRIPTION
When running a script with `npx` (but *not* with `npm exec`), `$npm_execpath` is set to ".../npm/bin/npx-cli.js". This causes packages to fail to detect the package manager.

Now `$npm_execpath` will always be the path to `npm-cli.js`.

## References
Fixes #6662