### PR TITLE
fix(perf): only import what is needed for type-defs

### DIFF
--- a/workspaces/config/lib/type-defs.js
+++ b/workspaces/config/lib/type-defs.js
@@ -2,9 +2,10 @@ const nopt = require('nopt')
 
 const { Umask, validate: validateUmask } = require('./umask.js')
 
-const semver = require('semver')
+const semverValid = require('semver/functions/valid.js')
+const Semver = require('semver/classes/semver.js')
 const validateSemver = (data, k, val) => {
-  const valid = semver.valid(val)
+  const valid = semverValid(val)
   if (!valid) {
     return false
   }
@@ -23,7 +24,7 @@ const validatePath = (data, k, val) => {
 module.exports = {
   ...nopt.typeDefs,
   semver: {
-    type: semver,
+    type: Semver,
     validate: validateSemver,
     description: 'full valid SemVer string',
   },


### PR DESCRIPTION
I think this is the last place where we load the entire `semver`.