### PR TITLE
docs: suggest correct bin entry

### DIFF
--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -368,7 +368,7 @@ For example, myapp could have this:
 ```json
 {
   "bin": {
-    "myapp": "./cli.js"
+    "myapp": "bin/cli.js"
   }
 }
 ```


### PR DESCRIPTION
Our existing example present in npm doc was giving warning, so just modified that so that we will not get any warning .

Bug: https://github.com/npm/cli/issues/7302

