### PR TITLE
fix: Add check to pkg command to deal with empty values

### DIFF
--- a/lib/commands/pkg.js
+++ b/lib/commands/pkg.js
@@ -76,18 +76,9 @@ class Pkg extends BaseCommand {
       result = q.query(args)
 
       // in case there's only a single result from the query
-      // just prints that one element to stdout taking into
-      // consideration that one of the args supplied may
-      // have not had a returned value from the query
-      //
-      // e.g. npm pkg get name author would previously
-      // return undefined because
-      // args=['name', 'author'] and the query
-      // result was { name: '...' }
+      // just prints that one element to stdout
       if (Object.keys(result).length === 1) {
-        // find the overlapping value in result and args
-        const argKey = Object.keys(result).find((key) => args.includes(key))
-        result = result[argKey]
+        result = result[args]
       }
     }
 

--- a/lib/commands/pkg.js
+++ b/lib/commands/pkg.js
@@ -76,9 +76,18 @@ class Pkg extends BaseCommand {
       result = q.query(args)
 
       // in case there's only a single result from the query
-      // just prints that one element to stdout
+      // just prints that one element to stdout taking into
+      // consideration that one of the args supplied may
+      // have not had a returned value from the query
+      //
+      // e.g. npm pkg get name author would previously
+      // return undefined because
+      // args=['name', 'author'] and the query
+      // result was { name: '...' }
       if (Object.keys(result).length === 1) {
-        result = result[args]
+        // find the overlapping value in result and args
+        const argKey = Object.keys(result).find((key) => args.includes(key))
+        result = result[argKey]
       }
     }
 

--- a/lib/utils/queryable.js
+++ b/lib/utils/queryable.js
@@ -111,11 +111,10 @@ const getter = ({ data, key }) => {
       }, {})
       return _data
     } else {
-      const value = _data[k]
-      if (value === undefined) {
+      if (_data[k] === undefined) {
         return undefined
       }
-      _data = value
+      _data = _data[k]
     }
 
     label += k

--- a/lib/utils/queryable.js
+++ b/lib/utils/queryable.js
@@ -111,14 +111,11 @@ const getter = ({ data, key }) => {
       }, {})
       return _data
     } else {
-        const value = _data[k]
-        if (typeof value === 'boolean' || (value === '' && Object.hasOwn(_data, k))) {
-            _data = value
-        } else if (value === undefined) {
-          return undefined
-        } else {
-          _data = value
-        }
+      const value = _data[k]
+      if (value === undefined) {
+        return undefined
+      }
+      _data = value
     }
 
     label += k

--- a/lib/utils/queryable.js
+++ b/lib/utils/queryable.js
@@ -111,7 +111,7 @@ const getter = ({ data, key }) => {
       }, {})
       return _data
     } else {
-      if (_data[k] === undefined) {
+      if (!Object.hasOwn(_data, k)) {
         return undefined
       }
       _data = _data[k]

--- a/lib/utils/queryable.js
+++ b/lib/utils/queryable.js
@@ -113,12 +113,14 @@ const getter = ({ data, key }) => {
     } else {
       // if can't find any more values, it means it's just over
       // and there's nothing to return
-      if (!_data[k]) {
+      if (Object.hasOwn(_data, k) && !_data[k]) {
+        _data = ''
+      } else if (!_data[k]) {
         return undefined
+      } else {
+        // otherwise sets the next value
+        _data = _data[k]
       }
-
-      // otherwise sets the next value
-      _data = _data[k]
     }
 
     label += k

--- a/lib/utils/queryable.js
+++ b/lib/utils/queryable.js
@@ -111,16 +111,14 @@ const getter = ({ data, key }) => {
       }, {})
       return _data
     } else {
-      // if can't find any more values, it means it's just over
-      // and there's nothing to return
-      if (Object.hasOwn(_data, k) && !_data[k]) {
-        _data = ''
-      } else if (!_data[k]) {
-        return undefined
-      } else {
-        // otherwise sets the next value
-        _data = _data[k]
-      }
+        const value = _data[k]
+        if (typeof value === 'boolean' || (value === '' && Object.hasOwn(_data, k))) {
+            _data = value
+        } else if (value === undefined) {
+          return undefined
+        } else {
+          _data = _data[k]
+        }
     }
 
     label += k

--- a/lib/utils/queryable.js
+++ b/lib/utils/queryable.js
@@ -117,7 +117,7 @@ const getter = ({ data, key }) => {
         } else if (value === undefined) {
           return undefined
         } else {
-          _data = _data[k]
+          _data = value
         }
     }
 

