### PR TITLE
fix: reverse direction of SPDX SBOM dependency rels

### DIFF
--- a/lib/utils/sbom-spdx.js
+++ b/lib/utils/sbom-spdx.js
@@ -11,10 +11,10 @@ const SPDX_IDENTIFER = 'SPDXRef-DOCUMENT'
 const NO_ASSERTION = 'NOASSERTION'
 
 const REL_DESCRIBES = 'DESCRIBES'
-const REL_PREREQ = 'HAS_PREREQUISITE'
+const REL_PREREQ = 'PREREQUISITE_FOR'
 const REL_OPTIONAL = 'OPTIONAL_DEPENDENCY_OF'
 const REL_DEV = 'DEV_DEPENDENCY_OF'
-const REL_DEP = 'DEPENDS_ON'
+const REL_DEP = 'DEPENDENCY_OF'
 
 const REF_CAT_PACKAGE_MANAGER = 'PACKAGE-MANAGER'
 const REF_TYPE_PURL = 'purl'
@@ -140,8 +140,8 @@ const toSpdxRelationship = (node, edge) => {
   }
 
   return {
-    spdxElementId: toSpdxID(node),
-    relatedSpdxElement: toSpdxID(edge.to),
+    spdxElementId: toSpdxID(edge.to),
+    relatedSpdxElement: toSpdxID(node),
     relationshipType: type,
   }
 }

--- a/tap-snapshots/test/lib/commands/sbom.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/sbom.js.test.cjs
@@ -82,14 +82,14 @@ exports[`test/lib/commands/sbom.js TAP sbom --omit dev > must match snapshot 1`]
       "relationshipType": "DESCRIBES"
     },
     {
-      "spdxElementId": "SPDXRef-Package-test-npm-sbom-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-foo-1.0.0",
-      "relationshipType": "DEPENDS_ON"
+      "spdxElementId": "SPDXRef-Package-foo-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-test-npm-sbom-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
     },
     {
-      "spdxElementId": "SPDXRef-Package-foo-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-dog-1.0.0",
-      "relationshipType": "DEPENDS_ON"
+      "spdxElementId": "SPDXRef-Package-dog-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-foo-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
     }
   ]
 }
@@ -155,9 +155,9 @@ exports[`test/lib/commands/sbom.js TAP sbom --omit optional > must match snapsho
       "relationshipType": "DESCRIBES"
     },
     {
-      "spdxElementId": "SPDXRef-Package-test-npm-sbom-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-chai-1.0.0",
-      "relationshipType": "DEPENDS_ON"
+      "spdxElementId": "SPDXRef-Package-chai-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-test-npm-sbom-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
     }
   ]
 }
@@ -223,9 +223,9 @@ exports[`test/lib/commands/sbom.js TAP sbom --omit peer > must match snapshot 1`
       "relationshipType": "DESCRIBES"
     },
     {
-      "spdxElementId": "SPDXRef-Package-test-npm-sbom-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-chai-1.0.0",
-      "relationshipType": "DEPENDS_ON"
+      "spdxElementId": "SPDXRef-Package-chai-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-test-npm-sbom-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
     }
   ]
 }
@@ -435,19 +435,19 @@ exports[`test/lib/commands/sbom.js TAP sbom basic sbom - spdx > must match snaps
       "relationshipType": "DESCRIBES"
     },
     {
-      "spdxElementId": "SPDXRef-Package-test-npm-sbom-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-foo-1.0.0",
-      "relationshipType": "DEPENDS_ON"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-test-npm-sbom-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-chai-1.0.0",
-      "relationshipType": "DEPENDS_ON"
-    },
-    {
       "spdxElementId": "SPDXRef-Package-foo-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-dog-1.0.0",
-      "relationshipType": "DEPENDS_ON"
+      "relatedSpdxElement": "SPDXRef-Package-test-npm-sbom-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-chai-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-test-npm-sbom-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-dog-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-foo-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
     }
   ]
 }
