### PR TITLE
chore: fix tests for zlib differences between node versions

### DIFF
--- a/tap-snapshots/test/lib/commands/pack.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/pack.js.test.cjs
@@ -16,10 +16,10 @@ Array [
     name:          test-package                            
     version:       1.0.0                                   
     filename:      test-package-1.0.0.tgz                  
-    package size:  136 B                                   
+    package size:  {size}
     unpacked size: 41 B                                    
-    shasum:        a92a0679a70a450f14f98a468756948a679e4107
-    integrity:     sha512-Gka9ZV/Bryxky[...]LgMJ+0F+FhXMA==
+    shasum:        {sha}
+    integrity:     {integrity}
     total files:   1                                       
   ),
   "",
@@ -41,14 +41,14 @@ Array [
         Object {
           "mode": 420,
           "path": "package.json",
-          "size": 41,
+          "size": "{size}",
         },
       ],
       "id": "test-package@1.0.0",
-      "integrity": "sha512-Gka9ZV/BryxkypfvMpTvLfaJE1AUi7PK1EAbYqnVzqtucf6QvUK4CFsLVzagY1GwZVx2T1jwWLgMJ+0F+FhXMA==",
+      "integrity": "{integrity}",
       "name": "test-package",
-      "shasum": "a92a0679a70a450f14f98a468756948a679e4107",
-      "size": 136,
+      "shasum": "{sha}",
+      "size": "{size}",
       "unpackedSize": 41,
       "version": "1.0.0",
     },
@@ -71,14 +71,14 @@ Array [
         Object {
           "mode": 420,
           "path": "package.json",
-          "size": 50,
+          "size": "{size}",
         },
       ],
       "id": "@myscope/test-package@1.0.0",
-      "integrity": "sha512-bUu8iTm2E5DZMrwKeyx963K6ViEmaFocXh75EujgI+FHSaJeqvObcdk1KFwdx8CbOgsfNHEvWNQw/bONAJsoNw==",
+      "integrity": "{integrity}",
       "name": "@myscope/test-package",
-      "shasum": "7e6eb2e1ca46bed6b8fa8e144e0fcd1b22fe2d98",
-      "size": 145,
+      "shasum": "{sha}",
+      "size": "{size}",
       "unpackedSize": 50,
       "version": "1.0.0",
     },
@@ -97,10 +97,10 @@ Array [
     name:          test-package                            
     version:       1.0.0                                   
     filename:      test-package-1.0.0.tgz                  
-    package size:  136 B                                   
+    package size:  {size}
     unpacked size: 41 B                                    
-    shasum:        a92a0679a70a450f14f98a468756948a679e4107
-    integrity:     sha512-Gka9ZV/Bryxky[...]LgMJ+0F+FhXMA==
+    shasum:        {sha}
+    integrity:     {integrity}
     total files:   1                                       
   ),
   "",

--- a/tap-snapshots/test/lib/commands/publish.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/publish.js.test.cjs
@@ -38,10 +38,10 @@ Array [
       name:          test-package                            
       version:       1.0.0                                   
       filename:      test-package-1.0.0.tgz                  
-      package size:  160 B                                   
+      package size:  {size}
       unpacked size: 87 B                                    
-      shasum:{sha}
-      integrity:{sha}
+      shasum:        {sha}
+      integrity:     {integrity}
       total files:   1                                       
     ),
   ],
