### PR TITLE
docs: correct search help output

### DIFF
--- a/lib/commands/search.js
+++ b/lib/commands/search.js
@@ -8,7 +8,6 @@ class Search extends BaseCommand {
   static description = 'Search for packages'
   static name = 'search'
   static params = [
-    'long',
     'json',
     'color',
     'parseable',
@@ -22,7 +21,7 @@ class Search extends BaseCommand {
     'offline',
   ]
 
-  static usage = ['[search terms ...]']
+  static usage = ['<search term> [<search term> ...]']
 
   async exec (args) {
     const opts = {

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -4065,11 +4065,11 @@ exports[`test/lib/docs.js TAP usage search > must match snapshot 1`] = `
 Search for packages
 
 Usage:
-npm search [search terms ...]
+npm search <search term> [<search term> ...]
 
 Options:
-[-l|--long] [--json] [--color|--no-color|--color always] [-p|--parseable]
-[--no-description] [--searchlimit <number>] [--searchopts <searchopts>]
+[--json] [--color|--no-color|--color always] [-p|--parseable] [--no-description]
+[--searchlimit <number>] [--searchopts <searchopts>]
 [--searchexclude <searchexclude>] [--registry <registry>] [--prefer-online]
 [--prefer-offline] [--offline]
 
@@ -4078,14 +4078,13 @@ aliases: find, s, se
 Run "npm help search" for more info
 
 \`\`\`bash
-npm search [search terms ...]
+npm search <search term> [<search term> ...]
 
 aliases: find, s, se
 \`\`\`
 
 Note: This command is unaware of workspaces.
 
-#### \`long\`
 #### \`json\`
 #### \`color\`
 #### \`parseable\`


### PR DESCRIPTION
`--long` does not do anything and hasn't in some time.
The first search param is also required.

Closes: https://github.com/npm/cli/issues/7402
Closes: https://github.com/npm/cli/issues/7434
