### PR TITLE
fix(powershell): fallback to script root if globalPrefix does not exist

### DIFF
--- a/bin/npm.ps1
+++ b/bin/npm.ps1
@@ -9,6 +9,7 @@ if (-not (Test-Path $NODE_EXE)) {
 }
 
 $NPM_PREFIX_JS="$PSScriptRoot/node_modules/npm/bin/npm-prefix.js"
+$NPM_CLI_JS="$PSScriptRoot/node_modules/npm/bin/npm-cli.js"
 $NPM_PREFIX=(& $NODE_EXE $NPM_PREFIX_JS)
 
 if ($LASTEXITCODE -ne 0) {
@@ -16,7 +17,10 @@ if ($LASTEXITCODE -ne 0) {
   exit 1
 }
 
-$NPM_CLI_JS="$NPM_PREFIX/node_modules/npm/bin/npm-cli.js"
+$NPM_PREFIX_NPM_CLI_JS="$NPM_PREFIX/node_modules/npm/bin/npm-cli.js"
+if (Test-Path $NPM_PREFIX_NPM_CLI_JS) {
+  $NPM_CLI_JS=$NPM_PREFIX_NPM_CLI_JS
+}
 
 # Support pipeline input
 if ($MyInvocation.ExpectingInput) {

--- a/bin/npx.ps1
+++ b/bin/npx.ps1
@@ -9,6 +9,7 @@ if (-not (Test-Path $NODE_EXE)) {
 }
 
 $NPM_PREFIX_JS="$PSScriptRoot/node_modules/npm/bin/npm-prefix.js"
+$NPX_CLI_JS="$PSScriptRoot/node_modules/npm/bin/npx-cli.js"
 $NPM_PREFIX=(& $NODE_EXE $NPM_PREFIX_JS)
 
 if ($LASTEXITCODE -ne 0) {
@@ -16,7 +17,10 @@ if ($LASTEXITCODE -ne 0) {
   exit 1
 }
 
-$NPX_CLI_JS="$NPM_PREFIX/node_modules/npm/bin/npx-cli.js"
+$NPM_PREFIX_NPX_CLI_JS="$NPM_PREFIX/node_modules/npm/bin/npx-cli.js"
+if (Test-Path $NPM_PREFIX_NPX_CLI_JS) {
+  $NPX_CLI_JS=$NPM_PREFIX_NPX_CLI_JS
+}
 
 # Support pipeline input
 if ($MyInvocation.ExpectingInput) {

--- a/tap-snapshots/test/lib/commands/doctor.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/doctor.js.test.cjs
@@ -731,11 +731,11 @@ Object {
   "warn": Array [
     String(
       doctor getGitPath Error: test error
-      doctor     at which {STACK}
-      doctor     at Doctor.getGitPath {STACK}
-      doctor     at Doctor.exec {STACK}
-      doctor     at processTicksAndRejections {STACK}
-      doctor     at MockNpm.exec {STACK}
+      doctor     at {STACK}
+      doctor     at {STACK}
+      doctor     at {STACK}
+      doctor     at {STACK}
+      doctor     at {STACK}
     ),
   ],
 }

--- a/test/lib/commands/doctor.js
+++ b/test/lib/commands/doctor.js
@@ -11,7 +11,7 @@ const cleanCacheSha = (str) =>
   str.replace(/content-v2\/sha512\/[^"]+/g, 'content-v2/sha512/{sha}')
 
 t.cleanSnapshot = p => cleanCacheSha(cleanDate(cleanCwd(p)))
-  .replace(/\s\((\{CWD\}|node:).*\d+:\d+\)$/gm, ' {STACK}')
+  .replace(/(doctor\s+at\s).*$/gm, '$1{STACK}')
 
 const npmManifest = (version) => {
   return {


### PR DESCRIPTION
This matches the behavior of the bash and cmd scripts.