### PR TITLE
fix: remove doctor log for each file permission check

### DIFF
--- a/lib/commands/doctor.js
+++ b/lib/commands/doctor.js
@@ -223,7 +223,6 @@ class Doctor extends BaseCommand {
       const gid = process.getgid()
       const files = new Set([root])
       for (const f of files) {
-        log.silly('doctor', 'checkFilesPermission', f.slice(root.length + 1))
         const st = await lstat(f).catch(er => {
           // if it can't be missing, or if it can and the error wasn't that it was missing
           if (!missingOk || er.code !== 'ENOENT') {


### PR DESCRIPTION
The previous change was made as part of the removal of the old progress bar for doctor. Log messages for each individual file scanned were moved from showing up in the progress message only to `log.silly`. There can be a very large amount of files scanned, and there is no reason to log each one individually.