### PR TITLE
fix(publish): validate dist-tag

### DIFF
--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -96,6 +96,10 @@ class Publish extends BaseCommand {
     }
 
     const resolved = npa.resolve(manifest.name, manifest.version)
+
+    // make sure tag is valid, this will throw if invalid
+    npa(`${manifest.name}@${defaultTag}`)
+
     const registry = npmFetch.pickRegistry(resolved, opts)
     const creds = this.npm.config.getCredentialsByURI(registry)
     const noCreds = !(creds.token || creds.username || creds.certfile && creds.keyfile)

--- a/test/lib/commands/publish.js
+++ b/test/lib/commands/publish.js
@@ -291,7 +291,7 @@ t.test('shows usage with wrong set of arguments', async t => {
   await t.rejects(publish.exec(['a', 'b', 'c']), publish.usage)
 })
 
-t.test('throws when invalid tag', async t => {
+t.test('throws when invalid tag is semver', async t => {
   const { npm } = await loadMockNpm(t, {
     config: {
       tag: '0.0.13',
@@ -303,6 +303,24 @@ t.test('throws when invalid tag', async t => {
   await t.rejects(
     npm.exec('publish', []),
     { message: 'Tag name must not be a valid SemVer range: 0.0.13' }
+  )
+})
+
+t.test('throws when invalid tag when not url encodable', async t => {
+  const { npm } = await loadMockNpm(t, {
+    config: {
+      tag: '@test',
+    },
+    prefixDir: {
+      'package.json': JSON.stringify(pkgJson, null, 2),
+    },
+  })
+  await t.rejects(
+    npm.exec('publish', []),
+    {
+      /* eslint-disable-next-line max-len */
+      message: 'Invalid tag name "@test" of package "test-package@@test": Tags may not have any characters that encodeURIComponent encodes.',
+    }
   )
 })
 


### PR DESCRIPTION
Currently as described in https://github.com/npm/cli/issues/7275 the publish command lacks the same check that `npm install` and `npm dist-tag add` have to validate that the tag is valid (url encoded correctly via npa.js [here](https://github.com/npm/npm-package-arg/blob/main/lib/npa.js#L405-L407)). There's many ways to do this, or places this can go, totally open to putting this in a more appropriate place if there is one.

I tested this locally:

<details>

<summary>Shown error locally</summary>

```bash
impose git:(main) ✗ lnpm publish --tag=@meow --dry-run
npm verbose cli /Users/reggi/.nvm/versions/node/v20.12.1/bin/node /Users/reggi/Documents/GitHub/cli/bin/npm-cli.js
npm info using npm@10.7.0
npm info using node@v20.12.1
npm silly config:load:file:/Users/reggi/Documents/GitHub/cli/npmrc
npm silly config:load:file:/Users/reggi/Documents/GitHub/impose/.npmrc
npm silly config:load:file:/Users/reggi/.npmrc
npm silly config:load:file:/Users/reggi/.nvm/versions/node/v20.12.1/etc/npmrc
npm verbose title npm publish
npm verbose argv "publish" "--tag" "@meow" "--dry-run"
npm verbose logfile logs-max:10 dir:/Users/reggi/.npm/_logs/2024-05-01T19_13_17_321Z-
npm verbose logfile /Users/reggi/.npm/_logs/2024-05-01T19_13_17_321Z-debug-0.log
npm verbose publish [ '.' ]
npm silly logfile start cleaning logs, removing 1 files
npm silly logfile done cleaning log files
npm notice
npm notice 📦  impose@2.1.2-test
npm notice Tarball Contents
npm notice 588B README.md
npm notice 2.6kB index.js
npm notice 601B package.json
npm notice Tarball Details
npm notice name: impose
npm notice version: 2.1.2-test
npm notice filename: impose-2.1.2-test.tgz
npm notice package size: 1.6 kB
npm notice unpacked size: 3.8 kB
npm notice shasum: f35c044ccc35dece301dd8c58811f67b380efe0c
npm notice integrity: sha512-rCNg1ITYFY5um[...]ujZctB8jCJkXg==
npm notice total files: 3
npm notice
npm verbose stack Error: Invalid tag name "@meow" of package "impose@@meow": Tags may not have any characters that encodeURIComponent encodes.
npm verbose stack     at invalidTagName (/Users/reggi/Documents/GitHub/cli/node_modules/npm-package-arg/lib/npa.js:118:15)
npm verbose stack     at fromRegistry (/Users/reggi/Documents/GitHub/cli/node_modules/npm-package-arg/lib/npa.js:406:13)
npm verbose stack     at resolve (/Users/reggi/Documents/GitHub/cli/node_modules/npm-package-arg/lib/npa.js:87:12)
npm verbose stack     at npa (/Users/reggi/Documents/GitHub/cli/node_modules/npm-package-arg/lib/npa.js:53:10)
npm verbose stack     at Publish.exec (/Users/reggi/Documents/GitHub/cli/lib/commands/publish.js:102:5)
npm verbose stack     at async module.exports (/Users/reggi/Documents/GitHub/cli/lib/cli/entry.js:74:5)
npm verbose cwd /Users/reggi/Documents/GitHub/impose
npm verbose Darwin 23.4.0
npm verbose node v20.12.1
npm verbose npm  v10.7.0
npm error code EINVALIDTAGNAME
npm error Invalid tag name "@meow" of package "impose@@meow": Tags may not have any characters that encodeURIComponent encodes.
npm verbose exit 1
npm verbose code 1

npm error A complete log of this run can be found in: /Users/reggi/.npm/_logs/2024-05-01T19_13_17_321Z-debug-0.log
➜  impose git:(main) ✗ npm dist-tag add test --dry-run
```
</details>