### PR TITLE
feat(format): print `--dry-run` diffs in table format

### DIFF
--- a/lib/utils/reify-output.js
+++ b/lib/utils/reify-output.js
@@ -15,6 +15,7 @@ const ms = require('ms')
 const npmAuditReport = require('npm-audit-report')
 const { readTree: getFundingInfo } = require('libnpmfund')
 const auditError = require('./audit-error.js')
+const Table = require('cli-table3')
 
 // TODO: output JSON if flatOptions.json is true
 const reifyOutput = (npm, arb) => {
@@ -104,31 +105,52 @@ const printAuditReport = (npm, report) => {
 
 // print the diff tree of actions that would be taken
 const printDiff = (npm, diff) => {
-  const msg = []
+  const table = new Table({
+    chars: {
+      top: '',
+      'top-mid': '',
+      'top-left': '',
+      'top-right': '',
+      bottom: '',
+      'bottom-mid': '',
+      'bottom-left': '',
+      'bottom-right': '',
+      left: '',
+      'left-mid': '',
+      mid: '',
+      'mid-mid': '',
+      right: '',
+      'right-mid': '',
+      middle: '  ',
+    },
+    style: {
+      'padding-left': 0,
+      'padding-right': 0,
+      border: 0,
+    },
+  })
 
   for (let i = 0; i < diff.children.length; ++i) {
     const child = diff.children[i]
-    msg.push('\n', child.action.toLowerCase(), '\t')
+    table[i] = [child.action.toLowerCase()]
 
     switch (child.action) {
       case 'ADD':
-        msg.push([child.ideal.name, child.ideal.package.version].join('\t'))
+        table[i].push(child.ideal.name, child.ideal.package.version)
         break
       case 'REMOVE':
-        msg.push([child.actual.name, child.actual.package.version].join('\t'))
+        table[i].push(child.actual.name, child.actual.package.version)
         break
       case 'CHANGE':
-        msg.push(
-          [
-            child.actual.name,
-            child.actual.package.version + ' -> ' + child.ideal.package.version,
-          ].join('\t')
+        table[i].push(
+          child.actual.name,
+          child.actual.package.version + ' -> ' + child.ideal.package.version
         )
         break
     }
   }
 
-  npm.output(msg.join(''))
+  npm.output('\n' + table.toString())
 }
 
 const getAuditReport = (npm, report) => {

--- a/tap-snapshots/test/lib/utils/reify-output.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/reify-output.js.test.cjs
@@ -1632,3 +1632,12 @@ exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added"
   }
 }
 `
+
+exports[`test/lib/utils/reify-output.js TAP prints dedupe difference > diff table 1`] = `
+
+add     foo  1.0.0         
+remove  bar  1.0.0         
+change  bar  1.0.0 -> 2.1.0
+
+removed 1 package, and changed 1 package in {TIME}
+`

--- a/test/lib/utils/reify-output.js
+++ b/test/lib/utils/reify-output.js
@@ -406,21 +406,5 @@ t.test('prints dedupe difference', async t => {
     'dry-run': true,
   })
 
-  t.match(
-    out,
-    'add\tfoo\t1.0.0',
-    'should print added package'
-  )
-
-  t.match(
-    out,
-    'remove\tbar\t1.0.0',
-    'should print removed package'
-  )
-
-  t.match(
-    out,
-    'change\tbar\t1.0.0 -> 2.1.0',
-    'should print changed package'
-  )
+  t.matchSnapshot(out, 'diff table')
 })


### PR DESCRIPTION
This PR adds tabular formatting to the outputted diffs for  `--dry-run` commands

![Screenshot 2024-01-23 at 18 03 47](https://github.com/npm/cli/assets/102221627/0bb03efc-3a3f-413a-bb12-677b7e061662)

## References
Related to #7133 