### PR TITLE
fix: changelog mentions of node support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ### ⚠️ BREAKING CHANGES
 
-* support for node <=18.17.0 has been removed
+* support for node <18.17.0 has been removed
 * support for node 16 has been removed
 * support for node 14 has been removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,16 +26,8 @@
 
 ### ⚠️ BREAKING CHANGES
 
-* support for node <=16.13 has been removed
-* support for node 14 has been removed
-* support for node 14 has been removed
-* support for node 14 has been removed
-* support for node 14 has been removed
-* support for node 14 has been removed
-* support for node 14 has been removed
-* support for node 14 has been removed
-* support for node 14 has been removed
-* support for node 14 has been removed
+* support for node <=18.17.0 has been removed
+* support for node 16 has been removed
 * support for node 14 has been removed
 
 ### Bug Fixes


### PR DESCRIPTION
npm v10 doesn't only drop support for `<=16.13` it also drops support for 16 entirely and `<18.17.0`

<img width="594" alt="image" src="https://github.com/npm/cli/assets/1328852/ca93e8c9-f3df-48b2-91da-3e04492c6e35">

This is also confusing, but I think is being addressed with other PRs.

<img width="465" alt="image" src="https://github.com/npm/cli/assets/1328852/e6342e6a-fd7b-4514-9d61-dd6db382004f">

Also the docs don't have v10 yet?