### PR TITLE
fix: dont write log file for completion commands

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -176,6 +176,7 @@ class Npm {
     // take a long time to resolve, but that is why process.exit is called explicitly
     // in the exit-handler.
     this.unrefPromises.push(this.#logFile.load({
+      command,
       path: this.logPath,
       logsMax: this.config.get('logs-max'),
       timing: this.config.get('timing'),

--- a/lib/utils/log-file.js
+++ b/lib/utils/log-file.js
@@ -48,7 +48,11 @@ class LogFiles {
     this.#endStream()
   }
 
-  load ({ path, logsMax = Infinity, timing } = {}) {
+  load ({ command, path, logsMax = Infinity, timing } = {}) {
+    if (['completion'].includes(command)) {
+      return
+    }
+
     // dir is user configurable and is required to exist so
     // this can error if the dir is missing or not configured correctly
     this.#path = path


### PR DESCRIPTION
Since npm completion is implemented by calling npm completion -- arg1
this will write a logfile for that command. I noticed this as I was trying
to look through my logs for a recent command and found that it had been removed
since I used enough tab completions to fill logs-max.
