### PR TITLE
feat: dedupe - display difference when `--dry-run` is enabled

### DIFF
--- a/lib/utils/reify-output.js
+++ b/lib/utils/reify-output.js
@@ -41,6 +41,10 @@ const reifyOutput = (npm, arb) => {
   }
 
   if (diff) {
+    if (npm.config.get('dry-run')) {
+      printDiff(npm, diff)
+    }
+
     depth({
       tree: diff,
       visit: d => {
@@ -96,6 +100,35 @@ const printAuditReport = (npm, report) => {
     return
   }
   npm.output(`\n${res.report}`)
+}
+
+// print the diff tree of actions that would be taken
+const printDiff = (npm, diff) => {
+  const msg = []
+
+  for (let i = 0; i < diff.children.length; ++i) {
+    const child = diff.children[i]
+    msg.push('\n', child.action.toLowerCase(), '\t')
+
+    switch (child.action) {
+      case 'ADD':
+        msg.push([child.ideal.name, child.ideal.package.version].join('\t'))
+        break
+      case 'REMOVE':
+        msg.push([child.actual.name, child.actual.package.version].join('\t'))
+        break
+      case 'CHANGE':
+        msg.push(
+          [
+            child.actual.name,
+            child.actual.package.version + ' -> ' + child.ideal.package.version,
+          ].join('\t')
+        )
+        break
+    }
+  }
+
+  npm.output(msg.join(''))
 }
 
 const getAuditReport = (npm, report) => {

--- a/test/lib/utils/reify-output.js
+++ b/test/lib/utils/reify-output.js
@@ -380,3 +380,47 @@ t.test('added packages should be looked up within returned tree', async t => {
     t.matchSnapshot(out)
   })
 })
+
+t.test('prints dedupe difference', async t => {
+  const mock = {
+    actualTree: {
+      name: 'foo',
+      inventory: {
+        has: () => false,
+      },
+    },
+    diff: {
+      children: [
+        { action: 'ADD', ideal: { name: 'foo', package: { version: '1.0.0' } } },
+        { action: 'REMOVE', actual: { name: 'bar', package: { version: '1.0.0' } } },
+        {
+          action: 'CHANGE',
+          actual: { name: 'bar', package: { version: '1.0.0' } },
+          ideal: { package: { version: '2.1.0' } },
+        },
+      ],
+    },
+  }
+
+  const out = await mockReify(t, mock, {
+    'dry-run': true,
+  })
+
+  t.match(
+    out,
+    'add\tfoo\t1.0.0',
+    'should print added package'
+  )
+
+  t.match(
+    out,
+    'remove\tbar\t1.0.0',
+    'should print removed package'
+  )
+
+  t.match(
+    out,
+    'change\tbar\t1.0.0 -> 2.1.0',
+    'should print changed package'
+  )
+})


### PR DESCRIPTION
This PR adds functionality to show the difference in what would have been changed if the user had run the `dedupe` command with the `--dry-run` flag. At the moment the output is not really useful and doesn't give the user any information other than something like `added 2 packages, removed 3 packages, and changed 12 packages in 48s`.

This PR changes that:
<img width="1019" alt="Screenshot 2024-01-13 at 00 18 07" src="https://github.com/npm/cli/assets/35810911/e7c08044-f9be-490b-8930-0e118de1c63d">

## References
Closes #2687
Closes #4398