### PR TITLE
issue/5051 - incorrect peer dependencies on v1 lockfile upgrade 

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -10,7 +10,6 @@ const pacote = require('pacote')
 const checks = require('npm-install-checks')
 
 const ArboristWorkspaceCmd = require('../arborist-cmd.js')
-const { defaultLockfileVersion } = require('@npmcli/arborist/lib/shrinkwrap.js')
 class Install extends ArboristWorkspaceCmd {
   static description = 'Install a package'
   static name = 'install'
@@ -151,7 +150,7 @@ class Install extends ArboristWorkspaceCmd {
     const arb = new Arborist(opts)
     await arb.reify(opts)
 
-    if (arb.options.lockfileVersion && arb.options.lockfileVersion < defaultLockfileVersion) {
+    if (arb.originalLockfileVersionOld) {
       await arb.reify(opts)
     }
 

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -10,6 +10,7 @@ const pacote = require('pacote')
 const checks = require('npm-install-checks')
 
 const ArboristWorkspaceCmd = require('../arborist-cmd.js')
+const { defaultLockfileVersion } = require('@npmcli/arborist/lib/shrinkwrap.js')
 class Install extends ArboristWorkspaceCmd {
   static description = 'Install a package'
   static name = 'install'
@@ -149,6 +150,10 @@ class Install extends ArboristWorkspaceCmd {
     }
     const arb = new Arborist(opts)
     await arb.reify(opts)
+
+    if (arb.options.lockfileVersion && arb.options.lockfileVersion < defaultLockfileVersion) {
+      await arb.reify(opts)
+    }
 
     if (!args.length && !isGlobalInstall && !ignoreScripts) {
       const scripts = [

--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -128,6 +128,7 @@ module.exports = cls => class IdealTreeBuilder extends cls {
     this.idealTree = idealTree
     this.installLinks = installLinks
     this.legacyPeerDeps = legacyPeerDeps
+    this.originalLockfileVersionOld = false
 
     this[_usePackageLock] = packageLock
     this[_global] = !!global
@@ -690,6 +691,7 @@ module.exports = cls => class IdealTreeBuilder extends cls {
     const heading = ancient ? 'ancient lockfile' : 'old lockfile'
     if (ancient || !this.options.lockfileVersion ||
         this.options.lockfileVersion >= defaultLockfileVersion) {
+      this.originalLockfileVersionOld = true
       log.warn(heading,
         `
 The ${meta.type} file was created with an old version of npm,


### PR DESCRIPTION
Npm does not capture conflicting dependencies with old lockfiles (npm@6) . On the first install from an old lockfile, the lockfile gets upgraded but the install command captures the old lockfile during the install. This update checks for old lockfiles and re reifies to ensure the updated lockfile is used during the second reification.

## References
closes #5051