### PR TITLE
npx.md: give alternative to --node-arg since it was removed

### DIFF
--- a/docs/lib/content/commands/npx.md
+++ b/docs/lib/content/commands/npx.md
@@ -145,7 +145,7 @@ This resulted in some shifts in its functionality:
   always present in the executed process `PATH`.
 - The `--npm` option is removed.  `npx` will always use the `npm` it ships
   with.
-- The `--node-arg` and `-n` options have been removed. Use [`NODE_OPTIONS`]([url](https://nodejs.org/api/cli.html#node_optionsoptions)) instead: e.g., 
+- The `--node-arg` and `-n` options have been removed. Use [`NODE_OPTIONS`](https://nodejs.org/api/cli.html#node_optionsoptions) instead: e.g., 
  `NODE_OPTIONS="--trace-warnings --trace-exit" npx jasmine --random=true`
 - The `--always-spawn` option is redundant, and thus removed.
 - The `--shell` option is replaced with `--script-shell`, but maintained

--- a/docs/lib/content/commands/npx.md
+++ b/docs/lib/content/commands/npx.md
@@ -145,7 +145,8 @@ This resulted in some shifts in its functionality:
   always present in the executed process `PATH`.
 - The `--npm` option is removed.  `npx` will always use the `npm` it ships
   with.
-- The `--node-arg` and `-n` options have been removed and replaced with <a new argument here>.
+- The `--node-arg` and `-n` options have been removed. Use [`NODE_OPTIONS`]([url](https://nodejs.org/api/cli.html#node_optionsoptions)) instead: e.g., 
+ `NODE_OPTIONS="--trace-warnings --trace-exit" npx jasmine --random=true`
 - The `--always-spawn` option is redundant, and thus removed.
 - The `--shell` option is replaced with `--script-shell`, but maintained
   in the `npx` executable for backwards compatibility.

--- a/docs/lib/content/commands/npx.md
+++ b/docs/lib/content/commands/npx.md
@@ -145,7 +145,7 @@ This resulted in some shifts in its functionality:
   always present in the executed process `PATH`.
 - The `--npm` option is removed.  `npx` will always use the `npm` it ships
   with.
-- The `--node-arg` and `-n` options are removed.
+- The `--node-arg` and `-n` options have been removed and replaced with <a new argument here>.
 - The `--always-spawn` option is redundant, and thus removed.
 - The `--shell` option is replaced with `--script-shell`, but maintained
   in the `npx` executable for backwards compatibility.

--- a/docs/lib/content/commands/npx.md
+++ b/docs/lib/content/commands/npx.md
@@ -146,7 +146,7 @@ This resulted in some shifts in its functionality:
 - The `--npm` option is removed.  `npx` will always use the `npm` it ships
   with.
 - The `--node-arg` and `-n` options have been removed. Use [`NODE_OPTIONS`](https://nodejs.org/api/cli.html#node_optionsoptions) instead: e.g., 
- `NODE_OPTIONS="--trace-warnings --trace-exit" npx jasmine --random=true`
+ `NODE_OPTIONS="--trace-warnings --trace-exit" npx foo --random=true`
 - The `--always-spawn` option is redundant, and thus removed.
 - The `--shell` option is replaced with `--script-shell`, but maintained
   in the `npx` executable for backwards compatibility.


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

Article: https://docs.npmjs.com/cli/v10/commands/npx

It's probably right in my face, but I can't figure out how to pass an argument to `node`/`node.exe` from the `npx` command. Even if this is elsewhere in the document, I still think this placeholder should be filled in: passing a `node.js` argument into `npx` isn't rare (in my experience). Therefore, it should be found through a search for `node` or `argument` within this article. Currently, [it only leads you to information that doesn't answer the question](https://docs.npmjs.com/cli/v10/commands/npx#compatibility-with-older-npx-versions):

> The `--node-arg` and `-n` options are removed.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
