### PR TITLE
chore: disable progress on shellout exit tests

### DIFF
--- a/test/lib/cli/exit-handler.js
+++ b/test/lib/cli/exit-handler.js
@@ -652,6 +652,7 @@ t.test('do no fancy handling for shellouts', async t => {
     argv: ['-c', 'exit'],
     config: {
       timing: false,
+      progress: false,
       ...opts.config,
     },
     ...opts,


### PR DESCRIPTION
These tests assert what happens if a shellout command like exec throws unexpected errors by checking what is written to stderr. Progress also gets written to stderr but is not always deterministic due to the nature of calling it via setInterval. So this disables progress for these tests so the stderr assertions can be relied on to be the same.
