### PR TITLE
docs(package-json): Reword warning about publishing local dependencies

### DIFF
--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -709,7 +709,7 @@ in which case they will be normalized to a relative path and added to your
 
 This feature is helpful for local offline development and creating tests
 that require npm installing where you don't want to hit an external server,
-but should not be used when publishing packages to the public registry.
+but should not be used when publishing your package to the public registry.
 
 *note*: Packages linked by local path will not have their own
 dependencies installed when `npm install` is ran in this case.  You must


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
```
Original: should not be used when publishing packages to the public registry.
New     : should not be used when publishing your package to the public registry.
```

When I read the original phrase, I interpreted it to mean, "Don't publish your package publicly if **other** packages depend on yours as a local dependency." Although I quickly realized the intended meaning, I believe I would've understood it from the get-go if it were written this new way.

(FWIW, I don't have a strong opinion about this and welcome any feedback.)

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
* https://docs.npmjs.com/cli/v9/configuring-npm/package-json#local-paths