### PR TITLE
fix(view): filter out invalid semver

### DIFF
--- a/lib/commands/view.js
+++ b/lib/commands/view.js
@@ -211,7 +211,13 @@ class View extends BaseCommand {
 
     const data = []
     const versions = pckmnt.versions || {}
-    pckmnt.versions = Object.keys(versions).sort(semver.compareLoose)
+    pckmnt.versions = Object.keys(versions).filter(v => {
+      if (semver.valid(v)) {
+        return true
+      }
+      log.info('view', `Ignoring invalid version: ${v}`)
+      return false
+    }).sort(semver.compareLoose)
 
     // remove readme unless we asked for it
     if (args.indexOf('readme') === -1) {

--- a/tap-snapshots/test/lib/commands/view.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/view.js.test.cjs
@@ -190,6 +190,10 @@ dist-tags:
 [1m[32mlatest[39m[22m: 1.0.0
 `
 
+exports[`test/lib/commands/view.js TAP package with invalid version > must match snapshot 1`] = `
+[ [32m'1.0.0'[39m, [32m'1.0.1'[39m ]
+`
+
 exports[`test/lib/commands/view.js TAP package with maintainers info as object > must match snapshot 1`] = `
 
 [4m[1m[32mpink[39m@[32m1.0.0[39m[22m[24m | [1m[31mProprietary[39m[22m | deps: [32mnone[39m | versions: [33m2[39m

--- a/test/lib/commands/view.js
+++ b/test/lib/commands/view.js
@@ -250,6 +250,8 @@ const packument = (nv, opts) => {
           },
         },
         '1.0.1': {},
+        '100000000000000000.0.0': {
+        },
       },
     },
   }
@@ -312,6 +314,12 @@ t.test('package with maintainers info as object', async t => {
 t.test('package with homepage', async t => {
   const { view, outputs } = await loadMockNpm(t, { config: { unicode: false } })
   await view.exec(['orange@1.0.0'])
+  t.matchSnapshot(outputs.join('\n'))
+})
+
+t.test('package with invalid version', async t => {
+  const { view, outputs } = await loadMockNpm(t, { config: { unicode: false } })
+  await view.exec(['orange', 'versions'])
   t.matchSnapshot(outputs.join('\n'))
 })
 


### PR DESCRIPTION
`node-semver` has tightened its validation on what is an acceptible
version since some old packages were published to the registry.  They
can no longer exceed the maximum safe integer value.  Packages with
invalid semver that were published before this validation cause npm to
crash when viewing info on the package as a whole.  This filters out
those invalid semver versions.
