### PR TITLE
fix: don't emit package-lock.json when package.json does not exist

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -148,10 +148,10 @@ class Install extends ArboristWorkspaceCmd {
       const isJsonEmptyObject = Object.keys(jsonContent).length === 0
         && jsonContent.constructor === Object
 
-      const emptyJson = new Error()
+      const emptyJson = new Error('EEMPTYPKGJSON: package.json is empty object')
       emptyJson.code = 'EEMPTYPKGJSON'
       emptyJson.path = pkgJson.filename
-      if(isJsonEmptyObject) {
+      if (isJsonEmptyObject) {
         throw emptyJson
       }
     }

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -8,6 +8,7 @@ const { resolve, join } = require('path')
 const runScript = require('@npmcli/run-script')
 const pacote = require('pacote')
 const checks = require('npm-install-checks')
+const PackageJson = require('@npmcli/package-json')
 
 const ArboristWorkspaceCmd = require('../arborist-cmd.js')
 class Install extends ArboristWorkspaceCmd {
@@ -138,6 +139,21 @@ class Install extends ArboristWorkspaceCmd {
     // name to global space, e.g: `npm i -g ""`
     if (where === globalTop && !args.every(Boolean)) {
       throw this.usageError()
+    }
+
+    if (!isGlobalInstall) {
+      const pkgJson = new PackageJson()
+      await pkgJson.load(this.npm.prefix)
+      const jsonContent = pkgJson.content
+      const isJsonEmptyObject = Object.keys(jsonContent).length === 0
+        && jsonContent.constructor === Object
+
+      const emptyJson = new Error()
+      emptyJson.code = 'EEMPTYPKGJSON'
+      emptyJson.path = pkgJson.filename
+      if(isJsonEmptyObject) {
+        throw emptyJson
+      }
     }
 
     const Arborist = require('@npmcli/arborist')

--- a/lib/utils/error-message.js
+++ b/lib/utils/error-message.js
@@ -409,6 +409,14 @@ const errorMessage = (er, npm) => {
       ])
       break
 
+    case 'EEMPTYPKGJSON':
+      short.push(['eemptypkgjson', er.message])
+      detail.push([
+        'eemptypkgjson',
+        'The root of package.json is an empty object',
+      ])
+      break
+
     default:
       short.push(['', er.message || er])
       if (er.signal) {

--- a/smoke-tests/test/proxy.js
+++ b/smoke-tests/test/proxy.js
@@ -3,6 +3,14 @@ const setup = require('./fixtures/setup.js')
 
 t.test('proxy', async t => {
   const { npm, readFile } = await setup(t, {
+    testdir: {
+      project: {
+        '.npmrc': '',
+        'package.json': {
+          name: 'placeholder',
+        },
+      },
+    },
     mockRegistry: false,
     useProxy: true,
   })
@@ -10,6 +18,7 @@ t.test('proxy', async t => {
   await npm('install', 'abbrev@1.0.4')
 
   t.strictSame(await readFile('package.json'), {
+    name: 'placeholder',
     dependencies: { abbrev: '^1.0.4' },
   })
 })

--- a/test/lib/utils/audit-error.js
+++ b/test/lib/utils/audit-error.js
@@ -11,7 +11,7 @@ const auditError = async (t, { command, error, ...config } = {}) => {
     command,
     config,
     exec: true,
-    prefixDir: { 'package.json': '{}', 'package-lock.json': '{}' },
+    prefixDir: { 'package.json': '{ "name": "does not matter" }', 'package-lock.json': '{}' },
   })
 
   const res = {}


### PR DESCRIPTION
`npm install` in a folder that doesn't have `package.json` doesn't write `package-lock.json` file.


## References
  Fixes #6986 
