### PR TITLE
fix(unpublish): bubble up all errors parsing local package.json

### DIFF
--- a/lib/commands/unpublish.js
+++ b/lib/commands/unpublish.js
@@ -109,13 +109,17 @@ class Unpublish extends BaseCommand {
       const { content } = await pkgJson.prepare(localPrefix)
       manifest = content
     } catch (err) {
-      // we needed the manifest to figure out the package to unpublish
-      if (!spec) {
-        if (err.code === 'ENOENT' || err.code === 'ENOTDIR') {
+      if (err.code === 'ENOENT' || err.code === 'ENOTDIR') {
+        if (!spec) {
+          // We needed a local package.json to figure out what package to
+          // unpublish
           throw this.usageError()
-        } else {
-          throw err
         }
+      } else {
+        // folks should know if ANY local package.json had a parsing error.
+        // They may be relying on `publishConfig` to be loading and we don't
+        // want to ignore errors in that case.
+        throw err
       }
     }
 

--- a/test/lib/commands/unpublish.js
+++ b/test/lib/commands/unpublish.js
@@ -63,6 +63,23 @@ t.test('no args --force error reading package.json', async t => {
   )
 })
 
+t.test('with args --force error reading package.json', async t => {
+  const { npm } = await loadMockNpm(t, {
+    config: {
+      force: true,
+    },
+    prefixDir: {
+      'package.json': '{ not valid json ]',
+    },
+  })
+
+  await t.rejects(
+    npm.exec('unpublish', [pkg]),
+    /Invalid package.json/,
+    'should throw error from reading package.json'
+  )
+})
+
 t.test('no force entire project', async t => {
   const { npm } = await loadMockNpm(t)
 


### PR DESCRIPTION
If the file is there and there is any error that's always a show stopper
