### PR TITLE
docs(package-json): note that line endings are inferred

### DIFF
--- a/docs/lib/content/configuring-npm/package-lock-json.md
+++ b/docs/lib/content/configuring-npm/package-lock-json.md
@@ -31,6 +31,8 @@ various purposes:
   picture of the package tree, reducing the need to read `package.json`
   files, and allowing for significant performance improvements.
 
+When `npm` creates or updates `package-lock.json`, it will infer line endings and indentation from `package.json` so that the formatting of both files matches.
+
 ### `package-lock.json` vs `npm-shrinkwrap.json`
 
 Both of these files have the same format, and perform similar functions in


### PR DESCRIPTION



## What

Per https://github.com/npm/json-parse-even-better-errors/issues/3#issuecomment-1668728929, npm will implicitly update line endings, spacing, etc of `package-lock.json` so that it matches `package.json` 

## Why
I'd like to add this documentation because it does not seem to be documented anywhere, and as it is an implicit and non-configurable behavior, it took me a long time to figure out the cause.

## References
https://github.com/npm/json-parse-even-better-errors/issues/3#issuecomment-1668728929
