### PR TITLE
fix: allow package installs in drive root directories

### DIFF
--- a/test/lib/commands/install.js
+++ b/test/lib/commands/install.js
@@ -294,6 +294,54 @@ t.test('exec commands', async t => {
       }
     )
   })
+
+  await t.test('Windows - npm install works in drive root directory', async t => {
+    if (process.platform !== 'win32') {
+      return t.skip('root directory install - test not relevant on platform')
+    }
+
+    let failed = false
+
+    const { npm } = await loadMockNpm(t, {
+      config: {
+        prefix: 'C:\\',
+        'dry-run': true,
+      },
+    })
+
+    try {
+      await npm.exec('install', ['fizzbuzz'])
+    } catch (error) {
+      failed = true
+      throw error
+    }
+
+    t.strictSame(failed, false, 'packages would install')
+  })
+
+  await t.test('Not Windows - npm install works in drive root directory', async t => {
+    if (process.platform === 'win32') {
+      return t.skip('root directory install - test not relevant on platform')
+    }
+
+    let failed = false
+
+    const { npm } = await loadMockNpm(t, {
+      config: {
+        prefix: '/',
+        'dry-run': true,
+      },
+    })
+
+    try {
+      await npm.exec('install', ['fizzbuzz'])
+    } catch (error) {
+      failed = true
+      throw error
+    }
+
+    t.strictSame(failed, false, 'packages would install')
+  })
 })
 
 t.test('completion', async t => {

--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -196,7 +196,7 @@ module.exports = cls => class Reifier extends cls {
     try {
       await access(resolve(this.path))
     } catch {
-      //The project directory is missing so we make it.
+      // The project directory is missing so we make it.
       await mkdir(resolve(this.path), { recursive: true })
     }
 

--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -18,6 +18,7 @@ const {
   mkdir,
   rm,
   symlink,
+  access,
 } = require('fs/promises')
 const { moveFile } = require('@npmcli/fs')
 const PackageJson = require('@npmcli/package-json')
@@ -192,7 +193,12 @@ module.exports = cls => class Reifier extends cls {
     // we do NOT want to set ownership on this folder, especially
     // recursively, because it can have other side effects to do that
     // in a project directory.  We just want to make it if it's missing.
-    await mkdir(resolve(this.path), { recursive: true })
+    try {
+      await access(resolve(this.path))
+    } catch {
+      //The project directory is missing so we make it.
+      await mkdir(resolve(this.path), { recursive: true })
+    }
 
     // do not allow the top-level node_modules to be a symlink
     await this[_validateNodeModules](resolve(this.path, 'node_modules'))


### PR DESCRIPTION
### What/Why
Previously trying to do `npm install` in a drive's root directory (e.g `C:\` or `E:\` in Windows or `/` in Linux or macOS) would fail. See screenshots:

### Ubuntu
<img width="737" alt="Ubuntu Error Console Log" src="https://github.com/npm/cli/assets/84299475/e31aa35b-eaa2-4f4d-926e-d16966a1697a">

### Windows
<img width="919" alt="Windows Error Console Log" src="https://github.com/npm/cli/assets/84299475/e3210234-9349-4198-a4fc-59dc88fd53b0">

This PR allows users to install npm packages in their drive root directories

### What does this PR do and why are these changes being made
The change in `workspaces/aborist/lib/aborist/reify.js`'s `_validatePath` method was made to check if the project directory exists before creating it. Previously if you were running `npm install` inside of the drive's root directory (in this example, the E drive), mkdir would get called with path `E:/` and it would try to create a directory at the path `E:\\` which is invalid, and so it would fail. In this example, with this PR, `E:\` already exists so it is not needed to be created, and thus no directory is tried to be created at `E:\\`.

2 tests were added to `test/lib/commands/install.js`.
The first one only runs on Windows and tests to see that installs in a root directory work by dry running `npm install` in `C:\`
The second one runs on platforms that are not Windows and tests to see that installs in a root directory work by dry running `npm install` in `/`