### PR TITLE
fix: file dependency is locked without name

### DIFF
--- a/workspaces/arborist/tap-snapshots/test/arborist/reify.js.test.cjs
+++ b/workspaces/arborist/tap-snapshots/test/arborist/reify.js.test.cjs
@@ -33172,6 +33172,29 @@ exports[`test/arborist/reify.js TAP scoped registries > should preserve original
 @ruyadorno/theoretically-private-pkg@https://npm.pkg.github.com/@ruyadorno/theoretically-private-pkg/-/theoretically-private-pkg-1.2.3.tgz
 `
 
+exports[`test/arborist/reify.js TAP second reify with file dependency should not change package-lock.json > must match snapshot 1`] = `
+{
+  "name": "tap-testdir-reify-second-reify-with-file-dependency-should-not-change-package-lock.json",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@test/a": "file:a"
+      }
+    },
+    "a": {
+      "name": "@test/a"
+    },
+    "node_modules/@test/a": {
+      "resolved": "a",
+      "link": true
+    }
+  }
+}
+
+`
+
 exports[`test/arborist/reify.js TAP still do not install optional deps with mismatched platform specifications even when forced > expect resolving Promise 1`] = `
 ArboristNode {
   "edgesOut": Map {

--- a/workspaces/arborist/test/arborist/reify.js
+++ b/workspaces/arborist/test/arborist/reify.js
@@ -3281,3 +3281,26 @@ t.test('install stategy linked', async (t) => {
     t.ok(abbrev.isSymbolicLink(), 'abbrev got installed')
   })
 })
+
+t.test('second reify with file dependency should not change package-lock.json', async t => {
+  const path = t.testdir({
+    'package.json': JSON.stringify({
+      dependencies: {
+        '@test/a': 'file:a',
+      },
+    }),
+    a: {
+      'package.json': JSON.stringify({
+        name: '@test/a',
+      }),
+    },
+  })
+
+  const arb = newArb({ path })
+  await arb.reify()
+  const packageLockContent1 = fs.readFileSync(path + '/package-lock.json', 'utf8')
+  t.matchSnapshot(packageLockContent1)
+  await arb.reify()
+  const packageLockContent2 = fs.readFileSync(path + '/package-lock.json', 'utf8')
+  t.equal(packageLockContent2, packageLockContent1)
+})


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

This PR currently only contains a reproduction test case for #6430. I have looked into it a bit, but was unable to find a fix for the issue.

It seems like this condition is causing the issue. Because on the first `npm install` or `reify()` call the condition is not met because `node.packageName` and `node.name` are both equal to `@test/a` and therefore `node.name` is not set for the `file:a` dependency. But on the second `npm install` or `reify()` call the condition is met because `node.packageName` is equal to `@test/a` and `node.name` is equal to `a`. Therefore, the `node.name` is set to `@test/a` and the `package-lock.json` will change.

https://github.com/npm/cli/blob/d04111d48ca59fce27909712b328fe5cfc4d016d/workspaces/arborist/lib/shrinkwrap.js#L232-L238

Can someone help me to fix this issue?

## References

Fixes #6430 
