### PR TITLE
docs: remove submodules part from the install docs

### DIFF
--- a/docs/lib/content/commands/npm-install.md
+++ b/docs/lib/content/commands/npm-install.md
@@ -256,9 +256,6 @@ into a tarball (b).
     `#semver:<semver>` is specified, then the default branch of the
     repository is used.
 
-    If the repository makes use of submodules, those submodules will be
-    cloned as well.
-
     If the package being installed contains a `prepare` script, its
     `dependencies` and `devDependencies` will be installed, and the prepare
     script will be run, before the package is packaged and installed.


### PR DESCRIPTION
# BUG Description

Contrary to what the docs say under [docs.npmjs.com/cli/v10/commands/npm-install](https://docs.npmjs.com/cli/v10/commands/npm-install)

> If the repository makes use of submodules, those submodules will be cloned as well.

Test results show that submodule cloning doesn't happen for (as in, docs are inaccurate for) npm 7 (v7.24.2), npm 8 (v8.19.4), npm 9 (v9.9.0), and npm latest/10 (v10.2.1).

This is an update to the docs in the meantime while waiting for the submodules to be brought back

# References

Related to #2774