@@ -547,18 +547,18 @@ exports[`test/lib/commands/sbom.js TAP sbom extraneous dep > must match snapshot
       "relationshipType": "DESCRIBES"
     },
     {
-      "spdxElementId": "SPDXRef-Package-test-npm-ls-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-foo-1.0.0",
-      "relationshipType": "DEPENDS_ON"
-    },
-    {
       "spdxElementId": "SPDXRef-Package-foo-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-dog-1.0.0",
-      "relationshipType": "DEPENDS_ON"
+      "relatedSpdxElement": "SPDXRef-Package-test-npm-ls-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
     },
     {
-      "spdxElementId": "SPDXRef-Package-test-npm-ls-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-chai-1.0.0",
+      "spdxElementId": "SPDXRef-Package-dog-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-foo-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-chai-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-test-npm-ls-1.0.0",
       "relationshipType": "OPTIONAL_DEPENDENCY_OF"
     }
   ]
@@ -710,39 +710,39 @@ exports[`test/lib/commands/sbom.js TAP sbom loading a tree containing workspaces
       "relationshipType": "DESCRIBES"
     },
     {
-      "spdxElementId": "SPDXRef-Package-workspaces-tree-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-a-1.0.0",
-      "relationshipType": "DEPENDS_ON"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-workspaces-tree-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-d-1.0.0",
-      "relationshipType": "DEPENDS_ON"
-    },
-    {
       "spdxElementId": "SPDXRef-Package-a-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-c-1.0.0",
-      "relationshipType": "DEPENDS_ON"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-a-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-d-1.0.0",
-      "relationshipType": "DEPENDS_ON"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-a-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-baz-1.0.0",
-      "relationshipType": "DEV_DEPENDENCY_OF"
+      "relatedSpdxElement": "SPDXRef-Package-workspaces-tree-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
     },
     {
       "spdxElementId": "SPDXRef-Package-d-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-foo-1.1.1",
-      "relationshipType": "DEPENDS_ON"
+      "relatedSpdxElement": "SPDXRef-Package-workspaces-tree-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-c-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-a-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-d-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-a-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-baz-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-a-1.0.0",
+      "relationshipType": "DEV_DEPENDENCY_OF"
     },
     {
       "spdxElementId": "SPDXRef-Package-foo-1.1.1",
-      "relatedSpdxElement": "SPDXRef-Package-bar-1.0.0",
-      "relationshipType": "DEPENDS_ON"
+      "relatedSpdxElement": "SPDXRef-Package-d-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-bar-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-foo-1.1.1",
+      "relationshipType": "DEPENDENCY_OF"
     }
   ]
 }
@@ -825,14 +825,14 @@ exports[`test/lib/commands/sbom.js TAP sbom loading a tree containing workspaces
       "relationshipType": "DESCRIBES"
     },
     {
-      "spdxElementId": "SPDXRef-Package-workspaces-tree-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-e-1.0.0",
-      "relationshipType": "DEPENDS_ON"
+      "spdxElementId": "SPDXRef-Package-e-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-workspaces-tree-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
     },
     {
-      "spdxElementId": "SPDXRef-Package-workspaces-tree-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-f-1.0.0",
-      "relationshipType": "DEPENDS_ON"
+      "spdxElementId": "SPDXRef-Package-f-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-workspaces-tree-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
     }
   ]
 }
@@ -1051,59 +1051,59 @@ exports[`test/lib/commands/sbom.js TAP sbom loading a tree containing workspaces
       "relationshipType": "DESCRIBES"
     },
     {
-      "spdxElementId": "SPDXRef-Package-workspaces-tree-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-a-1.0.0",
-      "relationshipType": "DEPENDS_ON"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-workspaces-tree-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-b-1.0.0",
-      "relationshipType": "DEPENDS_ON"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-workspaces-tree-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-d-1.0.0",
-      "relationshipType": "DEPENDS_ON"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-workspaces-tree-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-e-1.0.0",
-      "relationshipType": "DEPENDS_ON"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-workspaces-tree-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-f-1.0.0",
-      "relationshipType": "DEPENDS_ON"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-workspaces-tree-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-pacote-1.0.0",
-      "relationshipType": "DEPENDS_ON"
-    },
-    {
       "spdxElementId": "SPDXRef-Package-a-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-c-1.0.0",
-      "relationshipType": "DEPENDS_ON"
+      "relatedSpdxElement": "SPDXRef-Package-workspaces-tree-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
     },
     {
-      "spdxElementId": "SPDXRef-Package-a-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-d-1.0.0",
-      "relationshipType": "DEPENDS_ON"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-a-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-baz-1.0.0",
-      "relationshipType": "DEV_DEPENDENCY_OF"
+      "spdxElementId": "SPDXRef-Package-b-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-workspaces-tree-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
     },
     {
       "spdxElementId": "SPDXRef-Package-d-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-foo-1.1.1",
-      "relationshipType": "DEPENDS_ON"
+      "relatedSpdxElement": "SPDXRef-Package-workspaces-tree-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-e-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-workspaces-tree-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-f-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-workspaces-tree-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-pacote-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-workspaces-tree-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-c-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-a-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-d-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-a-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-baz-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-a-1.0.0",
+      "relationshipType": "DEV_DEPENDENCY_OF"
     },
     {
       "spdxElementId": "SPDXRef-Package-foo-1.1.1",
-      "relatedSpdxElement": "SPDXRef-Package-bar-1.0.0",
-      "relationshipType": "DEPENDS_ON"
+      "relatedSpdxElement": "SPDXRef-Package-d-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-bar-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-foo-1.1.1",
+      "relationshipType": "DEPENDENCY_OF"
     }
   ]
 }
