### PR TITLE
fix(audit): spelling error in message

### DIFF
--- a/lib/commands/audit.js
+++ b/lib/commands/audit.js
@@ -55,7 +55,7 @@ class VerifySignatures {
     // Didn't find any dependencies that could be verified, e.g. only local
     // deps, missing version, not on a registry etc.
     if (!this.auditedWithKeysCount) {
-      throw new Error('found no dependencies to audit that where installed from ' +
+      throw new Error('found no dependencies to audit that were installed from ' +
                       'a supported registry')
     }
 

--- a/test/lib/commands/audit.js
+++ b/test/lib/commands/audit.js
@@ -1393,7 +1393,7 @@ t.test('audit signatures', async t => {
 
     await t.rejects(
       npm.exec('audit', ['signatures']),
-      /found no dependencies to audit that where installed from a supported registry/
+      /found no dependencies to audit that were installed from a supported registry/
     )
   })
 
@@ -1424,7 +1424,7 @@ t.test('audit signatures', async t => {
 
     await t.rejects(
       npm.exec('audit', ['signatures']),
-      /found no dependencies to audit that where installed from a supported registry/
+      /found no dependencies to audit that were installed from a supported registry/
     )
   })
 
@@ -1766,7 +1766,7 @@ t.test('audit signatures', async t => {
 
     await t.rejects(
       npm.exec('audit', ['signatures']),
-      /found no dependencies to audit that where installed from a supported registry/
+      /found no dependencies to audit that were installed from a supported registry/
     )
   })
 
@@ -1787,7 +1787,7 @@ t.test('audit signatures', async t => {
 
     await t.rejects(
       npm.exec('audit', ['signatures']),
-      /found no dependencies to audit that where installed from a supported registry/
+      /found no dependencies to audit that were installed from a supported registry/
     )
   })
 
@@ -1815,7 +1815,7 @@ t.test('audit signatures', async t => {
 
     await t.rejects(
       npm.exec('audit', ['signatures']),
-      /found no dependencies to audit that where installed from a supported registry/
+      /found no dependencies to audit that were installed from a supported registry/
     )
   })
 
@@ -1844,7 +1844,7 @@ t.test('audit signatures', async t => {
 
     await t.rejects(
       npm.exec('audit', ['signatures']),
-      /found no dependencies to audit that where installed from a supported registry/
+      /found no dependencies to audit that were installed from a supported registry/
     )
   })
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
This PR fixes a small grammatical error in the error thrown when no audit keys are found.
"were" is a past tense form and is used to indicate that the dependencies were installed in the past, not "where".