@@ -82,15 +82,15 @@ exports[`test/lib/commands/publish.js TAP json > new package json 1`] = `
   "id": "test-package@1.0.0",
   "name": "test-package",
   "version": "1.0.0",
-  "size": 160,
+  "size": "{size}",
   "unpackedSize": 87,
   "shasum": "{sha}",
-  "integrity": "{sha}",
+  "integrity": "{integrity}",
   "filename": "test-package-1.0.0.tgz",
   "files": [
     {
       "path": "package.json",
-      "size": 87,
+      "size": "{size}",
       "mode": 420
     }
   ],
@@ -289,10 +289,10 @@ Array [
       name:          @npm/test-package                       
       version:       1.0.0                                   
       filename:      npm-test-package-1.0.0.tgz              
-      package size:  147 B                                   
+      package size:  {size}
       unpacked size: 55 B                                    
-      shasum:{sha}
-      integrity:{sha}
+      shasum:        {sha}
+      integrity:     {integrity}
       total files:   1                                       
     ),
   ],
@@ -344,10 +344,10 @@ Array [
       name:          @npm/test-package                       
       version:       1.0.0                                   
       filename:      npm-test-package-1.0.0.tgz              
-      package size:  147 B                                   
+      package size:  {size}
       unpacked size: 55 B                                    
-      shasum:{sha}
-      integrity:{sha}
+      shasum:        {sha}
+      integrity:     {integrity}
       total files:   1                                       
     ),
   ],
@@ -398,10 +398,10 @@ Array [
       name:          test-tar-package                        
       version:       1.0.0                                   
       filename:      test-tar-package-1.0.0.tgz              
-      package size:  218 B                                   
+      package size:  {size}
       unpacked size: 124 B                                   
-      shasum:{sha}
-      integrity:{sha}
+      shasum:        {sha}
+      integrity:     {integrity}
       total files:   2                                       
     ),
   ],
@@ -550,15 +550,15 @@ exports[`test/lib/commands/publish.js TAP workspaces json > all workspaces in js
     "id": "workspace-a@1.2.3-a",
     "name": "workspace-a",
     "version": "1.2.3-a",
-    "size": 162,
+    "size": "{size}",
     "unpackedSize": 82,
     "shasum": "{sha}",
-    "integrity": "{sha}",
+    "integrity": "{integrity}",
     "filename": "workspace-a-1.2.3-a.tgz",
     "files": [
       {
         "path": "package.json",
-        "size": 82,
+        "size": "{size}",
         "mode": 420
       }
     ],
