### PR TITLE
fix(view): dont immediately exit on first workspace 404

### DIFF
--- a/lib/commands/view.js
+++ b/lib/commands/view.js
@@ -1,7 +1,7 @@
 const columns = require('cli-columns')
 const { readFile } = require('fs/promises')
 const jsonParse = require('json-parse-even-better-errors')
-const { log, output } = require('proc-log')
+const { log, output, META } = require('proc-log')
 const npa = require('npm-package-arg')
 const { resolve } = require('path')
 const formatBytes = require('../utils/format-bytes.js')
@@ -11,6 +11,8 @@ const { inspect } = require('util')
 const { packument } = require('pacote')
 const Queryable = require('../utils/queryable.js')
 const BaseCommand = require('../base-cmd.js')
+const { getError } = require('../utils/error-message.js')
+const { jsonError, outputError } = require('../utils/output-error.js')
 
 const readJson = file => readFile(file, 'utf8').then(jsonParse)
 
@@ -76,10 +78,24 @@ class View extends BaseCommand {
       return this.exec([pkg, ...rest])
     }
 
+    const json = this.npm.config.get('json')
     await this.setWorkspaces()
 
     for (const name of this.workspaceNames) {
-      await this.#viewPackage(`${name}${pkg.slice(1)}`, rest, { workspace: true })
+      try {
+        await this.#viewPackage(`${name}${pkg.slice(1)}`, rest, { workspace: true })
+      } catch (e) {
+        const err = getError(e, { npm: this.npm, command: this })
+        if (err.code !== 'E404') {
+          throw e
+        }
+        if (json) {
+          output.buffer({ [META]: true, jsonError: { [name]: jsonError(err, this.npm) } })
+        } else {
+          outputError(err)
+        }
+        process.exitCode = err.exitCode
+      }
     }
   }
 

