### PR TITLE
docs: Link to the config command in the npm configuration description

### DIFF
--- a/docs/lib/content/using-npm/config.md
+++ b/docs/lib/content/using-npm/config.md
@@ -6,6 +6,9 @@ description: More than you probably want to know about npm configuration
 
 ### Description
 
+This article details general npm configuration. To learn about the `config` command, 
+see [`npm config`](/commands/npm-config).
+
 npm gets its configuration values from the following sources, sorted by priority:
 
 #### Command Line Flags

--- a/docs/lib/content/using-npm/config.md
+++ b/docs/lib/content/using-npm/config.md
@@ -6,7 +6,7 @@ description: More than you probably want to know about npm configuration
 
 ### Description
 
-This article details general npm configuration. To learn about the `config` command, 
+This article details npm configuration in general. To learn about the `config` command, 
 see [`npm config`](/commands/npm-config).
 
 npm gets its configuration values from the following sources, sorted by priority:


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
### Link to the config command in the npm configuration description
- When you are trying to learn about the `npm config` command, a search engine is likely to bring you here instead. This new link takes you to your intended destination.
- I am aware there is a "See also" section at the bottom of this page, but without knowing there is more than one "npm config" article, it never occurred to me that I might be in the wrong place. Therefore, this link would have saved time and confusion.
- I modeled this modification after the way Wikipedia disambiguates its articles.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
* https://docs.npmjs.com/cli/v10/using-npm/config
* https://docs.npmjs.com/cli/v10/commands/npm-config