### PR TITLE
fix: issue-5850 - Settle override conflicts between edges and propagate changes

### DIFF
--- a/workspaces/arborist/lib/dep-valid.js
+++ b/workspaces/arborist/lib/dep-valid.js
@@ -101,7 +101,7 @@ const depValid = (child, requested, requestor) => {
       })
     }
 
-    default: // unpossible, just being cautious
+    default: // impossible, just being cautious
       break
   }
 

--- a/workspaces/arborist/lib/edge.js
+++ b/workspaces/arborist/lib/edge.js
@@ -258,7 +258,7 @@ class Edge {
     const newTo = this.#from.resolve(this.#name)
     if (newTo !== this.#to) {
       if (this.#to) {
-        this.#to.edgesIn.delete(this)
+        this.#to.deleteEdgeIn(this)
       }
       this.#to = newTo
       this.#error = null
@@ -273,7 +273,7 @@ class Edge {
   detach () {
     this.#explanation = null
     if (this.#to) {
-      this.#to.edgesIn.delete(this)
+      this.#to.deleteEdgeIn(this)
     }
     this.#from.edgesOut.delete(this.#name)
     this.#to = null

--- a/workspaces/arborist/lib/edge.js
+++ b/workspaces/arborist/lib/edge.js
@@ -250,8 +250,20 @@ class Edge {
 
   reload (hard = false) {
     this.#explanation = null
+    let needToUpdateOverrideSet = false
+    let newOverrideSet
+    let oldOverrideSet
     if (this.#from.overrides) {
-      this.overrides = this.#from.overrides.getEdgeRule(this)
+      newOverrideSet = this.#from.overrides.getEdgeRule(this)
+      if (newOverrideSet && !newOverrideSet.isEqual(this.overrides)) {
+        needToUpdateOverrideSet = true
+        oldOverrideSet = this.overrides
+        this.overrides = newOverrideSet
+      }
+//      if (this.overrides !== this.#from.overrides) {
+//        console.log(this.#from.overrides)
+//        console.log(this.overrides)
+//      }
     } else {
       delete this.overrides
     }
@@ -267,6 +279,10 @@ class Edge {
       }
     } else if (hard) {
       this.#error = null
+    }
+    else if (needToUpdateOverrideSet) {
+      this.#to.updateNodeOverrideSetDueToEdgeRemoval(oldOverrideSet)
+      this.#to.updateNodeOverrideSet(newOverrideSet)
     }
   }
 

--- a/workspaces/arborist/lib/edge.js
+++ b/workspaces/arborist/lib/edge.js
@@ -114,7 +114,7 @@ class Edge {
     }
 
     // If there's no override we just use the spec.
-    if (!this.overridden) {
+    if (!this.overrides) {
       return depValid(node, this.spec, this.#accept, this.#from)
     }
     // There's some override. If the target node satisfies the overriding spec

--- a/workspaces/arborist/lib/edge.js
+++ b/workspaces/arborist/lib/edge.js
@@ -4,6 +4,7 @@
 const util = require('util')
 const npa = require('npm-package-arg')
 const depValid = require('./dep-valid.js')
+const OverrideSet = require('./override-set.js')
 
 class ArboristEdge {
   constructor (edge) {
@@ -267,7 +268,7 @@ class Edge {
         this.#error = 'PEER LOCAL'
       } else if (!this.satisfiedBy(this.#to)) {
         this.#error = 'INVALID'
-      } else if (this.overrides && this.#to.edgesOut.size && this.#to.constructor.doOverrideSetsConflict(this.overrides, this.#to.overrides)) {
+      } else if (this.overrides && this.#to.edgesOut.size && OverrideSet.doOverrideSetsConflict(this.overrides, this.#to.overrides)) {
         // Any inconsistency between the edge's override set and the target's override set is potentially problematic.
         // But we only say the edge is in error if the override sets are plainly conflicting.
         // Note that if the target doesn't have any dependencies of their own, then this inconsistency is irrelevant.

--- a/workspaces/arborist/lib/edge.js
+++ b/workspaces/arborist/lib/edge.js
@@ -263,7 +263,6 @@ class Edge {
         } else {
           this.#error = 'MISSING'
         }
-      } else if (this.peer && this.#from === this.#to.parent && !this.#from.isTop) {
       } else if (this.peer && this.#from === this.#to.parent && !this.#from?.isTop) {
         this.#error = 'PEER LOCAL'
       } else if (!this.satisfiedBy(this.#to)) {
@@ -289,7 +288,6 @@ class Edge {
     let needToUpdateOverrideSet = false
     let newOverrideSet
     let oldOverrideSet
-    if (this.#from.overrides) {
     if (this.#from?.overrides) {
       newOverrideSet = this.#from.overrides.getEdgeRule(this)
       if (newOverrideSet && !newOverrideSet.isEqual(this.overrides)) {
@@ -302,7 +300,6 @@ class Edge {
     } else {
       delete this.overrides
     }
-    const newTo = this.#from.resolve(this.#name)
     const newTo = this.#from?.resolve(this.#name)
     if (newTo !== this.#to) {
       if (this.#to) {
@@ -328,7 +325,6 @@ class Edge {
     if (this.#to) {
       this.#to.deleteEdgeIn(this)
     }
-    this.#from.edgesOut.delete(this.#name)
     this.#from?.edgesOut.delete(this.#name)
     this.#to = null
     this.#error = 'DETACHED'

--- a/workspaces/arborist/lib/edge.js
+++ b/workspaces/arborist/lib/edge.js
@@ -179,6 +179,9 @@ class Edge {
 
   get spec () {
     if (this.overrides?.value && this.overrides.value !== '*' && this.overrides.name === this.#name) {
+      if (this.overrides === this.#from.overrides) {
+        return this.#spec
+      }
       if (this.overrides.value.startsWith('$')) {
         const ref = this.overrides.value.slice(1)
         // we may be a virtual root, if we are we want to resolve reference overrides
@@ -238,6 +241,12 @@ class Edge {
         this.#error = 'PEER LOCAL'
       } else if (!this.satisfiedBy(this.#to)) {
         this.#error = 'INVALID'
+      } else if (this.overrides && this.#to.edgesOut.size) {
+        if (!this.#to.findSpecificOverrideSet(this.overrides, this.#to.overrides)) {
+          // In principle any kind of difference here has some potential for problem,
+          // but we'll say it's invalid only if the override sets are plainly conflicting.
+          this.#error = 'INVALID'
+        }
       } else {
         this.#error = 'OK'
       }
@@ -260,10 +269,6 @@ class Edge {
         oldOverrideSet = this.overrides
         this.overrides = newOverrideSet
       }
-//      if (this.overrides !== this.#from.overrides) {
-//        console.log(this.#from.overrides)
-//        console.log(this.overrides)
-//      }
     } else {
       delete this.overrides
     }

--- a/workspaces/arborist/lib/edge.js
+++ b/workspaces/arborist/lib/edge.js
@@ -204,7 +204,7 @@ class Edge {
   get spec () {
     if (this.overrides?.value && this.overrides.value !== '*' && this.overrides.name === this.#name) {
       // If this edge has the same overrides field as the source, then we're not applying an override for this edge.
-      if (this.overrides === this.#from.overrides) {
+      if (this.overrides === this.#from?.overrides) {
         return this.#spec
       }
 
@@ -212,9 +212,9 @@ class Edge {
         const ref = this.overrides.value.slice(1)
         // we may be a virtual root, if we are we want to resolve reference overrides
         // from the real root, not the virtual one
-        const pkg = this.#from.sourceReference
-          ? this.#from.sourceReference.root.package
-          : this.#from.root.package
+        const pkg = this.#from?.sourceReference
+          ? this.#from?.sourceReference.root.package
+          : this.#from?.root?.package
         if (pkg.devDependencies?.[ref]) {
           return pkg.devDependencies[ref]
         }
@@ -264,6 +264,7 @@ class Edge {
           this.#error = 'MISSING'
         }
       } else if (this.peer && this.#from === this.#to.parent && !this.#from.isTop) {
+      } else if (this.peer && this.#from === this.#to.parent && !this.#from?.isTop) {
         this.#error = 'PEER LOCAL'
       } else if (!this.satisfiedBy(this.#to)) {
         this.#error = 'INVALID'
@@ -289,6 +290,7 @@ class Edge {
     let newOverrideSet
     let oldOverrideSet
     if (this.#from.overrides) {
+    if (this.#from?.overrides) {
       newOverrideSet = this.#from.overrides.getEdgeRule(this)
       if (newOverrideSet && !newOverrideSet.isEqual(this.overrides)) {
         // If there's a new different override set we need to propagate it to the nodes.
@@ -301,6 +303,7 @@ class Edge {
       delete this.overrides
     }
     const newTo = this.#from.resolve(this.#name)
+    const newTo = this.#from?.resolve(this.#name)
     if (newTo !== this.#to) {
       if (this.#to) {
         this.#to.deleteEdgeIn(this)
@@ -326,6 +329,7 @@ class Edge {
       this.#to.deleteEdgeIn(this)
     }
     this.#from.edgesOut.delete(this.#name)
+    this.#from?.edgesOut.delete(this.#name)
     this.#to = null
     this.#error = 'DETACHED'
     this.#from = null

--- a/workspaces/arborist/lib/edge.js
+++ b/workspaces/arborist/lib/edge.js
@@ -267,7 +267,7 @@ class Edge {
         this.#error = 'PEER LOCAL'
       } else if (!this.satisfiedBy(this.#to)) {
         this.#error = 'INVALID'
-      } else if (this.overrides && this.#to.edgesOut.size && !this.#to.constructor.findSpecificOverrideSet(this.overrides, this.#to.overrides)) {
+      } else if (this.overrides && this.#to.edgesOut.size && this.#to.constructor.doOverrideSetsConflict(this.overrides, this.#to.overrides)) {
         // Any inconsistency between the edge's override set and the target's override set is potentially problematic.
         // But we only say the edge is in error if the override sets are plainly conflicting.
         // Note that if the target doesn't have any dependencies of their own, then this inconsistency is irrelevant.

--- a/workspaces/arborist/lib/edge.js
+++ b/workspaces/arborist/lib/edge.js
@@ -103,7 +103,6 @@ class Edge {
   }
 
   satisfiedBy (node) {
-    if (node.name !== this.#name) {
     if (node.name !== this.#name || !this.#from) {
       return false
     }
@@ -115,7 +114,6 @@ class Edge {
     }
 
     // If there's no override we just use the spec.
-    if (!this.overrides) {
     if (!this.overrides?.keySpec) {
       return depValid(node, this.spec, this.#accept, this.#from)
     }

--- a/workspaces/arborist/lib/edge.js
+++ b/workspaces/arborist/lib/edge.js
@@ -104,6 +104,7 @@ class Edge {
 
   satisfiedBy (node) {
     if (node.name !== this.#name) {
+    if (node.name !== this.#name || !this.#from) {
       return false
     }
 
@@ -115,6 +116,7 @@ class Edge {
 
     // If there's no override we just use the spec.
     if (!this.overrides) {
+    if (!this.overrides?.keySpec) {
       return depValid(node, this.spec, this.#accept, this.#from)
     }
     // There's some override. If the target node satisfies the overriding spec

--- a/workspaces/arborist/lib/edge.js
+++ b/workspaces/arborist/lib/edge.js
@@ -267,7 +267,7 @@ class Edge {
         this.#error = 'PEER LOCAL'
       } else if (!this.satisfiedBy(this.#to)) {
         this.#error = 'INVALID'
-      } else if (this.overrides && this.#to.edgesOut.size && !this.#to.findSpecificOverrideSet(this.overrides, this.#to.overrides)) {
+      } else if (this.overrides && this.#to.edgesOut.size && !this.#to.constructor.findSpecificOverrideSet(this.overrides, this.#to.overrides)) {
         // Any inconsistency between the edge's override set and the target's override set is potentially problematic.
         // But we only say the edge is in error if the override sets are plainly conflicting.
         // Note that if the target doesn't have any dependencies of their own, then this inconsistency is irrelevant.

--- a/workspaces/arborist/lib/node.js
+++ b/workspaces/arborist/lib/node.js
@@ -1346,8 +1346,7 @@ class Node {
 
   recalculateOutEdgesOverrides () {
     // For each edge out propogate the new overrides through.
-    for (const edgePair of this.edgesOut) {
-      const edge = edgePair[1]
+    for (const [, edge] of this.edgesOut) {
       edge.reload(true)
       if (edge.to) {
         edge.to.updateNodeOverrideSet(edge.overrides)
@@ -1366,7 +1365,6 @@ class Node {
         return first
       }
     }
-    return undefined
   }
 
   updateNodeOverrideSetDueToEdgeRemoval (otherOverrideSet) {
@@ -1409,7 +1407,7 @@ class Node {
     let newOverrideSet = this.findSpecificOverrideSet(this.overrides, otherOverrideSet)
     if (!newOverrideSet) {
       // There are conflicting relevant override sets here. We should keep the remaining override set and mark the incoming edge as invalid somehow.
-      console.log("Overrides are in conflict.")
+      throw Object.assign(new Error(`Two conflicting override sets for ${this.name}`), { code: 'EOVERRIDE' })
     } else {
       if (this.overrides != newOverrideSet) {
         this.overrides = newOverrideSet

--- a/workspaces/arborist/lib/node.js
+++ b/workspaces/arborist/lib/node.js
@@ -1356,12 +1356,12 @@ class Node {
 
   findSpecificOverrideSet (first, second) {
     for (let overrideSet = second; overrideSet; overrideSet = overrideSet.parent) {
-      if (overrideSet == first) {
+      if (overrideSet.isEqual(first)) {
         return second
       }
     }
     for (let overrideSet = first; overrideSet; overrideSet = overrideSet.parent) {
-      if (overrideSet == second) {
+      if (overrideSet.isEqual(second)) {
         return first
       }
     }
@@ -1370,7 +1370,7 @@ class Node {
 
   updateNodeOverrideSetDueToEdgeRemoval (otherOverrideSet) {
     // If this edge's overrides isn't equal to this node's overrides, then removing it won't change newOverrideSet later.
-    if (this.overrides != otherOverrideSet) {
+    if (!this.overrides.isEqual(otherOverrideSet)) {
       return false
     }
     let newOverrideSet
@@ -1381,7 +1381,7 @@ class Node {
         newOverrideSet = edge.overrides
       }
     }
-    if (this.overrides == newOverrideSet) {
+    if (this.overrides.isEqual(newOverrideSet)) {
       return false
     }
     this.overrides = newOverrideSet
@@ -1402,7 +1402,7 @@ class Node {
   // both, one of its dependencies might need to be different depending on the edge leading to it.
   // However, this might cause a lot of duplication, because the conflict in the dependencies might never actually happen.
   updateNodeOverrideSet (otherOverrideSet) {
-    if (this.overrides == otherOverrideSet) {
+    if (this.overrides.isEqual(otherOverrideSet)) {
       return false
     }
     if (!this.overrides) {
@@ -1415,7 +1415,7 @@ class Node {
       // This is an error condition. We can only get here if the new override set is in conflict with the existing.
       return false
     } else {
-      if (this.overrides != newOverrideSet) {
+      if (!this.overrides.isEqual(newOverrideSet)) {
         this.overrides = newOverrideSet
         this.recalculateOutEdgesOverrides()
         return true
@@ -1435,7 +1435,7 @@ class Node {
     // We need to handle the case where the new edge in has an overrides field which is different from the current value.
     // Assuming there are any overrides at all, the overrides field is never undefined for any node at the end state of the tree.
     // So if the new edge's overrides is undefined it will be updated later. So we can wait with updating the node's overrides field.
-    if (edge.overrides && this.overrides != edge.overrides) {
+    if (edge.overrides && !this.overrides.isEqual(edge.overrides)) {
       this.updateNodeOverrideSet(edge.overrides)
     }
 

--- a/workspaces/arborist/lib/node.js
+++ b/workspaces/arborist/lib/node.js
@@ -1365,7 +1365,7 @@ class Node {
         return first
       }
     }
-    console.log("Conflicting override sets")
+    console.log('Conflicting override sets')
   }
 
   updateNodeOverrideSetDueToEdgeRemoval (otherOverrideSet) {
@@ -1408,12 +1408,12 @@ class Node {
       }
       this.overrides = otherOverrideSet
       this.recalculateOutEdgesOverrides()
-      return true      
+      return true
     }
     if (this.overrides.isEqual(otherOverrideSet)) {
       return false
     }
-    let newOverrideSet = this.findSpecificOverrideSet(this.overrides, otherOverrideSet)
+    const newOverrideSet = this.findSpecificOverrideSet(this.overrides, otherOverrideSet)
     if (!newOverrideSet) {
       // This is an error condition. We can only get here if the new override set is in conflict with the existing.
       return false
@@ -1426,7 +1426,7 @@ class Node {
       return false
     }
   }
-  
+
   deleteEdgeIn (edge) {
     this.edgesIn.delete(edge)
     if (edge.overrides) {

--- a/workspaces/arborist/lib/node.js
+++ b/workspaces/arborist/lib/node.js
@@ -1370,7 +1370,7 @@ class Node {
 
   updateNodeOverrideSetDueToEdgeRemoval (otherOverrideSet) {
     // If this edge's overrides isn't equal to this node's overrides, then removing it won't change newOverrideSet later.
-    if (!this.overrides.isEqual(otherOverrideSet)) {
+    if (!this.overrides || !this.overrides.isEqual(otherOverrideSet)) {
       return false
     }
     let newOverrideSet
@@ -1402,13 +1402,16 @@ class Node {
   // both, one of its dependencies might need to be different depending on the edge leading to it.
   // However, this might cause a lot of duplication, because the conflict in the dependencies might never actually happen.
   updateNodeOverrideSet (otherOverrideSet) {
-    if (this.overrides.isEqual(otherOverrideSet)) {
-      return false
-    }
     if (!this.overrides) {
+      if (!otherOverrideSet) {
+        return false
+      }
       this.overrides = otherOverrideSet
       this.recalculateOutEdgesOverrides()
-      return true
+      return true      
+    }
+    if (this.overrides.isEqual(otherOverrideSet)) {
+      return false
     }
     let newOverrideSet = this.findSpecificOverrideSet(this.overrides, otherOverrideSet)
     if (!newOverrideSet) {

--- a/workspaces/arborist/lib/node.js
+++ b/workspaces/arborist/lib/node.js
@@ -1403,6 +1403,8 @@ class Node {
   // However, this might cause a lot of duplication, because the conflict in the dependencies might never actually happen.
   updateNodeOverrideSet (otherOverrideSet) {
     if (!this.overrides) {
+      // Assuming there are any overrides at all, the overrides field is never undefined for any node at the end state of the tree.
+      // So if the new edge's overrides is undefined it will be updated later. So we can wait with updating the node's overrides field.
       if (!otherOverrideSet) {
         return false
       }
@@ -1414,10 +1416,7 @@ class Node {
       return false
     }
     const newOverrideSet = this.findSpecificOverrideSet(this.overrides, otherOverrideSet)
-    if (!newOverrideSet) {
-      // This is an error condition. We can only get here if the new override set is in conflict with the existing.
-      return false
-    } else {
+    if (newOverrideSet) {
       if (!this.overrides.isEqual(newOverrideSet)) {
         this.overrides = newOverrideSet
         this.recalculateOutEdgesOverrides()
@@ -1425,6 +1424,7 @@ class Node {
       }
       return false
     }
+    // This is an error condition. We can only get here if the new override set is in conflict with the existing.
   }
 
   deleteEdgeIn (edge) {
@@ -1436,9 +1436,7 @@ class Node {
 
   addEdgeIn (edge) {
     // We need to handle the case where the new edge in has an overrides field which is different from the current value.
-    // Assuming there are any overrides at all, the overrides field is never undefined for any node at the end state of the tree.
-    // So if the new edge's overrides is undefined it will be updated later. So we can wait with updating the node's overrides field.
-    if (edge.overrides && (!this.overrides || !this.overrides.isEqual(edge.overrides))) {
+    if (!this.overrides || !this.overrides.isEqual(edge.overrides)) {
       this.updateNodeOverrideSet(edge.overrides)
     }
 

--- a/workspaces/arborist/lib/node.js
+++ b/workspaces/arborist/lib/node.js
@@ -1438,7 +1438,7 @@ class Node {
     // We need to handle the case where the new edge in has an overrides field which is different from the current value.
     // Assuming there are any overrides at all, the overrides field is never undefined for any node at the end state of the tree.
     // So if the new edge's overrides is undefined it will be updated later. So we can wait with updating the node's overrides field.
-    if (edge.overrides && !this.overrides.isEqual(edge.overrides)) {
+    if (edge.overrides && (!this.overrides || !this.overrides.isEqual(edge.overrides))) {
       this.updateNodeOverrideSet(edge.overrides)
     }
 

--- a/workspaces/arborist/lib/node.js
+++ b/workspaces/arborist/lib/node.js
@@ -1004,10 +1004,19 @@ class Node {
       return false
     }
 
-    // XXX need to check for two root nodes?
-    if (node.overrides !== this.overrides) {
-      return false
+    if (this.edgesOut.size) {
+      // XXX need to check for two root nodes?
+      if (node.overrides) {
+        if (!node.overrides.isEqual(this.overrides)) {
+          return false
+        }
+      } else {
+        if (this.overrides) {
+          return false
+        }
+      }
     }
+
     ignorePeers = new Set(ignorePeers)
 
     // gather up all the deps of this node and that are only depended

--- a/workspaces/arborist/lib/node.js
+++ b/workspaces/arborist/lib/node.js
@@ -1386,24 +1386,6 @@ class Node {
     }
   }
 
-  static findSpecificOverrideSet (first, second) {
-    for (let overrideSet = second; overrideSet; overrideSet = overrideSet.parent) {
-      if (overrideSet.isEqual(first)) {
-        return second
-      }
-    }
-    for (let overrideSet = first; overrideSet; overrideSet = overrideSet.parent) {
-      if (overrideSet.isEqual(second)) {
-        return first
-      }
-    }
-    log.silly('Conflicting override sets', first, second)
-  }
-
-  static doOverrideSetsConflict (first, second) {
-    return (this.findSpecificOverrideSet(first, second) === undefined)
-  }
-
   updateOverridesEdgeInRemoved (otherOverrideSet) {
     // If this edge's overrides isn't equal to this node's overrides, then removing it won't change newOverrideSet later.
     if (!this.overrides || !this.overrides.isEqual(otherOverrideSet)) {
@@ -1412,7 +1394,7 @@ class Node {
     let newOverrideSet
     for (const edge of this.edgesIn) {
       if (newOverrideSet && edge.overrides) {
-        newOverrideSet = Node.findSpecificOverrideSet(edge.overrides, newOverrideSet)
+        newOverrideSet = OverrideSet.findSpecificOverrideSet(edge.overrides, newOverrideSet)
       } else {
         newOverrideSet = edge.overrides
       }
@@ -1451,7 +1433,7 @@ class Node {
     if (this.overrides.isEqual(otherOverrideSet)) {
       return false
     }
-    const newOverrideSet = Node.findSpecificOverrideSet(this.overrides, otherOverrideSet)
+    const newOverrideSet = OverrideSet.findSpecificOverrideSet(this.overrides, otherOverrideSet)
     if (newOverrideSet) {
       if (!this.overrides.isEqual(newOverrideSet)) {
         this.overrides = newOverrideSet

--- a/workspaces/arborist/lib/node.js
+++ b/workspaces/arborist/lib/node.js
@@ -1397,7 +1397,7 @@ class Node {
     }
     let newOverrideSet
     for (const edge of this.edgesIn) {
-      if (newOverrideSet) {
+      if (newOverrideSet && edge.overrides) {
         newOverrideSet = this.findSpecificOverrideSet(edge.overrides, newOverrideSet)
       } else {
         newOverrideSet = edge.overrides
@@ -1424,12 +1424,12 @@ class Node {
   // both, one of its dependencies might need to be different depending on the edge leading to it.
   // However, this might cause a lot of duplication, because the conflict in the dependencies might never actually happen.
   updateNodeOverrideSet (otherOverrideSet) {
-    if (!this.overrides) {
+    if (!otherOverrideSet) {
       // Assuming there are any overrides at all, the overrides field is never undefined for any node at the end state of the tree.
       // So if the new edge's overrides is undefined it will be updated later. So we can wait with updating the node's overrides field.
-      if (!otherOverrideSet) {
-        return false
-      }
+      return false
+    }
+    if (!this.overrides) {
       this.overrides = otherOverrideSet
       this.recalculateOutEdgesOverrides()
       return true

--- a/workspaces/arborist/lib/node.js
+++ b/workspaces/arborist/lib/node.js
@@ -342,7 +342,24 @@ class Node {
   }
 
   get overridden () {
-    return !!(this.overrides && this.overrides.value && this.overrides.name === this.name)
+    if (!this.overrides) {
+      return false
+    }
+    if (!this.overrides.value) {
+      return false
+    }
+    if (this.overrides.name !== this.name) {
+      return false
+    }
+    for (const edge of this.edgesIn) {
+      if (this.overrides.isEqual(edge.overrides)) {
+        if (!edge.overrides.isEqual(edge.from.overrides)) {
+          return true
+        }
+      }
+    }
+
+    return false
   }
 
   get package () {

--- a/workspaces/arborist/lib/node.js
+++ b/workspaces/arborist/lib/node.js
@@ -1397,7 +1397,7 @@ class Node {
         return first
       }
     }
-    log.silly('Conflicting override sets', this, first, second)
+    log.silly('Conflicting override sets', first, second)
   }
 
   static doOverrideSetsConflict (first, second) {

--- a/workspaces/arborist/lib/node.js
+++ b/workspaces/arborist/lib/node.js
@@ -1408,7 +1408,7 @@ class Node {
     let newOverrideSet
     for (const edge of this.edgesIn) {
       if (newOverrideSet && edge.overrides) {
-        newOverrideSet = this.findSpecificOverrideSet(edge.overrides, newOverrideSet)
+        newOverrideSet = Node.findSpecificOverrideSet(edge.overrides, newOverrideSet)
       } else {
         newOverrideSet = edge.overrides
       }
@@ -1447,7 +1447,7 @@ class Node {
     if (this.overrides.isEqual(otherOverrideSet)) {
       return false
     }
-    const newOverrideSet = this.findSpecificOverrideSet(this.overrides, otherOverrideSet)
+    const newOverrideSet = Node.findSpecificOverrideSet(this.overrides, otherOverrideSet)
     if (newOverrideSet) {
       if (!this.overrides.isEqual(newOverrideSet)) {
         this.overrides = newOverrideSet

--- a/workspaces/arborist/lib/node.js
+++ b/workspaces/arborist/lib/node.js
@@ -1106,8 +1106,13 @@ class Node {
       return false
     }
 
-    // if we prefer dedupe, or if the version is greater/equal, take the other
-    if (preferDedupe || semver.gte(other.version, this.version)) {
+    // if we prefer dedupe, or if the version is equal, take the other
+    if (preferDedupe || semver.eq(other.version, this.version)) {
+      return true
+    }
+
+    // if our current version isn't the result of an override, then prefer to take the greater version
+    if (!this.overridden && semver.gt(other.version, this.version)) {
       return true
     }
 

--- a/workspaces/arborist/lib/node.js
+++ b/workspaces/arborist/lib/node.js
@@ -837,9 +837,6 @@ class Node {
       target.root = root
     }
 
-    if (!this.overrides && this.parent && this.parent.overrides) {
-      this.overrides = this.parent.overrides.getNodeRule(this)
-    }
     // tree should always be valid upon root setter completion.
     treeCheck(this)
     if (this !== root) {

--- a/workspaces/arborist/lib/node.js
+++ b/workspaces/arborist/lib/node.js
@@ -1378,7 +1378,7 @@ class Node {
 
   recalculateOutEdgesOverrides () {
     // For each edge out propogate the new overrides through.
-    for (const [, edge] of this.edgesOut) {
+    for (const edge of this.edgesOut.values()) {
       edge.reload(true)
       if (edge.to) {
         edge.to.updateOverridesEdgeInAdded(edge.overrides)
@@ -1386,7 +1386,7 @@ class Node {
     }
   }
 
-  findSpecificOverrideSet (first, second) {
+  static findSpecificOverrideSet (first, second) {
     for (let overrideSet = second; overrideSet; overrideSet = overrideSet.parent) {
       if (overrideSet.isEqual(first)) {
         return second

--- a/workspaces/arborist/lib/node.js
+++ b/workspaces/arborist/lib/node.js
@@ -1247,10 +1247,6 @@ class Node {
       this[_changePath](newPath)
     }
 
-    if (parent.overrides) {
-      this.overrides = parent.overrides.getNodeRule(this)
-    }
-
     // clobbers anything at that path, resets all appropriate references
     this.root = parent.root
   }

--- a/workspaces/arborist/lib/node.js
+++ b/workspaces/arborist/lib/node.js
@@ -358,7 +358,7 @@ class Node {
     // versions. To make sure this package was actually overridden, we check whether any edge going in
     // had the rule applied to it, in which case its overrides set is different than its source node.
     for (const edge of this.edgesIn) {
-      if (this.overrides.isEqual(edge.overrides)) {
+      if (edge.overrides && edge.overrides.name === this.name && edge.overrides.value === this.version) {
         if (!edge.overrides.isEqual(edge.from.overrides)) {
           return true
         }

--- a/workspaces/arborist/lib/node.js
+++ b/workspaces/arborist/lib/node.js
@@ -65,6 +65,8 @@ const CaseInsensitiveMap = require('./case-insensitive-map.js')
 
 const querySelectorAll = require('./query-selector-all.js')
 
+const log = require('proc-log')
+
 class Node {
   #global
   #meta
@@ -1390,7 +1392,7 @@ class Node {
         return first
       }
     }
-    console.log('Conflicting override sets')
+    log.silly('Conflicting override sets', this, first, second)
   }
 
   updateOverridesEdgeInRemoved (otherOverrideSet) {
@@ -1450,6 +1452,7 @@ class Node {
       return false
     }
     // This is an error condition. We can only get here if the new override set is in conflict with the existing.
+    throw Object.assign(new Error(`Conflicting override requirements for node ${this.name}`), { code: 'EOVERRIDE' })
   }
 
   deleteEdgeIn (edge) {

--- a/workspaces/arborist/lib/node.js
+++ b/workspaces/arborist/lib/node.js
@@ -1400,6 +1400,10 @@ class Node {
     log.silly('Conflicting override sets', this, first, second)
   }
 
+  static doOverrideSetsConflict (first, second) {
+    return (this.findSpecificOverrideSet(first, second) === undefined)
+  }
+
   updateOverridesEdgeInRemoved (otherOverrideSet) {
     // If this edge's overrides isn't equal to this node's overrides, then removing it won't change newOverrideSet later.
     if (!this.overrides || !this.overrides.isEqual(otherOverrideSet)) {
@@ -1457,7 +1461,7 @@ class Node {
       return false
     }
     // This is an error condition. We can only get here if the new override set is in conflict with the existing.
-    throw Object.assign(new Error(`Conflicting override requirements for node ${this.name}`), { code: 'EOVERRIDE' })
+    log.silly('Conflicting override sets', this.name)
   }
 
   deleteEdgeIn (edge) {

--- a/workspaces/arborist/lib/override-set.js
+++ b/workspaces/arborist/lib/override-set.js
@@ -44,6 +44,34 @@ class OverrideSet {
     }
   }
 
+  childrenAreEqual (other) {
+    if (this.children.size !== other.children.size) {
+      return false
+    }
+    for (const [key, ] of this.children) {
+      if (!other.children.has(key)) {
+        return false
+      }
+      if (!this.children[key].value === other.children[key].value) {
+        return false
+      }
+      if (!this.children[key].childrenAreEqual(other.children[key])) {
+        return false
+      }
+    }
+    return true
+  }
+
+  isEqual (other) {
+    if (this === other) {
+      return true
+    }
+    if (this.key !== other.key || this.value !== other.value || !this.childrenAreEqual(other) || !this.parent.isEqual(other.parent)) {
+      return false
+    }
+    return true
+  }
+
   getEdgeRule (edge) {
     for (const rule of this.ruleset.values()) {
       if (rule.name !== edge.name) {

--- a/workspaces/arborist/lib/override-set.js
+++ b/workspaces/arborist/lib/override-set.js
@@ -52,10 +52,10 @@ class OverrideSet {
       if (!other.children.has(key)) {
         return false
       }
-      if (!this.children[key].value === other.children[key].value) {
+      if (!this.children.get(key).value === other.children.get(key).value) {
         return false
       }
-      if (!this.children[key].childrenAreEqual(other.children[key])) {
+      if (!this.children.get(key).childrenAreEqual(other.children.get(key))) {
         return false
       }
     }
@@ -69,10 +69,16 @@ class OverrideSet {
     if (!other) {
       return false
     }
-    if (this.key !== other.key || this.value !== other.value || !this.childrenAreEqual(other) || !this.parent.isEqual(other.parent)) {
+    if (this.key !== other.key || this.value !== other.value) {
       return false
     }
-    return true
+    if (!this.childrenAreEqual(other)) {
+      return false
+    }
+    if (!this.parent) {
+      return !other.parent
+    }
+    return this.parent.isEqual(other.parent)
   }
 
   getEdgeRule (edge) {

--- a/workspaces/arborist/lib/override-set.js
+++ b/workspaces/arborist/lib/override-set.js
@@ -48,7 +48,7 @@ class OverrideSet {
     if (this.children.size !== other.children.size) {
       return false
     }
-    for (const [key, ] of this.children) {
+    for (const [key,] of this.children) {
       if (!other.children.has(key)) {
         return false
       }

--- a/workspaces/arborist/lib/override-set.js
+++ b/workspaces/arborist/lib/override-set.js
@@ -48,11 +48,11 @@ class OverrideSet {
     if (this.children.size !== other.children.size) {
       return false
     }
-    for (const [key,] of this.children) {
+    for (const [key] of this.children) {
       if (!other.children.has(key)) {
         return false
       }
-      if (!this.children.get(key).value === other.children.get(key).value) {
+      if (this.children.get(key).value !== other.children.get(key).value) {
         return false
       }
       if (!this.children.get(key).childrenAreEqual(other.children.get(key))) {

--- a/workspaces/arborist/lib/override-set.js
+++ b/workspaces/arborist/lib/override-set.js
@@ -66,6 +66,9 @@ class OverrideSet {
     if (this === other) {
       return true
     }
+    if (!other) {
+      return false
+    }
     if (this.key !== other.key || this.value !== other.value || !this.childrenAreEqual(other) || !this.parent.isEqual(other.parent)) {
       return false
     }

--- a/workspaces/arborist/lib/override-set.js
+++ b/workspaces/arborist/lib/override-set.js
@@ -200,8 +200,7 @@ class OverrideSet {
   
   static doOverrideSetsConflict (first, second) {
     // If override sets contain one another then we can try to use the more specific one.
-    // This is imperfect, since we may lose some of the context of the less specific override
-    // set. But the more specific override set is more important to propagate, so we go with it.
+    // If neither one is more specific, then we consider them to be in conflict.
     return (this.findSpecificOverrideSet(first, second) === undefined)
   }
 }

--- a/workspaces/arborist/lib/override-set.js
+++ b/workspaces/arborist/lib/override-set.js
@@ -92,6 +92,7 @@ class OverrideSet {
         return rule
       }
 
+      // We need to use the rawSpec here, because the spec has the overrides applied to it already.
       let spec = npa(`${edge.name}@${edge.rawSpec}`)
       if (spec.type === 'alias') {
         spec = spec.subSpec

--- a/workspaces/arborist/lib/override-set.js
+++ b/workspaces/arborist/lib/override-set.js
@@ -193,10 +193,15 @@ class OverrideSet {
         return first
       }
     }
+
+    // The override sets are incomparable. Neither one contains the other.
     log.silly('Conflicting override sets', first, second)
   }
   
   static doOverrideSetsConflict (first, second) {
+    // If override sets contain one another then we can try to use the more specific one.
+    // This is imperfect, since we may lose some of the context of the less specific override
+    // set. But the more specific override set is more important to propagate, so we go with it.
     return (this.findSpecificOverrideSet(first, second) === undefined)
   }
 }

--- a/workspaces/arborist/lib/override-set.js
+++ b/workspaces/arborist/lib/override-set.js
@@ -1,5 +1,6 @@
 const npa = require('npm-package-arg')
 const semver = require('semver')
+const log = require('proc-log')
 
 class OverrideSet {
   constructor ({ overrides, key, parent }) {
@@ -179,6 +180,24 @@ class OverrideSet {
     }
 
     return ruleset
+  }
+
+  static findSpecificOverrideSet (first, second) {
+    for (let overrideSet = second; overrideSet; overrideSet = overrideSet.parent) {
+      if (overrideSet.isEqual(first)) {
+        return second
+      }
+    }
+    for (let overrideSet = first; overrideSet; overrideSet = overrideSet.parent) {
+      if (overrideSet.isEqual(second)) {
+        return first
+      }
+    }
+    log.silly('Conflicting override sets', first, second)
+  }
+  
+  static doOverrideSetsConflict (first, second) {
+    return (this.findSpecificOverrideSet(first, second) === undefined)
   }
 }
 

--- a/workspaces/arborist/lib/override-set.js
+++ b/workspaces/arborist/lib/override-set.js
@@ -92,7 +92,7 @@ class OverrideSet {
         return rule
       }
 
-      let spec = npa(`${edge.name}@${edge.spec}`)
+      let spec = npa(`${edge.name}@${edge.rawSpec}`)
       if (spec.type === 'alias') {
         spec = spec.subSpec
       }

--- a/workspaces/arborist/tap-snapshots/test/edge.js.test.cjs
+++ b/workspaces/arborist/tap-snapshots/test/edge.js.test.cjs
@@ -52,6 +52,7 @@ Edge {
   "from": Object {
     "addEdgeIn": Function addEdgeIn(edge),
     "addEdgeOut": Function addEdgeOut(edge),
+    "deleteEdgeIn": Function deleteEdgeIn(edge),
     "edgesIn": Set {},
     "edgesOut": Map {
       "b" => Edge {
@@ -69,6 +70,7 @@ Edge {
     "parent": Object {
       "addEdgeIn": Function addEdgeIn(edge),
       "addEdgeOut": Function addEdgeOut(edge),
+      "deleteEdgeIn": Function deleteEdgeIn(edge),
       "edgesIn": Set {},
       "edgesOut": Map {
         "missing" => Edge {
@@ -91,6 +93,7 @@ Edge {
     "root": Object {
       "addEdgeIn": Function addEdgeIn(edge),
       "addEdgeOut": Function addEdgeOut(edge),
+      "deleteEdgeIn": Function deleteEdgeIn(edge),
       "edgesIn": Set {},
       "edgesOut": Map {
         "missing" => Edge {
@@ -122,6 +125,7 @@ Edge {
   "to": Object {
     "addEdgeIn": Function addEdgeIn(edge),
     "addEdgeOut": Function addEdgeOut(edge),
+    "deleteEdgeIn": Function deleteEdgeIn(edge),
     "edgesIn": Set {
       Edge {
         "peerConflicted": false,
@@ -139,6 +143,7 @@ Edge {
     "parent": Object {
       "addEdgeIn": Function addEdgeIn(edge),
       "addEdgeOut": Function addEdgeOut(edge),
+      "deleteEdgeIn": Function deleteEdgeIn(edge),
       "edgesIn": Set {},
       "edgesOut": Map {
         "missing" => Edge {
@@ -173,6 +178,7 @@ Edge {
   "from": Object {
     "addEdgeIn": Function addEdgeIn(edge),
     "addEdgeOut": Function addEdgeOut(edge),
+    "deleteEdgeIn": Function deleteEdgeIn(edge),
     "edgesIn": Set {},
     "edgesOut": Map {
       "b" => Edge {
@@ -190,6 +196,7 @@ Edge {
     "parent": Object {
       "addEdgeIn": Function addEdgeIn(edge),
       "addEdgeOut": Function addEdgeOut(edge),
+      "deleteEdgeIn": Function deleteEdgeIn(edge),
       "edgesIn": Set {},
       "edgesOut": Map {
         "missing" => Edge {
@@ -212,6 +219,7 @@ Edge {
     "root": Object {
       "addEdgeIn": Function addEdgeIn(edge),
       "addEdgeOut": Function addEdgeOut(edge),
+      "deleteEdgeIn": Function deleteEdgeIn(edge),
       "edgesIn": Set {},
       "edgesOut": Map {
         "missing" => Edge {
@@ -243,6 +251,7 @@ Edge {
   "to": Object {
     "addEdgeIn": Function addEdgeIn(edge),
     "addEdgeOut": Function addEdgeOut(edge),
+    "deleteEdgeIn": Function deleteEdgeIn(edge),
     "edgesIn": Set {
       Edge {
         "peerConflicted": false,
@@ -260,6 +269,7 @@ Edge {
     "parent": Object {
       "addEdgeIn": Function addEdgeIn(edge),
       "addEdgeOut": Function addEdgeOut(edge),
+      "deleteEdgeIn": Function deleteEdgeIn(edge),
       "edgesIn": Set {},
       "edgesOut": Map {
         "missing" => Edge {
@@ -294,6 +304,7 @@ Edge {
   "from": Object {
     "addEdgeIn": Function addEdgeIn(edge),
     "addEdgeOut": Function addEdgeOut(edge),
+    "deleteEdgeIn": Function deleteEdgeIn(edge),
     "edgesIn": Set {},
     "edgesOut": Map {
       "missing" => Edge {
@@ -334,6 +345,7 @@ Edge {
   "from": Object {
     "addEdgeIn": Function addEdgeIn(edge),
     "addEdgeOut": Function addEdgeOut(edge),
+    "deleteEdgeIn": Function deleteEdgeIn(edge),
     "edgesIn": Set {},
     "edgesOut": Map {
       "aa" => Edge {
@@ -351,6 +363,7 @@ Edge {
     "parent": Object {
       "addEdgeIn": Function addEdgeIn(edge),
       "addEdgeOut": Function addEdgeOut(edge),
+      "deleteEdgeIn": Function deleteEdgeIn(edge),
       "edgesIn": Set {},
       "edgesOut": Map {
         "b" => Edge {
@@ -368,6 +381,7 @@ Edge {
       "parent": Object {
         "addEdgeIn": Function addEdgeIn(edge),
         "addEdgeOut": Function addEdgeOut(edge),
+        "deleteEdgeIn": Function deleteEdgeIn(edge),
         "edgesIn": Set {},
         "edgesOut": Map {
           "missing" => Edge {
@@ -390,6 +404,7 @@ Edge {
       "root": Object {
         "addEdgeIn": Function addEdgeIn(edge),
         "addEdgeOut": Function addEdgeOut(edge),
+        "deleteEdgeIn": Function deleteEdgeIn(edge),
         "edgesIn": Set {},
         "edgesOut": Map {
           "missing" => Edge {
@@ -424,6 +439,7 @@ Edge {
   "to": Object {
     "addEdgeIn": Function addEdgeIn(edge),
     "addEdgeOut": Function addEdgeOut(edge),
+    "deleteEdgeIn": Function deleteEdgeIn(edge),
     "edgesIn": Set {
       Edge {
         "peerConflicted": false,
@@ -441,6 +457,7 @@ Edge {
     "parent": Object {
       "addEdgeIn": Function addEdgeIn(edge),
       "addEdgeOut": Function addEdgeOut(edge),
+      "deleteEdgeIn": Function deleteEdgeIn(edge),
       "edgesIn": Set {},
       "edgesOut": Map {
         "b" => Edge {
@@ -458,6 +475,7 @@ Edge {
       "parent": Object {
         "addEdgeIn": Function addEdgeIn(edge),
         "addEdgeOut": Function addEdgeOut(edge),
+        "deleteEdgeIn": Function deleteEdgeIn(edge),
         "edgesIn": Set {},
         "edgesOut": Map {
           "missing" => Edge {
@@ -480,6 +498,7 @@ Edge {
       "root": Object {
         "addEdgeIn": Function addEdgeIn(edge),
         "addEdgeOut": Function addEdgeOut(edge),
+        "deleteEdgeIn": Function deleteEdgeIn(edge),
         "edgesIn": Set {},
         "edgesOut": Map {
           "missing" => Edge {
@@ -516,6 +535,7 @@ Edge {
   "from": Object {
     "addEdgeIn": Function addEdgeIn(edge),
     "addEdgeOut": Function addEdgeOut(edge),
+    "deleteEdgeIn": Function deleteEdgeIn(edge),
     "edgesIn": Set {},
     "edgesOut": Map {
       "aa" => Edge {
@@ -533,6 +553,7 @@ Edge {
     "parent": Object {
       "addEdgeIn": Function addEdgeIn(edge),
       "addEdgeOut": Function addEdgeOut(edge),
+      "deleteEdgeIn": Function deleteEdgeIn(edge),
       "edgesIn": Set {},
       "edgesOut": Map {
         "missing" => Edge {
@@ -576,6 +597,7 @@ Edge {
   "from": Object {
     "addEdgeIn": Function addEdgeIn(edge),
     "addEdgeOut": Function addEdgeOut(edge),
+    "deleteEdgeIn": Function deleteEdgeIn(edge),
     "edgesIn": Set {},
     "edgesOut": Map {
       "aa" => Edge {
@@ -593,6 +615,7 @@ Edge {
     "parent": Object {
       "addEdgeIn": Function addEdgeIn(edge),
       "addEdgeOut": Function addEdgeOut(edge),
+      "deleteEdgeIn": Function deleteEdgeIn(edge),
       "edgesIn": Set {
         Edge {
           "peerConflicted": false,
@@ -610,6 +633,7 @@ Edge {
       "parent": Object {
         "addEdgeIn": Function addEdgeIn(edge),
         "addEdgeOut": Function addEdgeOut(edge),
+        "deleteEdgeIn": Function deleteEdgeIn(edge),
         "edgesIn": Set {},
         "edgesOut": Map {
           "missing" => Edge {
@@ -645,6 +669,7 @@ Edge {
   "to": Object {
     "addEdgeIn": Function addEdgeIn(edge),
     "addEdgeOut": Function addEdgeOut(edge),
+    "deleteEdgeIn": Function deleteEdgeIn(edge),
     "edgesIn": Set {
       Edge {
         "peerConflicted": false,
@@ -662,6 +687,7 @@ Edge {
     "parent": Object {
       "addEdgeIn": Function addEdgeIn(edge),
       "addEdgeOut": Function addEdgeOut(edge),
+      "deleteEdgeIn": Function deleteEdgeIn(edge),
       "edgesIn": Set {},
       "edgesOut": Map {
         "b" => Edge {
@@ -679,6 +705,7 @@ Edge {
       "parent": Object {
         "addEdgeIn": Function addEdgeIn(edge),
         "addEdgeOut": Function addEdgeOut(edge),
+        "deleteEdgeIn": Function deleteEdgeIn(edge),
         "edgesIn": Set {},
         "edgesOut": Map {
           "missing" => Edge {
@@ -701,6 +728,7 @@ Edge {
       "root": Object {
         "addEdgeIn": Function addEdgeIn(edge),
         "addEdgeOut": Function addEdgeOut(edge),
+        "deleteEdgeIn": Function deleteEdgeIn(edge),
         "edgesIn": Set {},
         "edgesOut": Map {
           "missing" => Edge {
@@ -737,6 +765,7 @@ Edge {
   "from": Object {
     "addEdgeIn": Function addEdgeIn(edge),
     "addEdgeOut": Function addEdgeOut(edge),
+    "deleteEdgeIn": Function deleteEdgeIn(edge),
     "edgesIn": Set {},
     "edgesOut": Map {
       "a" => Edge {
@@ -766,6 +795,7 @@ Edge {
   "to": Object {
     "addEdgeIn": Function addEdgeIn(edge),
     "addEdgeOut": Function addEdgeOut(edge),
+    "deleteEdgeIn": Function deleteEdgeIn(edge),
     "edgesIn": Set {
       Edge {
         "peerConflicted": false,
@@ -783,6 +813,7 @@ Edge {
     "parent": Object {
       "addEdgeIn": Function addEdgeIn(edge),
       "addEdgeOut": Function addEdgeOut(edge),
+      "deleteEdgeIn": Function deleteEdgeIn(edge),
       "edgesIn": Set {},
       "edgesOut": Map {
         "a" => Edge {
@@ -805,6 +836,7 @@ Edge {
     "root": Object {
       "addEdgeIn": Function addEdgeIn(edge),
       "addEdgeOut": Function addEdgeOut(edge),
+      "deleteEdgeIn": Function deleteEdgeIn(edge),
       "edgesIn": Set {},
       "edgesOut": Map {
         "a" => Edge {
@@ -838,6 +870,7 @@ Edge {
   "from": Object {
     "addEdgeIn": Function addEdgeIn(edge),
     "addEdgeOut": Function addEdgeOut(edge),
+    "deleteEdgeIn": Function deleteEdgeIn(edge),
     "edgesIn": Set {},
     "edgesOut": Map {
       "aa" => Edge {
@@ -855,6 +888,7 @@ Edge {
     "parent": Object {
       "addEdgeIn": Function addEdgeIn(edge),
       "addEdgeOut": Function addEdgeOut(edge),
+      "deleteEdgeIn": Function deleteEdgeIn(edge),
       "edgesIn": Set {},
       "edgesOut": Map {
         "missing" => Edge {
@@ -877,6 +911,7 @@ Edge {
     "root": Object {
       "addEdgeIn": Function addEdgeIn(edge),
       "addEdgeOut": Function addEdgeOut(edge),
+      "deleteEdgeIn": Function deleteEdgeIn(edge),
       "edgesIn": Set {},
       "edgesOut": Map {
         "missing" => Edge {
@@ -908,6 +943,7 @@ Edge {
   "to": Object {
     "addEdgeIn": Function addEdgeIn(edge),
     "addEdgeOut": Function addEdgeOut(edge),
+    "deleteEdgeIn": Function deleteEdgeIn(edge),
     "edgesIn": Set {
       Edge {
         "peerConflicted": false,
@@ -925,6 +961,7 @@ Edge {
     "parent": Object {
       "addEdgeIn": Function addEdgeIn(edge),
       "addEdgeOut": Function addEdgeOut(edge),
+      "deleteEdgeIn": Function deleteEdgeIn(edge),
       "edgesIn": Set {},
       "edgesOut": Map {
         "aa" => Edge {
@@ -942,6 +979,7 @@ Edge {
       "parent": Object {
         "addEdgeIn": Function addEdgeIn(edge),
         "addEdgeOut": Function addEdgeOut(edge),
+        "deleteEdgeIn": Function deleteEdgeIn(edge),
         "edgesIn": Set {},
         "edgesOut": Map {
           "missing" => Edge {
@@ -964,6 +1002,7 @@ Edge {
       "root": Object {
         "addEdgeIn": Function addEdgeIn(edge),
         "addEdgeOut": Function addEdgeOut(edge),
+        "deleteEdgeIn": Function deleteEdgeIn(edge),
         "edgesIn": Set {},
         "edgesOut": Map {
           "missing" => Edge {
@@ -1000,6 +1039,7 @@ Edge {
   "from": Object {
     "addEdgeIn": Function addEdgeIn(edge),
     "addEdgeOut": Function addEdgeOut(edge),
+    "deleteEdgeIn": Function deleteEdgeIn(edge),
     "edgesIn": Set {},
     "edgesOut": Map {
       "b" => Edge {
@@ -1017,6 +1057,7 @@ Edge {
     "parent": Object {
       "addEdgeIn": Function addEdgeIn(edge),
       "addEdgeOut": Function addEdgeOut(edge),
+      "deleteEdgeIn": Function deleteEdgeIn(edge),
       "edgesIn": Set {},
       "edgesOut": Map {
         "missing" => Edge {
@@ -1039,6 +1080,7 @@ Edge {
     "root": Object {
       "addEdgeIn": Function addEdgeIn(edge),
       "addEdgeOut": Function addEdgeOut(edge),
+      "deleteEdgeIn": Function deleteEdgeIn(edge),
       "edgesIn": Set {},
       "edgesOut": Map {
         "missing" => Edge {
@@ -1070,6 +1112,7 @@ Edge {
   "to": Object {
     "addEdgeIn": Function addEdgeIn(edge),
     "addEdgeOut": Function addEdgeOut(edge),
+    "deleteEdgeIn": Function deleteEdgeIn(edge),
     "edgesIn": Set {
       Edge {
         "peerConflicted": false,
@@ -1087,6 +1130,7 @@ Edge {
     "parent": Object {
       "addEdgeIn": Function addEdgeIn(edge),
       "addEdgeOut": Function addEdgeOut(edge),
+      "deleteEdgeIn": Function deleteEdgeIn(edge),
       "edgesIn": Set {},
       "edgesOut": Map {
         "missing" => Edge {

--- a/workspaces/arborist/test/edge.js
+++ b/workspaces/arborist/test/edge.js
@@ -57,6 +57,9 @@ const top = {
   addEdgeIn (edge) {
     this.edgesIn.add(edge)
   },
+  deleteEdgeIn (edge) {
+    this.edgesIn.delete(edge)
+  },
 }
 
 const a = {
@@ -81,6 +84,9 @@ const a = {
   addEdgeIn (edge) {
     this.edgesIn.add(edge)
   },
+  deleteEdgeIn (edge) {
+    this.edgesIn.delete(edge)
+  },
 }
 
 const b = {
@@ -103,6 +109,9 @@ const b = {
   },
   addEdgeIn (edge) {
     this.edgesIn.add(edge)
+  },
+  deleteEdgeIn (edge) {
+    this.edgesIn.delete(edge)
   },
 }
 
@@ -127,6 +136,9 @@ const bb = {
   addEdgeIn (edge) {
     this.edgesIn.add(edge)
   },
+  deleteEdgeIn (edge) {
+    this.edgesIn.delete(edge)
+  },
 }
 
 const aa = {
@@ -150,6 +162,9 @@ const aa = {
   addEdgeIn (edge) {
     this.edgesIn.add(edge)
   },
+  deleteEdgeIn (edge) {
+    this.edgesIn.delete(edge)
+  },
 }
 
 const c = {
@@ -172,6 +187,9 @@ const c = {
   },
   addEdgeIn (edge) {
     this.edgesIn.add(edge)
+  },
+  deleteEdgeIn (edge) {
+    this.edgesIn.delete(edge)
   },
 }
 
@@ -364,6 +382,9 @@ const referenceTop = {
   addEdgeIn (edge) {
     this.edgesIn.add(edge)
   },
+  deleteEdgeIn (edge) {
+    this.edgesIn.delete(edge)
+  },
   overrides: new OverrideSet({
     overrides: {
       referenceGrandchild: '$referenceChild',
@@ -403,6 +424,9 @@ const referenceChild = {
     this.overrides = edge.overrides
     this.edgesIn.add(edge)
   },
+  deleteEdgeIn (edge) {
+    this.edgesIn.delete(edge)
+  },
 }
 
 new Edge({
@@ -441,6 +465,9 @@ const referenceGrandchild = {
   addEdgeIn (edge) {
     this.overrides = edge.overrides
     this.edgesIn.add(edge)
+  },
+  deleteEdgeIn (edge) {
+    this.edgesIn.delete(edge)
   },
 }
 
@@ -489,6 +516,9 @@ const badOverride = {
   },
   addEdgeIn (edge) {
     this.edgesIn.add(edge)
+  },
+  deleteEdgeIn (edge) {
+    this.edgesIn.delete(edge)
   },
   overrides: new OverrideSet({
     overrides: {
@@ -775,6 +805,9 @@ const bundleChild = {
   addEdgeIn (edge) {
     this.edgesIn.add(edge)
   },
+  deleteEdgeIn (edge) {
+    this.edgesIn.delete(edge)
+  },
 }
 
 const bundleParent = {
@@ -796,6 +829,9 @@ const bundleParent = {
   },
   addEdgeIn (edge) {
     this.edgesIn.add(edge)
+  },
+  deleteEdgeIn (edge) {
+    this.edgesIn.delete(edge)
   },
 }
 
@@ -858,6 +894,9 @@ t.test('override references find the correct root', (t) => {
     addEdgeIn (edge) {
       this.edgesIn.add(edge)
     },
+    deleteEdgeIn (edge) {
+      this.edgesIn.delete(edge)
+    },
   }
 
   const foo = {
@@ -884,6 +923,9 @@ t.test('override references find the correct root', (t) => {
     },
     addEdgeIn (edge) {
       this.edgesIn.add(edge)
+    },
+    deleteEdgeIn (edge) {
+      this.edgesIn.delete(edge)
     },
   }
   foo.overrides = overrides.getNodeRule(foo)
@@ -915,6 +957,9 @@ t.test('override references find the correct root', (t) => {
     addEdgeIn (edge) {
       this.edgesIn.add(edge)
     },
+    deleteEdgeIn (edge) {
+      this.edgesIn.delete(edge)
+    },
   }
   bar.overrides = foo.overrides.getNodeRule(bar)
 
@@ -945,6 +990,9 @@ t.test('override references find the correct root', (t) => {
     },
     addEdgeIn (edge) {
       this.edgesIn.add(edge)
+    },
+    deleteEdgeIn (edge) {
+      this.edgesIn.delete(edge)
     },
   }
   virtualBar.overrides = overrides
@@ -999,6 +1047,9 @@ t.test('shrinkwrapped and bundled deps are not overridden and remain valid', (t)
     addEdgeIn (edge) {
       this.edgesIn.add(edge)
     },
+    deleteEdgeIn (edge) {
+      this.edgesIn.delete(edge)
+    },
   }
 
   const foo = {
@@ -1029,6 +1080,9 @@ t.test('shrinkwrapped and bundled deps are not overridden and remain valid', (t)
     addEdgeIn (edge) {
       this.edgesIn.add(edge)
     },
+    deleteEdgeIn (edge) {
+      this.edgesIn.delete(edge)
+    },
   }
   foo.overrides = overrides.getNodeRule(foo)
 
@@ -1058,6 +1112,9 @@ t.test('shrinkwrapped and bundled deps are not overridden and remain valid', (t)
     addEdgeIn (edge) {
       this.edgesIn.add(edge)
     },
+    deleteEdgeIn (edge) {
+      this.edgesIn.delete(edge)
+    },
   }
   bar.overrides = foo.overrides.getNodeRule(bar)
 
@@ -1070,5 +1127,71 @@ t.test('shrinkwrapped and bundled deps are not overridden and remain valid', (t)
   })
 
   t.ok(edge.valid, 'edge is valid')
+  t.end()
+})
+
+t.test('overrideset comparison logic', (t) => {
+  const overrides1 = new OverrideSet({
+    overrides: {
+      bar: '^2.0.0',
+    },
+  })
+
+  const overrides2 = new OverrideSet({
+    overrides: {
+      bar: '^2.0.0',
+    },
+  })
+
+  const overrides3 = new OverrideSet({
+    overrides: {
+      foo: '^2.0.0',
+    },
+  })
+
+  const overrides4 = new OverrideSet({
+    overrides: {
+      foo: '^1.0.0',
+    },
+  })
+
+  const overrides5 = new OverrideSet({
+    overrides: {
+      bar: '^2.0.0',
+      foo: '^2.0.0',
+    },
+  })
+
+  const overrides6 = new OverrideSet({
+    overrides: {
+    },
+  })
+
+  const overrides7 = new OverrideSet({
+    overrides: {
+      bar: {
+        '.': '^2.0.0',
+        baz: '1.2.3',
+      },
+    },
+  })
+
+  t.ok(overrides1.isEqual(overrides1), 'overridesets are equal')
+  t.ok(overrides1.isEqual(overrides2), 'overridesets are equal')
+  t.ok(!overrides1.isEqual(overrides3), 'overridesets are different')
+  t.ok(!overrides1.isEqual(overrides5), 'overridesets are different')
+  t.ok(!overrides1.isEqual(overrides6), 'overridesets are different')
+  t.ok(!overrides1.isEqual(overrides7), 'overridesets are different')
+  t.ok(!overrides3.isEqual(overrides1), 'overridesets are different')
+  t.ok(!overrides3.isEqual(overrides4), 'overridesets are different')
+  t.ok(!overrides3.isEqual(overrides5), 'overridesets are different')
+  t.ok(!overrides4.isEqual(overrides5), 'overridesets are different')
+  t.ok(!overrides5.isEqual(overrides1), 'overridesets are different')
+  t.ok(!overrides5.isEqual(overrides3), 'overridesets are different')
+  t.ok(!overrides5.isEqual(overrides6), 'overridesets are different')
+  t.ok(!overrides6.isEqual(overrides1), 'overridesets are different')
+  t.ok(!overrides6.isEqual(overrides3), 'overridesets are different')
+  t.ok(overrides6.isEqual(overrides6), 'overridesets are equal')
+  t.ok(!overrides7.isEqual(overrides1), 'overridesets are different')
   t.end()
 })

--- a/workspaces/arborist/test/override-set.js
+++ b/workspaces/arborist/test/override-set.js
@@ -271,4 +271,121 @@ t.test('constructor', async (t) => {
     const outOfRangeRule = bazEdgeRule.getEdgeRule({ name: 'buzz', spec: 'github:baz/buzz#semver:^2.0.0' })
     t.equal(outOfRangeRule.name, 'baz', 'no match - returned parent')
   })
+
+  t.test('isequal and findspecificoverrideset tests', async (t) => {
+    const overrides1 = new OverrideSet({
+      overrides: {
+        foo: {
+          bar: {
+            '.': '2.0.0',
+            baz: '3.0.0',
+          },
+          baz: '2.0.0',
+        },
+        bar: '1.0.0',
+        baz: '1.0.0',
+      },
+    })
+    const overrides2 = new OverrideSet({
+      overrides: {
+        foo: {
+          bar: {
+            '.': '2.0.0',
+            baz: '3.0.0',
+          },
+          baz: '2.0.0',
+        },
+        bar: '1.0.0',
+        baz: '1.0.0',
+      },
+    })
+    const overrides3 = new OverrideSet({
+      overrides: {
+        foo: {
+          bar: {
+            '.': '2.0.0',
+            baz: '3.1.0',
+          },
+          baz: '2.0.0',
+        },
+        bar: '1.0.0',
+        baz: '1.0.0',
+      },
+    })
+    const overrides4 = new OverrideSet({
+      overrides: {
+        foo: {
+          bar: {
+            '.': '2.0.0',
+          },
+          baz: '2.0.0',
+        },
+        bar: '1.0.0',
+        baz: '1.0.0',
+      },
+    })
+    const overrides5 = new OverrideSet({
+      overrides: {
+        foo: {
+          bar: {
+            '.': '2.0.0',
+          },
+          bat: '2.0.0',
+        },
+        bar: '1.0.0',
+        baz: '1.0.0',
+      },
+    })
+    const overrides6 = new OverrideSet({
+      overrides: {
+        bar: {
+          '.': '2.0.0',
+        },
+        bat: '2.0.0',
+      },
+    })
+    const overrides7 = new OverrideSet({
+      overrides: {
+        bat: '2.0.0',
+      },
+    })
+    const overrides8 = new OverrideSet({
+      overrides: {
+        bat: '1.2.0',
+      },
+    })
+    const overrides9 = new OverrideSet({
+      overrides: {
+        'bat@3.0.0': '1.2.0',
+      },
+    })
+
+    t.ok(overrides1.isEqual(overrides1), 'override set is equal to itself')
+    t.ok(overrides1.isEqual(overrides2), 'two identical override sets are equal')
+    t.ok(!overrides1.isEqual(overrides3), 'two different override sets are not equal')
+    t.ok(!overrides2.isEqual(overrides3), 'two different override sets are not equal')
+    t.ok(!overrides3.isEqual(overrides1), 'two different override sets are not equal')
+    t.ok(!overrides3.isEqual(overrides2), 'two different override sets are not equal')
+    t.ok(!overrides4.isEqual(overrides1), 'two different override sets are not equal')
+    t.ok(!overrides4.isEqual(overrides2), 'two different override sets are not equal')
+    t.ok(!overrides4.isEqual(overrides3), 'two different override sets are not equal')
+    t.ok(!overrides4.isEqual(overrides5), 'two override sets that differ only by package name are not equal')
+    t.ok(!overrides5.isEqual(overrides4), 'two override sets that differ only by package name are not equal')
+    t.equal(OverrideSet.findSpecificOverrideSet(overrides5, overrides5), overrides5, "find more specific override set when the sets are identical")
+    t.equal(OverrideSet.findSpecificOverrideSet(overrides5, overrides6), overrides6, "find more specific override set when it's the second")
+    t.equal(OverrideSet.findSpecificOverrideSet(overrides6, overrides5), overrides6, "find more specific override set when it's the first")
+    t.ok(!OverrideSet.doOverrideSetsConflict(overrides1, overrides2), "override sets are equal")
+    t.ok(!OverrideSet.doOverrideSetsConflict(overrides5, overrides5), "override sets are the same object")
+    t.ok(!OverrideSet.doOverrideSetsConflict(overrides5, overrides6), "one override set is the specific version of the other")
+    t.ok(!OverrideSet.doOverrideSetsConflict(overrides6, overrides5), "one override set is the specific version of the other")
+    t.ok(OverrideSet.doOverrideSetsConflict(overrides5, overrides7), "no override set is the specific version of the other")
+    t.ok(OverrideSet.doOverrideSetsConflict(overrides7, overrides5), "no override set is the specific version of the other")
+    t.ok(!overrides7.isEqual(overrides8), 'two override sets that differ in the version are not equal')
+    t.ok(!overrides8.isEqual(overrides9), 'two override sets that differ in the range are not equal')
+    t.ok(!overrides7.isEqual(overrides9), 'two override sets that differ in both version and range are not equal')
+    t.ok(OverrideSet.doOverrideSetsConflict(overrides7, overrides8), "override sets are incomparable due to version")
+    t.ok(OverrideSet.doOverrideSetsConflict(overrides7, overrides9), "override sets are incomparable due to version and range")
+    t.ok(OverrideSet.doOverrideSetsConflict(overrides8, overrides9), "override sets are incomparable due to range")
+
+  })
 })


### PR DESCRIPTION
A first step in fixing the overrides feature. In this PR I'm aiming to fix 3 bugs:

1. When we add an edge going into a node we update the node's overrides, but we don't update the overrides of that node's outgoing edges, and so forth. We need the up-to-date overrides to filter through.
2. When we remove an edge going into a node we don't update the overrides at all (and we don't update the outgoing edges like in the previous bug).
3. When we add an edge going in, and we already have a different override set for the node, we just ignore the existing override set and overwrite it with that of the new edge. Instead, this PR chooses the most specific override set. This still isn't the absolutely correct logic, since different override sets can have implications down the line of the dependency chain, but it has the advantage of being **consistent** (instead of just going with the last edge in). Also, it raises an error if it encounters a real conflict, meaning two incoming edges with override sets that aren't just a subset of one another.
So if we have dependency chains A->B->C and A->C, and we override C under B, then C will be overridden.

## References
Fixes some of the override [issues](https://github.com/npm/cli/issues/5850).