--- a/lib/utils/display.js
+++ b/lib/utils/display.js
@@ -104,7 +104,6 @@ const mergeJson = ({ [JSON_ERROR_KEY]: metaError }, buffer) => {
     if (obj && typeof obj === 'object') {
       items.push(obj)
     }
-    /* istanbul ignore next - this is not used yet but will be */
     if (error) {
       errors.push(error)
     }
@@ -127,9 +126,8 @@ const mergeJson = ({ [JSON_ERROR_KEY]: metaError }, buffer) => {
     // names. So the output could already have the same key. The choice here is to overwrite
     // it with our error since that is (probably?) more important.
     // XXX(BREAKING_CHANGE): all json output should be keyed under well known keys, eg `result` and `error`
-    /* istanbul ignore next */
     if (res[ERROR_KEY]) {
-      log.warn('display', `overwriting existing ${ERROR_KEY} on json output`)
+      log.warn('', `overwriting existing ${ERROR_KEY} on json output`)
     }
     res[ERROR_KEY] = getArrayOrObject(errors)
   }

--- a/tap-snapshots/test/lib/commands/view.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/view.js.test.cjs
@@ -363,6 +363,140 @@ yellow@1.0.1 'claudia'
 yellow@1.0.2 'claudia'
 `
 
+exports[`test/lib/commands/view.js TAP workspaces 404 workspaces basic > must match snapshot 1`] = `
+
+[4m[36mgreen@1.0.0[39m[24m | [32mACME[39m | deps: [36m2[39m | versions: [36m2[39m
+green is a very important color
+
+[91mDEPRECATED[39m!! - true
+
+keywords: [36mcolors[39m, [36mgreen[39m, [36mcrayola[39m
+
+bin: [36mgreen[39m
+
+dist
+.tarball: [34mhttp://hm.green.com/1.0.0.tgz[39m
+.shasum: [32m123[39m
+.integrity: [32m---[39m
+.unpackedSize: [34m1.0 GB[39m
+
+dependencies:
+[34mred[39m: 1.0.0
+[34myellow[39m: 1.0.0
+
+maintainers:
+- [34mclaudia[39m <[2mc@yellow.com[22m>
+- [34misaacs[39m <[2mi@yellow.com[22m>
+
+dist-tags:
+[34mlatest[39m: 1.0.0
+error [94mcode[39m E404
+error [94m404[39m 404
+`
+
+exports[`test/lib/commands/view.js TAP workspaces 404 workspaces json > must match snapshot 1`] = `
+{
+  "green": {
+    "_id": "green",
+    "name": "green",
+    "dist-tags": {
+      "latest": "1.0.0"
+    },
+    "maintainers": [
+      {
+        "name": "claudia",
+        "email": "c@yellow.com",
+        "twitter": "cyellow"
+      },
+      {
+        "name": "isaacs",
+        "email": "i@yellow.com",
+        "twitter": "iyellow"
+      }
+    ],
+    "keywords": [
+      "colors",
+      "green",
+      "crayola"
+    ],
+    "versions": [
+      "1.0.0",
+      "1.0.1"
+    ],
+    "version": "1.0.0",
+    "description": "green is a very important color",
+    "bugs": {
+      "url": "http://bugs.green.com"
+    },
+    "deprecated": true,
+    "repository": {
+      "url": "http://repository.green.com"
+    },
+    "license": {
+      "type": "ACME"
+    },
+    "bin": {
+      "green": "bin/green.js"
+    },
+    "dependencies": {
+      "red": "1.0.0",
+      "yellow": "1.0.0"
+    },
+    "dist": {
+      "shasum": "123",
+      "tarball": "http://hm.green.com/1.0.0.tgz",
+      "integrity": "---",
+      "fileCount": 1,
+      "unpackedSize": 1000000000
+    }
+  },
+  "error": {
+    "missing-package": {
+      "code": "E404",
+      "summary": "404",
+      "detail": ""
+    }
+  }
+}
+`
+
+exports[`test/lib/commands/view.js TAP workspaces 404 workspaces non-404 error rejects > must match snapshot 1`] = `
+
+[4m[36mgreen@1.0.0[39m[24m | [32mACME[39m | deps: [36m2[39m | versions: [36m2[39m
+green is a very important color
+
+[91mDEPRECATED[39m!! - true
+
+keywords: [36mcolors[39m, [36mgreen[39m, [36mcrayola[39m
+
+bin: [36mgreen[39m
+
+dist
+.tarball: [34mhttp://hm.green.com/1.0.0.tgz[39m
+.shasum: [32m123[39m
+.integrity: [32m---[39m
+.unpackedSize: [34m1.0 GB[39m
+
+dependencies:
+[34mred[39m: 1.0.0
+[34myellow[39m: 1.0.0
+
+maintainers:
+- [34mclaudia[39m <[2mc@yellow.com[22m>
+- [34misaacs[39m <[2mi@yellow.com[22m>
+
+dist-tags:
+[34mlatest[39m: 1.0.0
+error Unknown error
+`
+
+exports[`test/lib/commands/view.js TAP workspaces 404 workspaces non-404 error rejects with single arg > must match snapshot 1`] = `
+green:
+1.0.0
+unknown-error:
+error Unknown error
+`
+
 exports[`test/lib/commands/view.js TAP workspaces all workspaces --json > must match snapshot 1`] = `
 {
   "green": {

--- a/tap-snapshots/test/lib/commands/view.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/view.js.test.cjs
@@ -460,6 +460,19 @@ exports[`test/lib/commands/view.js TAP workspaces 404 workspaces json > must mat
 }
 `
 
+exports[`test/lib/commands/view.js TAP workspaces 404 workspaces json with package named error > must match snapshot 1`] = `
+warn overwriting existing error on json output
+{
+  "error": {
+    "missing-package": {
+      "code": "E404",
+      "summary": "404",
+      "detail": ""
+    }
+  }
+}
+`
+
 exports[`test/lib/commands/view.js TAP workspaces 404 workspaces non-404 error rejects > must match snapshot 1`] = `
 
 [4m[36mgreen@1.0.0[39m[24m | [32mACME[39m | deps: [36m2[39m | versions: [36m2[39m

--- a/test/fixtures/mock-logs.js
+++ b/test/fixtures/mock-logs.js
@@ -24,6 +24,7 @@ const logsByTitle = (logs) => ({
 module.exports = () => {
   const outputs = []
   const outputErrors = []
+  const fullOutput = []
 
   const levelLogs = []
   const logs = Object.defineProperties([], {
@@ -53,6 +54,7 @@ module.exports = () => {
         // in the future if/when we refactor what logs look like.
         if (!isLog(str)) {
           outputErrors.push(str)
+          fullOutput.push(str)
           return
         }
 
@@ -70,12 +72,14 @@ module.exports = () => {
         const level = stripAnsi(rawLevel)
 
         logs.push(str.replaceAll(prefix, `${level} `))
+        fullOutput.push(str.replaceAll(prefix, `${level} `))
         levelLogs.push({ level, message: str.replaceAll(prefix, '') })
       },
     },
     stdout: {
       write: (str) => {
         outputs.push(trimTrailingNewline(str))
+        fullOutput.push(trimTrailingNewline(str))
       },
     },
   }
@@ -88,9 +92,12 @@ module.exports = () => {
       clearOutput: () => {
         outputs.length = 0
         outputErrors.length = 0
+        fullOutput.length = 0
       },
       outputErrors,
       joinedOutputError: () => joinAndTrimTrailingNewlines(outputs),
+      fullOutput,
+      joinedFullOutput: () => joinAndTrimTrailingNewlines(fullOutput),
       logs,
       clearLogs: () => {
         levelLogs.length = 0


### PR DESCRIPTION
Fixes: #5444

This PR will continue running through all workspaces for `npm view` even when a workspace encounters an `E404` error. This usually happens when you run `npm view -ws` but have private workspaces. A future iteration could log a different message if an `E404` is encountered on a private workspace, but for this PR I wanted to keep it generic since there are a number of reasons a request for a package manifest could 404.

**`npm view . version -ws`**
```sh
# BEFORE
❯ npm view . version -ws
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/@npmcli%2fdocs - Not found
npm error 404
npm error 404  '@npmcli/docs@*' is not in this registry.
npm error 404
npm error 404 Note that you can also install from a
npm error 404 tarball, folder, http url, or git url.

npm error A complete log of this run can be found in: /Users/lukekarrys/.npm/_logs/2024-05-15T22_04_30_007Z-debug-0.log

# AFTER
❯ npmlocal view . version -ws
@npmcli/docs:
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/@npmcli%2fdocs - Not found
npm error 404
npm error 404  '@npmcli/docs@*' is not in this registry.
npm error 404
npm error 404 Note that you can also install from a
npm error 404 tarball, folder, http url, or git url.
@npmcli/smoke-tests:
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/@npmcli%2fsmoke-tests - Not found
npm error 404
npm error 404  '@npmcli/smoke-tests@*' is not in this registry.
npm error 404
npm error 404 Note that you can also install from a
npm error 404 tarball, folder, http url, or git url.
@npmcli/mock-globals:
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/@npmcli%2fmock-globals - Not found
npm error 404
npm error 404  '@npmcli/mock-globals@*' is not in this registry.
npm error 404
npm error 404 Note that you can also install from a
npm error 404 tarball, folder, http url, or git url.
@npmcli/mock-registry:
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/@npmcli%2fmock-registry - Not found
npm error 404
npm error 404  '@npmcli/mock-registry@*' is not in this registry.
npm error 404
npm error 404 Note that you can also install from a
npm error 404 tarball, folder, http url, or git url.
@npmcli/arborist:
7.5.1
@npmcli/config:
8.3.1
libnpmaccess:
8.0.5
libnpmdiff:
6.1.1
libnpmexec:
8.1.0
libnpmfund:
5.0.9
libnpmhook:
10.0.4
libnpmorg:
6.0.5
libnpmpack:
7.0.1
libnpmpublish:
9.0.7
libnpmsearch:
7.0.4
libnpmteam:
6.0.4
libnpmversion:
6.0.1
```

**`npm view . version -ws --json`**
```sh
# BEFORE
❯ npm view . version -ws --json
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/@npmcli%2fdocs - Not found
npm error 404
npm error 404  '@npmcli/docs@*' is not in this registry.
npm error 404
npm error 404 Note that you can also install from a
npm error 404 tarball, folder, http url, or git url.
{
  "error": {
    "code": "E404",
    "summary": "Not Found - GET https://registry.npmjs.org/@npmcli%2fdocs - Not found",
    "detail": "\n '@npmcli/docs@*' is not in this registry.\n\nNote that you can also install from a\ntarball, folder, http url, or git url."
  }
}

npm error A complete log of this run can be found in: /Users/lukekarrys/.npm/_logs/2024-05-15T22_04_55_076Z-debug-0.log

# AFTER
❯ npmlocal view . version -ws --json
{
  "@npmcli/arborist": "7.5.1",
  "@npmcli/config": "8.3.1",
  "libnpmaccess": "8.0.5",
  "libnpmdiff": "6.1.1",
  "libnpmexec": "8.1.0",
  "libnpmfund": "5.0.9",
  "libnpmhook": "10.0.4",
  "libnpmorg": "6.0.5",
  "libnpmpack": "7.0.1",
  "libnpmpublish": "9.0.7",
  "libnpmsearch": "7.0.4",
  "libnpmteam": "6.0.4",
  "libnpmversion": "6.0.1",
  "error": {
    "@npmcli/docs": {
      "code": "E404",
      "summary": "Not Found - GET https://registry.npmjs.org/@npmcli%2fdocs - Not found",
      "detail": "'@npmcli/docs@*' is not in this registry.\n\nNote that you can also install from a\ntarball, folder, http url, or git url."
    },
    "@npmcli/smoke-tests": {
      "code": "E404",
      "summary": "Not Found - GET https://registry.npmjs.org/@npmcli%2fsmoke-tests - Not found",
      "detail": "'@npmcli/smoke-tests@*' is not in this registry.\n\nNote that you can also install from a\ntarball, folder, http url, or git url."
    },
    "@npmcli/mock-globals": {
      "code": "E404",
      "summary": "Not Found - GET https://registry.npmjs.org/@npmcli%2fmock-globals - Not found",
      "detail": "'@npmcli/mock-globals@*' is not in this registry.\n\nNote that you can also install from a\ntarball, folder, http url, or git url."
    },
    "@npmcli/mock-registry": {
      "code": "E404",
      "summary": "Not Found - GET https://registry.npmjs.org/@npmcli%2fmock-registry - Not found",
      "detail": "'@npmcli/mock-registry@*' is not in this registry.\n\nNote that you can also install from a\ntarball, folder, http url, or git url."
    }
  }
}
```
