### PR TITLE
docs: npm help json/global command on windows

### DIFF
--- a/docs/lib/content/nav.yml
+++ b/docs/lib/content/nav.yml
@@ -215,9 +215,6 @@
   - title: Folders
     url: /configuring-npm/folders
     description: Folder structures used by npm
-  - title: Folders
-    url: /configuring-npm/npm-global
-    description: Folder structures used by npm
   - title: .npmrc
     url: /configuring-npm/npmrc
     description: The npm config files
@@ -226,9 +223,6 @@
     description: A publishable lockfile
   - title: package.json
     url: /configuring-npm/package-json
-    description: Specifics of npm's package.json handling
-  - title: package.json
-    url: /configuring-npm/npm-json
     description: Specifics of npm's package.json handling
   - title: package-lock.json
     url: /configuring-npm/package-lock-json

--- a/docs/lib/content/nav.yml
+++ b/docs/lib/content/nav.yml
@@ -215,6 +215,9 @@
   - title: Folders
     url: /configuring-npm/folders
     description: Folder structures used by npm
+  - title: Folders
+    url: /configuring-npm/npm-global
+    description: Folder structures used by npm
   - title: .npmrc
     url: /configuring-npm/npmrc
     description: The npm config files
@@ -223,6 +226,9 @@
     description: A publishable lockfile
   - title: package.json
     url: /configuring-npm/package-json
+    description: Specifics of npm's package.json handling
+  - title: package.json
+    url: /configuring-npm/npm-json
     description: Specifics of npm's package.json handling
   - title: package-lock.json
     url: /configuring-npm/package-lock-json


### PR DESCRIPTION
On Windows, `npm help json` and `npm help global` attempt to display `npm-json.html` and `npm-global.html` files which leads to an error because these files have not been generated.

This pull request duplicates the `package-json.md` and `folders.md` files in order to generate these files and make the above-mentioned commands functional.
## References
Closes: https://github.com/npm/cli/issues/7374