@@ -569,15 +569,15 @@ exports[`test/lib/commands/publish.js TAP workspaces json > all workspaces in js
     "id": "workspace-b@1.2.3-n",
     "name": "workspace-b",
     "version": "1.2.3-n",
-    "size": 171,
+    "size": "{size}",
     "unpackedSize": 92,
     "shasum": "{sha}",
-    "integrity": "{sha}",
+    "integrity": "{integrity}",
     "filename": "workspace-b-1.2.3-n.tgz",
     "files": [
       {
         "path": "package.json",
-        "size": 92,
+        "size": "{size}",
         "mode": 420
       }
     ],
@@ -588,15 +588,15 @@ exports[`test/lib/commands/publish.js TAP workspaces json > all workspaces in js
     "id": "workspace-n@1.2.3-n",
     "name": "workspace-n",
     "version": "1.2.3-n",
-    "size": 140,
+    "size": "{size}",
     "unpackedSize": 42,
     "shasum": "{sha}",
-    "integrity": "{sha}",
+    "integrity": "{integrity}",
     "filename": "workspace-n-1.2.3-n.tgz",
     "files": [
       {
         "path": "package.json",
-        "size": 42,
+        "size": "{size}",
         "mode": 420
       }
     ],

--- a/tap-snapshots/test/lib/utils/tar.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/tar.js.test.cjs
@@ -23,10 +23,10 @@ bundle-dep
 name:          my-cool-pkg                             
 version:       1.0.0                                   
 filename:      my-cool-pkg-1.0.0.tgz                   
-package size:  271 B                                   
+package size:  {size}
 unpacked size: 126 B                                   
-shasum:        23e31c8ad422f96301c07730e61ff403b10306f1
-integrity:     sha512-/Lg5tEGQv5A5y[...]gq8T9D5+Wat1A==
+shasum:        {sha}
+integrity:     {integrity}
 bundled deps:  1                                       
 bundled files: 0                                       
 own files:     5                                       
@@ -53,10 +53,10 @@ bundle-dep
 name:          @myscope/my-cool-pkg                    
 version:       1.0.0                                   
 filename:      myscope-my-cool-pkg-1.0.0.tgz           
-package size:  280 B                                   
+package size:  {size}
 unpacked size: 135 B                                   
-shasum:        a4f63307f2211e8fde72cd39bc1176b4fe997b71
-integrity:     sha512-b+RavF8JiErJt[...]YpwkJc8ycaabA==
+shasum:        {sha}
+integrity:     {integrity}
 bundled deps:  1                                       
 bundled files: 0                                       
 own files:     5                                       

--- a/test/fixtures/clean-snapshot.js
+++ b/test/fixtures/clean-snapshot.js
@@ -33,11 +33,21 @@ const cleanDate = (str) =>
 
 const cleanTime = str => str.replace(/in [0-9]+m?s\s*$/gm, 'in {TIME}')
 
+const cleanZlib = str => str
+  .replace(/shasum:( *)[0-9a-f]{40}/g, 'shasum:$1{sha}')
+  .replace(/integrity:( *).*/g, 'integrity:$1{integrity}')
+  .replace(/package size:( *)[0-9 A-Z]*/g, 'package size:$1{size}')
+
+  .replace(/"shasum": "[0-9a-f]{40}",/g, '"shasum": "{sha}",')
+  .replace(/"integrity": ".*",/g, '"integrity": "{integrity}",')
+  .replace(/"size": [0-9]*,/g, '"size": "{size}",')
+
 module.exports = {
-  normalizePath,
-  pathRegex,
   cleanCwd,
   cleanDate,
-  cleanTime,
   cleanNewlines,
+  cleanTime,
+  cleanZlib,
+  normalizePath,
+  pathRegex,
 }

--- a/test/lib/commands/pack.js
+++ b/test/lib/commands/pack.js
@@ -1,7 +1,10 @@
 const t = require('tap')
 const { load: loadMockNpm } = require('../../fixtures/mock-npm')
+const { cleanZlib } = require('../../fixtures/clean-snapshot')
 const path = require('path')
 const fs = require('fs')
+
+t.cleanSnapshot = data => cleanZlib(data)
 
 t.test('should pack current directory with no arguments', async t => {
   const { npm, outputs, logs } = await loadMockNpm(t, {

--- a/test/lib/commands/publish.js
+++ b/test/lib/commands/publish.js
@@ -1,5 +1,6 @@
 const t = require('tap')
 const { load: loadMockNpm } = require('../../fixtures/mock-npm')
+const { cleanZlib } = require('../../fixtures/clean-snapshot')
 const MockRegistry = require('@npmcli/mock-registry')
 const pacote = require('pacote')
 const Arborist = require('@npmcli/arborist')
@@ -19,12 +20,7 @@ const pkgJson = {
   version: '1.0.0',
 }
 
-t.cleanSnapshot = data => {
-  return data.replace(/shasum:.*/g, 'shasum:{sha}')
-    .replace(/integrity:.*/g, 'integrity:{sha}')
-    .replace(/"shasum": ".*",/g, '"shasum": "{sha}",')
-    .replace(/"integrity": ".*",/g, '"integrity": "{sha}",')
-}
+t.cleanSnapshot = data => cleanZlib(data)
 
 t.test('respects publishConfig.registry, runs appropriate scripts', async t => {
   const { npm, joinedOutput, prefix } = await loadMockNpm(t, {

--- a/test/lib/utils/tar.js
+++ b/test/lib/utils/tar.js
@@ -2,8 +2,10 @@ const t = require('tap')
 const pack = require('libnpmpack')
 const ssri = require('ssri')
 const tmock = require('../../fixtures/tmock')
+const { cleanZlib } = require('../../fixtures/clean-snapshot')
 
 const { getContents } = require('../../../lib/utils/tar.js')
+t.cleanSnapshot = data => cleanZlib(data)
 
 const mockTar = ({ notice }) => tmock(t, '{LIB}/utils/tar.js', {
   'proc-log': {
@@ -121,13 +123,15 @@ t.test('should getContents of a tarball', async (t) => {
     algorithms: ['sha1', 'sha512'],
   })
 
+  // zlib is nondeterministic
+  t.match(tarballContents.shasum, /^[0-9a-f]{40}$/)
+  delete tarballContents.shasum
   t.strictSame(tarballContents, {
     id: 'my-cool-pkg@1.0.0',
     name: 'my-cool-pkg',
     version: '1.0.0',
-    size: 146,
+    size: tarball.length,
     unpackedSize: 49,
-    shasum: 'b8379c5e69693cdda73aec3d81dae1d11c1e75bd',
     integrity: ssri.parse(integrity.sha512[0]),
     filename: 'my-cool-pkg-1.0.0.tgz',
     files: [{ path: 'package.json', size: 49, mode: 420 }],


### PR DESCRIPTION
Most of npm's tests are built around the fact that zlib is not deterministic, but it looks like for some small code paths it had been so far and those tests were still using static fixtures.  Enough changed in the latest node version to force the remaining tests we have w/ shasum fixtures to fail.

Good explanation at https://github.com/nodejs/node/issues/50138