### PR TITLE
Feat: Add Ignore publish config flag

### DIFF
--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -345,8 +345,8 @@ ${defData}
 
     if (!this.npm.global) {
       const { content } = await pkgJson.normalize(this.npm.prefix).catch(() => ({ content: {} }))
-
-      if (content.publishConfig) {
+      const ignorePublishConfig = this.npm.config.get('ignore-publish-config')
+      if (!ignorePublishConfig && content.publishConfig) {
         const pkgPath = resolve(this.npm.prefix, 'package.json')
         msg.push(`; "publishConfig" from ${pkgPath}`)
         msg.push('; This set of config values will be used at publish-time.', '')

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -31,6 +31,7 @@ class Publish extends BaseCommand {
     'workspaces',
     'include-workspace-root',
     'provenance',
+    'ignore-publish-config',
   ]
 
   static usage = ['<package-spec>']
@@ -219,7 +220,8 @@ class Publish extends BaseCommand {
         fullReadJson: true,
       })
     }
-    if (manifest.publishConfig) {
+    const ignorePublishConfig = this.npm.config.get('ignore-publish-config')
+    if (!ignorePublishConfig && manifest.publishConfig) {
       flatten(manifest.publishConfig, opts)
     }
     return manifest

--- a/lib/commands/unpublish.js
+++ b/lib/commands/unpublish.js
@@ -17,7 +17,7 @@ const BaseCommand = require('../base-command.js')
 class Unpublish extends BaseCommand {
   static description = 'Remove a package from the registry'
   static name = 'unpublish'
-  static params = ['dry-run', 'force', 'workspace', 'workspaces']
+  static params = ['dry-run', 'force', 'workspace', 'workspaces', 'ignore-publish-config']
   static usage = ['[<package-spec>]']
   static workspaces = true
   static ignoreImplicitWorkspace = false
@@ -140,7 +140,8 @@ class Unpublish extends BaseCommand {
 
     // If localPrefix has a package.json with a name that matches the package
     // being unpublished, load up the publishConfig
-    if (manifest?.name === spec.name && manifest.publishConfig) {
+    const ignorePublishConfig = this.npm.config.get('ignore-publish-config')
+    if (!ignorePublishConfig && manifest?.name === spec.name && manifest.publishConfig) {
       flatten(manifest.publishConfig, opts)
     }
 

--- a/tap-snapshots/test/lib/commands/config.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/config.js.test.cjs
@@ -15,6 +15,7 @@ exports[`test/lib/commands/config.js TAP config list --json > output matches sna
   "userloaded": "yes",
   "globalloaded": "yes",
   "access": null,
+  "ignore-publish-config": false,
   "all": false,
   "allow-same-version": false,
   "also": null,
@@ -228,6 +229,7 @@ globalconfig = "{GLOBALPREFIX}/npmrc"
 heading = "npm" 
 https-proxy = null 
 if-present = false 
+ignore-publish-config = false 
 ignore-scripts = false 
 include = [] 
 include-staged = false 

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -752,6 +752,18 @@ CI setup.
 
 This value is not exported to the environment for child processes.
 
+#### \`ignore-publish-config\`
+
+* Default: false
+* Type: Boolean
+
+When using \`npm publish\`, the \`--ignore-publish-config\` flag overrides the
+registry URL specified in the package's \`publishConfig\` field, allowing
+users to publish to a different repository. Similarly, when executing \`npm
+unpublish\`
+
+
+
 #### \`ignore-scripts\`
 
 * Default: false
@@ -2058,6 +2070,7 @@ exports[`test/lib/docs.js TAP config > all keys 1`] = `
 Array [
   "_auth",
   "access",
+  "ignore-publish-config",
   "all",
   "allow-same-version",
   "also",
@@ -2218,6 +2231,7 @@ exports[`test/lib/docs.js TAP config > keys that are flattened 1`] = `
 Array [
   "_auth",
   "access",
+  "ignore-publish-config",
   "all",
   "allow-same-version",
   "also",
@@ -2423,6 +2437,7 @@ Object {
   "heading": "npm",
   "httpsProxy": null,
   "ifPresent": false,
+  "ignorePublishConfig": false,
   "ignoreScripts": false,
   "includeStaged": false,
   "includeWorkspaceRoot": false,
@@ -3864,7 +3879,7 @@ Options:
 [--tag <tag>] [--access <restricted|public>] [--dry-run] [--otp <otp>]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [-ws|--workspaces] [--include-workspace-root]
-[--provenance|--provenance-file <file>]
+[--provenance|--provenance-file <file>] [--ignore-publish-config]
 
 Run "npm help publish" for more info
 
@@ -3881,6 +3896,7 @@ npm publish <package-spec>
 #### \`include-workspace-root\`
 #### \`provenance\`
 #### \`provenance-file\`
+#### \`ignore-publish-config\`
 `
 
 exports[`test/lib/docs.js TAP usage query > must match snapshot 1`] = `
@@ -4338,7 +4354,7 @@ npm unpublish [<package-spec>]
 Options:
 [--dry-run] [-f|--force]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
-[-ws|--workspaces]
+[-ws|--workspaces] [--ignore-publish-config]
 
 Run "npm help unpublish" for more info
 
@@ -4350,6 +4366,7 @@ npm unpublish [<package-spec>]
 #### \`force\`
 #### \`workspace\`
 #### \`workspaces\`
+#### \`ignore-publish-config\`
 `
 
 exports[`test/lib/docs.js TAP usage unstar > must match snapshot 1`] = `

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -172,6 +172,18 @@ define('access', {
   flatten,
 })
 
+define('ignore-publish-config', {
+  default: false,
+  type: Boolean,
+  description: `
+    When using \`npm publish\`, the \`--ignore-publish-config\` flag overrides the registry URL 
+    specified in the package's \`publishConfig\` field, allowing users to publish to a different 
+    repository.
+    Similarly, when executing \`npm unpublish\`
+  `,
+  flatten,
+})
+
 define('all', {
   default: false,
   type: Boolean,


### PR DESCRIPTION
Introducing the "Ignore publish config" flag to the npm CLI.

This enhancement provides users with the flexibility to publish packages configured with a specific repository URL in the publishConfig field of their package.json to a different registry. By including the --ignore-publish-config flag with the npm publish command, users can override the default repository specified in the package configuration, facilitating seamless publishing to alternative repositories as needed. This feature empowers developers to manage package distribution more efficiently, accommodating diverse publishing requirements across different environments.

## References
  Related to #6400
