### PR TITLE
fix: Switch refs for dev and opt dependencies in SPDX sboms

### DIFF
--- a/lib/utils/sbom-spdx.js
+++ b/lib/utils/sbom-spdx.js
@@ -139,9 +139,16 @@ const toSpdxRelationship = (node, edge) => {
       type = REL_DEP
   }
 
+  let from, to
+  if ([REL_OPTIONAL, REL_DEV].includes(type)) {
+    [from, to] = [edge.to, node]
+  } else {
+    [from, to] = [node, edge.to]
+  }
+
   return {
-    spdxElementId: toSpdxID(node),
-    relatedSpdxElement: toSpdxID(edge.to),
+    spdxElementId: toSpdxID(from),
+    relatedSpdxElement: toSpdxID(to),
     relationshipType: type,
   }
 }

--- a/tap-snapshots/test/lib/commands/sbom.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/sbom.js.test.cjs
@@ -557,8 +557,8 @@ exports[`test/lib/commands/sbom.js TAP sbom extraneous dep > must match snapshot
       "relationshipType": "DEPENDS_ON"
     },
     {
-      "spdxElementId": "SPDXRef-Package-test-npm-ls-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-chai-1.0.0",
+      "spdxElementId": "SPDXRef-Package-chai-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-test-npm-ls-1.0.0",
       "relationshipType": "OPTIONAL_DEPENDENCY_OF"
     }
   ]
@@ -730,8 +730,8 @@ exports[`test/lib/commands/sbom.js TAP sbom loading a tree containing workspaces
       "relationshipType": "DEPENDS_ON"
     },
     {
-      "spdxElementId": "SPDXRef-Package-a-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-baz-1.0.0",
+      "spdxElementId": "SPDXRef-Package-baz-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-a-1.0.0",
       "relationshipType": "DEV_DEPENDENCY_OF"
     },
     {
@@ -1091,8 +1091,8 @@ exports[`test/lib/commands/sbom.js TAP sbom loading a tree containing workspaces
       "relationshipType": "DEPENDS_ON"
     },
     {
-      "spdxElementId": "SPDXRef-Package-a-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-baz-1.0.0",
+      "spdxElementId": "SPDXRef-Package-baz-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-a-1.0.0",
       "relationshipType": "DEV_DEPENDENCY_OF"
     },
     {

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -1421,7 +1421,7 @@ SBOM format to use when generating SBOMs.
 * Type: "library", "application", or "framework"
 
 The type of package described by the generated SBOM. For SPDX, this is the
-value for the \`primaryPackagePurpose\` fieled. For CycloneDX, this is the
+value for the \`primaryPackagePurpose\` field. For CycloneDX, this is the
 value for the \`type\` field.
 
 

--- a/tap-snapshots/test/lib/utils/sbom-spdx.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/sbom-spdx.js.test.cjs
@@ -154,13 +154,13 @@ exports[`test/lib/utils/sbom-spdx.js TAP node - with deps > must match snapshot 
       "relationshipType": "HAS_PREREQUISITE"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-dep2-0.0.2",
+      "spdxElementId": "SPDXRef-Package-dep2-0.0.2",
+      "relatedSpdxElement": "SPDXRef-Package-root-1.0.0",
       "relationshipType": "OPTIONAL_DEPENDENCY_OF"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-dep3-0.0.3",
+      "spdxElementId": "SPDXRef-Package-dep3-0.0.3",
+      "relatedSpdxElement": "SPDXRef-Package-root-1.0.0",
       "relationshipType": "DEV_DEPENDENCY_OF"
     },
     {
@@ -174,8 +174,8 @@ exports[`test/lib/utils/sbom-spdx.js TAP node - with deps > must match snapshot 
       "relationshipType": "DEPENDS_ON"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-dep6-0.0.6",
+      "spdxElementId": "SPDXRef-Package-dep6-0.0.6",
+      "relatedSpdxElement": "SPDXRef-Package-root-1.0.0",
       "relationshipType": "OPTIONAL_DEPENDENCY_OF"
     }
   ]

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -1234,7 +1234,7 @@ define('sbom-type', {
   ],
   description: `
     The type of package described by the generated SBOM. For SPDX, this is the
-    value for the \`primaryPackagePurpose\` fieled. For CycloneDX, this is the
+    value for the \`primaryPackagePurpose\` field. For CycloneDX, this is the
     value for the \`type\` field.
   `,
   flatten,


### PR DESCRIPTION
As pointed out in [this comment](https://github.com/npm/cli/issues/6867#issuecomment-1749067908), the relationships in SPDX sboms are currently incorrect.

In order to keep the directions as intuitive as possible, we leave them as is for dependencies and prerequisites, and only swap the refs for dev and optional dependencies, where it is currently not correct.

Fixes https://github.com/npm/cli/issues/6867
