### PR TITLE
docs: fix incorrect npm audit key response link

### DIFF
--- a/docs/lib/content/commands/npm-audit.md
+++ b/docs/lib/content/commands/npm-audit.md
@@ -94,7 +94,7 @@ Keys response:
 - `scheme`: only `ecdsa-sha2-nistp256` is currently supported by the npm CLI
 - `key`: base64 encoded public key
 
-See this [example key's response from the public npm registry](https://registry.npmjs.org/-/npm/v1/keys").
+See this [example key's response from the public npm registry](https://registry.npmjs.org/-/npm/v1/keys).
 
 ### Audit Endpoints
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Link to keys example was broken due to `"` appended at the end.


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
