### PR TITLE
fix: Grammar mistake in authentication error message

### DIFF
--- a/lib/utils/error-message.js
+++ b/lib/utils/error-message.js
@@ -182,7 +182,7 @@ const errorMessage = (er, npm) => {
           ])
           detail.push([
             '',
-            ['To correct this please trying logging in again with:', '    npm login'].join('\n'),
+            ['To correct this please try logging in again with:', '    npm login'].join('\n'),
           ])
         } else if (auth.includes('Basic')) {
           short.push(['', 'Incorrect or missing password.'])

--- a/tap-snapshots/test/lib/utils/error-message.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/error-message.js.test.cjs
@@ -1137,7 +1137,7 @@ Object {
     Array [
       "",
       String(
-        To correct this please trying logging in again with:
+        To correct this please try logging in again with:
             npm login
       ),
     ],


### PR DESCRIPTION
Small grammar mistake in one of the error messages. "To correct this please trying logging in again..." should be "please try logging in" :)
