### PR TITLE
fix(search): include searchlimit option in help output

### DIFF
--- a/lib/commands/search.js
+++ b/lib/commands/search.js
@@ -42,6 +42,7 @@ class Search extends BaseCommand {
     'color',
     'parseable',
     'description',
+    'searchlimit',
     'searchopts',
     'searchexclude',
     'registry',

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -4069,8 +4069,9 @@ npm search [search terms ...]
 
 Options:
 [-l|--long] [--json] [--color|--no-color|--color always] [-p|--parseable]
-[--no-description] [--searchopts <searchopts>] [--searchexclude <searchexclude>]
-[--registry <registry>] [--prefer-online] [--prefer-offline] [--offline]
+[--no-description] [--searchlimit <number>] [--searchopts <searchopts>]
+[--searchexclude <searchexclude>] [--registry <registry>] [--prefer-online]
+[--prefer-offline] [--offline]
 
 aliases: find, s, se
 
@@ -4089,6 +4090,7 @@ Note: This command is unaware of workspaces.
 #### \`color\`
 #### \`parseable\`
 #### \`description\`
+#### \`searchlimit\`
 #### \`searchopts\`
 #### \`searchexclude\`
 #### \`registry\`


### PR DESCRIPTION
`npm search --help` and `man npm-search` did not list the `--searchlimit` option.