### PR TITLE
feat(run): Optional feature to allow running package scripts without requiring 'run' command

### DIFF
--- a/lib/cli-entry.js
+++ b/lib/cli-entry.js
@@ -62,6 +62,14 @@ module.exports = async (process, validateEngines) => {
     return exitHandler()
   } catch (err) {
     if (err.code === 'EUNKNOWNCOMMAND') {
+      // If there is a package script that matches the current command, run it, unless disabled by config
+      const runShortcutEnabled =
+          npm.config.get('require-run-keyword-for-package-scripts', 'cli') === false
+
+      if (runShortcutEnabled && await isPackageScript(npm, cmd)) {
+        return await runScript(npm, cmd, exitHandler)
+      }
+
       const didYouMean = require('./utils/did-you-mean.js')
       const suggestions = await didYouMean(npm.localPrefix, cmd)
       npm.output(`Unknown command: "${cmd}"${suggestions}\n`)
@@ -71,4 +79,25 @@ module.exports = async (process, validateEngines) => {
     }
     return exitHandler(err)
   }
+}
+
+/*
+ * Transform a command that matches a package script name
+ * into a run command with that script name as an argument
+ */
+async function runScript (npm, cmd, exitHandler) {
+  try {
+    await npm.exec('run', [cmd, ...npm.argv])
+    return exitHandler()
+  } catch (err) {
+    process.exitCode = 1
+    return exitHandler(err)
+  }
+}
+
+// Determine if there is a package script that matches the command
+async function isPackageScript (npm, cmd) {
+  const pkgJson = require('@npmcli/package-json')
+  const { content } = await pkgJson.normalize(npm.localPrefix)
+  return content?.scripts?.[cmd] !== undefined
 }

