### PR TITLE
fix: typo in `npm access` usage

### DIFF
--- a/lib/commands/access.js
+++ b/lib/commands/access.js
@@ -36,7 +36,7 @@ class Access extends BaseCommand {
   ]
 
   static usage = [
-    'list packages [<user>|<scope>|<scope:team> [<package>]',
+    'list packages [<user>|<scope>|<scope:team>] [<package>]',
     'list collaborators [<package> [<user>]]',
     'get status [<package>]',
     'set status=public|private [<package>]',

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -2552,7 +2552,7 @@ exports[`test/lib/docs.js TAP usage access > must match snapshot 1`] = `
 Set access level on published packages
 
 Usage:
-npm access list packages [<user>|<scope>|<scope:team> [<package>]
+npm access list packages [<user>|<scope>|<scope:team>] [<package>]
 npm access list collaborators [<package> [<user>]]
 npm access get status [<package>]
 npm access set status=public|private [<package>]
@@ -2566,7 +2566,7 @@ Options:
 Run "npm help access" for more info
 
 \`\`\`bash
-npm access list packages [<user>|<scope>|<scope:team> [<package>]
+npm access list packages [<user>|<scope>|<scope:team>] [<package>]
 npm access list collaborators [<package> [<user>]]
 npm access get status [<package>]
 npm access set status=public|private [<package>]


### PR DESCRIPTION
Add closing `]` for optional owner parameter.