--- a/tap-snapshots/test/lib/commands/view.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/view.js.test.cjs
@@ -315,6 +315,10 @@ maintainers[0].name = 'claudia'
 maintainers[1].name = 'isaacs'
 `
 
+exports[`test/lib/commands/view.js TAP specific field names fields with empty values > must match snapshot 1`] = `
+
+`
+
 exports[`test/lib/commands/view.js TAP specific field names maintainers with email > must match snapshot 1`] = `
 maintainers = [
   { name: 'claudia', email: 'c@yellow.com', twitter: 'cyellow' },

--- a/test/lib/commands/pkg.js
+++ b/test/lib/commands/pkg.js
@@ -83,6 +83,47 @@ t.test('get single arg', async t => {
   )
 })
 
+t.test('get multiple arg', async t => {
+  const { pkg, OUTPUT } = await mockNpm(t, {
+    prefixDir: {
+      'package.json': JSON.stringify({
+        name: 'foo',
+        version: '1.1.1',
+      }),
+    },
+  })
+
+  await pkg('get', 'name', 'version')
+
+  t.strictSame(
+    JSON.parse(OUTPUT()),
+    {
+      name: 'foo',
+      version: '1.1.1',
+    },
+    'should print retrieved package.json field'
+  )
+})
+
+t.test('get multiple arg with empty value', async t => {
+  const { pkg, OUTPUT } = await mockNpm(t, {
+    prefixDir: {
+      'package.json': JSON.stringify({
+        name: 'foo',
+        author: '',
+      }),
+    },
+  })
+
+  await pkg('get', 'name', 'author')
+
+  t.strictSame(
+    JSON.parse(OUTPUT()),
+    'foo',
+    'should print retrieved package.json field'
+  )
+})
+
 t.test('get nested arg', async t => {
   const { pkg, OUTPUT } = await mockNpm(t, {
     prefixDir: {

--- a/test/lib/commands/pkg.js
+++ b/test/lib/commands/pkg.js
@@ -119,8 +119,11 @@ t.test('get multiple arg with empty value', async t => {
 
   t.strictSame(
     JSON.parse(OUTPUT()),
-    'foo',
-    'should print retrieved package.json field'
+    {
+      name: 'foo',
+      author: '',
+    },
+    'should print retrieved package.json field regardless of empty value'
   )
 })
 

--- a/test/lib/commands/view.js
+++ b/test/lib/commands/view.js
@@ -101,6 +101,7 @@ const packument = (nv, opts) => {
         email: 'foo@yellow.com',
         twitter: 'foo',
       },
+      empty: '',
       readme: 'a very useful readme',
       versions: {
         '1.0.0': {

--- a/test/lib/commands/view.js
+++ b/test/lib/commands/view.js
@@ -425,6 +425,11 @@ t.test('specific field names', async t => {
     await view.exec(['yellow@1.x.x', 'maintainers.name'])
     t.matchSnapshot(outputs.join('\n'))
   })
+
+  t.test('fields with empty values', async t => {
+    await view.exec(['yellow@1.x.x', 'empty'])
+    t.matchSnapshot(outputs.join('\n'))
+  })
 })
 
 t.test('throw error if global mode', async t => {

--- a/test/lib/commands/view.js
+++ b/test/lib/commands/view.js
@@ -428,7 +428,7 @@ t.test('specific field names', async t => {
   })
 
   t.test('fields with empty values', async t => {
-    await view.exec(['yellow@1.x.x', 'empty'])
+    await view.exec(['yellow', 'empty'])
     t.matchSnapshot(outputs.join('\n'))
   })
 })


### PR DESCRIPTION
<!-- What / Why -->
If your package.json contains an empty value such as:
```
{
    "author": "",
    "name": "foo"
}
```
Executing, `npm pkg get name author` will return `undefined`. You'd expect it to return `"foo"`.

This is because the args is being used as an index when returning a single value. This patch fixes this and adds two new tests to the pkg command.
