### PR TITLE
fix: skip creation of log directory if `logs-max` is set to 0

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -216,11 +216,13 @@ class Npm {
       fs.mkdir(this.cache, { recursive: true })
         .catch((e) => log.verbose('cache', `could not create cache: ${e}`)))
 
-    // its ok if this fails. user might have specified an invalid dir
+    // it's ok if this fails. user might have specified an invalid dir
     // which we will tell them about at the end
-    await this.time('npm:load:mkdirplogs', () =>
-      fs.mkdir(this.logsDir, { recursive: true })
-        .catch((e) => log.verbose('logfile', `could not create logs-dir: ${e}`)))
+    if ( this.logsDir !== '' ) {
+      await this.time('npm:load:mkdirplogs', () =>
+        fs.mkdir(this.logsDir, { recursive: true })
+          .catch((e) => log.verbose('logfile', `could not create logs-dir: ${e}`)))
+    }
 
     // note: this MUST be shorter than the actual argv length, because it
     // uses the same memory, so node will truncate it if it's too long.

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -353,8 +353,7 @@ class Npm {
   }
 
   get logsDir () {
-    const theDir = this.config.get('logs-dir') === undefined ? '_logs' : this.config.get('logs-dir');
-    return join(this.cache, theDir)
+    return this.config.get('logs-dir') || join(this.cache, '_logs')
   }
 
   get logPath () {

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -353,7 +353,8 @@ class Npm {
   }
 
   get logsDir () {
-    return this.config.get('logs-dir') || join(this.cache, '_logs')
+    const theDir = this.config.get('logs-dir') === undefined ? '_logs' : this.config.get('logs-dir');
+    return join(this.cache, theDir)
   }
 
   get logPath () {

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -218,7 +218,7 @@ class Npm {
 
     // it's ok if this fails. user might have specified an invalid dir
     // which we will tell them about at the end
-    if ( this.logsDir !== '' ) {
+    if (this.config.get('logs-max') > 0) {
       await this.time('npm:load:mkdirplogs', () =>
         fs.mkdir(this.logsDir, { recursive: true })
           .catch((e) => log.verbose('logfile', `could not create logs-dir: ${e}`)))

--- a/test/lib/utils/exit-handler.js
+++ b/test/lib/utils/exit-handler.js
@@ -344,12 +344,13 @@ t.test('no logs dir', async (t) => {
   const { exitHandler, logs } = await mockExitHandler(t, {
     config: { 'logs-max': 0 },
   })
-
+  console.warn('logs', logs);
   await exitHandler(new Error())
 
   t.match(logs.error.filter(([t]) => t === ''), [
     ['', 'Log files were not written due to the config logs-max=0'],
   ])
+  t.match(logs.filter(([_,task]) => task === 'npm.load.mkdirplogs'), [])
 })
 
 t.test('timers fail to write', async (t) => {

--- a/test/lib/utils/exit-handler.js
+++ b/test/lib/utils/exit-handler.js
@@ -344,7 +344,6 @@ t.test('no logs dir', async (t) => {
   const { exitHandler, logs } = await mockExitHandler(t, {
     config: { 'logs-max': 0 },
   })
-  console.warn('logs', logs);
   await exitHandler(new Error())
 
   t.match(logs.error.filter(([t]) => t === ''), [

--- a/test/lib/utils/exit-handler.js
+++ b/test/lib/utils/exit-handler.js
@@ -349,7 +349,7 @@ t.test('no logs dir', async (t) => {
   t.match(logs.error.filter(([t]) => t === ''), [
     ['', 'Log files were not written due to the config logs-max=0'],
   ])
-  t.match(logs.filter(([_,task]) => task === 'npm.load.mkdirplogs'), [])
+  t.match(logs.filter(([_, task]) => task === 'npm.load.mkdirplogs'), [])
 })
 
 t.test('timers fail to write', async (t) => {


### PR DESCRIPTION
If no logs are needed, don't call the task that creates the directory anyway. This goes mainly to fix #7032. Also, typo.
