### PR TITLE
fix(cache): add both full and minified packument to cache

### DIFF
--- a/lib/commands/cache.js
+++ b/lib/commands/cache.js
@@ -152,15 +152,20 @@ class Cache extends BaseCommand {
       throw this.usageError('First argument to `add` is required')
     }
 
-    return Promise.all(args.map(spec => {
+    await Promise.all(args.map(async spec => {
       log.silly('cache add', 'spec', spec)
       // we ask pacote for the thing, and then just throw the data
       // away so that it tee-pipes it into the cache like it does
       // for a normal request.
-      return pacote.tarball.stream(spec, stream => {
+      await pacote.tarball.stream(spec, stream => {
         stream.resume()
         return stream.promise()
       }, { ...this.npm.flatOptions })
+
+      await pacote.manifest(spec, {
+        ...this.npm.flatOptions,
+        fullMetadata: true,
+      })
     }))
   }
 

--- a/test/lib/commands/cache.js
+++ b/test/lib/commands/cache.js
@@ -71,7 +71,11 @@ t.test('cache add single pkg', async t => {
     registry: npm.config.get('registry'),
   })
   const manifest = registry.manifest({ name: pkg })
-  await registry.package({ manifest, tarballs: { '1.0.0': path.join(npm.prefix, 'package') } })
+  await registry.package({
+    manifest,
+    times: 2,
+    tarballs: { '1.0.0': path.join(npm.prefix, 'package') },
+  })
   await npm.exec('cache', ['add', pkg])
   t.equal(joinedOutput(), '')
   // eslint-disable-next-line max-len
@@ -99,9 +103,13 @@ t.test('cache add multiple pkgs', async t => {
   })
   const manifest = registry.manifest({ name: pkg })
   const manifest2 = registry.manifest({ name: pkg2 })
-  await registry.package({ manifest, tarballs: { '1.0.0': path.join(npm.prefix, 'package') } })
   await registry.package({
-    manifest: manifest2, tarballs: { '1.0.0': path.join(npm.prefix, 'package') },
+    manifest,
+    times: 2,
+    tarballs: { '1.0.0': path.join(npm.prefix, 'package') },
+  })
+  await registry.package({
+    manifest: manifest2, times: 2, tarballs: { '1.0.0': path.join(npm.prefix, 'package') },
   })
   await npm.exec('cache', ['add', pkg, pkg2])
   t.equal(joinedOutput(), '')


### PR DESCRIPTION
This will fix the `npm cache add` to cache package with same header as it's used in `npm install` by adding extra manifest call with `fullMetadata: true` while caching to match behaviour with install command which internally request manifest with fullMetadata. 

## References
Closes #7465

