### PR TITLE
docs: Document that overrides only work in the root `package.json`

### DIFF
--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -928,6 +928,13 @@ Overrides provide a way to replace a package in your dependency tree with
 another version, or another package entirely. These changes can be scoped as
 specific or as vague as desired.
 
+Overrides are only considered in the root `package.json` file for a project.
+Overrides in installed dependencies (including
+[workspaces](/using-npm/workspaces)) are not considered in dependency tree
+resolution. Published packages may dictate their resolutions by pinning
+dependencies or using an
+[`npm-shrinkwrap.json`](/configuring-npm/npm-shrinkwrap-json) file.
+
 To make sure the package `foo` is always installed as version `1.0.0` no matter
 what version your dependencies rely on:
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Add documentation explaining that the `package.json` `"overrides"` field only takes effect at the root `package.json` of a project. Most of this text is copied from [the RFC](https://github.com/npm/rfcs/blob/main/accepted/0036-overrides.md#only-root-package-may-contain-overrides) which originally described this feature.

## References
Fixes #4517.