### PR TITLE
fix: account for registries with no publisher in search

### DIFF
--- a/lib/utils/format-search-stream.js
+++ b/lib/utils/format-search-stream.js
@@ -95,7 +95,7 @@ class TextOutputStream extends Minipass {
     // Normalize
     const pkg = {
       authors: data.maintainers.map((m) => `${strip(m.username)}`).join(' '),
-      publisher: strip(data.publisher.username),
+      publisher: strip(data.publisher?.username || ''),
       date: data.date ? data.date.toISOString().slice(0, 10) : 'prehistoric',
       description: strip(data.description ?? ''),
       keywords: [],
@@ -159,7 +159,11 @@ class TextOutputStream extends Minipass {
     } else {
       output = `${name}\n`
     }
-    output += `Version ${this.#chalk.blue(pkg.version)} published ${this.#chalk.blue(pkg.date)} by ${this.#chalk.blue(pkg.publisher)}\n`
+    if (pkg.publisher) {
+      output += `Version ${this.#chalk.blue(pkg.version)} published ${this.#chalk.blue(pkg.date)} by ${this.#chalk.blue(pkg.publisher)}\n`
+    } else {
+      output += `Version ${this.#chalk.blue(pkg.version)} published ${this.#chalk.blue(pkg.date)} by ${this.#chalk.yellow('???')}\n`
+    }
     output += `Maintainers: ${pkg.authors}\n`
     if (keywords) {
       output += `Keywords: ${keywords}\n`

--- a/tap-snapshots/test/lib/commands/search.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/search.js.test.cjs
@@ -5,10 +5,6 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/lib/commands/search.js TAP empty search results > should have expected search results 1`] = `
-No matches found for "foo"
-`
-
 exports[`test/lib/commands/search.js TAP search /<name>/--color > should have expected search results with color 1`] = `
 [34mlibnpm[39m
 Collection of programmatic APIs for the npm CLI
@@ -189,6 +185,10 @@ foo
 Version 1.0.0 published prehistoric by foo
 Maintainers: foo
 https://npm.im/foo
+custom-registry
+Version 1.0.0 published prehistoric by ???
+Maintainers: foo
+https://npm.im/custom-registry
 libnpmversion
 Version 1.0.0 published prehistoric by foo
 Maintainers: foo
@@ -272,6 +272,10 @@ pkg-no-desc
 Version 1.0.0 published 2019-09-26 by lukekarrys
 Maintainers: lukekarrys
 https://npm.im/pkg-no-desc
+`
+
+exports[`test/lib/commands/search.js TAP search empty search results > should have expected search results 1`] = `
+No matches found for "foo"
 `
 
 exports[`test/lib/commands/search.js TAP search exclude forward slash > results should not have libnpmversion 1`] = `
@@ -1008,4 +1012,15 @@ pkg-no-desc
 Version 1.0.0 published 2019-09-26 by lukekarrys
 Maintainers: lukekarrys
 https://npm.im/pkg-no-desc
+`
+
+exports[`test/lib/commands/search.js TAP search no publisher > should have filtered expected search results 1`] = `
+custom-registry
+Version 1.0.0 published prehistoric by ???
+Maintainers: foo
+https://npm.im/custom-registry
+libnpmversion
+Version 1.0.0 published prehistoric by foo
+Maintainers: foo
+https://npm.im/libnpmversion
 `

--- a/test/lib/commands/search.js
+++ b/test/lib/commands/search.js
@@ -4,222 +4,277 @@ const MockRegistry = require('@npmcli/mock-registry')
 const libnpmsearchResultFixture =
   require('../../fixtures/libnpmsearch-stream-result.js')
 
-t.test('no args', async t => {
-  const { npm } = await loadMockNpm(t)
-  await t.rejects(
-    npm.exec('search', []),
-    /search must be called with arguments/,
-    'should throw usage instructions'
-  )
-})
-
-t.test('search <name> text', async t => {
-  const { npm, joinedOutput } = await loadMockNpm(t)
-  const registry = new MockRegistry({
-    tap: t,
-    registry: npm.config.get('registry'),
+t.test('search', t => {
+  t.test('no args', async t => {
+    const { npm } = await loadMockNpm(t)
+    await t.rejects(
+      npm.exec('search', []),
+      /search must be called with arguments/,
+      'should throw usage instructions'
+    )
   })
 
-  registry.search({ results: libnpmsearchResultFixture })
-  await npm.exec('search', ['libnpm'])
-  t.matchSnapshot(joinedOutput(), 'should have expected search results')
-})
+  t.test('<name> text', async t => {
+    const { npm, joinedOutput } = await loadMockNpm(t)
+    const registry = new MockRegistry({
+      tap: t,
+      registry: npm.config.get('registry'),
+    })
 
-t.test('search <name> --json', async t => {
-  const { npm, joinedOutput } = await loadMockNpm(t, { config: { json: true } })
-  const registry = new MockRegistry({
-    tap: t,
-    registry: npm.config.get('registry'),
+    registry.search({ results: libnpmsearchResultFixture })
+    await npm.exec('search', ['libnpm'])
+    t.matchSnapshot(joinedOutput(), 'should have expected search results')
   })
 
-  registry.search({ results: libnpmsearchResultFixture })
+  t.test('<name> --json', async t => {
+    const { npm, joinedOutput } = await loadMockNpm(t, { config: { json: true } })
+    const registry = new MockRegistry({
+      tap: t,
+      registry: npm.config.get('registry'),
+    })
 
-  await npm.exec('search', ['libnpm'])
+    registry.search({ results: libnpmsearchResultFixture })
 
-  t.same(
-    JSON.parse(joinedOutput()),
-    libnpmsearchResultFixture,
-    'should have expected search results as json'
-  )
-})
+    await npm.exec('search', ['libnpm'])
 
-t.test('search <name> --parseable', async t => {
-  const { npm, joinedOutput } = await loadMockNpm(t, { config: { parseable: true } })
-  const registry = new MockRegistry({
-    tap: t,
-    registry: npm.config.get('registry'),
+    t.same(
+      JSON.parse(joinedOutput()),
+      libnpmsearchResultFixture,
+      'should have expected search results as json'
+    )
   })
 
-  registry.search({ results: libnpmsearchResultFixture })
-  await npm.exec('search', ['libnpm'])
-  t.matchSnapshot(joinedOutput(), 'should have expected search results as parseable')
-})
+  t.test('<name> --parseable', async t => {
+    const { npm, joinedOutput } = await loadMockNpm(t, { config: { parseable: true } })
+    const registry = new MockRegistry({
+      tap: t,
+      registry: npm.config.get('registry'),
+    })
 
-t.test('search <name> --color', async t => {
-  const { npm, joinedOutput } = await loadMockNpm(t, { config: { color: 'always' } })
-  const registry = new MockRegistry({
-    tap: t,
-    registry: npm.config.get('registry'),
+    registry.search({ results: libnpmsearchResultFixture })
+    await npm.exec('search', ['libnpm'])
+    t.matchSnapshot(joinedOutput(), 'should have expected search results as parseable')
   })
 
-  registry.search({ results: libnpmsearchResultFixture })
-  await npm.exec('search', ['libnpm'])
-  t.matchSnapshot(joinedOutput(), 'should have expected search results with color')
-})
+  t.test('<name> --color', async t => {
+    const { npm, joinedOutput } = await loadMockNpm(t, { config: { color: 'always' } })
+    const registry = new MockRegistry({
+      tap: t,
+      registry: npm.config.get('registry'),
+    })
 
-t.test('search /<name>/--color', async t => {
-  const { npm, joinedOutput } = await loadMockNpm(t, { config: { color: 'always' } })
-  const registry = new MockRegistry({
-    tap: t,
-    registry: npm.config.get('registry'),
+    registry.search({ results: libnpmsearchResultFixture })
+    await npm.exec('search', ['libnpm'])
+    t.matchSnapshot(joinedOutput(), 'should have expected search results with color')
   })
 
-  registry.search({ results: libnpmsearchResultFixture })
-  await npm.exec('search', ['/libnpm/'])
-  t.matchSnapshot(joinedOutput(), 'should have expected search results with color')
-})
+  t.test('/<name>/--color', async t => {
+    const { npm, joinedOutput } = await loadMockNpm(t, { config: { color: 'always' } })
+    const registry = new MockRegistry({
+      tap: t,
+      registry: npm.config.get('registry'),
+    })
 
-t.test('search <name>', async t => {
-  const { npm, joinedOutput } = await loadMockNpm(t)
-  const registry = new MockRegistry({
-    tap: t,
-    registry: npm.config.get('registry'),
+    registry.search({ results: libnpmsearchResultFixture })
+    await npm.exec('search', ['/libnpm/'])
+    t.matchSnapshot(joinedOutput(), 'should have expected search results with color')
   })
 
-  registry.search({ results: [{
-    name: 'foo',
-    scope: 'unscoped',
-    version: '1.0.0',
-    description: '',
-    keywords: [],
-    date: null,
-    author: { name: 'Foo', email: 'foo@npmjs.com' },
-    publisher: { username: 'foo', email: 'foo@npmjs.com' },
-    maintainers: [
-      { username: 'foo', email: 'foo@npmjs.com' },
-    ],
-  }, {
-    name: 'libnpmversion',
-    scope: 'unscoped',
-    version: '1.0.0',
-    description: '',
-    keywords: [],
-    date: null,
-    author: { name: 'Foo', email: 'foo@npmjs.com' },
-    publisher: { username: 'foo', email: 'foo@npmjs.com' },
-    maintainers: [
-      { username: 'foo', email: 'foo@npmjs.com' },
-    ],
-  }] })
+  t.test('<name>', async t => {
+    const { npm, joinedOutput } = await loadMockNpm(t)
+    const registry = new MockRegistry({
+      tap: t,
+      registry: npm.config.get('registry'),
+    })
 
-  await npm.exec('search', ['foo'])
+    registry.search({ results: [{
+      name: 'foo',
+      scope: 'unscoped',
+      version: '1.0.0',
+      description: '',
+      keywords: [],
+      date: null,
+      author: { name: 'Foo', email: 'foo@npmjs.com' },
+      publisher: { username: 'foo', email: 'foo@npmjs.com' },
+      maintainers: [
+        { username: 'foo', email: 'foo@npmjs.com' },
+      ],
+    }, {
+      name: 'custom-registry',
+      scope: 'unscoped',
+      version: '1.0.0',
+      description: '',
+      keywords: [],
+      date: null,
+      author: { name: 'Foo', email: 'foo@npmjs.com' },
+      maintainers: [
+        { username: 'foo', email: 'foo@npmjs.com' },
+      ],
+    }, {
+      name: 'libnpmversion',
+      scope: 'unscoped',
+      version: '1.0.0',
+      description: '',
+      keywords: [],
+      date: null,
+      author: { name: 'Foo', email: 'foo@npmjs.com' },
+      publisher: { username: 'foo', email: 'foo@npmjs.com' },
+      maintainers: [
+        { username: 'foo', email: 'foo@npmjs.com' },
+      ],
+    }] })
 
-  t.matchSnapshot(joinedOutput(), 'should have filtered expected search results')
-})
+    await npm.exec('search', ['foo'])
 
-t.test('empty search results', async t => {
-  const { npm, joinedOutput } = await loadMockNpm(t)
-  const registry = new MockRegistry({
-    tap: t,
-    registry: npm.config.get('registry'),
+    t.matchSnapshot(joinedOutput(), 'should have filtered expected search results')
   })
 
-  registry.search({ results: [] })
-  await npm.exec('search', ['foo'])
+  t.test('no publisher', async t => {
+    const { npm, joinedOutput } = await loadMockNpm(t)
+    const registry = new MockRegistry({
+      tap: t,
+      registry: npm.config.get('registry'),
+    })
 
-  t.matchSnapshot(joinedOutput(), 'should have expected search results')
-})
+    registry.search({ results: [{
+      name: 'custom-registry',
+      scope: 'unscoped',
+      version: '1.0.0',
+      description: '',
+      keywords: [],
+      date: null,
+      author: { name: 'Foo', email: 'foo@npmjs.com' },
+      maintainers: [
+        { username: 'foo', email: 'foo@npmjs.com' },
+      ],
+    }, {
+      name: 'libnpmversion',
+      scope: 'unscoped',
+      version: '1.0.0',
+      description: '',
+      keywords: [],
+      date: null,
+      author: { name: 'Foo', email: 'foo@npmjs.com' },
+      publisher: { username: 'foo', email: 'foo@npmjs.com' },
+      maintainers: [
+        { username: 'foo', email: 'foo@npmjs.com' },
+      ],
+    }] })
 
-t.test('empty search results --json', async t => {
-  const { npm, joinedOutput } = await loadMockNpm(t, { config: { json: true } })
-  const registry = new MockRegistry({
-    tap: t,
-    registry: npm.config.get('registry'),
+    await npm.exec('search', ['custom'])
+
+    t.matchSnapshot(joinedOutput(), 'should have filtered expected search results')
   })
 
-  registry.search({ results: [] })
+  t.test('empty search results', async t => {
+    const { npm, joinedOutput } = await loadMockNpm(t)
+    const registry = new MockRegistry({
+      tap: t,
+      registry: npm.config.get('registry'),
+    })
 
-  await npm.exec('search', ['foo'])
-  t.equal(joinedOutput(), '\n[]', 'should have expected empty square brackets')
-})
+    registry.search({ results: [] })
+    await npm.exec('search', ['foo'])
 
-t.test('search api response error', async t => {
-  const { npm } = await loadMockNpm(t)
-
-  const registry = new MockRegistry({
-    tap: t,
-    registry: npm.config.get('registry'),
+    t.matchSnapshot(joinedOutput(), 'should have expected search results')
   })
 
-  registry.search({ error: 'ERR' })
+  t.test('empty search results --json', async t => {
+    const { npm, joinedOutput } = await loadMockNpm(t, { config: { json: true } })
+    const registry = new MockRegistry({
+      tap: t,
+      registry: npm.config.get('registry'),
+    })
 
-  await t.rejects(
-    npm.exec('search', ['foo']),
-    /ERR/,
-    'should throw response error'
-  )
-})
+    registry.search({ results: [] })
 
-t.test('search exclude string', async t => {
-  const { npm, joinedOutput } = await loadMockNpm(t, { config: { searchexclude: 'libnpmversion' } })
-  const registry = new MockRegistry({
-    tap: t,
-    registry: npm.config.get('registry'),
+    await npm.exec('search', ['foo'])
+    t.equal(joinedOutput(), '\n[]', 'should have expected empty square brackets')
   })
 
-  registry.search({ results: libnpmsearchResultFixture })
-  await npm.exec('search', ['libnpm'])
-  t.matchSnapshot(joinedOutput(), 'results should not have libnpmversion')
-})
-t.test('search exclude string json', async t => {
-  const { npm, joinedOutput } = await loadMockNpm(t, {
-    config: {
-      json: true,
-      searchexclude: 'libnpmversion',
-    },
-  })
-  const registry = new MockRegistry({
-    tap: t,
-    registry: npm.config.get('registry'),
-  })
+  t.test('api response error', async t => {
+    const { npm } = await loadMockNpm(t)
 
-  registry.search({ results: libnpmsearchResultFixture })
-  await npm.exec('search', ['libnpm'])
-  t.matchSnapshot(JSON.parse(joinedOutput()), 'results should not have libnpmversion')
-})
+    const registry = new MockRegistry({
+      tap: t,
+      registry: npm.config.get('registry'),
+    })
 
-t.test('search exclude username with upper case letters', async t => {
-  const { npm, joinedOutput } = await loadMockNpm(t, { config: { searchexclude: 'NLF' } })
-  const registry = new MockRegistry({
-    tap: t,
-    registry: npm.config.get('registry'),
+    registry.search({ error: 'ERR' })
+
+    await t.rejects(
+      npm.exec('search', ['foo']),
+      /ERR/,
+      'should throw response error'
+    )
   })
 
-  registry.search({ results: libnpmsearchResultFixture })
-  await npm.exec('search', ['libnpm'])
-  t.matchSnapshot(joinedOutput(), 'results should not have nlf')
-})
+  t.test('exclude string', async t => {
+    const { npm, joinedOutput } = await loadMockNpm(t, {
+      config: {
+        searchexclude: 'libnpmversion',
+      },
+    })
+    const registry = new MockRegistry({
+      tap: t,
+      registry: npm.config.get('registry'),
+    })
 
-t.test('search exclude regex', async t => {
-  const { npm, joinedOutput } = await loadMockNpm(t, { config: { searchexclude: '/version/' } })
-  const registry = new MockRegistry({
-    tap: t,
-    registry: npm.config.get('registry'),
+    registry.search({ results: libnpmsearchResultFixture })
+    await npm.exec('search', ['libnpm'])
+    t.matchSnapshot(joinedOutput(), 'results should not have libnpmversion')
+  })
+  t.test('exclude string json', async t => {
+    const { npm, joinedOutput } = await loadMockNpm(t, {
+      config: {
+        json: true,
+        searchexclude: 'libnpmversion',
+      },
+    })
+    const registry = new MockRegistry({
+      tap: t,
+      registry: npm.config.get('registry'),
+    })
+
+    registry.search({ results: libnpmsearchResultFixture })
+    await npm.exec('search', ['libnpm'])
+    t.matchSnapshot(JSON.parse(joinedOutput()), 'results should not have libnpmversion')
   })
 
-  registry.search({ results: libnpmsearchResultFixture })
-  await npm.exec('search', ['libnpm'])
-  t.matchSnapshot(joinedOutput(), 'results should not have libnpmversion')
-})
+  t.test('exclude username with upper case letters', async t => {
+    const { npm, joinedOutput } = await loadMockNpm(t, { config: { searchexclude: 'NLF' } })
+    const registry = new MockRegistry({
+      tap: t,
+      registry: npm.config.get('registry'),
+    })
 
-t.test('search exclude forward slash', async t => {
-  const { npm, joinedOutput } = await loadMockNpm(t, { config: { searchexclude: '/version' } })
-  const registry = new MockRegistry({
-    tap: t,
-    registry: npm.config.get('registry'),
+    registry.search({ results: libnpmsearchResultFixture })
+    await npm.exec('search', ['libnpm'])
+    t.matchSnapshot(joinedOutput(), 'results should not have nlf')
   })
 
-  registry.search({ results: libnpmsearchResultFixture })
-  await npm.exec('search', ['libnpm'])
-  t.matchSnapshot(joinedOutput(), 'results should not have libnpmversion')
+  t.test('exclude regex', async t => {
+    const { npm, joinedOutput } = await loadMockNpm(t, { config: { searchexclude: '/version/' } })
+    const registry = new MockRegistry({
+      tap: t,
+      registry: npm.config.get('registry'),
+    })
+
+    registry.search({ results: libnpmsearchResultFixture })
+    await npm.exec('search', ['libnpm'])
+    t.matchSnapshot(joinedOutput(), 'results should not have libnpmversion')
+  })
+
+  t.test('exclude forward slash', async t => {
+    const { npm, joinedOutput } = await loadMockNpm(t, { config: { searchexclude: '/version' } })
+    const registry = new MockRegistry({
+      tap: t,
+      registry: npm.config.get('registry'),
+    })
+
+    registry.search({ results: libnpmsearchResultFixture })
+    await npm.exec('search', ['libnpm'])
+    t.matchSnapshot(joinedOutput(), 'results should not have libnpmversion')
+  })
+  t.end()
 })


### PR DESCRIPTION
Fixes: https://github.com/npm/cli/issues/7447