--- a/lib/cli-entry.js
+++ b/lib/cli-entry.js
@@ -64,7 +64,7 @@ module.exports = async (process, validateEngines) => {
     if (err.code === 'EUNKNOWNCOMMAND') {
       // If there is a package script that matches the current command, run it, unless disabled by config
       const runShortcutEnabled =
-          npm.config.get('require-run-keyword-for-package-scripts', 'cli') === false
+          npm.config.get('require-run-command-for-package-scripts', 'cli') === false
 
       if (runShortcutEnabled && await isPackageScript(npm, cmd)) {
         return await runScript(npm, cmd, exitHandler)

--- a/tap-snapshots/test/lib/commands/config.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/config.js.test.cjs
@@ -128,6 +128,7 @@ exports[`test/lib/commands/config.js TAP config list --json > output matches sna
   "rebuild-bundle": true,
   "registry": "https://registry.npmjs.org/",
   "replace-registry-host": "npmjs",
+  "require-run-keyword-for-package-scripts": true,
   "save": true,
   "save-bundle": false,
   "save-dev": false,
@@ -286,6 +287,7 @@ read-only = false
 rebuild-bundle = true 
 registry = "https://registry.npmjs.org/" 
 replace-registry-host = "npmjs" 
+require-run-keyword-for-package-scripts = true 
 save = true 
 save-bundle = false 
 save-dev = false 

--- a/tap-snapshots/test/lib/commands/config.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/config.js.test.cjs
@@ -128,7 +128,7 @@ exports[`test/lib/commands/config.js TAP config list --json > output matches sna
   "rebuild-bundle": true,
   "registry": "https://registry.npmjs.org/",
   "replace-registry-host": "npmjs",
-  "require-run-keyword-for-package-scripts": true,
+  "require-run-command-for-package-scripts": true,
   "save": true,
   "save-bundle": false,
   "save-dev": false,
@@ -287,7 +287,7 @@ read-only = false
 rebuild-bundle = true 
 registry = "https://registry.npmjs.org/" 
 replace-registry-host = "npmjs" 
-require-run-keyword-for-package-scripts = true 
+require-run-command-for-package-scripts = true 
 save = true 
 save-bundle = false 
 save-dev = false 

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -1323,6 +1323,20 @@ You may also specify a bare hostname (e.g., "registry.npmjs.org").
 
 
 
+#### \`require-run-keyword-for-package-scripts\`
+
+* Default: true
+* Type: Boolean
+
+If true, requires the 'run' command to access most scripts in package.json
+(ones that do not have a shortcut already i.e. 'start').
+
+If false, commands like 'npm test-ci' will automatically execute as 'npm run
+test-ci', if there is a matching 'test-ci' script in the project's
+package.json file.
+
+
+
 #### \`save\`
 
 * Default: \`true\` unless when using \`npm update\` where it defaults to \`false\`
@@ -2152,6 +2166,7 @@ Array [
   "rebuild-bundle",
   "registry",
   "replace-registry-host",
+  "require-run-keyword-for-package-scripts",
   "save",
   "save-bundle",
   "save-dev",
@@ -2292,6 +2307,7 @@ Array [
   "rebuild-bundle",
   "registry",
   "replace-registry-host",
+  "require-run-keyword-for-package-scripts",
   "save",
   "save-bundle",
   "save-dev",
@@ -2444,6 +2460,7 @@ Object {
   "rebuildBundle": true,
   "registry": "https://registry.npmjs.org/",
   "replaceRegistryHost": "npmjs",
+  "requireRunKeywordForPackageScripts": true,
   "retry": Object {
     "factor": 10,
     "maxTimeout": 60000,

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -1323,7 +1323,7 @@ You may also specify a bare hostname (e.g., "registry.npmjs.org").
 
 
 
-#### \`require-run-keyword-for-package-scripts\`
+#### \`require-run-command-for-package-scripts\`
 
 * Default: true
 * Type: Boolean
@@ -2166,7 +2166,7 @@ Array [
   "rebuild-bundle",
   "registry",
   "replace-registry-host",
-  "require-run-keyword-for-package-scripts",
+  "require-run-command-for-package-scripts",
   "save",
   "save-bundle",
   "save-dev",
@@ -2307,7 +2307,7 @@ Array [
   "rebuild-bundle",
   "registry",
   "replace-registry-host",
-  "require-run-keyword-for-package-scripts",
+  "require-run-command-for-package-scripts",
   "save",
   "save-bundle",
   "save-dev",

--- a/test/lib/cli-entry.js
+++ b/test/lib/cli-entry.js
@@ -168,7 +168,7 @@ t.test('run package script if one matches command exactly, if configured', async
       'process.argv': ['node', 'npm', 'licenses'],
     },
     npm: {
-      'require-run-keyword-for-package-scripts': false,
+      'require-run-command-for-package-scripts': false,
     },
   })
   await cli(process)

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -1754,7 +1754,7 @@ define('replace-registry-host', {
   flatten,
 })
 
-define('require-run-keyword-for-package-scripts', {
+define('require-run-command-for-package-scripts', {
   default: true,
   type: Boolean,
   description: `

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -1754,6 +1754,19 @@ define('replace-registry-host', {
   flatten,
 })
 
+define('require-run-keyword-for-package-scripts', {
+  default: true,
+  type: Boolean,
+  description: `
+   If true, requires the 'run' command to access most scripts in package.json (ones 
+   that do not have a shortcut already i.e. 'start').
+   
+   If false, commands like 'npm test-ci' will automatically execute as 'npm run test-ci',
+   if there is a matching 'test-ci' script in the project's package.json file.
+  `,
+  flatten,
+})
+
 define('save', {
   default: true,
   defaultDescription: `\`true\` unless when using \`npm update\` where it


### PR DESCRIPTION
Optional feature, based on new config flag: 

If a user has a script in their package.json  (e.g. `test-all`)
and they use the script name as a CLI command (e.g. `npm test-all`)
and they have the new feature enabled via npm config
Run the script they reference, instead of simply halting with a "did you mean X?" log

This feature only applies if npm cannot already find a command to run from the standard cli docs list, meaning users cannot accidentally override a script like `npm install`. 

The feature is currently disabled by defaultin case it might cause sudden behavior changes in existing environments after updating npm. (though I would love to have it enabled by default; people should probably not be relying on invalid scripts that halt with 'did you mean  X' in their CI pipeline and similar)

In addition, the `@npmcli/package-json` library is not loaded, and the local package.json is not parsed, unless the feature is enabled and the user enters a non-standard cli command, to ensure performance is not affected.

This is a feature that has successfully been implemented and appreciated, with extremely widespread use, in similar managers (see https://yarnpkg.com/cli/run). Not only does this pre-existing testing allow us to know the feature will see use, it also will help alleviate confusion and friction points when developers migrate code, or otherwise change context, from other managers to npm.