### PR TITLE
chore: log if `npm deprecate` does not match any version

### DIFF
--- a/lib/commands/deprecate.js
+++ b/lib/commands/deprecate.js
@@ -3,6 +3,7 @@ const { otplease } = require('../utils/auth.js')
 const npa = require('npm-package-arg')
 const semver = require('semver')
 const getIdentity = require('../utils/get-identity.js')
+const log = require('../utils/log-shim.js')
 const libaccess = require('libnpmaccess')
 const BaseCommand = require('../base-cmd.js')
 

--- a/lib/commands/deprecate.js
+++ b/lib/commands/deprecate.js
@@ -66,6 +66,8 @@ class Deprecate extends BaseCommand {
         body: packument,
         ignoreBody: true,
       }))
+    } else {
+      log.verbose('no version found for', p)
     }
   }
 }


### PR DESCRIPTION
If the package specification does not match any existing version, a verbose message is added to the log.

## References

Closes https://github.com/npm/cli/issues/7180
