### PR TITLE
fix: npm link does not respect --no-save

### DIFF
--- a/lib/commands/link.js
+++ b/lib/commands/link.js
@@ -64,7 +64,6 @@ class Link extends ArboristWorkspaceCmd {
   }
 
   async linkInstall (args) {
-
     // load current packages from the global space,
     // and then add symlinks installs locally
     const globalTop = resolve(this.npm.globalDir, '..')
@@ -110,7 +109,7 @@ class Link extends ArboristWorkspaceCmd {
     // using any of --save-dev or other types
     const save =
       Boolean(
-        (this.npm.config.find('save') !== 'default' && 
+        (this.npm.config.find('save') !== 'default' &&
         this.npm.config.get('save')) ||
         this.npm.config.get('save-optional') ||
         this.npm.config.get('save-peer') ||

--- a/lib/commands/link.js
+++ b/lib/commands/link.js
@@ -64,6 +64,7 @@ class Link extends ArboristWorkspaceCmd {
   }
 
   async linkInstall (args) {
+
     // load current packages from the global space,
     // and then add symlinks installs locally
     const globalTop = resolve(this.npm.globalDir, '..')
@@ -108,15 +109,14 @@ class Link extends ArboristWorkspaceCmd {
     // npm link should not save=true by default unless you're
     // using any of --save-dev or other types
     const save =
-      !Boolean(this.npm.config.argv[3] === '--no-save') &&
       Boolean(
-        this.npm.config.find('save') !== 'default' ||
+        (this.npm.config.find('save') !== 'default' && 
+        this.npm.config.get('save')) ||
         this.npm.config.get('save-optional') ||
         this.npm.config.get('save-peer') ||
         this.npm.config.get('save-dev') ||
         this.npm.config.get('save-prod')
       )
-
     // create a new arborist instance for the local prefix and
     // reify all the pending names as symlinks there
     const localArb = new Arborist({

--- a/lib/commands/link.js
+++ b/lib/commands/link.js
@@ -108,6 +108,7 @@ class Link extends ArboristWorkspaceCmd {
     // npm link should not save=true by default unless you're
     // using any of --save-dev or other types
     const save =
+      !Boolean(this.npm.config.argv[3] === '--no-save') &&
       Boolean(
         this.npm.config.find('save') !== 'default' ||
         this.npm.config.get('save-optional') ||

--- a/test/lib/commands/link.js
+++ b/test/lib/commands/link.js
@@ -395,7 +395,7 @@ t.test('should not saving link to package file', async t => {
     config: { save: false },
   })
 
-  npm.config.find = () => 'cli'
+  console.log('222222222222222 ', npm.config.find('save'))
   await link.exec(['@myscope/linked'])
   t.match(
     require(resolve(prefix, 'package.json')).dependencies,

--- a/test/lib/commands/link.js
+++ b/test/lib/commands/link.js
@@ -369,7 +369,7 @@ t.test('link pkg already in global space when prefix is a symlink', async t => {
   t.matchSnapshot(await printLinks(), 'should create a local symlink to global pkg')
 })
 
-t.test('should not saving link to package file', async t => {
+t.test('should not save link to package file', async t => {
   const { link, prefix } = await mockLink(t, {
     globalPrefixDir: {
       node_modules: {

--- a/test/lib/commands/link.js
+++ b/test/lib/commands/link.js
@@ -316,8 +316,9 @@ t.test('link pkg already in global space', async t => {
 
   // XXX: how to convert this to a config that gets passed in?
   npm.config.find = () => 'default'
-  
+
   await link.exec(['@myscope/linked'])
+
   t.equal(
     require(resolve(prefix, 'package.json')).dependencies,
     undefined,
@@ -325,43 +326,6 @@ t.test('link pkg already in global space', async t => {
   )
 
   t.matchSnapshot(await printLinks(), 'should create a local symlink to global pkg')
-})
-
-
-t.test('saving link to package file', async t => {
-  const { npm, link, printLinks, prefix } = await mockLink(t, {
-    globalPrefixDir: {
-      node_modules: {
-        '@myscope': {
-          linked: t.fixture('symlink', '../../../other/scoped-linked'),
-        },
-      },
-    },
-    otherDirs: {
-      'scoped-linked': {
-        'package.json': JSON.stringify({
-          name: '@myscope/linked',
-          version: '1.0.0',
-        }),
-      },
-    },
-    prefixDir: {
-      'package.json': JSON.stringify({
-        name: 'my-project',
-        version: '1.0.0',
-      }),
-    },
-  })
-
-  // XXX: how to convert this to a config that gets passed in?
-  npm.config.find = () => '--save'
-
-  await link.exec(['@myscope/linked'])
-  t.match(
-    require(resolve(prefix, 'package.json')).dependencies,
-    { '@myscope/linked': 'file:../other/scoped-linked' },
-    'should save to package.json upon linking'
-  )
 })
 
 t.test('link pkg already in global space when prefix is a symlink', async t => {
@@ -403,6 +367,43 @@ t.test('link pkg already in global space when prefix is a symlink', async t => {
   )
 
   t.matchSnapshot(await printLinks(), 'should create a local symlink to global pkg')
+})
+
+t.test('saving link to package file', async t => {
+  const { npm, link, printLinks, prefix } = await mockLink(t, {
+    globalPrefixDir: {
+      node_modules: {
+        '@myscope': {
+          linked: t.fixture('symlink', '../../../other/scoped-linked'),
+        },
+      },
+    },
+    otherDirs: {
+      'scoped-linked': {
+        'package.json': JSON.stringify({
+          name: '@myscope/linked',
+          version: '1.0.0',
+        }),
+      },
+    },
+    prefixDir: {
+      'package.json': JSON.stringify({
+        name: 'my-project',
+        version: '1.0.0',
+      }),
+    },
+  })
+
+  // XXX: how to convert this to a config that gets passed in?
+  npm.config.find = () => '--save'
+
+  await link.exec(['@myscope/linked'])
+  
+  t.match(
+    require(resolve(prefix, 'package.json')).dependencies,
+    { '@myscope/linked': 'file:../other/scoped-linked' },
+    'should save to package.json upon linking'
+  )
 })
 
 t.test('should not prune dependencies when linking packages', async t => {

--- a/test/lib/commands/link.js
+++ b/test/lib/commands/link.js
@@ -369,7 +369,7 @@ t.test('link pkg already in global space when prefix is a symlink', async t => {
   t.matchSnapshot(await printLinks(), 'should create a local symlink to global pkg')
 })
 
-t.test('saving link to package file', async t => {
+t.test('should not saving link to package file', async t => {
   const { npm, link, prefix } = await mockLink(t, {
     globalPrefixDir: {
       node_modules: {
@@ -392,16 +392,15 @@ t.test('saving link to package file', async t => {
         version: '1.0.0',
       }),
     },
+    config: { save: false },
   })
 
-  // XXX: how to convert this to a config that gets passed in?
-  npm.config.find = () => '--save'
-
+  npm.config.find = () => 'cli'
   await link.exec(['@myscope/linked'])
   t.match(
     require(resolve(prefix, 'package.json')).dependencies,
-    { '@myscope/linked': 'file:../other/scoped-linked' },
-    'should save to package.json upon linking'
+    undefined,
+    'should not save to package.json upon linking'
   )
 })
 

--- a/test/lib/commands/link.js
+++ b/test/lib/commands/link.js
@@ -315,6 +315,45 @@ t.test('link pkg already in global space', async t => {
   })
 
   // XXX: how to convert this to a config that gets passed in?
+  npm.config.find = () => 'default'
+  
+  await link.exec(['@myscope/linked'])
+  t.equal(
+    require(resolve(prefix, 'package.json')).dependencies,
+    undefined,
+    'should not save to package.json upon linking'
+  )
+
+  t.matchSnapshot(await printLinks(), 'should create a local symlink to global pkg')
+})
+
+
+t.test('saving link to package file', async t => {
+  const { npm, link, printLinks, prefix } = await mockLink(t, {
+    globalPrefixDir: {
+      node_modules: {
+        '@myscope': {
+          linked: t.fixture('symlink', '../../../other/scoped-linked'),
+        },
+      },
+    },
+    otherDirs: {
+      'scoped-linked': {
+        'package.json': JSON.stringify({
+          name: '@myscope/linked',
+          version: '1.0.0',
+        }),
+      },
+    },
+    prefixDir: {
+      'package.json': JSON.stringify({
+        name: 'my-project',
+        version: '1.0.0',
+      }),
+    },
+  })
+
+  // XXX: how to convert this to a config that gets passed in?
   npm.config.find = () => '--save'
 
   await link.exec(['@myscope/linked'])
@@ -323,8 +362,6 @@ t.test('link pkg already in global space', async t => {
     { '@myscope/linked': 'file:../other/scoped-linked' },
     'should save to package.json upon linking'
   )
-
-  t.matchSnapshot(await printLinks(), 'should create a local symlink to global pkg')
 })
 
 t.test('link pkg already in global space when prefix is a symlink', async t => {

--- a/test/lib/commands/link.js
+++ b/test/lib/commands/link.js
@@ -370,7 +370,7 @@ t.test('link pkg already in global space when prefix is a symlink', async t => {
 })
 
 t.test('saving link to package file', async t => {
-  const { npm, link, printLinks, prefix } = await mockLink(t, {
+  const { npm, link, prefix } = await mockLink(t, {
     globalPrefixDir: {
       node_modules: {
         '@myscope': {
@@ -398,7 +398,6 @@ t.test('saving link to package file', async t => {
   npm.config.find = () => '--save'
 
   await link.exec(['@myscope/linked'])
-  
   t.match(
     require(resolve(prefix, 'package.json')).dependencies,
     { '@myscope/linked': 'file:../other/scoped-linked' },

--- a/test/lib/commands/link.js
+++ b/test/lib/commands/link.js
@@ -315,14 +315,13 @@ t.test('link pkg already in global space', async t => {
   })
 
   // XXX: how to convert this to a config that gets passed in?
-  npm.config.find = () => 'default'
+  npm.config.find = () => '--save'
 
   await link.exec(['@myscope/linked'])
-
-  t.equal(
+  t.match(
     require(resolve(prefix, 'package.json')).dependencies,
-    undefined,
-    'should not save to package.json upon linking'
+    { '@myscope/linked': 'file:../other/scoped-linked' },
+    'should save to package.json upon linking'
   )
 
   t.matchSnapshot(await printLinks(), 'should create a local symlink to global pkg')

--- a/test/lib/commands/link.js
+++ b/test/lib/commands/link.js
@@ -370,7 +370,7 @@ t.test('link pkg already in global space when prefix is a symlink', async t => {
 })
 
 t.test('should not saving link to package file', async t => {
-  const { npm, link, prefix } = await mockLink(t, {
+  const { link, prefix } = await mockLink(t, {
     globalPrefixDir: {
       node_modules: {
         '@myscope': {
@@ -395,7 +395,6 @@ t.test('should not saving link to package file', async t => {
     config: { save: false },
   })
 
-  console.log('222222222222222 ', npm.config.find('save'))
   await link.exec(['@myscope/linked'])
   t.match(
     require(resolve(prefix, 'package.json')).dependencies,


### PR DESCRIPTION
Issue: https://github.com/npm/cli/issues/3619
there was no condition to capture no-save scenario, read that from CLI and included condition to check that which will end up not saving anything if -no-save is passed as arguments.