### PR TITLE
docs: fix formatting on npm version example

### DIFF
--- a/docs/content/commands/npm-version.md
+++ b/docs/content/commands/npm-version.md
@@ -9,9 +9,9 @@ description: Bump a package version
 ```bash
 npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease [--preid=<prerelease-id>] | from-git]
 
-'npm [-v | --version]' to print npm version
-'npm view <pkg> version' to view a package's published version
-'npm ls' to inspect current package/dependency versions
+npm [-v | --version] # to print npm version
+npm view <pkg> version # to view a package's published version
+npm ls # to inspect current package/dependency versions
 ```
 
 ### Configuration


### PR DESCRIPTION
Made description to individual command to resolve color coding issue in website mode, due to conflict in single inverted commas.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
The documentation website automatically adds color coding to bash code in the block. The description is mixed with the actual bash commands, hence the color coding gets mixed when showing commands alongside the description.
![image](https://github.com/npm/cli/assets/43519784/ee54b146-3023-4718-b508-8e49ace9d8a4)


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
