### PR TITLE
docs: npm publish content modification

### DIFF
--- a/docs/lib/content/using-npm/scripts.md
+++ b/docs/lib/content/using-npm/scripts.md
@@ -159,8 +159,6 @@ These are run from the scripts of `<pkg-name>`
 * `publish`
 * `postpublish`
 
-`prepare` will not run during `--dry-run`
-
 #### [`npm rebuild`](/commands/npm-rebuild)
 
 * `preinstall`


### PR DESCRIPTION
"prepare will not run during --dry-run" is removed from npm publish content


## References
Closes: #5210 
