### PR TITLE
fix: ensure workspace links query parents correctly

### DIFF
--- a/workspaces/arborist/lib/query-selector-all.js
+++ b/workspaces/arborist/lib/query-selector-all.js
@@ -695,7 +695,11 @@ const depTypes = {
 // the compare nodes array
 const hasParent = (node, compareNodes) => {
   // All it takes is one so we loop and return on the first hit
-  for (const compareNode of compareNodes) {
+  for (let compareNode of compareNodes) {
+    if (compareNode.isLink) {
+      compareNode = compareNode.target
+    }
+
     // follows logical parent for link anscestors
     if (node.isTop && (node.resolveParent === compareNode)) {
       return true

--- a/workspaces/arborist/test/query-selector-all.js
+++ b/workspaces/arborist/test/query-selector-all.js
@@ -10,10 +10,10 @@ const q = require('../lib/query-selector-all.js')
 // and deduplicates link/target from results
 const querySelectorAll = async (tree, query, options) => {
   const res = await q(tree, query, options)
-  return [...new Set(res.map((i) => i.pkgid))]
+  return [...new Set(res.map(i => i.pkgid))]
 }
 
-t.test('query-selector-all', async (t) => {
+t.test('query-selector-all', async t => {
   /*
    fixture tree:
 
@@ -43,8 +43,8 @@ t.test('query-selector-all', async (t) => {
 
   const now = Date.now()
   const today = new Date(now)
-  const yesterday = new Date(now - 1000 * 60 * 60 * 24)
-  const dayBeforeYesterday = new Date(now - 1000 * 60 * 60 * 24 * 2)
+  const yesterday = new Date(now - (1000 * 60 * 60 * 24))
+  const dayBeforeYesterday = new Date(now - (1000 * 60 * 60 * 24 * 2))
   // @npmcli/abbrev is deliberately left out of this list to cover the case when
   // fetching a packument fails
   const packumentStubs = {
@@ -233,7 +233,9 @@ t.test('query-selector-all', async (t) => {
           devDependencies: {
             moo: '^3.0.0',
           },
-          funding: [{ type: 'GitHub', url: 'https://github.com/sponsors' }],
+          funding: [
+            { type: 'GitHub', url: 'https://github.com/sponsors' },
+          ],
         }),
       },
       moo: {
@@ -261,28 +263,24 @@ t.test('query-selector-all', async (t) => {
         }),
       },
     },
-    a: {
-      'package.json': JSON.stringify({
-        name: 'a',
-        version: '1.0.0',
-        optionalDependencies: {
-          baz: '^1.0.0',
-        },
-      }),
-    },
-    b: {
-      'package.json': JSON.stringify({
-        name: 'b',
-        version: '1.0.0',
-        private: true,
-        devDependencies: {
-          a: '^1.0.0',
-        },
-        dependencies: {
-          bar: '^2.0.0',
-        },
-      }),
-    },
+    a: { 'package.json': JSON.stringify({
+      name: 'a',
+      version: '1.0.0',
+      optionalDependencies: {
+        baz: '^1.0.0',
+      },
+    }) },
+    b: { 'package.json': JSON.stringify({
+      name: 'b',
+      version: '1.0.0',
+      private: true,
+      devDependencies: {
+        a: '^1.0.0',
+      },
+      dependencies: {
+        bar: '^2.0.0',
+      },
+    }) },
     c: {
       'package.json': JSON.stringify({
         name: 'c',
@@ -371,94 +369,87 @@ t.test('query-selector-all', async (t) => {
   t.same(scopeRes, ['foo@2.2.2'], ':scope')
 
   const scopeChildren = await querySelectorAll(nodeFoo, ':scope > *')
-  t.same(
-    scopeChildren,
-    ['dash-separated-pkg@1.0.0', 'bar@1.4.0'],
-    ':scope > *'
-  )
+  t.same(scopeChildren, [
+    'dash-separated-pkg@1.0.0',
+    'bar@1.4.0',
+  ], ':scope > *')
 
-  const runSpecParsing = async (testCase) => {
+  const runSpecParsing = async testCase => {
     for (const [selector, expected, options = {}] of testCase) {
       let title = selector
       if (options.before) {
-        const friendlyTime =
-          options.before === today
-            ? 'today'
-            : options.before === yesterday
-              ? 'yesterday'
-              : options.before
+        const friendlyTime = options.before === today
+          ? 'today'
+          : options.before === yesterday
+            ? 'yesterday'
+            : options.before
         title += ` before ${friendlyTime}`
       }
-      t.test(title, async (t) => {
+      t.test(title, async t => {
         const res = await querySelectorAll(tree, selector, options)
-        t.same(res, expected, title)
+        t.same(
+          res,
+          expected,
+          title
+        )
       })
     }
   }
 
   await runSpecParsing([
     // universal selector
-    [
-      '*',
-      [
-        'query-selector-all-tests@1.0.0',
-        'a@1.0.0',
-        'b@1.0.0',
-        'c@1.0.0',
-        '@npmcli/abbrev@2.0.0-beta.45',
-        'abbrev@1.1.1',
-        'bar@2.0.0',
-        'baz@1.0.0',
-        'dash-separated-pkg@1.0.0',
-        'dasher@2.0.0',
-        'foo@2.2.2',
-        'bar@1.4.0',
-        'ipsum@npm:sit@1.0.0',
-        'lorem@1.0.0',
-        'moo@3.0.0',
-        'recur@1.0.0',
-        'sive@1.0.0',
-      ],
-    ],
-    [
-      '* > *',
-      [
-        'a@1.0.0',
-        'b@1.0.0',
-        'c@1.0.0',
-        'abbrev@1.1.1',
-        'bar@2.0.0',
-        'baz@1.0.0',
-        'dash-separated-pkg@1.0.0',
-        'dasher@2.0.0',
-        'foo@2.2.2',
-        'bar@1.4.0',
-        'ipsum@npm:sit@1.0.0',
-        'lorem@1.0.0',
-        'moo@3.0.0',
-        'recur@1.0.0',
-        'sive@1.0.0',
-      ],
-    ],
+    ['*', [
+      'query-selector-all-tests@1.0.0',
+      'a@1.0.0',
+      'b@1.0.0',
+      'c@1.0.0',
+      '@npmcli/abbrev@2.0.0-beta.45',
+      'abbrev@1.1.1',
+      'bar@2.0.0',
+      'baz@1.0.0',
+      'dash-separated-pkg@1.0.0',
+      'dasher@2.0.0',
+      'foo@2.2.2',
+      'bar@1.4.0',
+      'ipsum@npm:sit@1.0.0',
+      'lorem@1.0.0',
+      'moo@3.0.0',
+      'recur@1.0.0',
+      'sive@1.0.0',
+    ]],
+    ['* > *', [
+      'a@1.0.0',
+      'b@1.0.0',
+      'c@1.0.0',
+      'abbrev@1.1.1',
+      'bar@2.0.0',
+      'baz@1.0.0',
+      'dash-separated-pkg@1.0.0',
+      'dasher@2.0.0',
+      'foo@2.2.2',
+      'bar@1.4.0',
+      'ipsum@npm:sit@1.0.0',
+      'lorem@1.0.0',
+      'moo@3.0.0',
+      'recur@1.0.0',
+      'sive@1.0.0',
+    ]],
     ['> #a', ['a@1.0.0']],
 
     // pseudo :root
     [':root', ['query-selector-all-tests@1.0.0']],
     [':scope', ['query-selector-all-tests@1.0.0']], // same as root in this context
-    [
-      ':root > *',
-      [
-        'a@1.0.0',
-        'b@1.0.0',
-        'c@1.0.0',
-        'abbrev@1.1.1',
-        'bar@2.0.0',
-        'foo@2.2.2',
-        'ipsum@npm:sit@1.0.0',
-        'moo@3.0.0',
-        'recur@1.0.0',
-      ],
-    ],
+    [':root > *', [
+      'a@1.0.0',
+      'b@1.0.0',
+      'c@1.0.0',
+      'abbrev@1.1.1',
+      'bar@2.0.0',
+      'foo@2.2.2',
+      'ipsum@npm:sit@1.0.0',
+      'moo@3.0.0',
+      'recur@1.0.0',
+    ]],
     [':root > .workspace', ['a@1.0.0', 'b@1.0.0', 'c@1.0.0']],
     [':root > *.workspace', ['a@1.0.0', 'b@1.0.0', 'c@1.0.0']],
     [':root > .workspace[name=a]', ['a@1.0.0']],
@@ -474,65 +465,70 @@ t.test('query-selector-all', async (t) => {
     ['#a ~ :root', []],
 
     // pseudo miscelaneous
-    [
-      ':empty',
-      [
-        '@npmcli/abbrev@2.0.0-beta.45',
-        'a@1.0.0',
-        'abbrev@1.1.1',
-        'b@1.0.0',
-        'c@1.0.0',
-        'dash-separated-pkg@1.0.0',
-        'dasher@2.0.0',
-        'lorem@1.0.0',
-        'moo@3.0.0',
-      ],
-    ],
-    [':root > :empty', ['a@1.0.0', 'abbrev@1.1.1', 'b@1.0.0', 'c@1.0.0', 'moo@3.0.0']],
+    [':empty', [
+      '@npmcli/abbrev@2.0.0-beta.45',
+      'a@1.0.0',
+      'abbrev@1.1.1',
+      'b@1.0.0',
+      'c@1.0.0',
+      'dash-separated-pkg@1.0.0',
+      'dasher@2.0.0',
+      'lorem@1.0.0',
+      'moo@3.0.0',
+    ]],
+    [':root > :empty', [
+      'a@1.0.0',
+      'abbrev@1.1.1',
+      'b@1.0.0',
+      'c@1.0.0',
+      'moo@3.0.0',
+    ]],
     [':extraneous', ['@npmcli/abbrev@2.0.0-beta.45']],
     [':invalid', ['lorem@1.0.0']],
     [':link', ['a@1.0.0', 'b@1.0.0', 'c@1.0.0']],
-    [':deduped', ['bar@2.0.0', 'moo@3.0.0', 'recur@1.0.0']],
+    [':deduped', [
+      'bar@2.0.0',
+      'moo@3.0.0',
+      'recur@1.0.0',
+    ]],
     [':missing', ['missing-dep@^1.0.0']],
     [':private', ['b@1.0.0']],
     [':overridden', ['dasher@2.0.0']],
 
     // :not pseudo
-    [
-      ':not(#foo)',
-      [
-        'query-selector-all-tests@1.0.0',
-        'a@1.0.0',
-        'b@1.0.0',
-        'c@1.0.0',
-        '@npmcli/abbrev@2.0.0-beta.45',
-        'abbrev@1.1.1',
-        'bar@2.0.0',
-        'baz@1.0.0',
-        'dash-separated-pkg@1.0.0',
-        'dasher@2.0.0',
-        'bar@1.4.0',
-        'ipsum@npm:sit@1.0.0',
-        'lorem@1.0.0',
-        'moo@3.0.0',
-        'recur@1.0.0',
-        'sive@1.0.0',
-      ],
-    ],
+    [':not(#foo)', [
+      'query-selector-all-tests@1.0.0',
+      'a@1.0.0',
+      'b@1.0.0',
+      'c@1.0.0',
+      '@npmcli/abbrev@2.0.0-beta.45',
+      'abbrev@1.1.1',
+      'bar@2.0.0',
+      'baz@1.0.0',
+      'dash-separated-pkg@1.0.0',
+      'dasher@2.0.0',
+      'bar@1.4.0',
+      'ipsum@npm:sit@1.0.0',
+      'lorem@1.0.0',
+      'moo@3.0.0',
+      'recur@1.0.0',
+      'sive@1.0.0',
+    ]],
     [':root > .workspace:not(#b)', ['a@1.0.0', 'c@1.0.0']],
     [':root > .workspace > *:not(#bar)', ['a@1.0.0', 'b@1.0.0', 'baz@1.0.0']],
-    [
-      '.bundled ~ :not(.workspace)',
-      [
-        'bar@2.0.0',
-        'foo@2.2.2',
-        'ipsum@npm:sit@1.0.0',
-        'moo@3.0.0',
-        'recur@1.0.0',
-      ],
-    ],
+    ['.bundled ~ :not(.workspace)', [
+      'bar@2.0.0',
+      'foo@2.2.2',
+      'ipsum@npm:sit@1.0.0',
+      'moo@3.0.0',
+      'recur@1.0.0',
+    ]],
     ['*:root > *:empty:not(*[name^=a], #b, #c)', ['moo@3.0.0']],
-    [':not(:not(:link))', ['a@1.0.0', 'b@1.0.0', 'c@1.0.0']],
+    [':not(:not(:link))', [
+      'a@1.0.0',
+      'b@1.0.0',
+      'c@1.0.0',
+    ]],
 
     // has pseudo
     [':root > *:has(* > #bar:semver(1.4.0))', ['foo@2.2.2']],
@@ -545,149 +541,152 @@ t.test('query-selector-all', async (t) => {
     [':is(#a, #b) > *', ['a@1.0.0', 'bar@2.0.0', 'baz@1.0.0']],
     // TODO: ipsum is not empty but its child is missing so it doesn't return a
     // result here
-    [
-      ':root > *:is(.prod:not(:empty), .dev > [name=bar]) > *',
-      ['a@1.0.0', 'b@1.0.0', 'bar@2.0.0', 'baz@1.0.0', 'dasher@2.0.0', 'moo@3.0.0'],
-    ],
-    [
-      ':is(*:semver(2.0.0), :semver(=2.0.0-beta.45))',
-      ['@npmcli/abbrev@2.0.0-beta.45', 'bar@2.0.0', 'dasher@2.0.0'],
-    ],
+    [':root > *:is(.prod:not(:empty), .dev > [name=bar]) > *', [
+      'a@1.0.0',
+      'b@1.0.0',
+      'bar@2.0.0',
+      'baz@1.0.0',
+      'dasher@2.0.0',
+      'moo@3.0.0',
+    ]],
+    [':is(*:semver(2.0.0), :semver(=2.0.0-beta.45))', [
+      '@npmcli/abbrev@2.0.0-beta.45',
+      'bar@2.0.0',
+      'dasher@2.0.0',
+    ]],
 
     // type pseudo
-    [
-      ':type()',
-      [
-        'query-selector-all-tests@1.0.0',
-        'a@1.0.0',
-        'b@1.0.0',
-        'c@1.0.0',
-        '@npmcli/abbrev@2.0.0-beta.45',
-        'abbrev@1.1.1',
-        'bar@2.0.0',
-        'baz@1.0.0',
-        'dash-separated-pkg@1.0.0',
-        'dasher@2.0.0',
-        'foo@2.2.2',
-        'bar@1.4.0',
-        'ipsum@npm:sit@1.0.0',
-        'lorem@1.0.0',
-        'moo@3.0.0',
-        'recur@1.0.0',
-        'sive@1.0.0',
-      ],
-    ],
+    [':type()', [
+      'query-selector-all-tests@1.0.0',
+      'a@1.0.0',
+      'b@1.0.0',
+      'c@1.0.0',
+      '@npmcli/abbrev@2.0.0-beta.45',
+      'abbrev@1.1.1',
+      'bar@2.0.0',
+      'baz@1.0.0',
+      'dash-separated-pkg@1.0.0',
+      'dasher@2.0.0',
+      'foo@2.2.2',
+      'bar@1.4.0',
+      'ipsum@npm:sit@1.0.0',
+      'lorem@1.0.0',
+      'moo@3.0.0',
+      'recur@1.0.0',
+      'sive@1.0.0',
+    ]],
     [':type(tag)', ['lorem@1.0.0']],
     [':type(alias)', ['ipsum@npm:sit@1.0.0']],
-    [
-      ':type(range)',
-      [
-        'a@1.0.0',
-        'abbrev@1.1.1',
-        'b@1.0.0',
-        'bar@2.0.0',
-        'baz@1.0.0',
-        'dash-separated-pkg@1.0.0',
-        'foo@2.2.2',
-        'bar@1.4.0',
-        'moo@3.0.0',
-      ],
-    ],
+    [':type(range)', [
+      'a@1.0.0',
+      'abbrev@1.1.1',
+      'b@1.0.0',
+      'bar@2.0.0',
+      'baz@1.0.0',
+      'dash-separated-pkg@1.0.0',
+      'foo@2.2.2',
+      'bar@1.4.0',
+      'moo@3.0.0',
+    ]],
     [':type(git)', []],
 
     // path pseudo
-    [
-      ':path(node_modules/*)',
-      [
-        'abbrev@1.1.1',
-        'bar@2.0.0',
-        'baz@1.0.0',
-        'dash-separated-pkg@1.0.0',
-        'dasher@2.0.0',
-        'foo@2.2.2',
-        'ipsum@npm:sit@1.0.0',
-        'lorem@1.0.0',
-        'moo@3.0.0',
-        'recur@1.0.0',
-        'sive@1.0.0',
-      ],
-    ],
+    [':path(node_modules/*)', [
+      'abbrev@1.1.1',
+      'bar@2.0.0',
+      'baz@1.0.0',
+      'dash-separated-pkg@1.0.0',
+      'dasher@2.0.0',
+      'foo@2.2.2',
+      'ipsum@npm:sit@1.0.0',
+      'lorem@1.0.0',
+      'moo@3.0.0',
+      'recur@1.0.0',
+      'sive@1.0.0',
+    ]],
     [':path(node_modules/bar)', ['bar@2.0.0']],
     [':path(./node_modules/bar)', ['bar@2.0.0']],
     [':path(node_modules/foo/node_modules/bar)', ['bar@1.4.0']],
     [':path(**/bar)', ['bar@2.0.0', 'bar@1.4.0']],
     [':path(*)', ['a@1.0.0', 'b@1.0.0', 'c@1.0.0']],
-    [
-      ':path()',
-      [
-        'query-selector-all-tests@1.0.0',
-        'a@1.0.0',
-        'b@1.0.0',
-        'c@1.0.0',
-        '@npmcli/abbrev@2.0.0-beta.45',
-        'abbrev@1.1.1',
-        'bar@2.0.0',
-        'baz@1.0.0',
-        'dash-separated-pkg@1.0.0',
-        'dasher@2.0.0',
-        'foo@2.2.2',
-        'bar@1.4.0',
-        'ipsum@npm:sit@1.0.0',
-        'lorem@1.0.0',
-        'moo@3.0.0',
-        'recur@1.0.0',
-        'sive@1.0.0',
-      ],
-    ],
+    [':path()', [
+      'query-selector-all-tests@1.0.0',
+      'a@1.0.0',
+      'b@1.0.0',
+      'c@1.0.0',
+      '@npmcli/abbrev@2.0.0-beta.45',
+      'abbrev@1.1.1',
+      'bar@2.0.0',
+      'baz@1.0.0',
+      'dash-separated-pkg@1.0.0',
+      'dasher@2.0.0',
+      'foo@2.2.2',
+      'bar@1.4.0',
+      'ipsum@npm:sit@1.0.0',
+      'lorem@1.0.0',
+      'moo@3.0.0',
+      'recur@1.0.0',
+      'sive@1.0.0',
+    ]],
 
     // semver pseudo
-    [
-      ':semver()',
-      [
-        'query-selector-all-tests@1.0.0',
-        'a@1.0.0',
-        'b@1.0.0',
-        'c@1.0.0',
-        '@npmcli/abbrev@2.0.0-beta.45',
-        'abbrev@1.1.1',
-        'bar@2.0.0',
-        'baz@1.0.0',
-        'dash-separated-pkg@1.0.0',
-        'dasher@2.0.0',
-        'foo@2.2.2',
-        'bar@1.4.0',
-        'ipsum@npm:sit@1.0.0',
-        'lorem@1.0.0',
-        'moo@3.0.0',
-        'recur@1.0.0',
-        'sive@1.0.0',
-      ],
-    ],
-    [
-      ':semver(*)',
-      [
-        'query-selector-all-tests@1.0.0',
-        'a@1.0.0',
-        'b@1.0.0',
-        'c@1.0.0',
-        'abbrev@1.1.1',
-        'bar@2.0.0',
-        'baz@1.0.0',
-        'dash-separated-pkg@1.0.0',
-        'dasher@2.0.0',
-        'foo@2.2.2',
-        'bar@1.4.0',
-        'ipsum@npm:sit@1.0.0',
-        'lorem@1.0.0',
-        'moo@3.0.0',
-        'recur@1.0.0',
-        'sive@1.0.0',
-      ],
-    ],
-    [':semver(2.0.0)', ['bar@2.0.0', 'dasher@2.0.0']],
-    [':semver(>=2)', ['bar@2.0.0', 'dasher@2.0.0', 'foo@2.2.2', 'moo@3.0.0']],
-    [':semver(~2.0.x)', ['bar@2.0.0', 'dasher@2.0.0']],
-    [':semver(2 - 3)', ['bar@2.0.0', 'dasher@2.0.0', 'foo@2.2.2', 'moo@3.0.0']],
+    [':semver()', [
+      'query-selector-all-tests@1.0.0',
+      'a@1.0.0',
+      'b@1.0.0',
+      'c@1.0.0',
+      '@npmcli/abbrev@2.0.0-beta.45',
+      'abbrev@1.1.1',
+      'bar@2.0.0',
+      'baz@1.0.0',
+      'dash-separated-pkg@1.0.0',
+      'dasher@2.0.0',
+      'foo@2.2.2',
+      'bar@1.4.0',
+      'ipsum@npm:sit@1.0.0',
+      'lorem@1.0.0',
+      'moo@3.0.0',
+      'recur@1.0.0',
+      'sive@1.0.0',
+    ]],
+    [':semver(*)', [
+      'query-selector-all-tests@1.0.0',
+      'a@1.0.0',
+      'b@1.0.0',
+      'c@1.0.0',
+      'abbrev@1.1.1',
+      'bar@2.0.0',
+      'baz@1.0.0',
+      'dash-separated-pkg@1.0.0',
+      'dasher@2.0.0',
+      'foo@2.2.2',
+      'bar@1.4.0',
+      'ipsum@npm:sit@1.0.0',
+      'lorem@1.0.0',
+      'moo@3.0.0',
+      'recur@1.0.0',
+      'sive@1.0.0',
+    ]],
+    [':semver(2.0.0)', [
+      'bar@2.0.0',
+      'dasher@2.0.0',
+    ]],
+    [':semver(>=2)', [
+      'bar@2.0.0',
+      'dasher@2.0.0',
+      'foo@2.2.2',
+      'moo@3.0.0',
+    ]],
+    [':semver(~2.0.x)', [
+      'bar@2.0.0',
+      'dasher@2.0.0',
+    ]],
+    [':semver(2 - 3)', [
+      'bar@2.0.0',
+      'dasher@2.0.0',
+      'foo@2.2.2',
+      'moo@3.0.0',
+    ]],
     [':semver(=1.4.0)', ['bar@1.4.0']],
     [':semver(1.4.0 || 2.2.2)', ['foo@2.2.2', 'bar@1.4.0']],
     [':semver(^16.0.0, :attr(engines, [node]))', ['abbrev@1.1.1', 'bar@2.0.0']],
@@ -695,223 +694,152 @@ t.test('query-selector-all', async (t) => {
     [':semver(^16.0.0, :attr(engines, [node^=">="]))', ['bar@2.0.0']],
     [':semver(3.0.0, [version], eq)', ['moo@3.0.0']],
     [':semver(^3.0.0, [version], eq)', []],
-    [
-      ':semver(1.0.0, [version], neq)',
-      [
-        '@npmcli/abbrev@2.0.0-beta.45',
-        'abbrev@1.1.1',
-        'bar@2.0.0',
-        'dasher@2.0.0',
-        'foo@2.2.2',
-        'bar@1.4.0',
-        'moo@3.0.0',
-      ],
-    ],
+    [':semver(1.0.0, [version], neq)', [
+      '@npmcli/abbrev@2.0.0-beta.45',
+      'abbrev@1.1.1',
+      'bar@2.0.0',
+      'dasher@2.0.0',
+      'foo@2.2.2',
+      'bar@1.4.0',
+      'moo@3.0.0',
+    ]],
     [':semver(^1.0.0, [version], neq)', []],
     [':semver(2.0.0, [version], gt)', ['foo@2.2.2', 'moo@3.0.0']],
     [':semver(^2.0.0, [version], gt)', []],
-    [
-      ':semver(2.0.0, [version], gte)',
-      ['bar@2.0.0', 'dasher@2.0.0', 'foo@2.2.2', 'moo@3.0.0'],
-    ],
+    [':semver(2.0.0, [version], gte)', [
+      'bar@2.0.0',
+      'dasher@2.0.0',
+      'foo@2.2.2',
+      'moo@3.0.0',
+    ]],
     [':semver(^2.0.0, [version], gte)', []],
-    [
-      ':semver(1.1.1, [version], lt)',
-      [
-        'query-selector-all-tests@1.0.0',
-        'a@1.0.0',
-        'b@1.0.0',
-        'c@1.0.0',
-        'baz@1.0.0',
-        'dash-separated-pkg@1.0.0',
-        'ipsum@npm:sit@1.0.0',
-        'lorem@1.0.0',
-        'recur@1.0.0',
-        'sive@1.0.0',
-      ],
-    ],
+    [':semver(1.1.1, [version], lt)', [
+      'query-selector-all-tests@1.0.0',
+      'a@1.0.0',
+      'b@1.0.0',
+      'c@1.0.0',
+      'baz@1.0.0',
+      'dash-separated-pkg@1.0.0',
+      'ipsum@npm:sit@1.0.0',
+      'lorem@1.0.0',
+      'recur@1.0.0',
+      'sive@1.0.0',
+    ]],
     [':semver(^1.1.1, [version], lt)', []],
-    [
-      ':semver(1.1.1, [version], lte)',
-      [
-        'query-selector-all-tests@1.0.0',
-        'a@1.0.0',
-        'b@1.0.0',
-        'c@1.0.0',
-        'abbrev@1.1.1',
-        'baz@1.0.0',
-        'dash-separated-pkg@1.0.0',
-        'ipsum@npm:sit@1.0.0',
-        'lorem@1.0.0',
-        'recur@1.0.0',
-        'sive@1.0.0',
-      ],
-    ],
+    [':semver(1.1.1, [version], lte)', [
+      'query-selector-all-tests@1.0.0',
+      'a@1.0.0',
+      'b@1.0.0',
+      'c@1.0.0',
+      'abbrev@1.1.1',
+      'baz@1.0.0',
+      'dash-separated-pkg@1.0.0',
+      'ipsum@npm:sit@1.0.0',
+      'lorem@1.0.0',
+      'recur@1.0.0',
+      'sive@1.0.0',
+    ]],
     [':semver(^1.1.1, [version], lte)', []],
     [':semver(^14.0.0, :attr(engines, [node]), intersects)', ['bar@2.0.0']],
-    [
-      ':semver(>=14, :attr(engines, [node]), subset)',
-      ['abbrev@1.1.1', 'bar@2.0.0'],
-    ],
+    [':semver(>=14, :attr(engines, [node]), subset)', ['abbrev@1.1.1', 'bar@2.0.0']],
     [':semver(^2.0.0, [version], gtr)', ['moo@3.0.0']],
     [':semver(^2.0.0, :attr(engines, [node]), gtr)', []],
     [':semver(20.0.0, :attr(engines, [node]), gtr)', ['abbrev@1.1.1']],
-    [
-      ':semver(1.0.1, [version], gtr)',
-      [
-        'query-selector-all-tests@1.0.0',
-        'a@1.0.0',
-        'b@1.0.0',
-        'c@1.0.0',
-        'baz@1.0.0',
-        'dash-separated-pkg@1.0.0',
-        'ipsum@npm:sit@1.0.0',
-        'lorem@1.0.0',
-        'recur@1.0.0',
-        'sive@1.0.0',
-      ],
-    ],
-    [
-      ':semver(^1.1.1, [version], ltr)',
-      [
-        'query-selector-all-tests@1.0.0',
-        'a@1.0.0',
-        'b@1.0.0',
-        'c@1.0.0',
-        'baz@1.0.0',
-        'dash-separated-pkg@1.0.0',
-        'ipsum@npm:sit@1.0.0',
-        'lorem@1.0.0',
-        'recur@1.0.0',
-        'sive@1.0.0',
-      ],
-    ],
+    [':semver(1.0.1, [version], gtr)', [
+      'query-selector-all-tests@1.0.0',
+      'a@1.0.0',
+      'b@1.0.0',
+      'c@1.0.0',
+      'baz@1.0.0',
+      'dash-separated-pkg@1.0.0',
+      'ipsum@npm:sit@1.0.0',
+      'lorem@1.0.0',
+      'recur@1.0.0',
+      'sive@1.0.0',
+    ]],
+    [':semver(^1.1.1, [version], ltr)', [
+      'query-selector-all-tests@1.0.0',
+      'a@1.0.0',
+      'b@1.0.0',
+      'c@1.0.0',
+      'baz@1.0.0',
+      'dash-separated-pkg@1.0.0',
+      'ipsum@npm:sit@1.0.0',
+      'lorem@1.0.0',
+      'recur@1.0.0',
+      'sive@1.0.0',
+    ]],
     [':semver(^1.1.1, :attr(engines, [node]), ltr)', []],
-    [
-      ':semver(0.0.1, :attr(engines, [node]), ltr)',
-      ['abbrev@1.1.1', 'bar@2.0.0'],
-    ],
-    [
-      ':semver(1.1.1, [version], ltr)',
-      [
-        '@npmcli/abbrev@2.0.0-beta.45',
-        'bar@2.0.0',
-        'dasher@2.0.0',
-        'foo@2.2.2',
-        'bar@1.4.0',
-        'moo@3.0.0',
-      ],
-    ],
+    [':semver(0.0.1, :attr(engines, [node]), ltr)', ['abbrev@1.1.1', 'bar@2.0.0']],
+    [':semver(1.1.1, [version], ltr)', [
+      '@npmcli/abbrev@2.0.0-beta.45',
+      'bar@2.0.0',
+      'dasher@2.0.0',
+      'foo@2.2.2',
+      'bar@1.4.0',
+      'moo@3.0.0',
+    ]],
 
     // outdated pseudo
-    [
-      ':outdated',
-      [
-        'abbrev@1.1.1', // 1.2.0 is available
-        'baz@1.0.0', // 1.0.1 is available
-        'dash-separated-pkg@1.0.0', // 2.0.0 is available
-        'bar@1.4.0', // 2.0.0 is available
-      ],
-    ],
-    [
-      ':outdated(any)',
-      [
-        'abbrev@1.1.1', // 1.2.0 is available
-        'baz@1.0.0', // 1.0.1 is available
-        'dash-separated-pkg@1.0.0', // 2.0.0 is available
-        'bar@1.4.0', // 2.0.0 is available
-      ],
-    ],
-    [
-      ':outdated(major)',
-      [
-        'dash-separated-pkg@1.0.0', // 2.0.0 is available
-        'bar@1.4.0', // 2.0.0 is available
-      ],
-    ],
-    [
-      ':outdated(minor)',
-      [
-        'abbrev@1.1.1', // 1.2.0 is available
-      ],
-    ],
-    [
-      ':outdated(patch)',
-      [
-        'baz@1.0.0', // 1.0.1 is available
-      ],
-    ],
-    [
-      ':outdated(in-range)',
-      [
-        'abbrev@1.1.1', // 1.2.0 is available and in-range
-        'baz@1.0.0', // 1.0.1 is available and in-range
-      ],
-    ],
-    [
-      ':outdated(out-of-range)',
-      [
-        'dash-separated-pkg@1.0.0', // 2.0.0 is available
-        'bar@1.4.0', // 2.0.0 is available and out-of-range
-      ],
-    ],
+    [':outdated', [
+      'abbrev@1.1.1', // 1.2.0 is available
+      'baz@1.0.0', // 1.0.1 is available
+      'dash-separated-pkg@1.0.0', // 2.0.0 is available
+      'bar@1.4.0', // 2.0.0 is available
+    ]],
+    [':outdated(any)', [
+      'abbrev@1.1.1', // 1.2.0 is available
+      'baz@1.0.0', // 1.0.1 is available
+      'dash-separated-pkg@1.0.0', // 2.0.0 is available
+      'bar@1.4.0', // 2.0.0 is available
+    ]],
+    [':outdated(major)', [
+      'dash-separated-pkg@1.0.0', // 2.0.0 is available
+      'bar@1.4.0', // 2.0.0 is available
+    ]],
+    [':outdated(minor)', [
+      'abbrev@1.1.1', // 1.2.0 is available
+    ]],
+    [':outdated(patch)', [
+      'baz@1.0.0', // 1.0.1 is available
+    ]],
+    [':outdated(in-range)', [
+      'abbrev@1.1.1', // 1.2.0 is available and in-range
+      'baz@1.0.0', // 1.0.1 is available and in-range
+    ]],
+    [':outdated(out-of-range)', [
+      'dash-separated-pkg@1.0.0', // 2.0.0 is available
+      'bar@1.4.0', // 2.0.0 is available and out-of-range
+    ]],
     [':outdated(nonsense)', []], // invalid, no results ever
 
     // :outdated combined with --before
-    [
-      ':outdated',
-      [
-        'abbrev@1.1.1', // 1.2.0 is available and published yesterday
-        'baz@1.0.0', // 1.0.1 is available and published yesterday
-        'dash-separated-pkg@1.0.0', // 2.0.0 is available and published yesterday
-      ],
-      { before: yesterday },
-    ],
-    [
-      ':outdated(any)',
-      [
-        'abbrev@1.1.1', // 1.2.0 is available and published yesterday
-        'baz@1.0.0', // 1.0.1 is available and published yesterday
-        'dash-separated-pkg@1.0.0', // 2.0.0 is available and published yesterday
-      ],
-      { before: yesterday },
-    ],
-    [
-      ':outdated(major)',
-      [
-        'dash-separated-pkg@1.0.0', // 2.0.0 is available and published yesterday
-      ],
-      { before: yesterday },
-    ],
-    [
-      ':outdated(minor)',
-      [
-        'abbrev@1.1.1', // 1.2.0 is available and published yesterday
-      ],
-      { before: yesterday },
-    ],
-    [
-      ':outdated(patch)',
-      [
-        'baz@1.0.0', // 1.0.1 is available and published yesterday
-      ],
-      { before: yesterday },
-    ],
-    [
-      ':outdated(in-range)',
-      [
-        'abbrev@1.1.1', // 1.2.0 is available, in-range and published yesterday
-        'baz@1.0.0', // 1.0.1 is available, in-range and published yesterday
-      ],
-      { before: yesterday },
-    ],
-    [
-      ':outdated(out-of-range)',
-      [
-        'dash-separated-pkg@1.0.0', // 2.0.0 is available, out-of-range and published yesterday
-      ],
-      { before: yesterday },
-    ],
+    [':outdated', [
+      'abbrev@1.1.1', // 1.2.0 is available and published yesterday
+      'baz@1.0.0', // 1.0.1 is available and published yesterday
+      'dash-separated-pkg@1.0.0', // 2.0.0 is available and published yesterday
+    ], { before: yesterday }],
+    [':outdated(any)', [
+      'abbrev@1.1.1', // 1.2.0 is available and published yesterday
+      'baz@1.0.0', // 1.0.1 is available and published yesterday
+      'dash-separated-pkg@1.0.0', // 2.0.0 is available and published yesterday
+    ], { before: yesterday }],
+    [':outdated(major)', [
+      'dash-separated-pkg@1.0.0', // 2.0.0 is available and published yesterday
+    ], { before: yesterday }],
+    [':outdated(minor)', [
+      'abbrev@1.1.1', // 1.2.0 is available and published yesterday
+    ], { before: yesterday }],
+    [':outdated(patch)', [
+      'baz@1.0.0', // 1.0.1 is available and published yesterday
+    ], { before: yesterday }],
+    [':outdated(in-range)', [
+      'abbrev@1.1.1', // 1.2.0 is available, in-range and published yesterday
+      'baz@1.0.0', // 1.0.1 is available, in-range and published yesterday
+    ], { before: yesterday }],
+    [':outdated(out-of-range)', [
+      'dash-separated-pkg@1.0.0', // 2.0.0 is available, out-of-range and published yesterday
+    ], { before: yesterday }],
     [':outdated(nonsense)', [], { before: yesterday }], // again, no results here ever
 
     // attr pseudo
@@ -928,29 +856,28 @@ t.test('query-selector-all', async (t) => {
     [':attr(arbitrary, :attr([foo=10000]))', ['bar@2.0.0']],
 
     // attribute matchers
-    ['[scripts]', ['baz@1.0.0']],
-    [
-      '[name]',
-      [
-        'query-selector-all-tests@1.0.0',
-        'a@1.0.0',
-        'b@1.0.0',
-        'c@1.0.0',
-        '@npmcli/abbrev@2.0.0-beta.45',
-        'abbrev@1.1.1',
-        'bar@2.0.0',
-        'baz@1.0.0',
-        'dash-separated-pkg@1.0.0',
-        'dasher@2.0.0',
-        'foo@2.2.2',
-        'bar@1.4.0',
-        'ipsum@npm:sit@1.0.0',
-        'lorem@1.0.0',
-        'moo@3.0.0',
-        'recur@1.0.0',
-        'sive@1.0.0',
-      ],
-    ],
+    ['[scripts]', [
+      'baz@1.0.0',
+    ]],
+    ['[name]', [
+      'query-selector-all-tests@1.0.0',
+      'a@1.0.0',
+      'b@1.0.0',
+      'c@1.0.0',
+      '@npmcli/abbrev@2.0.0-beta.45',
+      'abbrev@1.1.1',
+      'bar@2.0.0',
+      'baz@1.0.0',
+      'dash-separated-pkg@1.0.0',
+      'dasher@2.0.0',
+      'foo@2.2.2',
+      'bar@1.4.0',
+      'ipsum@npm:sit@1.0.0',
+      'lorem@1.0.0',
+      'moo@3.0.0',
+      'recur@1.0.0',
+      'sive@1.0.0',
+    ]],
     ['[name=a]', ['a@1.0.0']],
     ['[name=@npmcli/abbrev]', ['@npmcli/abbrev@2.0.0-beta.45']],
     ['[name=a], [name=b]', ['a@1.0.0', 'b@1.0.0']],
@@ -958,100 +885,88 @@ t.test('query-selector-all', async (t) => {
     ['[name^=a]', ['a@1.0.0', 'abbrev@1.1.1']],
     ['[name|=dash]', ['dash-separated-pkg@1.0.0']],
     ['[name$=oo]', ['foo@2.2.2', 'moo@3.0.0']],
-    ['[description]', ['dash-separated-pkg@1.0.0', 'dasher@2.0.0']],
+    ['[description]', [
+      'dash-separated-pkg@1.0.0',
+      'dasher@2.0.0',
+    ]],
     ['[description~=ever]', ['dasher@2.0.0']],
-    ['[description~=best]', ['dash-separated-pkg@1.0.0', 'dasher@2.0.0']],
-    [
-      '[name*=a]',
-      [
-        'query-selector-all-tests@1.0.0',
-        'a@1.0.0',
-        '@npmcli/abbrev@2.0.0-beta.45',
-        'abbrev@1.1.1',
-        'bar@2.0.0',
-        'baz@1.0.0',
-        'dash-separated-pkg@1.0.0',
-        'dasher@2.0.0',
-        'bar@1.4.0',
-      ],
-    ],
+    ['[description~=best]', [
+      'dash-separated-pkg@1.0.0',
+      'dasher@2.0.0',
+    ]],
+    ['[name*=a]', [
+      'query-selector-all-tests@1.0.0',
+      'a@1.0.0',
+      '@npmcli/abbrev@2.0.0-beta.45',
+      'abbrev@1.1.1',
+      'bar@2.0.0',
+      'baz@1.0.0',
+      'dash-separated-pkg@1.0.0',
+      'dasher@2.0.0',
+      'bar@1.4.0',
+    ]],
     ['[arbitrary^=foo]', ['foo@2.2.2']],
     ['[license=ISC]', ['abbrev@1.1.1', 'baz@1.0.0']],
     ['[license=isc i]', ['abbrev@1.1.1', 'baz@1.0.0']],
 
     // types
-    [
-      '.prod',
-      [
-        'query-selector-all-tests@1.0.0',
-        'a@1.0.0',
-        'b@1.0.0',
-        'c@1.0.0',
-        'abbrev@1.1.1',
-        'bar@2.0.0',
-        'baz@1.0.0',
-        'ipsum@npm:sit@1.0.0',
-        'lorem@1.0.0',
-        'moo@3.0.0',
-      ],
-    ],
+    ['.prod', [
+      'query-selector-all-tests@1.0.0',
+      'a@1.0.0',
+      'b@1.0.0',
+      'c@1.0.0',
+      'abbrev@1.1.1',
+      'bar@2.0.0',
+      'baz@1.0.0',
+      'ipsum@npm:sit@1.0.0',
+      'lorem@1.0.0',
+      'moo@3.0.0',
+    ]],
     ['.workspace', ['a@1.0.0', 'b@1.0.0', 'c@1.0.0']],
     ['.workspace > *', ['a@1.0.0', 'b@1.0.0', 'bar@2.0.0', 'baz@1.0.0']],
     ['.workspace .workspace', ['a@1.0.0', 'b@1.0.0']],
     ['.workspace .workspace .workspace', ['a@1.0.0']],
-    [
-      '.workspace ~ *',
-      [
-        'abbrev@1.1.1',
-        'bar@2.0.0',
-        'foo@2.2.2',
-        'ipsum@npm:sit@1.0.0',
-        'moo@3.0.0',
-        'recur@1.0.0',
-      ],
-    ],
-    [
-      '.dev',
-      [
-        '@npmcli/abbrev@2.0.0-beta.45',
-        'a@1.0.0',
-        'dash-separated-pkg@1.0.0',
-        'dasher@2.0.0',
-        'foo@2.2.2',
-        'bar@1.4.0',
-        'moo@3.0.0',
-        'recur@1.0.0',
-        'sive@1.0.0',
-      ],
-    ],
-    [
-      '.dev *',
-      [
-        'baz@1.0.0',
-        'dash-separated-pkg@1.0.0',
-        'dasher@2.0.0',
-        'bar@1.4.0',
-        'lorem@1.0.0',
-        'recur@1.0.0',
-        'sive@1.0.0',
-      ],
-    ],
+    ['.workspace ~ *', [
+      'abbrev@1.1.1',
+      'bar@2.0.0',
+      'foo@2.2.2',
+      'ipsum@npm:sit@1.0.0',
+      'moo@3.0.0',
+      'recur@1.0.0',
+    ]],
+    ['.dev', [
+      '@npmcli/abbrev@2.0.0-beta.45',
+      'a@1.0.0',
+      'dash-separated-pkg@1.0.0',
+      'dasher@2.0.0',
+      'foo@2.2.2',
+      'bar@1.4.0',
+      'moo@3.0.0',
+      'recur@1.0.0',
+      'sive@1.0.0',
+    ]],
+    ['.dev *', [
+      'baz@1.0.0',
+      'dash-separated-pkg@1.0.0',
+      'dasher@2.0.0',
+      'bar@1.4.0',
+      'lorem@1.0.0',
+      'recur@1.0.0',
+      'sive@1.0.0',
+    ]],
     ['.peer', ['@npmcli/abbrev@2.0.0-beta.45', 'dasher@2.0.0']],
     ['.optional', ['@npmcli/abbrev@2.0.0-beta.45', 'baz@1.0.0', 'lorem@1.0.0']],
     ['.bundled', ['abbrev@1.1.1']],
-    [
-      '.bundled ~ *',
-      [
-        'a@1.0.0',
-        'b@1.0.0',
-        'c@1.0.0',
-        'bar@2.0.0',
-        'foo@2.2.2',
-        'ipsum@npm:sit@1.0.0',
-        'moo@3.0.0',
-        'recur@1.0.0',
-      ],
-    ],
+    ['.bundled ~ *', [
+      'a@1.0.0',
+      'b@1.0.0',
+      'c@1.0.0',
+      'bar@2.0.0',
+      'foo@2.2.2',
+      'ipsum@npm:sit@1.0.0',
+      'moo@3.0.0',
+      'recur@1.0.0',
+    ]],
 
     // id selector
     ['#bar', ['bar@2.0.0', 'bar@1.4.0']],
@@ -1083,10 +998,7 @@ t.test('query-selector-all', async (t) => {
     [':root #bar:semver(1) > *', ['dasher@2.0.0']],
     [':root #bar:semver(1) ~ *', ['dash-separated-pkg@1.0.0']],
     ['#bar:semver(2), #foo', ['bar@2.0.0', 'foo@2.2.2']],
-    [
-      '#a, #bar:semver(2), #foo:semver(2.2.2)',
-      ['a@1.0.0', 'bar@2.0.0', 'foo@2.2.2'],
-    ],
+    ['#a, #bar:semver(2), #foo:semver(2.2.2)', ['a@1.0.0', 'bar@2.0.0', 'foo@2.2.2']],
     ['#b *', ['a@1.0.0', 'bar@2.0.0', 'baz@1.0.0', 'lorem@1.0.0', 'moo@3.0.0']],
   ])
 })

--- a/workspaces/arborist/test/query-selector-all.js
+++ b/workspaces/arborist/test/query-selector-all.js
@@ -10,10 +10,10 @@ const q = require('../lib/query-selector-all.js')
 // and deduplicates link/target from results
 const querySelectorAll = async (tree, query, options) => {
   const res = await q(tree, query, options)
-  return [...new Set(res.map(i => i.pkgid))]
+  return [...new Set(res.map((i) => i.pkgid))]
 }
 
-t.test('query-selector-all', async t => {
+t.test('query-selector-all', async (t) => {
   /*
    fixture tree:
 
@@ -28,6 +28,8 @@ t.test('query-selector-all', async t => {
     │ └── bar@2.0.0 (production dep of b, deduped)
     ├─┬ bar@2.0.0 (production dep of query-selector-all-tests)
     │ └── moo@3.0.0 (production dep of bar)
+    |-┬ c@1.0.0 -> ./c (workspace)
+    │ └── b@1.0.0 (production dep of c, deduped)
     ├─┬ foo@2.2.2 (dev dep of query-selector-all-tests)
     │ ├─┬ bar@1.4.0 (production dep of foo, deduped)
     │ │ └── dasher@2.0.0 (overridden peer dep of bar)
@@ -41,8 +43,8 @@ t.test('query-selector-all', async t => {
 
   const now = Date.now()
   const today = new Date(now)
-  const yesterday = new Date(now - (1000 * 60 * 60 * 24))
-  const dayBeforeYesterday = new Date(now - (1000 * 60 * 60 * 24 * 2))
+  const yesterday = new Date(now - 1000 * 60 * 60 * 24)
+  const dayBeforeYesterday = new Date(now - 1000 * 60 * 60 * 24 * 2)
   // @npmcli/abbrev is deliberately left out of this list to cover the case when
   // fetching a packument fails
   const packumentStubs = {
@@ -64,6 +66,9 @@ t.test('query-selector-all', async t => {
       // undefined for coverage in --before mode
       '1.0.0': undefined,
       '1.0.1': yesterday,
+    },
+    c: {
+      '1.0.0': today,
     },
     'dash-separated-pkg': {
       '1.0.0': dayBeforeYesterday,
@@ -173,6 +178,7 @@ t.test('query-selector-all', async t => {
           },
         }),
       },
+      c: t.fixture('symlink', '../c'),
       foo: {
         node_modules: {
           bar: {
@@ -227,9 +233,7 @@ t.test('query-selector-all', async t => {
           devDependencies: {
             moo: '^3.0.0',
           },
-          funding: [
-            { type: 'GitHub', url: 'https://github.com/sponsors' },
-          ],
+          funding: [{ type: 'GitHub', url: 'https://github.com/sponsors' }],
         }),
       },
       moo: {
@@ -257,28 +261,41 @@ t.test('query-selector-all', async t => {
         }),
       },
     },
-    a: { 'package.json': JSON.stringify({
-      name: 'a',
-      version: '1.0.0',
-      optionalDependencies: {
-        baz: '^1.0.0',
-      },
-    }) },
-    b: { 'package.json': JSON.stringify({
-      name: 'b',
-      version: '1.0.0',
-      private: true,
-      devDependencies: {
-        a: '^1.0.0',
-      },
-      dependencies: {
-        bar: '^2.0.0',
-      },
-    }) },
+    a: {
+      'package.json': JSON.stringify({
+        name: 'a',
+        version: '1.0.0',
+        optionalDependencies: {
+          baz: '^1.0.0',
+        },
+      }),
+    },
+    b: {
+      'package.json': JSON.stringify({
+        name: 'b',
+        version: '1.0.0',
+        private: true,
+        devDependencies: {
+          a: '^1.0.0',
+        },
+        dependencies: {
+          bar: '^2.0.0',
+        },
+      }),
+    },
+    c: {
+      'package.json': JSON.stringify({
+        name: 'c',
+        version: '1.0.0',
+        dependencies: {
+          b: '^1.0.0',
+        },
+      }),
+    },
     'package.json': JSON.stringify({
       name: 'query-selector-all-tests',
       version: '1.0.0',
-      workspaces: ['a', 'b'],
+      workspaces: ['a', 'b', 'c'],
       dependencies: {
         a: '^1.0.0',
         abbrev: '^1.1.1',
@@ -354,89 +371,99 @@ t.test('query-selector-all', async t => {
   t.same(scopeRes, ['foo@2.2.2'], ':scope')
 
   const scopeChildren = await querySelectorAll(nodeFoo, ':scope > *')
-  t.same(scopeChildren, [
-    'dash-separated-pkg@1.0.0',
-    'bar@1.4.0',
-  ], ':scope > *')
+  t.same(
+    scopeChildren,
+    ['dash-separated-pkg@1.0.0', 'bar@1.4.0'],
+    ':scope > *'
+  )
 
-  const runSpecParsing = async testCase => {
+  const runSpecParsing = async (testCase) => {
     for (const [selector, expected, options = {}] of testCase) {
       let title = selector
       if (options.before) {
-        const friendlyTime = options.before === today
-          ? 'today'
-          : options.before === yesterday
-            ? 'yesterday'
-            : options.before
+        const friendlyTime =
+          options.before === today
+            ? 'today'
+            : options.before === yesterday
+              ? 'yesterday'
+              : options.before
         title += ` before ${friendlyTime}`
       }
-      t.test(title, async t => {
+      t.test(title, async (t) => {
         const res = await querySelectorAll(tree, selector, options)
-        t.same(
-          res,
-          expected,
-          title
-        )
+        t.same(res, expected, title)
       })
     }
   }
 
   await runSpecParsing([
     // universal selector
-    ['*', [
-      'query-selector-all-tests@1.0.0',
-      'a@1.0.0',
-      'b@1.0.0',
-      '@npmcli/abbrev@2.0.0-beta.45',
-      'abbrev@1.1.1',
-      'bar@2.0.0',
-      'baz@1.0.0',
-      'dash-separated-pkg@1.0.0',
-      'dasher@2.0.0',
-      'foo@2.2.2',
-      'bar@1.4.0',
-      'ipsum@npm:sit@1.0.0',
-      'lorem@1.0.0',
-      'moo@3.0.0',
-      'recur@1.0.0',
-      'sive@1.0.0',
-    ]],
-    ['* > *', [
-      'a@1.0.0',
-      'b@1.0.0',
-      'abbrev@1.1.1',
-      'bar@2.0.0',
-      'baz@1.0.0',
-      'dash-separated-pkg@1.0.0',
-      'dasher@2.0.0',
-      'foo@2.2.2',
-      'bar@1.4.0',
-      'ipsum@npm:sit@1.0.0',
-      'lorem@1.0.0',
-      'moo@3.0.0',
-      'recur@1.0.0',
-      'sive@1.0.0',
-    ]],
+    [
+      '*',
+      [
+        'query-selector-all-tests@1.0.0',
+        'a@1.0.0',
+        'b@1.0.0',
+        'c@1.0.0',
+        '@npmcli/abbrev@2.0.0-beta.45',
+        'abbrev@1.1.1',
+        'bar@2.0.0',
+        'baz@1.0.0',
+        'dash-separated-pkg@1.0.0',
+        'dasher@2.0.0',
+        'foo@2.2.2',
+        'bar@1.4.0',
+        'ipsum@npm:sit@1.0.0',
+        'lorem@1.0.0',
+        'moo@3.0.0',
+        'recur@1.0.0',
+        'sive@1.0.0',
+      ],
+    ],
+    [
+      '* > *',
+      [
+        'a@1.0.0',
+        'b@1.0.0',
+        'c@1.0.0',
+        'abbrev@1.1.1',
+        'bar@2.0.0',
+        'baz@1.0.0',
+        'dash-separated-pkg@1.0.0',
+        'dasher@2.0.0',
+        'foo@2.2.2',
+        'bar@1.4.0',
+        'ipsum@npm:sit@1.0.0',
+        'lorem@1.0.0',
+        'moo@3.0.0',
+        'recur@1.0.0',
+        'sive@1.0.0',
+      ],
+    ],
     ['> #a', ['a@1.0.0']],
 
     // pseudo :root
     [':root', ['query-selector-all-tests@1.0.0']],
     [':scope', ['query-selector-all-tests@1.0.0']], // same as root in this context
-    [':root > *', [
-      'a@1.0.0',
-      'b@1.0.0',
-      'abbrev@1.1.1',
-      'bar@2.0.0',
-      'foo@2.2.2',
-      'ipsum@npm:sit@1.0.0',
-      'moo@3.0.0',
-      'recur@1.0.0',
-    ]],
-    [':root > .workspace', ['a@1.0.0', 'b@1.0.0']],
-    [':root > *.workspace', ['a@1.0.0', 'b@1.0.0']],
+    [
+      ':root > *',
+      [
+        'a@1.0.0',
+        'b@1.0.0',
+        'c@1.0.0',
+        'abbrev@1.1.1',
+        'bar@2.0.0',
+        'foo@2.2.2',
+        'ipsum@npm:sit@1.0.0',
+        'moo@3.0.0',
+        'recur@1.0.0',
+      ],
+    ],
+    [':root > .workspace', ['a@1.0.0', 'b@1.0.0', 'c@1.0.0']],
+    [':root > *.workspace', ['a@1.0.0', 'b@1.0.0', 'c@1.0.0']],
     [':root > .workspace[name=a]', ['a@1.0.0']],
     [':root > [name=bar]', ['bar@2.0.0']],
-    [':root > .workspace[version=1.0.0]', ['a@1.0.0', 'b@1.0.0']],
+    [':root > .workspace[version=1.0.0]', ['a@1.0.0', 'b@1.0.0', 'c@1.0.0']],
     [':root > .workspace[name=a][version=1.0.0]', ['a@1.0.0']],
     [':root > :root', []],
     ['* > :root', []],
@@ -447,219 +474,220 @@ t.test('query-selector-all', async t => {
     ['#a ~ :root', []],
 
     // pseudo miscelaneous
-    [':empty', [
-      '@npmcli/abbrev@2.0.0-beta.45',
-      'a@1.0.0',
-      'abbrev@1.1.1',
-      'b@1.0.0',
-      'dash-separated-pkg@1.0.0',
-      'dasher@2.0.0',
-      'lorem@1.0.0',
-      'moo@3.0.0',
-    ]],
-    [':root > :empty', [
-      'a@1.0.0',
-      'abbrev@1.1.1',
-      'b@1.0.0',
-      'moo@3.0.0',
-    ]],
+    [
+      ':empty',
+      [
+        '@npmcli/abbrev@2.0.0-beta.45',
+        'a@1.0.0',
+        'abbrev@1.1.1',
+        'b@1.0.0',
+        'c@1.0.0',
+        'dash-separated-pkg@1.0.0',
+        'dasher@2.0.0',
+        'lorem@1.0.0',
+        'moo@3.0.0',
+      ],
+    ],
+    [':root > :empty', ['a@1.0.0', 'abbrev@1.1.1', 'b@1.0.0', 'c@1.0.0', 'moo@3.0.0']],
     [':extraneous', ['@npmcli/abbrev@2.0.0-beta.45']],
     [':invalid', ['lorem@1.0.0']],
-    [':link', ['a@1.0.0', 'b@1.0.0']],
-    [':link', ['a@1.0.0', 'b@1.0.0']],
-    [':deduped', [
-      'bar@2.0.0',
-      'moo@3.0.0',
-      'recur@1.0.0',
-    ]],
+    [':link', ['a@1.0.0', 'b@1.0.0', 'c@1.0.0']],
+    [':deduped', ['bar@2.0.0', 'moo@3.0.0', 'recur@1.0.0']],
     [':missing', ['missing-dep@^1.0.0']],
     [':private', ['b@1.0.0']],
     [':overridden', ['dasher@2.0.0']],
 
     // :not pseudo
-    [':not(#foo)', [
-      'query-selector-all-tests@1.0.0',
-      'a@1.0.0',
-      'b@1.0.0',
-      '@npmcli/abbrev@2.0.0-beta.45',
-      'abbrev@1.1.1',
-      'bar@2.0.0',
-      'baz@1.0.0',
-      'dash-separated-pkg@1.0.0',
-      'dasher@2.0.0',
-      'bar@1.4.0',
-      'ipsum@npm:sit@1.0.0',
-      'lorem@1.0.0',
-      'moo@3.0.0',
-      'recur@1.0.0',
-      'sive@1.0.0',
-    ]],
-    [':root > .workspace:not(#b)', ['a@1.0.0']],
-    [':root > .workspace > *:not(#bar)', ['a@1.0.0', 'baz@1.0.0']],
-    ['.bundled ~ :not(.workspace)', [
-      'bar@2.0.0',
-      'foo@2.2.2',
-      'ipsum@npm:sit@1.0.0',
-      'moo@3.0.0',
-      'recur@1.0.0',
-    ]],
-    ['*:root > *:empty:not(*[name^=a], #b)', ['moo@3.0.0']],
-    [':not(:not(:link))', [
-      'a@1.0.0',
-      'b@1.0.0',
-    ]],
+    [
+      ':not(#foo)',
+      [
+        'query-selector-all-tests@1.0.0',
+        'a@1.0.0',
+        'b@1.0.0',
+        'c@1.0.0',
+        '@npmcli/abbrev@2.0.0-beta.45',
+        'abbrev@1.1.1',
+        'bar@2.0.0',
+        'baz@1.0.0',
+        'dash-separated-pkg@1.0.0',
+        'dasher@2.0.0',
+        'bar@1.4.0',
+        'ipsum@npm:sit@1.0.0',
+        'lorem@1.0.0',
+        'moo@3.0.0',
+        'recur@1.0.0',
+        'sive@1.0.0',
+      ],
+    ],
+    [':root > .workspace:not(#b)', ['a@1.0.0', 'c@1.0.0']],
+    [':root > .workspace > *:not(#bar)', ['a@1.0.0', 'b@1.0.0', 'baz@1.0.0']],
+    [
+      '.bundled ~ :not(.workspace)',
+      [
+        'bar@2.0.0',
+        'foo@2.2.2',
+        'ipsum@npm:sit@1.0.0',
+        'moo@3.0.0',
+        'recur@1.0.0',
+      ],
+    ],
+    ['*:root > *:empty:not(*[name^=a], #b, #c)', ['moo@3.0.0']],
+    [':not(:not(:link))', ['a@1.0.0', 'b@1.0.0', 'c@1.0.0']],
 
     // has pseudo
     [':root > *:has(* > #bar:semver(1.4.0))', ['foo@2.2.2']],
     ['*:has(* > #bar:semver(1.4.0))', ['foo@2.2.2']],
     ['*:has(> #bar:semver(1.4.0))', ['foo@2.2.2']],
     ['.workspace:has(> * > #lorem)', ['a@1.0.0']],
-    ['.workspace:has(* #lorem, ~ #b)', ['a@1.0.0', 'b@1.0.0']],
+    ['.workspace:has(* #lorem, ~ #b)', ['a@1.0.0', 'b@1.0.0', 'c@1.0.0']],
 
     // is pseudo
     [':is(#a, #b) > *', ['a@1.0.0', 'bar@2.0.0', 'baz@1.0.0']],
     // TODO: ipsum is not empty but its child is missing so it doesn't return a
     // result here
-    [':root > *:is(.prod:not(:empty), .dev > [name=bar]) > *', [
-      'a@1.0.0',
-      'bar@2.0.0',
-      'baz@1.0.0',
-      'dasher@2.0.0',
-      'moo@3.0.0',
-    ]],
-    [':is(*:semver(2.0.0), :semver(=2.0.0-beta.45))', [
-      '@npmcli/abbrev@2.0.0-beta.45',
-      'bar@2.0.0',
-      'dasher@2.0.0',
-    ]],
+    [
+      ':root > *:is(.prod:not(:empty), .dev > [name=bar]) > *',
+      ['a@1.0.0', 'b@1.0.0', 'bar@2.0.0', 'baz@1.0.0', 'dasher@2.0.0', 'moo@3.0.0'],
+    ],
+    [
+      ':is(*:semver(2.0.0), :semver(=2.0.0-beta.45))',
+      ['@npmcli/abbrev@2.0.0-beta.45', 'bar@2.0.0', 'dasher@2.0.0'],
+    ],
 
     // type pseudo
-    [':type()', [
-      'query-selector-all-tests@1.0.0',
-      'a@1.0.0',
-      'b@1.0.0',
-      '@npmcli/abbrev@2.0.0-beta.45',
-      'abbrev@1.1.1',
-      'bar@2.0.0',
-      'baz@1.0.0',
-      'dash-separated-pkg@1.0.0',
-      'dasher@2.0.0',
-      'foo@2.2.2',
-      'bar@1.4.0',
-      'ipsum@npm:sit@1.0.0',
-      'lorem@1.0.0',
-      'moo@3.0.0',
-      'recur@1.0.0',
-      'sive@1.0.0',
-    ]],
+    [
+      ':type()',
+      [
+        'query-selector-all-tests@1.0.0',
+        'a@1.0.0',
+        'b@1.0.0',
+        'c@1.0.0',
+        '@npmcli/abbrev@2.0.0-beta.45',
+        'abbrev@1.1.1',
+        'bar@2.0.0',
+        'baz@1.0.0',
+        'dash-separated-pkg@1.0.0',
+        'dasher@2.0.0',
+        'foo@2.2.2',
+        'bar@1.4.0',
+        'ipsum@npm:sit@1.0.0',
+        'lorem@1.0.0',
+        'moo@3.0.0',
+        'recur@1.0.0',
+        'sive@1.0.0',
+      ],
+    ],
     [':type(tag)', ['lorem@1.0.0']],
     [':type(alias)', ['ipsum@npm:sit@1.0.0']],
-    [':type(range)', [
-      'a@1.0.0',
-      'abbrev@1.1.1',
-      'bar@2.0.0',
-      'baz@1.0.0',
-      'dash-separated-pkg@1.0.0',
-      'foo@2.2.2',
-      'bar@1.4.0',
-      'moo@3.0.0',
-    ]],
+    [
+      ':type(range)',
+      [
+        'a@1.0.0',
+        'abbrev@1.1.1',
+        'b@1.0.0',
+        'bar@2.0.0',
+        'baz@1.0.0',
+        'dash-separated-pkg@1.0.0',
+        'foo@2.2.2',
+        'bar@1.4.0',
+        'moo@3.0.0',
+      ],
+    ],
     [':type(git)', []],
 
     // path pseudo
-    [':path(node_modules/*)', [
-      'abbrev@1.1.1',
-      'bar@2.0.0',
-      'baz@1.0.0',
-      'dash-separated-pkg@1.0.0',
-      'dasher@2.0.0',
-      'foo@2.2.2',
-      'ipsum@npm:sit@1.0.0',
-      'lorem@1.0.0',
-      'moo@3.0.0',
-      'recur@1.0.0',
-      'sive@1.0.0',
-    ]],
+    [
+      ':path(node_modules/*)',
+      [
+        'abbrev@1.1.1',
+        'bar@2.0.0',
+        'baz@1.0.0',
+        'dash-separated-pkg@1.0.0',
+        'dasher@2.0.0',
+        'foo@2.2.2',
+        'ipsum@npm:sit@1.0.0',
+        'lorem@1.0.0',
+        'moo@3.0.0',
+        'recur@1.0.0',
+        'sive@1.0.0',
+      ],
+    ],
     [':path(node_modules/bar)', ['bar@2.0.0']],
     [':path(./node_modules/bar)', ['bar@2.0.0']],
     [':path(node_modules/foo/node_modules/bar)', ['bar@1.4.0']],
     [':path(**/bar)', ['bar@2.0.0', 'bar@1.4.0']],
-    [':path(*)', ['a@1.0.0', 'b@1.0.0']],
-    [':path()', [
-      'query-selector-all-tests@1.0.0',
-      'a@1.0.0',
-      'b@1.0.0',
-      '@npmcli/abbrev@2.0.0-beta.45',
-      'abbrev@1.1.1',
-      'bar@2.0.0',
-      'baz@1.0.0',
-      'dash-separated-pkg@1.0.0',
-      'dasher@2.0.0',
-      'foo@2.2.2',
-      'bar@1.4.0',
-      'ipsum@npm:sit@1.0.0',
-      'lorem@1.0.0',
-      'moo@3.0.0',
-      'recur@1.0.0',
-      'sive@1.0.0',
-    ]],
+    [':path(*)', ['a@1.0.0', 'b@1.0.0', 'c@1.0.0']],
+    [
+      ':path()',
+      [
+        'query-selector-all-tests@1.0.0',
+        'a@1.0.0',
+        'b@1.0.0',
+        'c@1.0.0',
+        '@npmcli/abbrev@2.0.0-beta.45',
+        'abbrev@1.1.1',
+        'bar@2.0.0',
+        'baz@1.0.0',
+        'dash-separated-pkg@1.0.0',
+        'dasher@2.0.0',
+        'foo@2.2.2',
+        'bar@1.4.0',
+        'ipsum@npm:sit@1.0.0',
+        'lorem@1.0.0',
+        'moo@3.0.0',
+        'recur@1.0.0',
+        'sive@1.0.0',
+      ],
+    ],
 
     // semver pseudo
-    [':semver()', [
-      'query-selector-all-tests@1.0.0',
-      'a@1.0.0',
-      'b@1.0.0',
-      '@npmcli/abbrev@2.0.0-beta.45',
-      'abbrev@1.1.1',
-      'bar@2.0.0',
-      'baz@1.0.0',
-      'dash-separated-pkg@1.0.0',
-      'dasher@2.0.0',
-      'foo@2.2.2',
-      'bar@1.4.0',
-      'ipsum@npm:sit@1.0.0',
-      'lorem@1.0.0',
-      'moo@3.0.0',
-      'recur@1.0.0',
-      'sive@1.0.0',
-    ]],
-    [':semver(*)', [
-      'query-selector-all-tests@1.0.0',
-      'a@1.0.0',
-      'b@1.0.0',
-      'abbrev@1.1.1',
-      'bar@2.0.0',
-      'baz@1.0.0',
-      'dash-separated-pkg@1.0.0',
-      'dasher@2.0.0',
-      'foo@2.2.2',
-      'bar@1.4.0',
-      'ipsum@npm:sit@1.0.0',
-      'lorem@1.0.0',
-      'moo@3.0.0',
-      'recur@1.0.0',
-      'sive@1.0.0',
-    ]],
-    [':semver(2.0.0)', [
-      'bar@2.0.0',
-      'dasher@2.0.0',
-    ]],
-    [':semver(>=2)', [
-      'bar@2.0.0',
-      'dasher@2.0.0',
-      'foo@2.2.2',
-      'moo@3.0.0',
-    ]],
-    [':semver(~2.0.x)', [
-      'bar@2.0.0',
-      'dasher@2.0.0',
-    ]],
-    [':semver(2 - 3)', [
-      'bar@2.0.0',
-      'dasher@2.0.0',
-      'foo@2.2.2',
-      'moo@3.0.0',
-    ]],
+    [
+      ':semver()',
+      [
+        'query-selector-all-tests@1.0.0',
+        'a@1.0.0',
+        'b@1.0.0',
+        'c@1.0.0',
+        '@npmcli/abbrev@2.0.0-beta.45',
+        'abbrev@1.1.1',
+        'bar@2.0.0',
+        'baz@1.0.0',
+        'dash-separated-pkg@1.0.0',
+        'dasher@2.0.0',
+        'foo@2.2.2',
+        'bar@1.4.0',
+        'ipsum@npm:sit@1.0.0',
+        'lorem@1.0.0',
+        'moo@3.0.0',
+        'recur@1.0.0',
+        'sive@1.0.0',
+      ],
+    ],
+    [
+      ':semver(*)',
+      [
+        'query-selector-all-tests@1.0.0',
+        'a@1.0.0',
+        'b@1.0.0',
+        'c@1.0.0',
+        'abbrev@1.1.1',
+        'bar@2.0.0',
+        'baz@1.0.0',
+        'dash-separated-pkg@1.0.0',
+        'dasher@2.0.0',
+        'foo@2.2.2',
+        'bar@1.4.0',
+        'ipsum@npm:sit@1.0.0',
+        'lorem@1.0.0',
+        'moo@3.0.0',
+        'recur@1.0.0',
+        'sive@1.0.0',
+      ],
+    ],
+    [':semver(2.0.0)', ['bar@2.0.0', 'dasher@2.0.0']],
+    [':semver(>=2)', ['bar@2.0.0', 'dasher@2.0.0', 'foo@2.2.2', 'moo@3.0.0']],
+    [':semver(~2.0.x)', ['bar@2.0.0', 'dasher@2.0.0']],
+    [':semver(2 - 3)', ['bar@2.0.0', 'dasher@2.0.0', 'foo@2.2.2', 'moo@3.0.0']],
     [':semver(=1.4.0)', ['bar@1.4.0']],
     [':semver(1.4.0 || 2.2.2)', ['foo@2.2.2', 'bar@1.4.0']],
     [':semver(^16.0.0, :attr(engines, [node]))', ['abbrev@1.1.1', 'bar@2.0.0']],
@@ -667,148 +695,223 @@ t.test('query-selector-all', async t => {
     [':semver(^16.0.0, :attr(engines, [node^=">="]))', ['bar@2.0.0']],
     [':semver(3.0.0, [version], eq)', ['moo@3.0.0']],
     [':semver(^3.0.0, [version], eq)', []],
-    [':semver(1.0.0, [version], neq)', [
-      '@npmcli/abbrev@2.0.0-beta.45',
-      'abbrev@1.1.1',
-      'bar@2.0.0',
-      'dasher@2.0.0',
-      'foo@2.2.2',
-      'bar@1.4.0',
-      'moo@3.0.0',
-    ]],
+    [
+      ':semver(1.0.0, [version], neq)',
+      [
+        '@npmcli/abbrev@2.0.0-beta.45',
+        'abbrev@1.1.1',
+        'bar@2.0.0',
+        'dasher@2.0.0',
+        'foo@2.2.2',
+        'bar@1.4.0',
+        'moo@3.0.0',
+      ],
+    ],
     [':semver(^1.0.0, [version], neq)', []],
     [':semver(2.0.0, [version], gt)', ['foo@2.2.2', 'moo@3.0.0']],
     [':semver(^2.0.0, [version], gt)', []],
-    [':semver(2.0.0, [version], gte)', [
-      'bar@2.0.0',
-      'dasher@2.0.0',
-      'foo@2.2.2',
-      'moo@3.0.0',
-    ]],
+    [
+      ':semver(2.0.0, [version], gte)',
+      ['bar@2.0.0', 'dasher@2.0.0', 'foo@2.2.2', 'moo@3.0.0'],
+    ],
     [':semver(^2.0.0, [version], gte)', []],
-    [':semver(1.1.1, [version], lt)', [
-      'query-selector-all-tests@1.0.0',
-      'a@1.0.0',
-      'b@1.0.0',
-      'baz@1.0.0',
-      'dash-separated-pkg@1.0.0',
-      'ipsum@npm:sit@1.0.0',
-      'lorem@1.0.0',
-      'recur@1.0.0',
-      'sive@1.0.0',
-    ]],
+    [
+      ':semver(1.1.1, [version], lt)',
+      [
+        'query-selector-all-tests@1.0.0',
+        'a@1.0.0',
+        'b@1.0.0',
+        'c@1.0.0',
+        'baz@1.0.0',
+        'dash-separated-pkg@1.0.0',
+        'ipsum@npm:sit@1.0.0',
+        'lorem@1.0.0',
+        'recur@1.0.0',
+        'sive@1.0.0',
+      ],
+    ],
     [':semver(^1.1.1, [version], lt)', []],
-    [':semver(1.1.1, [version], lte)', [
-      'query-selector-all-tests@1.0.0',
-      'a@1.0.0',
-      'b@1.0.0',
-      'abbrev@1.1.1',
-      'baz@1.0.0',
-      'dash-separated-pkg@1.0.0',
-      'ipsum@npm:sit@1.0.0',
-      'lorem@1.0.0',
-      'recur@1.0.0',
-      'sive@1.0.0',
-    ]],
+    [
+      ':semver(1.1.1, [version], lte)',
+      [
+        'query-selector-all-tests@1.0.0',
+        'a@1.0.0',
+        'b@1.0.0',
+        'c@1.0.0',
+        'abbrev@1.1.1',
+        'baz@1.0.0',
+        'dash-separated-pkg@1.0.0',
+        'ipsum@npm:sit@1.0.0',
+        'lorem@1.0.0',
+        'recur@1.0.0',
+        'sive@1.0.0',
+      ],
+    ],
     [':semver(^1.1.1, [version], lte)', []],
     [':semver(^14.0.0, :attr(engines, [node]), intersects)', ['bar@2.0.0']],
-    [':semver(>=14, :attr(engines, [node]), subset)', ['abbrev@1.1.1', 'bar@2.0.0']],
+    [
+      ':semver(>=14, :attr(engines, [node]), subset)',
+      ['abbrev@1.1.1', 'bar@2.0.0'],
+    ],
     [':semver(^2.0.0, [version], gtr)', ['moo@3.0.0']],
     [':semver(^2.0.0, :attr(engines, [node]), gtr)', []],
     [':semver(20.0.0, :attr(engines, [node]), gtr)', ['abbrev@1.1.1']],
-    [':semver(1.0.1, [version], gtr)', [
-      'query-selector-all-tests@1.0.0',
-      'a@1.0.0',
-      'b@1.0.0',
-      'baz@1.0.0',
-      'dash-separated-pkg@1.0.0',
-      'ipsum@npm:sit@1.0.0',
-      'lorem@1.0.0',
-      'recur@1.0.0',
-      'sive@1.0.0',
-    ]],
-    [':semver(^1.1.1, [version], ltr)', [
-      'query-selector-all-tests@1.0.0',
-      'a@1.0.0',
-      'b@1.0.0',
-      'baz@1.0.0',
-      'dash-separated-pkg@1.0.0',
-      'ipsum@npm:sit@1.0.0',
-      'lorem@1.0.0',
-      'recur@1.0.0',
-      'sive@1.0.0',
-    ]],
+    [
+      ':semver(1.0.1, [version], gtr)',
+      [
+        'query-selector-all-tests@1.0.0',
+        'a@1.0.0',
+        'b@1.0.0',
+        'c@1.0.0',
+        'baz@1.0.0',
+        'dash-separated-pkg@1.0.0',
+        'ipsum@npm:sit@1.0.0',
+        'lorem@1.0.0',
+        'recur@1.0.0',
+        'sive@1.0.0',
+      ],
+    ],
+    [
+      ':semver(^1.1.1, [version], ltr)',
+      [
+        'query-selector-all-tests@1.0.0',
+        'a@1.0.0',
+        'b@1.0.0',
+        'c@1.0.0',
+        'baz@1.0.0',
+        'dash-separated-pkg@1.0.0',
+        'ipsum@npm:sit@1.0.0',
+        'lorem@1.0.0',
+        'recur@1.0.0',
+        'sive@1.0.0',
+      ],
+    ],
     [':semver(^1.1.1, :attr(engines, [node]), ltr)', []],
-    [':semver(0.0.1, :attr(engines, [node]), ltr)', ['abbrev@1.1.1', 'bar@2.0.0']],
-    [':semver(1.1.1, [version], ltr)', [
-      '@npmcli/abbrev@2.0.0-beta.45',
-      'bar@2.0.0',
-      'dasher@2.0.0',
-      'foo@2.2.2',
-      'bar@1.4.0',
-      'moo@3.0.0',
-    ]],
+    [
+      ':semver(0.0.1, :attr(engines, [node]), ltr)',
+      ['abbrev@1.1.1', 'bar@2.0.0'],
+    ],
+    [
+      ':semver(1.1.1, [version], ltr)',
+      [
+        '@npmcli/abbrev@2.0.0-beta.45',
+        'bar@2.0.0',
+        'dasher@2.0.0',
+        'foo@2.2.2',
+        'bar@1.4.0',
+        'moo@3.0.0',
+      ],
+    ],
 
     // outdated pseudo
-    [':outdated', [
-      'abbrev@1.1.1', // 1.2.0 is available
-      'baz@1.0.0', // 1.0.1 is available
-      'dash-separated-pkg@1.0.0', // 2.0.0 is available
-      'bar@1.4.0', // 2.0.0 is available
-    ]],
-    [':outdated(any)', [
-      'abbrev@1.1.1', // 1.2.0 is available
-      'baz@1.0.0', // 1.0.1 is available
-      'dash-separated-pkg@1.0.0', // 2.0.0 is available
-      'bar@1.4.0', // 2.0.0 is available
-    ]],
-    [':outdated(major)', [
-      'dash-separated-pkg@1.0.0', // 2.0.0 is available
-      'bar@1.4.0', // 2.0.0 is available
-    ]],
-    [':outdated(minor)', [
-      'abbrev@1.1.1', // 1.2.0 is available
-    ]],
-    [':outdated(patch)', [
-      'baz@1.0.0', // 1.0.1 is available
-    ]],
-    [':outdated(in-range)', [
-      'abbrev@1.1.1', // 1.2.0 is available and in-range
-      'baz@1.0.0', // 1.0.1 is available and in-range
-    ]],
-    [':outdated(out-of-range)', [
-      'dash-separated-pkg@1.0.0', // 2.0.0 is available
-      'bar@1.4.0', // 2.0.0 is available and out-of-range
-    ]],
+    [
+      ':outdated',
+      [
+        'abbrev@1.1.1', // 1.2.0 is available
+        'baz@1.0.0', // 1.0.1 is available
+        'dash-separated-pkg@1.0.0', // 2.0.0 is available
+        'bar@1.4.0', // 2.0.0 is available
+      ],
+    ],
+    [
+      ':outdated(any)',
+      [
+        'abbrev@1.1.1', // 1.2.0 is available
+        'baz@1.0.0', // 1.0.1 is available
+        'dash-separated-pkg@1.0.0', // 2.0.0 is available
+        'bar@1.4.0', // 2.0.0 is available
+      ],
+    ],
+    [
+      ':outdated(major)',
+      [
+        'dash-separated-pkg@1.0.0', // 2.0.0 is available
+        'bar@1.4.0', // 2.0.0 is available
+      ],
+    ],
+    [
+      ':outdated(minor)',
+      [
+        'abbrev@1.1.1', // 1.2.0 is available
+      ],
+    ],
+    [
+      ':outdated(patch)',
+      [
+        'baz@1.0.0', // 1.0.1 is available
+      ],
+    ],
+    [
+      ':outdated(in-range)',
+      [
+        'abbrev@1.1.1', // 1.2.0 is available and in-range
+        'baz@1.0.0', // 1.0.1 is available and in-range
+      ],
+    ],
+    [
+      ':outdated(out-of-range)',
+      [
+        'dash-separated-pkg@1.0.0', // 2.0.0 is available
+        'bar@1.4.0', // 2.0.0 is available and out-of-range
+      ],
+    ],
     [':outdated(nonsense)', []], // invalid, no results ever
 
     // :outdated combined with --before
-    [':outdated', [
-      'abbrev@1.1.1', // 1.2.0 is available and published yesterday
-      'baz@1.0.0', // 1.0.1 is available and published yesterday
-      'dash-separated-pkg@1.0.0', // 2.0.0 is available and published yesterday
-    ], { before: yesterday }],
-    [':outdated(any)', [
-      'abbrev@1.1.1', // 1.2.0 is available and published yesterday
-      'baz@1.0.0', // 1.0.1 is available and published yesterday
-      'dash-separated-pkg@1.0.0', // 2.0.0 is available and published yesterday
-    ], { before: yesterday }],
-    [':outdated(major)', [
-      'dash-separated-pkg@1.0.0', // 2.0.0 is available and published yesterday
-    ], { before: yesterday }],
-    [':outdated(minor)', [
-      'abbrev@1.1.1', // 1.2.0 is available and published yesterday
-    ], { before: yesterday }],
-    [':outdated(patch)', [
-      'baz@1.0.0', // 1.0.1 is available and published yesterday
-    ], { before: yesterday }],
-    [':outdated(in-range)', [
-      'abbrev@1.1.1', // 1.2.0 is available, in-range and published yesterday
-      'baz@1.0.0', // 1.0.1 is available, in-range and published yesterday
-    ], { before: yesterday }],
-    [':outdated(out-of-range)', [
-      'dash-separated-pkg@1.0.0', // 2.0.0 is available, out-of-range and published yesterday
-    ], { before: yesterday }],
+    [
+      ':outdated',
+      [
+        'abbrev@1.1.1', // 1.2.0 is available and published yesterday
+        'baz@1.0.0', // 1.0.1 is available and published yesterday
+        'dash-separated-pkg@1.0.0', // 2.0.0 is available and published yesterday
+      ],
+      { before: yesterday },
+    ],
+    [
+      ':outdated(any)',
+      [
+        'abbrev@1.1.1', // 1.2.0 is available and published yesterday
+        'baz@1.0.0', // 1.0.1 is available and published yesterday
+        'dash-separated-pkg@1.0.0', // 2.0.0 is available and published yesterday
+      ],
+      { before: yesterday },
+    ],
+    [
+      ':outdated(major)',
+      [
+        'dash-separated-pkg@1.0.0', // 2.0.0 is available and published yesterday
+      ],
+      { before: yesterday },
+    ],
+    [
+      ':outdated(minor)',
+      [
+        'abbrev@1.1.1', // 1.2.0 is available and published yesterday
+      ],
+      { before: yesterday },
+    ],
+    [
+      ':outdated(patch)',
+      [
+        'baz@1.0.0', // 1.0.1 is available and published yesterday
+      ],
+      { before: yesterday },
+    ],
+    [
+      ':outdated(in-range)',
+      [
+        'abbrev@1.1.1', // 1.2.0 is available, in-range and published yesterday
+        'baz@1.0.0', // 1.0.1 is available, in-range and published yesterday
+      ],
+      { before: yesterday },
+    ],
+    [
+      ':outdated(out-of-range)',
+      [
+        'dash-separated-pkg@1.0.0', // 2.0.0 is available, out-of-range and published yesterday
+      ],
+      { before: yesterday },
+    ],
     [':outdated(nonsense)', [], { before: yesterday }], // again, no results here ever
 
     // attr pseudo
@@ -825,27 +928,29 @@ t.test('query-selector-all', async t => {
     [':attr(arbitrary, :attr([foo=10000]))', ['bar@2.0.0']],
 
     // attribute matchers
-    ['[scripts]', [
-      'baz@1.0.0',
-    ]],
-    ['[name]', [
-      'query-selector-all-tests@1.0.0',
-      'a@1.0.0',
-      'b@1.0.0',
-      '@npmcli/abbrev@2.0.0-beta.45',
-      'abbrev@1.1.1',
-      'bar@2.0.0',
-      'baz@1.0.0',
-      'dash-separated-pkg@1.0.0',
-      'dasher@2.0.0',
-      'foo@2.2.2',
-      'bar@1.4.0',
-      'ipsum@npm:sit@1.0.0',
-      'lorem@1.0.0',
-      'moo@3.0.0',
-      'recur@1.0.0',
-      'sive@1.0.0',
-    ]],
+    ['[scripts]', ['baz@1.0.0']],
+    [
+      '[name]',
+      [
+        'query-selector-all-tests@1.0.0',
+        'a@1.0.0',
+        'b@1.0.0',
+        'c@1.0.0',
+        '@npmcli/abbrev@2.0.0-beta.45',
+        'abbrev@1.1.1',
+        'bar@2.0.0',
+        'baz@1.0.0',
+        'dash-separated-pkg@1.0.0',
+        'dasher@2.0.0',
+        'foo@2.2.2',
+        'bar@1.4.0',
+        'ipsum@npm:sit@1.0.0',
+        'lorem@1.0.0',
+        'moo@3.0.0',
+        'recur@1.0.0',
+        'sive@1.0.0',
+      ],
+    ],
     ['[name=a]', ['a@1.0.0']],
     ['[name=@npmcli/abbrev]', ['@npmcli/abbrev@2.0.0-beta.45']],
     ['[name=a], [name=b]', ['a@1.0.0', 'b@1.0.0']],
@@ -853,82 +958,100 @@ t.test('query-selector-all', async t => {
     ['[name^=a]', ['a@1.0.0', 'abbrev@1.1.1']],
     ['[name|=dash]', ['dash-separated-pkg@1.0.0']],
     ['[name$=oo]', ['foo@2.2.2', 'moo@3.0.0']],
-    ['[description]', [
-      'dash-separated-pkg@1.0.0',
-      'dasher@2.0.0',
-    ]],
+    ['[description]', ['dash-separated-pkg@1.0.0', 'dasher@2.0.0']],
     ['[description~=ever]', ['dasher@2.0.0']],
-    ['[description~=best]', [
-      'dash-separated-pkg@1.0.0',
-      'dasher@2.0.0',
-    ]],
-    ['[name*=a]', [
-      'query-selector-all-tests@1.0.0',
-      'a@1.0.0',
-      '@npmcli/abbrev@2.0.0-beta.45',
-      'abbrev@1.1.1',
-      'bar@2.0.0',
-      'baz@1.0.0',
-      'dash-separated-pkg@1.0.0',
-      'dasher@2.0.0',
-      'bar@1.4.0',
-    ]],
+    ['[description~=best]', ['dash-separated-pkg@1.0.0', 'dasher@2.0.0']],
+    [
+      '[name*=a]',
+      [
+        'query-selector-all-tests@1.0.0',
+        'a@1.0.0',
+        '@npmcli/abbrev@2.0.0-beta.45',
+        'abbrev@1.1.1',
+        'bar@2.0.0',
+        'baz@1.0.0',
+        'dash-separated-pkg@1.0.0',
+        'dasher@2.0.0',
+        'bar@1.4.0',
+      ],
+    ],
     ['[arbitrary^=foo]', ['foo@2.2.2']],
     ['[license=ISC]', ['abbrev@1.1.1', 'baz@1.0.0']],
     ['[license=isc i]', ['abbrev@1.1.1', 'baz@1.0.0']],
 
     // types
-    ['.prod', [
-      'query-selector-all-tests@1.0.0',
-      'a@1.0.0',
-      'b@1.0.0',
-      'abbrev@1.1.1',
-      'bar@2.0.0',
-      'baz@1.0.0',
-      'ipsum@npm:sit@1.0.0',
-      'lorem@1.0.0',
-      'moo@3.0.0',
-    ]],
-    ['.workspace', ['a@1.0.0', 'b@1.0.0']],
-    ['.workspace > *', ['a@1.0.0', 'bar@2.0.0', 'baz@1.0.0']],
-    ['.workspace ~ *', [
-      'abbrev@1.1.1',
-      'bar@2.0.0',
-      'foo@2.2.2',
-      'ipsum@npm:sit@1.0.0',
-      'moo@3.0.0',
-      'recur@1.0.0',
-    ]],
-    ['.dev', [
-      '@npmcli/abbrev@2.0.0-beta.45',
-      'a@1.0.0',
-      'dash-separated-pkg@1.0.0',
-      'dasher@2.0.0',
-      'foo@2.2.2',
-      'bar@1.4.0',
-      'moo@3.0.0',
-      'recur@1.0.0',
-      'sive@1.0.0',
-    ]],
-    ['.dev *', [
-      'dash-separated-pkg@1.0.0',
-      'dasher@2.0.0',
-      'bar@1.4.0',
-      'recur@1.0.0',
-      'sive@1.0.0',
-    ]],
+    [
+      '.prod',
+      [
+        'query-selector-all-tests@1.0.0',
+        'a@1.0.0',
+        'b@1.0.0',
+        'c@1.0.0',
+        'abbrev@1.1.1',
+        'bar@2.0.0',
+        'baz@1.0.0',
+        'ipsum@npm:sit@1.0.0',
+        'lorem@1.0.0',
+        'moo@3.0.0',
+      ],
+    ],
+    ['.workspace', ['a@1.0.0', 'b@1.0.0', 'c@1.0.0']],
+    ['.workspace > *', ['a@1.0.0', 'b@1.0.0', 'bar@2.0.0', 'baz@1.0.0']],
+    ['.workspace .workspace', ['a@1.0.0', 'b@1.0.0']],
+    ['.workspace .workspace .workspace', ['a@1.0.0']],
+    [
+      '.workspace ~ *',
+      [
+        'abbrev@1.1.1',
+        'bar@2.0.0',
+        'foo@2.2.2',
+        'ipsum@npm:sit@1.0.0',
+        'moo@3.0.0',
+        'recur@1.0.0',
+      ],
+    ],
+    [
+      '.dev',
+      [
+        '@npmcli/abbrev@2.0.0-beta.45',
+        'a@1.0.0',
+        'dash-separated-pkg@1.0.0',
+        'dasher@2.0.0',
+        'foo@2.2.2',
+        'bar@1.4.0',
+        'moo@3.0.0',
+        'recur@1.0.0',
+        'sive@1.0.0',
+      ],
+    ],
+    [
+      '.dev *',
+      [
+        'baz@1.0.0',
+        'dash-separated-pkg@1.0.0',
+        'dasher@2.0.0',
+        'bar@1.4.0',
+        'lorem@1.0.0',
+        'recur@1.0.0',
+        'sive@1.0.0',
+      ],
+    ],
     ['.peer', ['@npmcli/abbrev@2.0.0-beta.45', 'dasher@2.0.0']],
     ['.optional', ['@npmcli/abbrev@2.0.0-beta.45', 'baz@1.0.0', 'lorem@1.0.0']],
     ['.bundled', ['abbrev@1.1.1']],
-    ['.bundled ~ *', [
-      'a@1.0.0',
-      'b@1.0.0',
-      'bar@2.0.0',
-      'foo@2.2.2',
-      'ipsum@npm:sit@1.0.0',
-      'moo@3.0.0',
-      'recur@1.0.0',
-    ]],
+    [
+      '.bundled ~ *',
+      [
+        'a@1.0.0',
+        'b@1.0.0',
+        'c@1.0.0',
+        'bar@2.0.0',
+        'foo@2.2.2',
+        'ipsum@npm:sit@1.0.0',
+        'moo@3.0.0',
+        'recur@1.0.0',
+      ],
+    ],
 
     // id selector
     ['#bar', ['bar@2.0.0', 'bar@1.4.0']],
@@ -960,7 +1083,10 @@ t.test('query-selector-all', async t => {
     [':root #bar:semver(1) > *', ['dasher@2.0.0']],
     [':root #bar:semver(1) ~ *', ['dash-separated-pkg@1.0.0']],
     ['#bar:semver(2), #foo', ['bar@2.0.0', 'foo@2.2.2']],
-    ['#a, #bar:semver(2), #foo:semver(2.2.2)', ['a@1.0.0', 'bar@2.0.0', 'foo@2.2.2']],
+    [
+      '#a, #bar:semver(2), #foo:semver(2.2.2)',
+      ['a@1.0.0', 'bar@2.0.0', 'foo@2.2.2'],
+    ],
     ['#b *', ['a@1.0.0', 'bar@2.0.0', 'baz@1.0.0', 'lorem@1.0.0', 'moo@3.0.0']],
   ])
 })


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

The `hasParent` query handler does not handle `ArboristLink`(s) correctly. This causes child workspaces to not return their dependencies when not in a direct child query.


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Fixes #6828 

Not sure why the formatting got changed. I ran the linter and it seemed to do all this change.
