### PR TITLE
fix: add back `bin/node-gyp-bin/node-gyp` files

### DIFF
--- a/bin/node-gyp-bin/node-gyp
+++ b/bin/node-gyp-bin/node-gyp
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+if [ "x$npm_config_node_gyp" = "x" ]; then
+  node "`dirname "$0"`/../../node_modules/node-gyp/bin/node-gyp.js" "$@"
+else
+  "$npm_config_node_gyp" "$@"
+fi

--- a/bin/node-gyp-bin/node-gyp.cmd
+++ b/bin/node-gyp-bin/node-gyp.cmd
@@ -1,0 +1,5 @@
+if not defined npm_config_node_gyp (
+  node "%~dp0\..\..\node_modules\node-gyp\bin\node-gyp.js" %*
+) else (
+  node "%npm_config_node_gyp%" %*
+)

--- a/test/bin/windows-shims.js
+++ b/test/bin/windows-shims.js
@@ -1,7 +1,7 @@
 const t = require('tap')
 const { spawnSync } = require('child_process')
 const { resolve, join, extname, basename, sep } = require('path')
-const { readFileSync, chmodSync, readdirSync } = require('fs')
+const { readFileSync, chmodSync, readdirSync, statSync } = require('fs')
 const Diff = require('diff')
 const { sync: which } = require('which')
 const { version } = require('../../package.json')
@@ -10,8 +10,9 @@ const ROOT = resolve(__dirname, '../..')
 const BIN = join(ROOT, 'bin')
 const NODE = readFileSync(process.execPath)
 const SHIMS = readdirSync(BIN).reduce((acc, shim) => {
-  if (extname(shim) !== '.js') {
-    acc[shim] = readFileSync(join(BIN, shim), 'utf-8')
+  const p = join(BIN, shim)
+  if (extname(p) !== '.js' && !statSync(p).isDirectory()) {
+    acc[shim] = readFileSync(p, 'utf-8')
   }
   return acc
 }, {})


### PR DESCRIPTION
This was an unintended breaking change as part of #6554. The `node-gyp`
bin files are not used by the CLI directly but they are relied on by
other tooling. This change is only intended to land on the v9 release
line.

This partially reverts commit 3a7378d889707d2a4c1f8a6397dda87825e9f5a3.
