### PR TITLE
Cache manifests not promises

### DIFF
--- a/tap-snapshots/test/lib/commands/config.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/config.js.test.cjs
@@ -8,6 +8,7 @@
 exports[`test/lib/commands/config.js TAP config list --json > output matches snapshot 1`] = `
 {
   "cache": "{CACHE}",
+  "color": {COLOR},
   "json": true,
   "projectloaded": "yes",
   "userloaded": "yes",
@@ -29,7 +30,6 @@ exports[`test/lib/commands/config.js TAP config list --json > output matches sna
   "call": "",
   "cert": null,
   "cidr": null,
-  "color": {COLOR},
   "commit-hooks": true,
   "cpu": null,
   "depth": null,
@@ -192,7 +192,7 @@ cafile = null
 call = "" 
 cert = null 
 cidr = null 
-color = {COLOR}
+; color = {COLOR}
 commit-hooks = true 
 cpu = null 
 depth = null 
@@ -345,6 +345,7 @@ projectloaded = "yes"
 ; "cli" config from command line options
 
 cache = "{CACHE}" 
+color = {COLOR}
 long = true
 `
 
@@ -364,6 +365,7 @@ projectloaded = "yes"
 ; "cli" config from command line options
 
 cache = "{CACHE}" 
+color = {COLOR}
 
 ; node bin location = {NODE-BIN-LOCATION}
 ; node version = {NODE-VERSION}
@@ -378,6 +380,7 @@ exports[`test/lib/commands/config.js TAP config list with publishConfig global >
 ; "cli" config from command line options
 
 cache = "{CACHE}" 
+color = {COLOR}
 global = true 
 
 ; node bin location = {NODE-BIN-LOCATION}
@@ -393,6 +396,7 @@ exports[`test/lib/commands/config.js TAP config list with publishConfig local > 
 ; "cli" config from command line options
 
 cache = "{CACHE}" 
+color = {COLOR}
 
 ; node bin location = {NODE-BIN-LOCATION}
 ; node version = {NODE-VERSION}

--- a/test/lib/cli/exit-handler.js
+++ b/test/lib/cli/exit-handler.js
@@ -652,6 +652,7 @@ t.test('do no fancy handling for shellouts', async t => {
     argv: ['-c', 'exit'],
     config: {
       timing: false,
+      progress: false,
       ...opts.config,
     },
     ...opts,

--- a/test/lib/commands/config.js
+++ b/test/lib/commands/config.js
@@ -37,7 +37,7 @@ const loadMockNpm = (t, opts = {}) => _loadMockNpm(t, {
     // Reset configs that mock npm sets by default
     'fetch-retries': undefined,
     loglevel: undefined,
-    color: undefined,
+    color: false,
   },
 })
 

--- a/test/lib/commands/pack.js
+++ b/test/lib/commands/pack.js
@@ -82,7 +82,10 @@ t.test('should log scoped package output as valid json', async t => {
         },
       }),
     },
-    config: { json: true },
+    config: {
+      json: true,
+      progress: false,
+    },
   })
   await npm.exec('pack', [])
   const filename = 'myscope-test-package-1.0.0.tgz'


### PR DESCRIPTION
- **chore: disable progress on shellout exit tests**
- **chore: disable color in config tests**
- **chore: disable progress on npm pack test**
- **fix: avoid caching manifests as promises**
