### PR TITLE
fix: add back bin/node-gyp-bin/node-gyp files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,7 @@
 /configure text eol=lf
 
 # our cmd scripts always need to be CRLF
-/bin/*.cmd text eol=crlf
+/bin/**/*.cmd text eol=crlf
 
 # ignore all line endings in node_modules since we dont control that
 /node_modules/** -text

--- a/bin/node-gyp-bin/node-gyp
+++ b/bin/node-gyp-bin/node-gyp
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+if [ "x$npm_config_node_gyp" = "x" ]; then
+  node "`dirname "$0"`/../../node_modules/node-gyp/bin/node-gyp.js" "$@"
+else
+  "$npm_config_node_gyp" "$@"
+fi

--- a/bin/node-gyp-bin/node-gyp.cmd
+++ b/bin/node-gyp-bin/node-gyp.cmd
@@ -1,0 +1,5 @@
+if not defined npm_config_node_gyp (
+  node "%~dp0\..\..\node_modules\node-gyp\bin\node-gyp.js" %*
+) else (
+  node "%npm_config_node_gyp%" %*
+)


### PR DESCRIPTION
This was an unintended breaking change as part of #6554. The `node-gyp`
bin files are not used by the CLI directly but they are relied on by
other tooling.

This partially reverts commit 3a7378d889707d2a4c1f8a6397dda87825e9f5a3.
