### PR TITLE
fix: split github workflow ref (v9 backport)

### DIFF
--- a/workspaces/libnpmpublish/lib/provenance.js
+++ b/workspaces/libnpmpublish/lib/provenance.js
@@ -19,9 +19,11 @@ const generateProvenance = async (subject, opts) => {
   let payload
   if (ci.GITHUB_ACTIONS) {
     /* istanbul ignore next - not covering missing env var case */
-    const [workflowPath, workflowRef] = (env.GITHUB_WORKFLOW_REF || '')
-      .replace(env.GITHUB_REPOSITORY + '/', '')
-      .split('@')
+    const relativeRef = (env.GITHUB_WORKFLOW_REF || '').replace(env.GITHUB_REPOSITORY + '/', '')
+    const delimiterIndex = relativeRef.indexOf('@')
+    const workflowPath = relativeRef.slice(0, delimiterIndex)
+    const workflowRef = relativeRef.slice(delimiterIndex + 1)
+
     payload = {
       _type: INTOTO_STATEMENT_V1_TYPE,
       subject,

--- a/workspaces/libnpmpublish/test/publish.js
+++ b/workspaces/libnpmpublish/test/publish.js
@@ -606,7 +606,7 @@ t.test('publish existing package with provenance in gha', async t => {
   const workflowPath = '.github/workflows/publish.yml'
   const repository = 'github/foo'
   const serverUrl = 'https://github.com'
-  const ref = 'refs/heads/main'
+  const ref = 'refs/tags/pkg@1.0.0'
   const sha = 'deadbeef'
   const runID = '123456'
   const runAttempt = '1'
@@ -790,6 +790,9 @@ t.test('publish existing package with provenance in gha', async t => {
     t.hasStrict(provenance.predicate.buildDefinition.buildType,
       'https://slsa-framework.github.io/github-actions-buildtypes/workflow/v1',
       'buildType matches expectations')
+    t.hasStrict(provenance.predicate.buildDefinition.externalParameters.workflow.ref,
+      'refs/tags/pkg@1.0.0',
+      'workflowRef matches expectations')
     t.hasStrict(provenance.predicate.runDetails.builder.id,
       `https://github.com/actions/runner/${runnerEnv}`,
       'builder id matches expectations')


### PR DESCRIPTION
Properly splits the github workflow ref on only the first `@`, ignoring any potential extras in the tag field.

Backport of #6978 
