### PR TITLE
Properly differintiate http and https proxies

### DIFF
--- a/node_modules/@npmcli/agent/lib/agents.js
+++ b/node_modules/@npmcli/agent/lib/agents.js
@@ -62,7 +62,7 @@ module.exports = class Agent extends AgentBase {
 
     let ProxyAgent = this.#ProxyAgent
     if (Array.isArray(ProxyAgent)) {
-      ProxyAgent = options.secureEndpoint ? ProxyAgent[1] : ProxyAgent[0]
+      ProxyAgent = this.isSecureEndpoint(options) ? ProxyAgent[1] : ProxyAgent[0]
     }
 
     const proxyAgent = new ProxyAgent(proxy, this.#options)
@@ -124,7 +124,7 @@ module.exports = class Agent extends AgentBase {
         timeout = timeout - (Date.now() - start)
       }
     } else {
-      socket = (options.secureEndpoint ? tls : net).connect(options)
+      socket = (this.isSecureEndpoint(options) ? tls : net).connect(options)
     }
 
     socket.setKeepAlive(this.keepAlive, this.keepAliveMsecs)
@@ -133,8 +133,8 @@ module.exports = class Agent extends AgentBase {
     const abortController = new AbortController()
     const { signal } = abortController
 
-    const connectPromise = socket[options.secureEndpoint ? 'secureConnecting' : 'connecting']
-      ? once(socket, options.secureEndpoint ? 'secureConnect' : 'connect', { signal })
+    const connectPromise = socket[this.isSecureEndpoint(options) ? 'secureConnecting' : 'connecting']
+      ? once(socket, this.isSecureEndpoint(options) ? 'secureConnect' : 'connect', { signal })
       : Promise.resolve()
 
     await this.#timeoutConnection({


### PR DESCRIPTION
options.secureEndpoint is not always defined. There is however, a function to properly identify the type of connection in the base class, so intead of rolling the own check, relly on the base class implementation.

Fixes #7024

Contributed by STMicroelectronics

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
