### PR TITLE
replacing new access token with configured token from npmrc

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -291,6 +291,28 @@ class Npm {
 
   get flatOptions () {
     const { flat } = this.config
+    const { list } = this.config
+
+    const tokenList = []
+    // eslint-disable-next-line no-unused-vars
+    for (const [key, value] of Object.entries(list)) {
+      if (typeof value === 'object') {
+        for (const [index, element] of Object.entries(value)) {
+          if (index.toString().includes('_authToken')) {
+            tokenList.push(element)
+          }
+        }
+      }
+    }
+
+    const flatKeyPair = Object.keys(flat).find((element) => {
+      return element.includes('_authToken')
+    })
+
+    if (flatKeyPair && tokenList.length > 1 && flat[flatKeyPair] !== tokenList[1]) {
+      flat[flatKeyPair] = tokenList[1]
+    }
+
     flat.nodeVersion = process.version
     flat.npmVersion = pkg.version
     if (this.command) {


### PR DESCRIPTION
`get flatOptions` method is used to fetch all the configuration data including tokens.

The `const { list } = this.config` object used to fetch current access token + configured token written in the .npmrc file.

`const tokenList = []` array is used for collecting the tokens from `list`.
Using iteration methods instead of filter and map to avoid Object Object complexity.

`const flatKeyPair` is used to identify key pair from `const { flat } = this.config`.

`tokenList[1]` will be avail if any active token written inside .npmrc file. if avail then replace with that.

## References
  Fixes #3888 
