### PR TITLE
fix(pkg): properly output in workspace mode

### DIFF
--- a/lib/commands/pkg.js
+++ b/lib/commands/pkg.js
@@ -82,10 +82,9 @@ class Pkg extends BaseCommand {
       }
     }
 
-    // only outputs if not running with workspaces config,
-    // in case you're retrieving info for workspaces the pkgWorkspaces
-    // will handle the output to make sure it get keyed by ws name
-    if (!this.npm.config.get('workspaces')) {
+    // only outputs if not running with workspaces config
+    // execWorkspaces will handle the output otherwise
+    if (!this.workspaces) {
       this.npm.output(JSON.stringify(result, null, 2))
     }
 

--- a/test/lib/commands/pkg.js
+++ b/test/lib/commands/pkg.js
@@ -662,6 +662,43 @@ t.test('workspaces', async t => {
   )
 })
 
+t.test('single workspace', async t => {
+  const { pkg, OUTPUT } = await mockNpm(t, {
+    prefixDir: {
+      'package.json': JSON.stringify({
+        name: 'root',
+        version: '1.0.0',
+        workspaces: [
+          'packages/*',
+        ],
+      }),
+      packages: {
+        a: {
+          'package.json': JSON.stringify({
+            name: 'a',
+            version: '1.0.0',
+          }),
+        },
+        b: {
+          'package.json': JSON.stringify({
+            name: 'b',
+            version: '1.2.3',
+          }),
+        },
+      },
+    },
+    config: { workspace: ['packages/a'] },
+  })
+
+  await pkg('get', 'name', 'version')
+
+  t.strictSame(
+    JSON.parse(OUTPUT()),
+    { a: { name: 'a', version: '1.0.0' } },
+    'should only return info for one workspace'
+  )
+})
+
 t.test('fix', async t => {
   const { pkg, readPackageJson } = await mockNpm(t, {
     prefixDir: {


### PR DESCRIPTION
```sh
~/D/n/c/b/main (gar/pkg-get-workspaces|✔) $ npm pkg get name -w libnpmexec
"libnpmexec"
{
  "libnpmexec": "libnpmexec"
}
~/D/n/c/b/main (gar/pkg-get-workspaces|✔) $ node . pkg get name -w libnpmexec
{
  "libnpmexec": "libnpmexec"
}
```