### PR TITLE
fix: avoid caching manifests as promises

### DIFF
--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -1211,21 +1211,16 @@ This is a one-time fix-up, please be patient...
 
     if (this.#manifests.has(spec.raw)) {
       return this.#manifests.get(spec.raw)
-    } else {
-      const cleanRawSpec = redact(spec.rawSpec)
-      log.silly('fetch manifest', spec.raw.replace(spec.rawSpec, cleanRawSpec))
-      const o = {
-        ...options,
-        fullMetadata: true,
-      }
-      const p = pacote.manifest(spec, o)
-        .then(({ license, ...mani }) => {
-          this.#manifests.set(spec.raw, mani)
-          return mani
-        })
-      this.#manifests.set(spec.raw, p)
-      return p
     }
+    const cleanRawSpec = redact(spec.rawSpec)
+    log.silly('fetch manifest', spec.raw.replace(spec.rawSpec, cleanRawSpec))
+    const o = {
+      ...options,
+      fullMetadata: true,
+    }
+    const mani = await pacote.manifest(spec, o)
+    this.#manifests.set(spec.raw, mani)
+    return mani
   }
 
   #nodeFromSpec (name, spec, parent, edge) {


### PR DESCRIPTION
Somewhat related to #7276 and #7463. I don't think there is a reason to cache the promise here. And if we ever did choose to replace this with an LRUCache we would need to know the size of what we are caching which will be easier if we only cache the resulting manifest.

~~I also added a comment about why I think we are removing the license from manifests here. License was removed in #7126 which looks to be a purposeful change but I could not find a reason. Adding the license back in causes many snapshots to fail because the license is now present in lockfiles, so that's how I came up with the comment.~~ Edit: opened #7475 to address the license/lockfile behavior.
