### PR TITLE
fix: require stdout to be a TTY for progress

### DIFF
--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -1549,13 +1549,16 @@ const definitions = {
     type: Boolean,
     description: `
       When set to \`true\`, npm will display a progress bar during time
-      intensive operations, if \`process.stderr\` is a TTY.
+      intensive operations, if \`process.stderr\` and \`process.stdout\` are a TTY.
 
       Set to \`false\` to suppress the progress bar.
     `,
     flatten (key, obj, flatOptions) {
       flatOptions.progress = !obj.progress ? false
-        : !!process.stderr.isTTY && process.env.TERM !== 'dumb'
+        // progress is only written to stderr but we disable it unless stdout is a tty
+        // also. This prevents the progress from appearing when piping output to another
+        // command which doesn't break anything, but does look very odd to users.
+        : !!process.stderr.isTTY && !!process.stdout.isTTY && process.env.TERM !== 'dumb'
     },
   }),
   provenance: new Definition('provenance', {

--- a/workspaces/config/test/definitions/definitions.js
+++ b/workspaces/config/test/definitions/definitions.js
@@ -396,6 +396,7 @@ t.test('color', t => {
 t.test('progress', t => {
   const setEnv = ({ tty, term } = {}) => mockGlobals(t, {
     'process.stderr.isTTY': tty,
+    'process.stdout.isTTY': tty,
     'process.env.TERM': term,
   })
 


### PR DESCRIPTION
Progress is shown on stderr but looks weird when stdout is piped to
another command. So we should only show it by default if both streams
are TTYs.

Here's an example from my terminal to highlight the issue:

```
❯ npm view tiny-tarball --json | jq .name
⠼"tiny-tarball"
❯ npmlocal view tiny-tarball --json | jq .name
"tiny-tarball"
```