### PR TITLE
fix: added check for dry-run

### DIFF
--- a/lib/commands/ci.js
+++ b/lib/commands/ci.js
@@ -75,14 +75,16 @@ class CI extends ArboristWorkspaceCmd {
       )
     }
 
-    if (!this.npm.flatOptions.dryRun) {
+    const dryRun = this.npm.config.get('dry-run')
+    if (!dryRun) {
       // Only remove node_modules after we've successfully loaded the virtual
       // tree and validated the lockfile
       await this.npm.time('npm-ci:rm', async () => {
         const path = `${where}/node_modules`
         // get the list of entries so we can skip the glob for performance
         const entries = await fs.readdir(path, null).catch(er => [])
-        return Promise.all(entries.map(f => fs.rm(`${path}/${f}`, { force: true, recursive: true })))
+        return Promise.all(entries.map(f => fs.rm(`${path}/${f}`,
+          { force: true, recursive: true })))
       })
     }
 

--- a/lib/commands/ci.js
+++ b/lib/commands/ci.js
@@ -75,14 +75,16 @@ class CI extends ArboristWorkspaceCmd {
       )
     }
 
-    // Only remove node_modules after we've successfully loaded the virtual
-    // tree and validated the lockfile
-    await this.npm.time('npm-ci:rm', async () => {
-      const path = `${where}/node_modules`
-      // get the list of entries so we can skip the glob for performance
-      const entries = await fs.readdir(path, null).catch(er => [])
-      return Promise.all(entries.map(f => fs.rm(`${path}/${f}`, { force: true, recursive: true })))
-    })
+    if (!this.npm.flatOptions.dryRun) {
+      // Only remove node_modules after we've successfully loaded the virtual
+      // tree and validated the lockfile
+      await this.npm.time('npm-ci:rm', async () => {
+        const path = `${where}/node_modules`
+        // get the list of entries so we can skip the glob for performance
+        const entries = await fs.readdir(path, null).catch(er => [])
+        return Promise.all(entries.map(f => fs.rm(`${path}/${f}`, { force: true, recursive: true })))
+      })
+    }
 
     await arb.reify(opts)
 

--- a/test/lib/commands/ci.js
+++ b/test/lib/commands/ci.js
@@ -56,6 +56,26 @@ const abbrev = {
   test: 'test file',
 }
 
+t.test('reifies, but doesn\'t remove node_modules because --dry-run', async t => {
+  const { npm, joinedOutput } = await loadMockNpm(t, {
+    config: {
+      'dry-run': true,
+    },
+    prefixDir: {
+      abbrev: abbrev,
+      'package.json': JSON.stringify(packageJson),
+      'package-lock.json': JSON.stringify(packageLock),
+      node_modules: { test: 'test file that will not be removed' },
+    },
+  })
+  await npm.exec('ci', [])
+  t.match(joinedOutput(), 'added 1 package, and removed 1 package in')
+  const nmTest = path.join(npm.prefix, 'node_modules', 'test')
+  t.equal(fs.existsSync(nmTest), true, 'existing node_modules is not removed')
+  const nmAbbrev = path.join(npm.prefix, 'node_modules', 'abbrev')
+  t.equal(fs.existsSync(nmAbbrev), false, 'does not install abbrev')
+})
+
 t.test('reifies, audits, removes node_modules', async t => {
   const { npm, joinedOutput, registry } = await loadMockNpm(t, {
     prefixDir: {


### PR DESCRIPTION
added a check for dry-run for `npm ci` so that node_modules won't be deleted.

`npm ci --dry-run` currently removes the node_modules folder even though the docs say that dry-run, "Indicates that you don't want npm to make any changes and that it should only report what it would have done".

This commit adds a check for dryRun in the npm.flatOptions object which will be true if `--dry-run` is added on the cli or if `dry-run=true` is set in .npmrc

closes #7239
