### PR TITLE
fix(perf): lazy load workspace dependency

### DIFF
--- a/workspaces/config/lib/index.js
+++ b/workspaces/config/lib/index.js
@@ -2,7 +2,6 @@
 const { walkUp } = require('walk-up-path')
 const ini = require('ini')
 const nopt = require('nopt')
-const mapWorkspaces = require('@npmcli/map-workspaces')
 const rpj = require('read-package-json-fast')
 const log = require('proc-log')
 
@@ -704,6 +703,7 @@ class Config {
           continue
         }
 
+        const mapWorkspaces = require('@npmcli/map-workspaces')
         const workspaces = await mapWorkspaces({ cwd: p, pkg })
         for (const w of workspaces.values()) {
           if (w === this.localPrefix) {


### PR DESCRIPTION
Lazy loading `workspaces` and `glob` dependencies, will avoid loading the dependency when running inside a repo that is not a workspace and also will not load `glob` when is not needed.

Before:

![image](https://github.com/npm/cli/assets/12551007/5d8d50f3-d855-4d00-964d-b6b0526361b0)

After:

![image](https://github.com/npm/cli/assets/12551007/75744909-0fcb-43cc-9986-ff68bc46a078)
