### PR TITLE
docs: update `CONTRIBUTING.md` to prevent errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ $ git clone git@github.com:npm/cli.git npm
 **2. Navigate into project & install development-specific dependencies...**
 
 ```bash
-$ cd ./npm && node . install
+$ cd ./npm && node ./scripts/resetdeps.js
 ```
 
 **3. Write some code &/or add some tests...**


### PR DESCRIPTION
- following the previous steps with a fresh clone of `npm/cli` will error out if your try to run `node . install` because the `@npmcli/config` dep is missing
- need to run `node ./scripts/resetdeps.js` prior to running any `node .`/`npm` command

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References

Fixes #6635
Closes #6635
