### PR TITLE
fix(arborist): add v1 upgrade info to cli

### DIFF
--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -696,6 +696,9 @@ The ${meta.type} file was created with an old version of npm,
 so supplemental metadata must be fetched from the registry.
 
 This is a one-time fix-up, please be patient...
+
+V1 lockfiles do not catch incorrect dependencies. Instead, run
+npm install again to catch them on the generated v2 lockfile
 `)
     }
 


### PR DESCRIPTION
Add documentation about upgrading lockfile from v1 to v2 based on the issue comment below.

https://github.com/npm/cli/issues/5051#issuecomment-1863346654

## References
Closes #5051
