### PR TITLE
docs(publish): add missing closing parenthesis

### DIFF
--- a/docs/lib/content/commands/npm-publish.md
+++ b/docs/lib/content/commands/npm-publish.md
@@ -20,7 +20,7 @@ scope-configured registry (see
 
 
 A `package` is interpreted the same way as other commands (like
-`npm install` and can be:
+`npm install`) and can be:
 
 * a) a folder containing a program described by a
   [`package.json`](/configuring-npm/package-json) file


### PR DESCRIPTION
There was a missing closing bracket at line 23

```diff
- A ``package`` is interpreted the same way as other commands (like ``npm install`` and can be:
+ A ``package`` is interpreted the same way as other commands (like ``npm install``) and can be:
```

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

