### PR TITLE
fix: properly catch missing url opener error on interactive prompt

### DIFF
--- a/lib/utils/open-url-prompt.js
+++ b/lib/utils/open-url-prompt.js
@@ -1,5 +1,5 @@
 const readline = require('readline')
-const promiseSpawn = require('@npmcli/promise-spawn')
+const open = require('./open-url.js')
 
 function print (npm, title, url) {
   const json = npm.config.get('json')
@@ -63,8 +63,7 @@ const promptOpen = async (npm, url, title, prompt, emitter) => {
     return
   }
 
-  const command = browser === true ? null : browser
-  await promiseSpawn.open(url, { command })
+  await open(npm, url, 'Browser unavailable.  Please open the URL manually')
 }
 
 module.exports = promptOpen

--- a/lib/utils/open-url.js
+++ b/lib/utils/open-url.js
@@ -39,7 +39,7 @@ const open = async (npm, url, errMsg, isFile) => {
   const command = browser === true ? null : browser
   await promiseSpawn.open(url, { command })
     .catch((err) => {
-      if (err.code !== 'ENOENT') {
+      if (err.code !== 127) {
         throw err
       }
 

--- a/tap-snapshots/test/lib/utils/open-url-prompt.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/open-url-prompt.js.test.cjs
@@ -5,6 +5,14 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/lib/utils/open-url-prompt.js TAP does not error when opener can not find command > Outputs extra Browser unavailable message and url 1`] = `
+npm home:
+https://www.npmjs.com
+Browser unavailable.  Please open the URL manually:
+  https://www.npmjs.com
+
+`
+
 exports[`test/lib/utils/open-url-prompt.js TAP opens a url > must match snapshot 1`] = `
 npm home:
 https://www.npmjs.com

--- a/test/lib/utils/open-url-prompt.js
+++ b/test/lib/utils/open-url-prompt.js
@@ -126,11 +126,22 @@ t.test('does not open url if canceled', async t => {
 
 t.test('returns error when opener errors', async t => {
   const { error, openerUrl } = await mockOpenUrlPrompt(t, {
-    openerResult: new Error('Opener failed'),
+    openerResult: Object.assign(new Error('Opener failed'), { code: 1 }),
   })
 
   t.match(error, /Opener failed/, 'got the correct error')
   t.equal(openerUrl, 'https://www.npmjs.com', 'did not open')
+})
+
+t.test('does not error when opener can not find command', async t => {
+  const { OUTPUT, error, openerUrl } = await mockOpenUrlPrompt(t, {
+    // openerResult: new Error('Opener failed'),
+    openerResult: Object.assign(new Error('Opener failed'), { code: 127 }),
+  })
+
+  t.notOk(error, 'Did not error')
+  t.equal(openerUrl, 'https://www.npmjs.com', 'did not open')
+  t.matchSnapshot(OUTPUT, 'Outputs extra Browser unavailable message and url')
 })
 
 t.test('throws "canceled" error on SIGINT', async t => {

--- a/test/lib/utils/open-url.js
+++ b/test/lib/utils/open-url.js
@@ -124,7 +124,7 @@ t.test('prints where to go when given browser does not exist', async t => {
   const { openerUrl, openerOpts, joinedOutput } = await mockOpenUrl(t,
     ['https://www.npmjs.com', 'npm home'],
     {
-      openerResult: Object.assign(new Error('failed'), { code: 'ENOENT' }),
+      openerResult: Object.assign(new Error('failed'), { code: 127 }),
     }
   )
 


### PR DESCRIPTION
v9 backport of #6951
v9 backport of #7005 