### PR TITLE
fix: query with workspace descendents

### DIFF
--- a/workspaces/arborist/lib/query-selector-all.js
+++ b/workspaces/arborist/lib/query-selector-all.js
@@ -719,7 +719,10 @@ const hasAscendant = (node, compareNodes, seen = new Set()) => {
   }
 
   if (node.isTop && node.resolveParent) {
-    return hasAscendant(node.resolveParent, compareNodes)
+    /* istanbul ignore if - investigate if linksIn check obviates need for this */
+    if (hasAscendant(node.resolveParent, compareNodes)) {
+      return true
+    }
   }
   for (const edge of node.edgesIn) {
     // TODO Need a test with an infinite loop
@@ -728,6 +731,11 @@ const hasAscendant = (node, compareNodes, seen = new Set()) => {
     }
     seen.add(edge)
     if (edge && edge.from && hasAscendant(edge.from, compareNodes, seen)) {
+      return true
+    }
+  }
+  for (const linkNode of node.linksIn) {
+    if (hasAscendant(linkNode, compareNodes, seen)) {
       return true
     }
   }

--- a/workspaces/arborist/test/query-selector-all.js
+++ b/workspaces/arborist/test/query-selector-all.js
@@ -24,6 +24,7 @@ t.test('query-selector-all', async t => {
     │   └── lorem@1.0.0 (production dep of baz)
     ├── abbrev@1.1.1 (production dep of query-selector-all-tests)
     ├─┬ b@1.0.0 -> ./b (workspace)
+    │ ├── a@2.0.0 (dev dep of b, deduped)
     │ └── bar@2.0.0 (production dep of b, deduped)
     ├─┬ bar@2.0.0 (production dep of query-selector-all-tests)
     │ └── moo@3.0.0 (production dep of bar)
@@ -513,7 +514,7 @@ t.test('query-selector-all', async t => {
     ['*:has(* > #bar:semver(1.4.0))', ['foo@2.2.2']],
     ['*:has(> #bar:semver(1.4.0))', ['foo@2.2.2']],
     ['.workspace:has(> * > #lorem)', ['a@1.0.0']],
-    ['.workspace:has(* #lorem, ~ #b)', ['a@1.0.0']],
+    ['.workspace:has(* #lorem, ~ #b)', ['a@1.0.0', 'b@1.0.0']],
 
     // is pseudo
     [':is(#a, #b) > *', ['a@1.0.0', 'bar@2.0.0', 'baz@1.0.0']],
@@ -960,5 +961,6 @@ t.test('query-selector-all', async t => {
     [':root #bar:semver(1) ~ *', ['dash-separated-pkg@1.0.0']],
     ['#bar:semver(2), #foo', ['bar@2.0.0', 'foo@2.2.2']],
     ['#a, #bar:semver(2), #foo:semver(2.2.2)', ['a@1.0.0', 'bar@2.0.0', 'foo@2.2.2']],
+    ['#b *', ['a@1.0.0', 'bar@2.0.0', 'baz@1.0.0', 'lorem@1.0.0', 'moo@3.0.0']],
   ])
 })


### PR DESCRIPTION
Fixes https://github.com/npm/statusboard/issues/703

In scenarios where one workspace has a dependency on another workspace, `querySelectorAll` may omit some child dependencies. This stems from the fact that the algorithm to find dependencies, starts at the leaf and tries to find a path (following `edgesIn`) which leads back to the selected node. When workspaces are involved you can't reliably walk back up the dependency tree in this direction (`ArboristNode`s representing a workspace have no `edgesIn`).

The proposed fix updates the `hasAscendant` function to also follow the `linksIn` collection when trying to find a path to the selected node. 