### PR TITLE
logout bugfixes

### DIFF
--- a/lib/commands/logout.js
+++ b/lib/commands/logout.js
@@ -1,5 +1,5 @@
-const getAuth = require('npm-registry-fetch/lib/auth.js')
 const npmFetch = require('npm-registry-fetch')
+const { getAuth } = npmFetch
 const log = require('../utils/log-shim')
 const BaseCommand = require('../base-command.js')
 
@@ -26,6 +26,7 @@ class Logout extends BaseCommand {
       log.verbose('logout', `clearing token for ${reg}`)
       await npmFetch(`/-/user/token/${encodeURIComponent(auth.token)}`, {
         ...this.npm.flatOptions,
+        registry: reg,
         method: 'DELETE',
         ignoreBody: true,
       })

--- a/lib/commands/logout.js
+++ b/lib/commands/logout.js
@@ -19,6 +19,9 @@ class Logout extends BaseCommand {
 
     const auth = getAuth(reg, this.npm.flatOptions)
 
+    const level = this.npm.config.find(`${auth.regKey}:${auth.authKey}`)
+
+    // find the config level and only delete from there
     if (auth.token) {
       log.verbose('logout', `clearing token for ${reg}`)
       await npmFetch(`/-/user/token/${encodeURIComponent(auth.token)}`, {
@@ -34,12 +37,12 @@ class Logout extends BaseCommand {
     }
 
     if (scope) {
-      this.npm.config.delete(regRef, 'user')
+      this.npm.config.delete(regRef, level)
     }
 
-    this.npm.config.clearCredentialsByURI(reg)
+    this.npm.config.clearCredentialsByURI(reg, level)
 
-    await this.npm.config.save('user')
+    await this.npm.config.save(level)
   }
 }
 module.exports = Logout

--- a/mock-registry/lib/index.js
+++ b/mock-registry/lib/index.js
@@ -252,6 +252,11 @@ class MockRegistry {
       .reply(200, { token })
   }
 
+  logout (token) {
+    this.nock = this.nock.delete(this.fullPath(`/-/user/token/${encodeURIComponent(token)}`))
+      .reply(200, { ok: true })
+  }
+
   // team can be a team or a username
   getPackages ({ user, team, packages = {}, times = 1, responseCode = 200 }) {
     let uri

--- a/node_modules/npm-registry-fetch/lib/index.js
+++ b/node_modules/npm-registry-fetch/lib/index.js
@@ -166,6 +166,8 @@ function regFetch (uri, /* istanbul ignore next */ opts_ = {}) {
   return Promise.resolve(body).then(doFetch)
 }
 
+module.exports.getAuth = getAuth
+
 module.exports.json = fetchJSON
 function fetchJSON (uri, opts) {
   return regFetch(uri, opts).then(res => res.json())

--- a/node_modules/npm-registry-fetch/package.json
+++ b/node_modules/npm-registry-fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-registry-fetch",
-  "version": "16.0.0",
+  "version": "16.1.0",
   "description": "Fetch-based http client for use with npm registry APIs",
   "main": "lib",
   "files": [
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@npmcli/eslint-config": "^4.0.0",
-    "@npmcli/template-oss": "4.18.0",
+    "@npmcli/template-oss": "4.19.0",
     "cacache": "^18.0.0",
     "nock": "^13.2.4",
     "require-inject": "^1.4.4",
@@ -61,13 +61,7 @@
   },
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
-    "version": "4.18.0",
-    "publish": "true",
-    "ciVersions": [
-      "16.14.0",
-      "16.x",
-      "18.0.0",
-      "18.x"
-    ]
+    "version": "4.19.0",
+    "publish": "true"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -139,7 +139,7 @@
         "npm-package-arg": "^11.0.1",
         "npm-pick-manifest": "^9.0.0",
         "npm-profile": "^9.0.0",
-        "npm-registry-fetch": "^16.0.0",
+        "npm-registry-fetch": "^16.1.0",
         "npm-user-validate": "^2.0.0",
         "npmlog": "^7.0.1",
         "p-map": "^4.0.0",
@@ -10927,9 +10927,9 @@
       }
     },
     "node_modules/npm-registry-fetch": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-16.0.0.tgz",
-      "integrity": "sha512-JFCpAPUpvpwfSydv99u85yhP68rNIxSFmDpNbNnRWKSe3gpjHnWL8v320gATwRzjtgmZ9Jfe37+ZPOLZPwz6BQ==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-16.1.0.tgz",
+      "integrity": "sha512-PQCELXKt8Azvxnt5Y85GseQDJJlglTFM9L9U9gkv2y4e9s0k3GVDdOx3YoB6gm2Do0hlkzC39iCGXby+Wve1Bw==",
       "inBundle": true,
       "dependencies": {
         "make-fetch-happen": "^13.0.0",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "npm-package-arg": "^11.0.1",
     "npm-pick-manifest": "^9.0.0",
     "npm-profile": "^9.0.0",
-    "npm-registry-fetch": "^16.0.0",
+    "npm-registry-fetch": "^16.1.0",
     "npm-user-validate": "^2.0.0",
     "npmlog": "^7.0.1",
     "p-map": "^4.0.0",

--- a/test/lib/commands/logout.js
+++ b/test/lib/commands/logout.js
@@ -1,170 +1,115 @@
 const t = require('tap')
 const fs = require('fs/promises')
-const npmFetch = require('npm-registry-fetch')
-const mockNpm = require('../../fixtures/mock-npm')
+const { load: loadMockNpm } = require('../../fixtures/mock-npm.js')
+const MockRegistry = require('@npmcli/mock-registry')
 const { join } = require('path')
 
-const mockLogout = async (t, { userRc = [], ...npmOpts } = {}) => {
-  let result = null
-
-  const mock = await mockNpm(t, {
-    command: 'logout',
-    mocks: {
-      // XXX: refactor to use mock registry
-      'npm-registry-fetch': Object.assign(async (url, opts) => {
-        result = { url, opts }
-      }, npmFetch),
-    },
-    ...npmOpts,
+t.test('token logout - user config', async t => {
+  const { npm, home, logs } = await loadMockNpm(t, {
     homeDir: {
-      '.npmrc': userRc.join('\n'),
+      '.npmrc': [
+        '//registry.npmjs.org/:_authToken=@foo/',
+        'other-config=true',
+      ].join('\n'),
     },
   })
 
-  return {
-    ...mock,
-    result: () => result,
-    // get only the message portion of the verbose log from the command
-    logMsg: () => mock.logs.verbose.find(l => l[0] === 'logout')[1],
-    userRc: () => fs.readFile(join(mock.home, '.npmrc'), 'utf-8').then(r => r.trim()),
-  }
-}
-
-t.test('token logout', async t => {
-  const { logout, logMsg, result, userRc } = await mockLogout(t, {
-    userRc: [
-      '//registry.npmjs.org/:_authToken=@foo/',
-      'other-config=true',
-    ],
-  })
-
-  await logout.exec([])
-
+  const mockRegistry = new MockRegistry({ tap: t, registry: 'https://registry.npmjs.org/' })
+  mockRegistry.logout('@foo/')
+  await npm.exec('logout', [])
   t.equal(
-    logMsg(),
+    logs.verbose.find(l => l[0] === 'logout')[1],
     'clearing token for https://registry.npmjs.org/',
     'should log message with correct registry'
   )
-
-  t.match(
-    result(),
-    {
-      url: '/-/user/token/%40foo%2F',
-      opts: {
-        registry: 'https://registry.npmjs.org/',
-        scope: '',
-        '//registry.npmjs.org/:_authToken': '@foo/',
-        method: 'DELETE',
-        ignoreBody: true,
-      },
-    },
-    'should call npm-registry-fetch with expected values'
-  )
-
-  t.equal(await userRc(), 'other-config=true')
+  const userRc = await fs.readFile(join(home, '.npmrc'), 'utf-8')
+  t.equal(userRc.trim(), 'other-config=true')
 })
 
-t.test('token scoped logout', async t => {
-  const { logout, logMsg, result, userRc } = await mockLogout(t, {
-    config: { scope: '@myscope' },
-    userRc: [
-      '//diff-registry.npmjs.com/:_authToken=@bar/',
-      '//registry.npmjs.org/:_authToken=@foo/',
-      '@myscope:registry=https://diff-registry.npmjs.com/',
-    ],
+t.test('token scoped logout - user config', async t => {
+  const { npm, home, logs } = await loadMockNpm(t, {
+    config: {
+      scope: '@myscope',
+    },
+    homeDir: {
+      '.npmrc': [
+        '//diff-registry.npmjs.com/:_authToken=@bar/',
+        '//registry.npmjs.org/:_authToken=@foo/',
+        '@myscope:registry=https://diff-registry.npmjs.com/',
+
+      ].join('\n'),
+    },
   })
 
-  await logout.exec([])
-
+  const mockRegistry = new MockRegistry({ tap: t, registry: 'https://diff-registry.npmjs.com/' })
+  mockRegistry.logout('@bar/')
+  await npm.exec('logout', [])
   t.equal(
-    logMsg(),
+    logs.verbose.find(l => l[0] === 'logout')[1],
     'clearing token for https://diff-registry.npmjs.com/',
     'should log message with correct registry'
   )
 
-  t.match(
-    result(),
-    {
-      url: '/-/user/token/%40bar%2F',
-      opts: {
-        registry: 'https://registry.npmjs.org/',
-        '@myscope:registry': 'https://diff-registry.npmjs.com/',
-        scope: '@myscope',
-        '//registry.npmjs.org/:_authToken': '@foo/', // <- removed by npm-registry-fetch
-        '//diff-registry.npmjs.com/:_authToken': '@bar/',
-        method: 'DELETE',
-        ignoreBody: true,
-      },
-    },
-    'should call npm-registry-fetch with expected values'
-  )
-
-  t.equal(await userRc(), '//registry.npmjs.org/:_authToken=@foo/')
+  const userRc = await fs.readFile(join(home, '.npmrc'), 'utf-8')
+  t.equal(userRc.trim(), '//registry.npmjs.org/:_authToken=@foo/')
 })
 
-t.test('user/pass logout', async t => {
-  const { logout, logMsg, userRc } = await mockLogout(t, {
-    userRc: [
+t.test('user/pass logout - user config', async t => {
+  const { npm, home, logs } = await loadMockNpm(t, {
+    homeDir: {
+      '.npmrc': [
       '//registry.npmjs.org/:username=foo',
       '//registry.npmjs.org/:_password=bar',
       'other-config=true',
-    ],
+      ].join('\n'),
+    },
   })
 
-  await logout.exec([])
-
+  await npm.exec('logout', [])
   t.equal(
-    logMsg(),
+    logs.verbose.find(l => l[0] === 'logout')[1],
     'clearing user credentials for https://registry.npmjs.org/',
     'should log message with correct registry'
   )
 
-  t.equal(await userRc(), 'other-config=true')
+  const userRc = await fs.readFile(join(home, '.npmrc'), 'utf-8')
+  t.equal(userRc.trim(), 'other-config=true')
 })
 
 t.test('missing credentials', async t => {
-  const { logout } = await mockLogout(t)
+  const { npm, logs } = await loadMockNpm(t)
 
   await t.rejects(
-    logout.exec([]),
+    npm.exec('logout', []),
     {
       code: 'ENEEDAUTH',
       message: /not logged in to https:\/\/registry.npmjs.org\/, so can't log out!/,
     },
-    'should throw with expected error code'
+    'should reject with expected error code'
   )
 })
 
 t.test('ignore invalid scoped registry config', async t => {
-  const { logout, logMsg, result, userRc } = await mockLogout(t, {
+  const { npm, home, logs } = await loadMockNpm(t, {
     config: { scope: '@myscope' },
-    userRc: [
+    homeDir: {
+      '.npmrc': [
       '//registry.npmjs.org/:_authToken=@foo/',
       'other-config=true',
-    ],
+
+      ].join('\n'),
+    },
   })
 
-  await logout.exec([])
+  const mockRegistry = new MockRegistry({ tap: t, registry: 'https://registry.npmjs.org/' })
+  mockRegistry.logout('@foo/')
+  await npm.exec('logout', [])
 
   t.equal(
-    logMsg(),
+    logs.verbose.find(l => l[0] === 'logout')[1],
     'clearing token for https://registry.npmjs.org/',
     'should log message with correct registry'
   )
-
-  t.match(
-    result(),
-    {
-      url: '/-/user/token/%40foo%2F',
-      opts: {
-        '//registry.npmjs.org/:_authToken': '@foo/',
-        registry: 'https://registry.npmjs.org/',
-        method: 'DELETE',
-        ignoreBody: true,
-      },
-    },
-    'should call npm-registry-fetch with expected values'
-  )
-
-  t.equal(await userRc(), 'other-config=true')
+  const userRc = await fs.readFile(join(home, '.npmrc'), 'utf-8')
+  t.equal(userRc.trim(), 'other-config=true')
 })

--- a/workspaces/config/lib/index.js
+++ b/workspaces/config/lib/index.js
@@ -774,29 +774,29 @@ class Config {
     await chmod(conf.source, mode)
   }
 
-  clearCredentialsByURI (uri) {
+  clearCredentialsByURI (uri, level = 'user') {
     const nerfed = nerfDart(uri)
     const def = nerfDart(this.get('registry'))
     if (def === nerfed) {
-      this.delete(`-authtoken`, 'user')
-      this.delete(`_authToken`, 'user')
-      this.delete(`_authtoken`, 'user')
-      this.delete(`_auth`, 'user')
-      this.delete(`_password`, 'user')
-      this.delete(`username`, 'user')
+      this.delete(`-authtoken`, level)
+      this.delete(`_authToken`, level)
+      this.delete(`_authtoken`, level)
+      this.delete(`_auth`, level)
+      this.delete(`_password`, level)
+      this.delete(`username`, level)
       // de-nerf email if it's nerfed to the default registry
-      const email = this.get(`${nerfed}:email`, 'user')
+      const email = this.get(`${nerfed}:email`, level)
       if (email) {
-        this.set('email', email, 'user')
+        this.set('email', email, level)
       }
     }
-    this.delete(`${nerfed}:_authToken`, 'user')
-    this.delete(`${nerfed}:_auth`, 'user')
-    this.delete(`${nerfed}:_password`, 'user')
-    this.delete(`${nerfed}:username`, 'user')
-    this.delete(`${nerfed}:email`, 'user')
-    this.delete(`${nerfed}:certfile`, 'user')
-    this.delete(`${nerfed}:keyfile`, 'user')
+    this.delete(`${nerfed}:_authToken`, level)
+    this.delete(`${nerfed}:_auth`, level)
+    this.delete(`${nerfed}:_password`, level)
+    this.delete(`${nerfed}:username`, level)
+    this.delete(`${nerfed}:email`, level)
+    this.delete(`${nerfed}:certfile`, level)
+    this.delete(`${nerfed}:keyfile`, level)
   }
 
   setCredentialsByURI (uri, { token, username, password, email, certfile, keyfile }) {


### PR DESCRIPTION
Fixes two bugs with `npm logout`

First, the token delete request is sent to the same registry that the
token was nerf-darted to.

Second, the token is deleted from the config that it was found in.

The tests were also rewritten to use the mock registry, which is how the
first bug was found.

Closes https://github.com/npm/cli/issues/3888
