### PR TITLE
fix: properly catch missing url opener error

### DIFF
--- a/lib/utils/open-url.js
+++ b/lib/utils/open-url.js
@@ -39,7 +39,7 @@ const open = async (npm, url, errMsg, isFile) => {
   const command = browser === true ? null : browser
   await promiseSpawn.open(url, { command })
     .catch((err) => {
-      if (err.code !== 'ENOENT') {
+      if (err.code !== 127) {
         throw err
       }
 

--- a/test/lib/utils/open-url.js
+++ b/test/lib/utils/open-url.js
@@ -124,7 +124,7 @@ t.test('prints where to go when given browser does not exist', async t => {
   const { openerUrl, openerOpts, joinedOutput } = await mockOpenUrl(t,
     ['https://www.npmjs.com', 'npm home'],
     {
-      openerResult: Object.assign(new Error('failed'), { code: 'ENOENT' }),
+      openerResult: Object.assign(new Error('failed'), { code: 127 }),
     }
   )
 


### PR DESCRIPTION
npm used to use `opener`, which called `childProcess.execFile`
npm now uses `@npmcli/promise-spawn` which uses `childProcess.open`

The 'not found' error is different between those two methods