### PR TITLE
perf: avoid importing npm-registry-fetch for replace-info

### DIFF
--- a/lib/utils/replace-info.js
+++ b/lib/utils/replace-info.js
@@ -1,4 +1,29 @@
-const { cleanUrl } = require('npm-registry-fetch')
+const { URL } = require('url')
+
+const replace = '***'
+const tokenRegex = /\bnpm_[a-zA-Z0-9]{36}\b/g
+const guidRegex = /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/g
+
+const cleanUrl = (str) => {
+  if (typeof str !== 'string' || !str) {
+    return str
+  }
+
+  try {
+    const url = new URL(str)
+    if (url.password) {
+      url.password = replace
+      str = url.toString()
+    }
+  } catch {
+    // ignore errors
+  }
+
+  return str
+    .replace(tokenRegex, `npm_${replace}`)
+    .replace(guidRegex, `npm_${replace}`)
+}
+
 const isString = (v) => typeof v === 'string'
 
 // split on \s|= similar to how nopt parses options


### PR DESCRIPTION
Instead of importing the entire module, just copy the function from the `npm-registry-fetch`.

Benchmark:

```bash
hyperfine --warmup 3 "node ./bin/npm-cli.js run echo"
```

Before:

```
Benchmark 1: node ./bin/npm-cli.js run echo
  Time (mean ± σ):     219.8 ms ±   4.0 ms    [User: 224.8 ms, System: 47.2 ms]
  Range (min … max):   213.2 ms … 225.9 ms    13 runs
```

After:

```
Benchmark 1: node ./bin/npm-cli.js run echo
  Time (mean ± σ):     180.0 ms ±   5.9 ms    [User: 178.7 ms, System: 34.7 ms]
  Range (min … max):   165.5 ms … 191.4 ms    16 runs
```