### PR TITLE
docs: update npm-prune description

### DIFF
--- a/docs/lib/content/commands/npm-prune.md
+++ b/docs/lib/content/commands/npm-prune.md
@@ -16,10 +16,9 @@ then only packages matching one of the supplied names are removed.
 Extraneous packages are those present in the `node_modules` folder that are
 not listed as any package's dependency list.
 
-If the `--production` flag is specified or the `NODE_ENV` environment
+If the `--omit=dev` flag is specified or the `NODE_ENV` environment
 variable is set to `production`, this command will remove the packages
-specified in your `devDependencies`. Setting `--no-production` will negate
-`NODE_ENV` being set to `production`.
+specified in your `devDependencies`.
 
 If the `--dry-run` flag is used then no changes will actually be made.
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

The documentation uses a deprecated `--production` flag.
Using it shows the following warning:

```
$ npm prune --production
npm WARN config production Use `--omit=dev` instead.
```

The `--production` flag is not documented as well:

<img width="271" alt="image" src="https://github.com/npm/cli/assets/11404065/70de0850-2758-4f62-8593-9a45a33bdf07">



## References

Relates to:

- https://github.com/npm/cli/issues/6698

This PR makes clear that `--production` should not be used anymore.