### PR TITLE
docs: fix incorrect ISO 8601 reference

### DIFF
--- a/docs/lib/content/commands/npm-audit.md
+++ b/docs/lib/content/commands/npm-audit.md
@@ -88,7 +88,7 @@ The `sig` is generated using the following template: `${package.name}@${package.
 
 Keys response:
 
-- `expires`: null or a simplified extended [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601"): `YYYY-MM-DDTHH:mm:ss.sssZ`
+- `expires`: null or a simplified extended [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601): `YYYY-MM-DDTHH:mm:ss.sssZ`
 - `keydid`: sha256 fingerprint of the public key
 - `keytype`: only `ecdsa-sha2-nistp256` is currently supported by the npm CLI
 - `scheme`: only `ecdsa-sha2-nistp256` is currently supported by the npm CLI


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
**PR Summary**:
The ISO 8601 references is broken broken due to `"` appended at the end.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
