### PR TITLE
chore: use proxy instead of http-proxy

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -716,7 +716,6 @@ graph LR;
   npmcli-run-script-->npmcli-promise-spawn["@npmcli/promise-spawn"];
   npmcli-run-script-->read-package-json-fast;
   npmcli-run-script-->which;
-  npmcli-smoke-tests-->http-proxy;
   npmcli-smoke-tests-->npmcli-eslint-config["@npmcli/eslint-config"];
   npmcli-smoke-tests-->npmcli-mock-registry["@npmcli/mock-registry"];
   npmcli-smoke-tests-->npmcli-promise-spawn["@npmcli/promise-spawn"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -6803,26 +6803,6 @@
       "dev": true,
       "peer": true
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -7615,20 +7595,6 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
       "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "inBundle": true
-    },
-    "node_modules/http-proxy": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
-      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-      "dev": true,
-      "dependencies": {
-        "eventemitter3": "^4.0.0",
-        "follow-redirects": "^1.0.0",
-        "requires-port": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
@@ -17375,7 +17341,6 @@
         "@npmcli/mock-registry": "^1.0.0",
         "@npmcli/promise-spawn": "^7.0.0",
         "@npmcli/template-oss": "4.19.0",
-        "http-proxy": "^1.18.1",
         "proxy": "^2.1.1",
         "semver": "^7.5.4",
         "tap": "^16.3.8",

--- a/smoke-tests/package.json
+++ b/smoke-tests/package.json
@@ -22,7 +22,6 @@
     "@npmcli/mock-registry": "^1.0.0",
     "@npmcli/promise-spawn": "^7.0.0",
     "@npmcli/template-oss": "4.19.0",
-    "http-proxy": "^1.18.1",
     "proxy": "^2.1.1",
     "semver": "^7.5.4",
     "tap": "^16.3.8",
@@ -38,6 +37,7 @@
   "tap": {
     "no-coverage": true,
     "timeout": 600,
+    "jobs": 1,
     "test-ignore": "fixtures/*",
     "nyc-arg": [
       "--exclude",

--- a/smoke-tests/test/max-listeners.js
+++ b/smoke-tests/test/max-listeners.js
@@ -10,7 +10,7 @@ const getFixture = (p) => require(
 
 const runTest = async (t, { env } = {}) => {
   const { npm } = await setup(t, {
-    registry: false,
+    mockRegistry: false,
     testdir: {
       project: {
         'package.json': getFixture('package.json'),

--- a/smoke-tests/test/npm-replace-global.js
+++ b/smoke-tests/test/npm-replace-global.js
@@ -110,7 +110,7 @@ t.test('publish and replace global self', async t => {
   } = await setupNpmGlobal(t, {
     testdir: {
       home: {
-        '.npmrc': `${setup.HTTP_PROXY.slice(5)}:_authToken = test-token`,
+        '.npmrc': `//${setup.MOCK_REGISTRY.host}/:_authToken = test-token`,
       },
     },
   })

--- a/smoke-tests/test/proxy.js
+++ b/smoke-tests/test/proxy.js
@@ -1,23 +1,11 @@
 const t = require('tap')
 const setup = require('./fixtures/setup.js')
-const { createProxy } = require('proxy')
-const http = require('http')
 
 t.test('proxy', async t => {
-  const { PROXY_PORT: PORT } = setup
-
   const { npm, readFile } = await setup(t, {
-    registry: false,
-    testdir: {
-      home: {
-        '.npmrc': `proxy = "http://localhost:${PORT}/"`,
-      },
-    },
+    mockRegistry: false,
+    useProxy: true,
   })
-
-  const server = createProxy(http.createServer())
-  await new Promise(res => server.listen(PORT, res))
-  t.teardown(() => server.close())
 
   await npm('install', 'abbrev@1.0.4')
 


### PR DESCRIPTION
The proxy package is more spec compliant and works out-of-the-box
so we no longer have to pass --registry=PROXY to the tests.

The goal here is to make it simpler to help debug #6793.
