### PR TITLE
chore: filter node prs by base branch

### DIFF
--- a/scripts/create-node-pr.js
+++ b/scripts/create-node-pr.js
@@ -230,6 +230,7 @@ const main = async (spec, branch = 'main', opts) => withTempDir(CWD, async (tmpD
   const npmPrs = await gh.json(
     ...nodePrArgs, 'list',
     '-S', `in:title "${npmMessage('')}"`,
+    '--base', nodeBranch,
     'number,title,url'
   )
 


### PR DESCRIPTION
This is a fix to allow multiple Node PRs to be open.
Previously the script would attempt to edit an existing PR but
PRs to different branches were getting incorrectly edited.
