### PR TITLE
fix: Add better error message when lockfile is malformed

### DIFF
--- a/workspaces/arborist/lib/arborist/load-virtual.js
+++ b/workspaces/arborist/lib/arborist/load-virtual.js
@@ -2,6 +2,7 @@
 const mapWorkspaces = require('@npmcli/map-workspaces')
 
 const { resolve } = require('path')
+const assert = require('assert');
 
 const nameFromFolder = require('@npmcli/name-from-folder')
 const consistentResolve = require('../consistent-resolve.js')
@@ -200,6 +201,9 @@ module.exports = cls => class VirtualLoader extends cls {
       const targetPath = resolve(this.path, meta.resolved)
       const targetLoc = relpath(this.path, targetPath)
       const target = nodes.get(targetLoc)
+
+      assert(target, `Missing target node for "${targetLoc}", remove the entry in your lock file and try again.`);
+
       const link = this.#loadLink(location, targetLoc, target, meta)
       nodes.set(location, link)
       nodes.set(targetLoc, link.target)


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Sometimes when I am working with a monorepo of many workspaces with intermittencies I encounter the following error:

```
npm ERR! Cannot read properties of undefined (reading 'extraneous')
```

Which isn't very actionable. It also isn't very actionable with I add the `--verbose` option. All that does is point to `@npmcli/arborist/lib/arborist/load-virtual.js:297:30`.

Having added some logging manually I have been always able to fix up the lock file merely but removing the offending entry and then running `npm install` again.