### PR TITLE
fix: lazy load validate npm package name on error message

### DIFF
--- a/lib/utils/error-message.js
+++ b/lib/utils/error-message.js
@@ -1,6 +1,5 @@
 const { format } = require('util')
 const { resolve } = require('path')
-const nameValidator = require('validate-npm-package-name')
 const { redactLog: replaceInfo } = require('@npmcli/redact')
 const { report } = require('./explain-eresolve.js')
 const log = require('./log-shim')
@@ -215,6 +214,7 @@ const errorMessage = (er, npm) => {
         detail.push(['404', ''])
         detail.push(['404', '', `'${replaceInfo(er.pkgid)}' is not in this registry.`])
 
+        const nameValidator = require('validate-npm-package-name')
         const valResult = nameValidator(pkg)
 
         if (!valResult.validForNewPackages) {


### PR DESCRIPTION
![image](https://github.com/npm/cli/assets/12551007/0a573258-858d-406c-bbf5-926f62fde964)

This package takes 5ms to load even if we didn't use it.