### PR TITLE
fix: log if `npm deprecate` does not match any version

### DIFF
--- a/lib/commands/deprecate.js
+++ b/lib/commands/deprecate.js
@@ -68,7 +68,7 @@ class Deprecate extends BaseCommand {
         ignoreBody: true,
       }))
     } else {
-      log.warn('deprecate', 'No version found for', p)
+      log.warn('deprecate', 'No version found for', p.rawSpec)
     }
   }
 }

--- a/lib/commands/deprecate.js
+++ b/lib/commands/deprecate.js
@@ -1,6 +1,7 @@
 const fetch = require('npm-registry-fetch')
 const { otplease } = require('../utils/auth.js')
 const npa = require('npm-package-arg')
+const { log } = require('proc-log')
 const semver = require('semver')
 const getIdentity = require('../utils/get-identity.js')
 const libaccess = require('libnpmaccess')
@@ -66,6 +67,8 @@ class Deprecate extends BaseCommand {
         body: packument,
         ignoreBody: true,
       }))
+    } else {
+      log.warn('deprecate', 'No version found for', p)
     }
   }
 }

--- a/test/lib/commands/deprecate.js
+++ b/test/lib/commands/deprecate.js
@@ -155,7 +155,7 @@ t.test('deprecates all versions when no range is specified', async t => {
 })
 
 t.test('does nothing if version does not actually exist', async t => {
-  const { npm, joinedOutput } = await loadMockNpm(t, { config: { ...auth } })
+  const { npm, logs, joinedOutput } = await loadMockNpm(t, { config: { ...auth } })
   const registry = new MockRegistry({
     tap: t,
     registry: npm.config.get('registry'),
@@ -168,4 +168,5 @@ t.test('does nothing if version does not actually exist', async t => {
   await registry.package({ manifest, query: { write: true } })
   await npm.exec('deprecate', ['foo@1.0.99', 'this should be ignored'])
   t.match(joinedOutput(), '')
+  t.equal(logs.warn[0], 'deprecate No version found for 1.0.99')  
 })

--- a/test/lib/commands/deprecate.js
+++ b/test/lib/commands/deprecate.js
@@ -168,5 +168,5 @@ t.test('does nothing if version does not actually exist', async t => {
   await registry.package({ manifest, query: { write: true } })
   await npm.exec('deprecate', ['foo@1.0.99', 'this should be ignored'])
   t.match(joinedOutput(), '')
-  t.equal(logs.warn[0], 'deprecate No version found for 1.0.99')  
+  t.equal(logs.warn[0], 'deprecate No version found for 1.0.99')
 })


### PR DESCRIPTION
Let's try again. If the package specification does not match any existing version, a verbose message is added to the log.

## References

Ref https://github.com/npm/cli/pull/7472
Closes https://github.com/npm/cli/issues/7180
