### PR TITLE
RFC: do - literally - anything to stop the copy button masking content

### DIFF
--- a/docs/content/commands/npm-version.md
+++ b/docs/content/commands/npm-version.md
@@ -7,6 +7,7 @@ description: Bump a package version
 ### Synopsis
 
 ```bash
+# npm version
 npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease [--preid=<prerelease-id>] | from-git]
 
 'npm [-v | --version]' to print npm version


### PR DESCRIPTION
I'll evolve the commit tree based on feedback. But right now, there is an accessibility issue with the copy button overlaying text.

Options:

1. Move the copy button to the bottom right corner
2. Include an innocuous comment to the start of these types of code blocks - not too dissimilar to hinting at file names (for different reasons) - so as to not be jarring to readers.

![Screenshot 2023-09-29 at 09 18 55](https://github.com/npm/cli/assets/956290/3326e7f7-8108-411b-916c-7f60327c3e14)
![Screenshot 2023-09-29 at 09 18 57](https://github.com/npm/cli/assets/956290/7cf52111-8c66-4960-b1dd-a8d35301a470)
