### PR TITLE
docs: remove duplicate `.npmrc` list item

### DIFF
--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -298,7 +298,6 @@ Some files are always ignored by default:
 * `.DS_Store`
 * `._*`
 * `.git`
-* `.npmrc`
 * `.hg`
 * `.lock-wscript`
 * `.npmrc`


### PR DESCRIPTION
The list of files that are excluded from a npm package contained a duplicate entry of `.npmrc`. This PR removes it.