### PR TITLE
fix(pack, publish): default foreground-scripts to true

### DIFF
--- a/lib/commands/pack.js
+++ b/lib/commands/pack.js
@@ -47,6 +47,9 @@ class Pack extends BaseCommand {
     for (const { arg, manifest } of manifests) {
       const tarballData = await libpack(arg, {
         ...this.npm.flatOptions,
+        foregroundScripts: this.npm.config.isDefault('foreground-scripts')
+          ? true
+          : this.npm.config.get('foreground-scripts'),
         prefix: this.npm.localPrefix,
         workspaces: this.workspacePaths,
       })

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -80,6 +80,9 @@ class Publish extends BaseCommand {
     // we pass dryRun: true to libnpmpack so it doesn't write the file to disk
     const tarballData = await pack(spec, {
       ...opts,
+      foregroundScripts: this.npm.config.isDefault('foreground-scripts')
+        ? true
+        : this.npm.config.get('foreground-scripts'),
       dryRun: true,
       prefix: this.npm.localPrefix,
       workspaces: this.workspacePaths,

--- a/tap-snapshots/test/lib/commands/pack.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/pack.js.test.cjs
@@ -26,6 +26,48 @@ Array [
 ]
 `
 
+exports[`test/lib/commands/pack.js TAP foreground-scripts can still be set to false > logs pack contents 1`] = `
+Array [
+  undefined,
+  "package: test-fg-scripts@0.0.0",
+  undefined,
+  "110B package.json",
+  undefined,
+  String(
+    name:          test-fg-scripts                         
+    version:       0.0.0                                   
+    filename:      test-fg-scripts-0.0.0.tgz               
+    package size:  {size}
+    unpacked size: 110 B                                   
+    shasum:        {sha}
+    integrity:     {integrity}
+    total files:   1                                       
+  ),
+  "",
+]
+`
+
+exports[`test/lib/commands/pack.js TAP foreground-scripts defaults to true > logs pack contents 1`] = `
+Array [
+  undefined,
+  "package: test-fg-scripts@0.0.0",
+  undefined,
+  "110B package.json",
+  undefined,
+  String(
+    name:          test-fg-scripts                         
+    version:       0.0.0                                   
+    filename:      test-fg-scripts-0.0.0.tgz               
+    package size:  {size}
+    unpacked size: 110 B                                   
+    shasum:        {sha}
+    integrity:     {integrity}
+    total files:   1                                       
+  ),
+  "",
+]
+`
+
 exports[`test/lib/commands/pack.js TAP should log output as valid json > logs pack contents 1`] = `
 Array []
 `

--- a/tap-snapshots/test/lib/commands/publish.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/publish.js.test.cjs
@@ -56,6 +56,92 @@ Array [
 ]
 `
 
+exports[`test/lib/commands/publish.js TAP foreground-scripts can still be set to false > must match snapshot 1`] = `
+Array [
+  Array [
+    "",
+  ],
+  Array [
+    "",
+    "package: test-fg-scripts@0.0.0",
+  ],
+  Array [
+    "=== Tarball Contents ===",
+  ],
+  Array [
+    "",
+    "110B package.json",
+  ],
+  Array [
+    "=== Tarball Details ===",
+  ],
+  Array [
+    "",
+    String(
+      name:          test-fg-scripts                         
+      version:       0.0.0                                   
+      filename:      test-fg-scripts-0.0.0.tgz               
+      package size:  {size}
+      unpacked size: 110 B                                   
+      shasum:        {sha}
+      integrity:     {integrity}
+      total files:   1                                       
+    ),
+  ],
+  Array [
+    "",
+    "",
+  ],
+  Array [
+    "",
+    "Publishing to https://registry.npmjs.org/ with tag latest and default access (dry-run)",
+  ],
+]
+`
+
+exports[`test/lib/commands/publish.js TAP foreground-scripts defaults to true > must match snapshot 1`] = `
+Array [
+  Array [
+    "",
+  ],
+  Array [
+    "",
+    "package: test-fg-scripts@0.0.0",
+  ],
+  Array [
+    "=== Tarball Contents ===",
+  ],
+  Array [
+    "",
+    "110B package.json",
+  ],
+  Array [
+    "=== Tarball Details ===",
+  ],
+  Array [
+    "",
+    String(
+      name:          test-fg-scripts                         
+      version:       0.0.0                                   
+      filename:      test-fg-scripts-0.0.0.tgz               
+      package size:  {size}
+      unpacked size: 110 B                                   
+      shasum:        {sha}
+      integrity:     {integrity}
+      total files:   1                                       
+    ),
+  ],
+  Array [
+    "",
+    "",
+  ],
+  Array [
+    "",
+    "Publishing to https://registry.npmjs.org/ with tag latest and default access (dry-run)",
+  ],
+]
+`
+
 exports[`test/lib/commands/publish.js TAP has mTLS auth for scope configured registry > new package version 1`] = `
 + @npm/test-package@1.0.0
 `

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -637,7 +637,8 @@ recommended that you do not use this option!
 
 #### \`foreground-scripts\`
 
-* Default: false
+* Default: \`false\` unless when using \`npm pack\` or \`npm publish\` where it
+  defaults to \`true\`
 * Type: Boolean
 
 Run all build scripts (ie, \`preinstall\`, \`install\`, and \`postinstall\`)

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -786,6 +786,8 @@ define('force', {
 
 define('foreground-scripts', {
   default: false,
+  defaultDescription: `\`false\` unless when using \`npm pack\` or \`npm publish\` where it
+  defaults to \`true\``,
   type: Boolean,
   description: `
     Run all build scripts (ie, \`preinstall\`, \`install\`, and


### PR DESCRIPTION
Fixes #6816

This fixes a regression in both npm 9 and 10.

An alternative approach to adding a constructor could be, add something in BaseCommand that runs super, and then reads the default from the derived command class, and then sets the default - that way it'd be more declarative. Happy to change to something like that, if preferred.