@@ -1169,9 +1169,9 @@ exports[`test/lib/commands/sbom.js TAP sbom loading a tree containing workspaces
       "relationshipType": "DESCRIBES"
     },
     {
-      "spdxElementId": "SPDXRef-Package-workspaces-tree-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-pacote-1.0.0",
-      "relationshipType": "DEPENDS_ON"
+      "spdxElementId": "SPDXRef-Package-pacote-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-workspaces-tree-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
     }
   ]
 }
@@ -1275,19 +1275,19 @@ exports[`test/lib/commands/sbom.js TAP sbom lock file only > must match snapshot
       "relationshipType": "DESCRIBES"
     },
     {
-      "spdxElementId": "SPDXRef-Package-test-npm-ls-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-foo-1.0.0",
-      "relationshipType": "DEPENDS_ON"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-test-npm-ls-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-chai-1.0.0",
-      "relationshipType": "DEPENDS_ON"
-    },
-    {
       "spdxElementId": "SPDXRef-Package-foo-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-dog-1.0.0",
-      "relationshipType": "DEPENDS_ON"
+      "relatedSpdxElement": "SPDXRef-Package-test-npm-ls-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-chai-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-test-npm-ls-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-dog-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-foo-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
     }
   ]
 }
@@ -1387,19 +1387,19 @@ exports[`test/lib/commands/sbom.js TAP sbom missing (optional) dep > must match 
       "relationshipType": "DESCRIBES"
     },
     {
-      "spdxElementId": "SPDXRef-Package-test-npm-ls-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-foo-1.0.0",
-      "relationshipType": "DEPENDS_ON"
-    },
-    {
-      "spdxElementId": "SPDXRef-Package-test-npm-ls-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-chai-1.0.0",
-      "relationshipType": "DEPENDS_ON"
-    },
-    {
       "spdxElementId": "SPDXRef-Package-foo-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-dog-1.0.0",
-      "relationshipType": "DEPENDS_ON"
+      "relatedSpdxElement": "SPDXRef-Package-test-npm-ls-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-chai-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-test-npm-ls-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-dog-1.0.0",
+      "relatedSpdxElement": "SPDXRef-Package-foo-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
     }
   ]
 }

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -1421,7 +1421,7 @@ SBOM format to use when generating SBOMs.
 * Type: "library", "application", or "framework"
 
 The type of package described by the generated SBOM. For SPDX, this is the
-value for the \`primaryPackagePurpose\` fieled. For CycloneDX, this is the
+value for the \`primaryPackagePurpose\` field. For CycloneDX, this is the
 value for the \`type\` field.
 
 

--- a/tap-snapshots/test/lib/utils/sbom-spdx.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/sbom-spdx.js.test.cjs
@@ -149,33 +149,33 @@ exports[`test/lib/utils/sbom-spdx.js TAP node - with deps > must match snapshot 
       "relationshipType": "DESCRIBES"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-dep1-0.0.1",
-      "relationshipType": "HAS_PREREQUISITE"
+      "spdxElementId": "SPDXRef-Package-dep1-0.0.1",
+      "relatedSpdxElement": "SPDXRef-Package-root-1.0.0",
+      "relationshipType": "PREREQUISITE_FOR"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-dep2-0.0.2",
+      "spdxElementId": "SPDXRef-Package-dep2-0.0.2",
+      "relatedSpdxElement": "SPDXRef-Package-root-1.0.0",
       "relationshipType": "OPTIONAL_DEPENDENCY_OF"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-dep3-0.0.3",
+      "spdxElementId": "SPDXRef-Package-dep3-0.0.3",
+      "relatedSpdxElement": "SPDXRef-Package-root-1.0.0",
       "relationshipType": "DEV_DEPENDENCY_OF"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-dep4-0.0.4",
-      "relationshipType": "DEPENDS_ON"
-    },
-    {
       "spdxElementId": "SPDXRef-Package-dep4-0.0.4",
-      "relatedSpdxElement": "SPDXRef-Package-dep5-0.0.5",
-      "relationshipType": "DEPENDS_ON"
+      "relatedSpdxElement": "SPDXRef-Package-root-1.0.0",
+      "relationshipType": "DEPENDENCY_OF"
     },
     {
-      "spdxElementId": "SPDXRef-Package-root-1.0.0",
-      "relatedSpdxElement": "SPDXRef-Package-dep6-0.0.6",
+      "spdxElementId": "SPDXRef-Package-dep5-0.0.5",
+      "relatedSpdxElement": "SPDXRef-Package-dep4-0.0.4",
+      "relationshipType": "DEPENDENCY_OF"
+    },
+    {
+      "spdxElementId": "SPDXRef-Package-dep6-0.0.6",
+      "relatedSpdxElement": "SPDXRef-Package-root-1.0.0",
       "relationshipType": "OPTIONAL_DEPENDENCY_OF"
     }
   ]

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -1234,7 +1234,7 @@ define('sbom-type', {
   ],
   description: `
     The type of package described by the generated SBOM. For SPDX, this is the
-    value for the \`primaryPackagePurpose\` fieled. For CycloneDX, this is the
+    value for the \`primaryPackagePurpose\` field. For CycloneDX, this is the
     value for the \`type\` field.
   `,
   flatten,


### PR DESCRIPTION
As discussed in #6867 some of the relationship types in the SPDX SBOM are using labels which don't match the direction of the relationship. This change fixes generated relationship entries so that the `relationshipType` aligns with the direction of the dependency relationship being described.

For some types of relationships SPDX defines a pair of related types which can be used to describe dependency relationships from either parent-to-child or child-to-parent. For example:

```json
{
  "spdxElementId": "parent-1.0.0",
  "relatedSpdxElement": "child-1.0.0",
  "relationshipType": "DEPENDS_ON"
}
```

Which can also be represented as 

```json
{
  "spdxElementId": "child-1.0.0",
  "relatedSpdxElement": "parent-1.0.0",
  "relationshipType": "DEPENDENCY_OF"
}
```

Note how the second example swaps the place of the parent/child and switches the relationship type from "DEPENDS_ON" to "DEPENDENCY_OF".

Unfortunately, not all of the SPDX-supported relationship types have a matched inverse. Specifically, `OPTIONAL_DEPENDENCY_OF` and `DEV_DEPENDENCY_OF` have no matching type which would allow the relationship to be reversed (`HAS_OPTIONAL_DEPENDENCY` and `HAS_DEV_DEPENDENCY` would make sense, but aren't supported in the SPDX spec).

In order to consistently represent ALL of the different relationships and ensure that the supplied type properly describes the direction of the relationship, we're going to swap the position of the parent/child nodes in the relationship (`spdxElementId` will always reference the child, while `relatedSpdxElement` will always reference the parent) and exclusively use the child-to-parent relationship type labels: `DEPENDENCY_OF`, `DEV_DEPENDENCY_OF`, `OPTIONAL_DEPENDENCY_OF`, and `PREREQUISITE_FOR`.

## References
Fixes https://github.com/npm/cli/issues/6867
