### PR TITLE
fix: prioritize CLI flags over publishConfig settings

### DIFF
--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -221,15 +221,14 @@ class Publish extends BaseCommand {
     }
     if (manifest.publishConfig) {
       const cliFlags = this.npm.config.data.get('cli').raw
-      if(cliFlags){
-          // Filter out properties set in CLI flags to prioritize them over
-          // corresponding `publishConfig` settings
-          const filteredPublishConfig = Object.fromEntries(
-          Object.entries(manifest.publishConfig).filter(([key]) => !cliFlags.hasOwnProperty(key))
-        )
-      flatten(filteredPublishConfig, opts)
-      }else{
-      flatten(manifest.publishConfig, opts)
+      if (cliFlags) {
+        // Filter out properties set in CLI flags to prioritize them over
+        // corresponding `publishConfig` settings
+        const filteredPublishConfig = Object.fromEntries(
+          Object.entries(manifest.publishConfig).filter(([key]) => !(key in cliFlags)))
+        flatten(filteredPublishConfig, opts)
+      } else {
+        flatten(manifest.publishConfig, opts)
       }
     }
     return manifest

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -221,15 +221,11 @@ class Publish extends BaseCommand {
     }
     if (manifest.publishConfig) {
       const cliFlags = this.npm.config.data.get('cli').raw
-      if (cliFlags) {
-        // Filter out properties set in CLI flags to prioritize them over
-        // corresponding `publishConfig` settings
-        const filteredPublishConfig = Object.fromEntries(
-          Object.entries(manifest.publishConfig).filter(([key]) => !(key in cliFlags)))
-        flatten(filteredPublishConfig, opts)
-      } else {
-        flatten(manifest.publishConfig, opts)
-      }
+      // Filter out properties set in CLI flags to prioritize them over
+      // corresponding `publishConfig` settings
+      const filteredPublishConfig = Object.fromEntries(
+        Object.entries(manifest.publishConfig).filter(([key]) => !(key in cliFlags)))
+      flatten(filteredPublishConfig, opts)
     }
     return manifest
   }

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -220,7 +220,17 @@ class Publish extends BaseCommand {
       })
     }
     if (manifest.publishConfig) {
+      const cliFlags = this.npm.config.data.get('cli').raw
+      if(cliFlags){
+          // Filter out properties set in CLI flags to prioritize them over
+          // corresponding `publishConfig` settings
+          const filteredPublishConfig = Object.fromEntries(
+          Object.entries(manifest.publishConfig).filter(([key]) => !cliFlags.hasOwnProperty(key))
+        )
+      flatten(filteredPublishConfig, opts)
+      }else{
       flatten(manifest.publishConfig, opts)
+      }
     }
     return manifest
   }

--- a/lib/commands/unpublish.js
+++ b/lib/commands/unpublish.js
@@ -141,7 +141,17 @@ class Unpublish extends BaseCommand {
     // If localPrefix has a package.json with a name that matches the package
     // being unpublished, load up the publishConfig
     if (manifest?.name === spec.name && manifest.publishConfig) {
+      const cliFlags = this.npm.config.data.get('cli').raw
+      if(cliFlags){
+          // Filter out properties set in CLI flags to prioritize them over
+          // corresponding `publishConfig` settings
+          const filteredPublishConfig = Object.fromEntries(
+          Object.entries(manifest.publishConfig).filter(([key]) => !cliFlags.hasOwnProperty(key))
+        )
+      flatten(filteredPublishConfig, opts)
+      }else{
       flatten(manifest.publishConfig, opts)
+      }
     }
 
     const versions = await Unpublish.getKeysOfVersions(spec.name, opts)

--- a/lib/commands/unpublish.js
+++ b/lib/commands/unpublish.js
@@ -142,15 +142,11 @@ class Unpublish extends BaseCommand {
     // being unpublished, load up the publishConfig
     if (manifest?.name === spec.name && manifest.publishConfig) {
       const cliFlags = this.npm.config.data.get('cli').raw
-      if (cliFlags) {
-        // Filter out properties set in CLI flags to prioritize them over
-        // corresponding `publishConfig` settings
-        const filteredPublishConfig = Object.fromEntries(
-          Object.entries(manifest.publishConfig).filter(([key]) => !(key in cliFlags)))
-        flatten(filteredPublishConfig, opts)
-      } else {
-        flatten(manifest.publishConfig, opts)
-      }
+      // Filter out properties set in CLI flags to prioritize them over
+      // corresponding `publishConfig` settings
+      const filteredPublishConfig = Object.fromEntries(
+        Object.entries(manifest.publishConfig).filter(([key]) => !(key in cliFlags)))
+      flatten(filteredPublishConfig, opts)
     }
 
     const versions = await Unpublish.getKeysOfVersions(spec.name, opts)

--- a/lib/commands/unpublish.js
+++ b/lib/commands/unpublish.js
@@ -142,15 +142,14 @@ class Unpublish extends BaseCommand {
     // being unpublished, load up the publishConfig
     if (manifest?.name === spec.name && manifest.publishConfig) {
       const cliFlags = this.npm.config.data.get('cli').raw
-      if(cliFlags){
-          // Filter out properties set in CLI flags to prioritize them over
-          // corresponding `publishConfig` settings
-          const filteredPublishConfig = Object.fromEntries(
-          Object.entries(manifest.publishConfig).filter(([key]) => !cliFlags.hasOwnProperty(key))
-        )
-      flatten(filteredPublishConfig, opts)
-      }else{
-      flatten(manifest.publishConfig, opts)
+      if (cliFlags) {
+        // Filter out properties set in CLI flags to prioritize them over
+        // corresponding `publishConfig` settings
+        const filteredPublishConfig = Object.fromEntries(
+          Object.entries(manifest.publishConfig).filter(([key]) => !(key in cliFlags)))
+        flatten(filteredPublishConfig, opts)
+      } else {
+        flatten(manifest.publishConfig, opts)
       }
     }
 

--- a/tap-snapshots/test/lib/commands/publish.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/publish.js.test.cjs
@@ -452,6 +452,10 @@ exports[`test/lib/commands/publish.js TAP restricted access > new package versio
 + @npm/test-package@1.0.0
 `
 
+exports[`test/lib/commands/publish.js TAP prioritize CLI flags over publishConfig > new package version 1`] = `
++ test-package@1.0.0
+`
+
 exports[`test/lib/commands/publish.js TAP scoped _auth config scoped registry > new package version 1`] = `
 + @npm/test-package@1.0.0
 `


### PR DESCRIPTION
This PR addresses an issue where CLI flags were not taking precedence over publishConfig settings. To ensure CLI flags have higher priority, properties from the publishConfig object that also exist in CLI flags are filtered out.


  Related to #6400 
