### PR TITLE
fix(arborist): `node.target` can be `null`

### DIFF
--- a/workspaces/arborist/lib/calc-dep-flags.js
+++ b/workspaces/arborist/lib/calc-dep-flags.js
@@ -30,7 +30,7 @@ const calcDepFlagsStep = (node) => {
   resetParents(node, 'optional')
 
   // for links, map their hierarchy appropriately
-  if (node.isLink) {
+  if (node.isLink && node.target) {
     node.target.dev = node.dev
     node.target.optional = node.optional
     node.target.devOptional = node.devOptional


### PR DESCRIPTION
Followup to #7027. Fixes #6815.

Fixes this issue: https://github.com/ljharb/list-exports/actions/runs/7537180864/job/20515721981