### PR TITLE
fix: refactor ls to use output.buffer for json

### DIFF
--- a/lib/commands/ls.js
+++ b/lib/commands/ls.js
@@ -177,11 +177,14 @@ class LS extends ArboristWorkspaceCmd {
     const [rootError] = tree.errors.filter(e =>
       e.code === 'EJSONPARSE' && e.path === resolve(path, 'package.json'))
 
-    output.buffer(
-      json ? jsonOutput({ path, problems, result, rootError, seenItems }) :
-      parseable ? parseableOutput({ seenNodes, global, long }) :
-      humanOutput({ chalk, result, seenItems, unicode })
-    )
+    if (json) {
+      output.buffer(jsonOutput({ path, problems, result, rootError, seenItems }))
+    } else {
+      output.standard(parseable
+        ? parseableOutput({ seenNodes, global, long })
+        : humanOutput({ chalk, result, seenItems, unicode })
+      )
+    }
 
     // if filtering items, should exit with error code on no results
     if (result && !result[_include] && args.length) {


### PR DESCRIPTION
This has no functional difference but matches where
we landed for the rest of the commands.
