### PR TITLE
libnpmexec: allow custom stdio option value.

### DIFF
--- a/workspaces/libnpmexec/lib/index.js
+++ b/workspaces/libnpmexec/lib/index.js
@@ -90,6 +90,7 @@ const exec = async (opts) => {
     path = '.',
     runPath = '.',
     scriptShell = isWindows ? process.env.ComSpec || 'cmd' : 'sh',
+    stdio,
     ...flatOptions
   } = opts
 
@@ -104,6 +105,7 @@ const exec = async (opts) => {
     binPaths,
     runPath,
     scriptShell,
+    stdio,
   })
 
   // interactive mode

--- a/workspaces/libnpmexec/lib/run-script.js
+++ b/workspaces/libnpmexec/lib/run-script.js
@@ -32,9 +32,7 @@ const run = async ({
     },
   }
 
-  if (stdio === 'inherit') {
-    npmlog.disableProgress()
-  }
+  npmlog.disableProgress()
 
   try {
     if (script === scriptShell) {

--- a/workspaces/libnpmexec/lib/run-script.js
+++ b/workspaces/libnpmexec/lib/run-script.js
@@ -15,6 +15,7 @@ const run = async ({
   binPaths,
   runPath,
   scriptShell,
+  stdio = 'inherit',
 }) => {
   // turn list of args into command string
   const script = call || args.shift() || scriptShell
@@ -31,7 +32,9 @@ const run = async ({
     },
   }
 
-  npmlog.disableProgress()
+  if (stdio === 'inherit') {
+    npmlog.disableProgress()
+  }
 
   try {
     if (script === scriptShell) {
@@ -60,11 +63,13 @@ const run = async ({
       binPaths,
       event: 'npx',
       args,
-      stdio: 'inherit',
+      stdio,
       scriptShell,
     })
   } finally {
-    npmlog.enableProgress()
+    if (stdio === 'inherit') {
+      npmlog.enableProgress()
+    }
   }
 }
 

--- a/workspaces/libnpmexec/test/index.js
+++ b/workspaces/libnpmexec/test/index.js
@@ -14,3 +14,17 @@ t.test('no args', async t => {
 
   await exec()
 })
+
+t.test('stdio value', async t => {
+  t.plan(1)
+
+  const { exec } = setup(t, {
+    mocks: {
+      '../../lib/run-script': ({ stdio }) => {
+        t.equal(stdio, 'pipe', 'should use expected stdio value')
+      },
+    },
+  })
+
+  await exec({ stdio: 'pipe' })
+})

--- a/workspaces/libnpmexec/test/run-script.js
+++ b/workspaces/libnpmexec/test/run-script.js
@@ -141,3 +141,41 @@ t.test('ci env', async t => {
 
   await runScript()
 })
+
+t.test('stdio value', t => {
+  t.test('stdio default value', async t => {
+    const runScript = await mockRunScript(t, {
+      '@npmcli/run-script': (opt) => {
+        t.equal(opt.stdio, 'inherit', 'should use expected stdio value')
+      },
+      npmlog: {
+        disableProgress () {
+          t.ok('should disable progress')
+        },
+        enableProgress () {
+          t.ok('should enable progress')
+        },
+      },
+    })
+    await runScript({ args: [], runPath: t.testDirName })
+  })
+
+  t.test('stdio custom value', async t => {
+    const runScript = await mockRunScript(t, {
+      '@npmcli/run-script': (opt) => {
+        t.equal(opt.stdio, 'pipe', 'should use expected stdio value')
+      },
+      npmlog: {
+        disableProgress () {
+          t.ok('should disable progress')
+        },
+        enableProgress () {
+          t.fail('should not enable progress')
+        },
+      },
+    })
+    await runScript({ args: [], stdio: 'pipe', runPath: t.testDirName })
+  })
+
+  t.end()
+})


### PR DESCRIPTION
<!-- What / Why -->
`libnpmexec` forces 'inherit' value in stdio option.
Others stdio values are required for non interactive usage.
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
