### PR TITLE
fix: tolerate null bugs URLs

### DIFF
--- a/lib/commands/bugs.js
+++ b/lib/commands/bugs.js
@@ -21,8 +21,9 @@ class Bugs extends PackageUrlCmd {
 
     // try to get it from the repo, if possible
     const info = this.hostedFromMani(mani)
-    if (info) {
-      return info.bugs()
+    const infoUrl = info?.bugs()
+    if (infoUrl) {
+      return infoUrl
     }
 
     // just send them to the website, hopefully that has some info!

--- a/test/lib/commands/bugs.js
+++ b/test/lib/commands/bugs.js
@@ -6,6 +6,10 @@ const pacote = {
     return spec === 'nobugs' ? {
       name: 'nobugs',
       version: '1.2.3',
+    } : spec === 'nullbugs' ? {
+      name: 'nullbugs',
+      version: '1.2.3',
+      bugs: null,
     } : spec === 'bugsurl' ? {
       name: 'bugsurl',
       version: '1.2.3',
@@ -66,6 +70,7 @@ t.test('open bugs urls & emails', async t => {
   const expected = {
     '.': 'https://example.com',
     nobugs: 'https://www.npmjs.com/package/nobugs',
+    nullbugs: 'https://www.npmjs.com/package/nullbugs',
     'bugsobj-nourl': 'https://www.npmjs.com/package/bugsobj-nourl',
     bugsurl: 'https://bugzilla.localhost/bugsurl',
     bugsobj: 'https://bugzilla.localhost/bugsobj',


### PR DESCRIPTION
Currently, if the bugs URL returned from `package.json`, which is processed through
[hosted-git-info](https://github.com/npm/hosted-git-info), is falsy, an error is thrown. However, hosted-git-info may well return a falsy bugs URL. This can happen when there is no bugs URL in the repo, but hosted-git-info tries to infer one, but one cannot be inferred, for example if the repository URL is a SourceHut URL. This is described here: https://github.com/npm/hosted-git-info/pull/213

For this reason, we should tolerate falsy URLs and fall back to whatever is defined in `bugs.js`, in this case being sent to https://www.npmjs.com/package/<packageName>.