### PR TITLE
fix(publish): skip workspace packages marked private on publish

### DIFF
--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -127,6 +127,15 @@ class Publish extends BaseCommand {
     const noCreds = !(creds.token || creds.username || creds.certfile && creds.keyfile)
     const outputRegistry = replaceInfo(registry)
 
+    // if a workspace package is marked private then we skip it
+    if (workspace && manifest.private) {
+      throw Object.assign(
+        new Error(`This package has been marked as private
+  Remove the 'private' field from the package.json to publish it.`),
+        { code: 'EPRIVATE' }
+      )
+    }
+
     if (noCreds) {
       const msg = `This command requires you to be logged in to ${outputRegistry}`
       if (dryRun) {

--- a/tap-snapshots/test/lib/commands/publish.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/publish.js.test.cjs
@@ -418,6 +418,10 @@ Array [
 ]
 `
 
+exports[`test/lib/commands/publish.js TAP workspaces all workspaces - some marked private > one marked private 1`] = `
++ workspace-a@1.2.3-a
+`
+
 exports[`test/lib/commands/publish.js TAP workspaces json > all workspaces in json 1`] = `
 {
   "workspace-a": {


### PR DESCRIPTION
`npm publish --workspaces` will skip workspace packages marked as private in package.json. 
Currently it's skipping those packages only when you have configured auth for those packages, it would error out with `ENEEDAUTH` if it doesn't find the valid auth information. 

this fix checks for the private property before checking for auth for the packages that will essentially not going to get published. 

Fixes https://github.com/npm/cli/issues/7199