### PR TITLE
docs(update): Fix a typo and remove unneeded statement

### DIFF
--- a/docs/lib/content/commands/npm-update.md
+++ b/docs/lib/content/commands/npm-update.md
@@ -76,13 +76,13 @@ However, if `app`'s `package.json` contains:
 ```
 
 In this case, running `npm update` will install `dep1@1.1.2`.  Even though the
-`latest` tag points to `1.2.2`, this version do not satisfy `~1.1.1`, which is
+`latest` tag points to `1.2.2`, this version does not satisfy `~1.1.1`, which is
 equivalent to `>=1.1.1 <1.2.0`.  So the highest-sorting version that satisfies
 `~1.1.1` is used, which is `1.1.2`.
 
 #### Caret Dependencies below 1.0.0
 
-Suppose `app` has a caret dependency on a version below `1.0.0`, for example:
+Caret dependencies below 1.0.0 consider minor versions to be breaking changes. Suppose `app` has a caret dependency on a version below `1.0.0`, for example:
 
 ```json
 "dependencies": {
@@ -90,8 +90,7 @@ Suppose `app` has a caret dependency on a version below `1.0.0`, for example:
 }
 ```
 
-`npm update` will install `dep1@0.2.0`, because there are no other
-versions which satisfy `^0.2.0`.
+`npm update` will install `dep1@0.2.0`.
 
 If the dependence were on `^0.4.0`:
 

--- a/docs/lib/content/commands/npm-update.md
+++ b/docs/lib/content/commands/npm-update.md
@@ -82,7 +82,7 @@ equivalent to `>=1.1.1 <1.2.0`.  So the highest-sorting version that satisfies
 
 #### Caret Dependencies below 1.0.0
 
-Caret dependencies below 1.0.0 consider minor versions to be breaking changes. Suppose `app` has a caret dependency on a version below `1.0.0`, for example:
+Suppose `app` has a caret dependency on a version below `1.0.0`, for example:
 
 ```json
 "dependencies": {


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
- <s>I have explicitly stated how caret dependencies below 1.0.0 behave differently. Before, this information had to be inferred from the examples.</s>
- Fixed a typo

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
* https://docs.npmjs.com/cli/v10/commands/npm-update#caret-dependencies-below-100