### PR TITLE
docs: add npm version to every local help output

### DIFF
--- a/docs/lib/index.js
+++ b/docs/lib/index.js
@@ -157,7 +157,7 @@ const replaceHelpLinks = (src) => {
 
 const transformMan = (src, { data, unified, remarkParse, remarkMan }) => unified()
   .use(remarkParse)
-  .use(remarkMan, { version })
+  .use(remarkMan, { version: `NPM@${version}` })
   .processSync(`# ${data.title}(${data.section}) - ${data.description}\n\n${src}`)
   .toString()
 

--- a/docs/lib/index.js
+++ b/docs/lib/index.js
@@ -157,7 +157,7 @@ const replaceHelpLinks = (src) => {
 
 const transformMan = (src, { data, unified, remarkParse, remarkMan }) => unified()
   .use(remarkParse)
-  .use(remarkMan)
+  .use(remarkMan, { version })
   .processSync(`# ${data.title}(${data.section}) - ${data.description}\n\n${src}`)
   .toString()
 

--- a/docs/lib/template.html
+++ b/docs/lib/template.html
@@ -115,6 +115,11 @@ header.title > .description {
     line-height: 1;
 }
 
+header.title .version {
+    font-size: 0.8em;
+    color: #666666;
+}
+
 footer#edit {
     border-top: solid 1px #e1e4e8;
     margin: 3em 0 4em 0;
@@ -138,7 +143,10 @@ npm command-line interface
 
 <section id="content">
 <header class="title">
-<h1>{{ title }}</h1>
+<h1>
+    <span>{{ title }}</span>
+    <span class="version">@{{ version }}</span>
+</h1>
 <span class="description">{{ description }}</span>
 </header>
 

--- a/docs/lib/transform-html.js
+++ b/docs/lib/transform-html.js
@@ -1,4 +1,5 @@
 const jsdom = require('jsdom')
+const { version } = require('../../package.json')
 
 function transformHTML (
   src,
@@ -35,6 +36,9 @@ function transformHTML (
       case 'config.github_branch':
       case 'config.github_path':
         return data[key.replace(/^config\./, '')]
+
+      case 'version':
+        return version
 
       default:
         throw new Error(`warning: unknown token '${token}' in ${path}`)


### PR DESCRIPTION
Every page of npm help <x> display the local npm version.

This pull request helps the local reader of the documentation to know which version of the documentation they are reading.

## References
Closes: https://github.com/npm/cli/issues/7110