### PR TITLE
chore: benchmark script fixes

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,16 +18,18 @@ jobs:
     steps:
       - name: Incoming Pull Request
         if: |
-          github.event_name == 'pull_request' || (
+          (
+            github.event_name == 'pull_request' &&
+            github.event.pull_request.head.repo.full_name == 'npm/cli' 
+          ) || (
             github.event_name == 'issue_comment' &&
             github.event.issue.pull_request &&
             github.event.issue.state == 'open' &&
             startsWith(github.event.comment.body, '@npm-cli-bot benchmark this')
           )
-        env:
-          GITHUB_TOKEN: ${{ secrets.BENCHMARK_DISPATCH_TOKEN }}
         uses: actions/github-script@v6
         with:
+          github-token: ${{ secrets.BENCHMARK_DISPATCH_TOKEN }}
           script: |
             const {
               payload,
@@ -35,11 +37,6 @@ jobs:
               repo: { owner, repo },
               issue: { number },
             } = context
-          
-            if (eventName === 'pull_request' && !process.env.GITHUB_TOKEN) {
-              core.info('No GITHUB_TOKEN - from fork pull request, exiting')
-              return
-            }
           
             if (eventName === 'issue_comment') {
               const res = await github.rest.repos.getCollaboratorPermissionLevel({


### PR DESCRIPTION
This passes the token to the github-script action and now skips the PR workflow for forks in the if statement instead of while running the script
