### PR TITLE
docs(config): State default configuration file affected by `npm config set`

### DIFF
--- a/docs/lib/content/commands/npm-config.md
+++ b/docs/lib/content/commands/npm-config.md
@@ -33,7 +33,8 @@ npm config set key=value [key=value...]
 npm set key=value [key=value...]
 ```
 
-Sets each of the config keys to the value provided.
+Sets each of the config keys to the value provided. Modifies the user configuration
+file unless [`location`](/commands/npm-config#location) is passed.
 
 If value is omitted, the key will be removed from your config file entirely.
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
State default configuration file affected by `npm config set`. After trying this command for the first time, it took me a while to figure out what changed. That information is provided in the `location` section, but I think it would be helpful to most users to inform them upfront. 

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

* https://docs.npmjs.com/cli/v10/commands/npm-config#set
* https://docs.npmjs.com/cli/v10/commands/npm-config#location