### PR TITLE
fix(arborist): safeguard against null node.target in flag calculation

### DIFF
--- a/workspaces/arborist/lib/calc-dep-flags.js
+++ b/workspaces/arborist/lib/calc-dep-flags.js
@@ -101,13 +101,13 @@ const unsetFlag = (node, flag) => {
       tree: node,
       visit: node => {
         node.extraneous = node[flag] = false
-        if (node.isLink) {
+        if (node.isLink && node.target) {
           node.target.extraneous = node.target[flag] = false
         }
       },
       getChildren: node => {
         const children = []
-        const targetNode = node.isLink ? node.target : node
+        const targetNode = node.isLink && node.target ? node.target : node;
         for (const edge of targetNode.edgesOut.values()) {
           if (
             edge.to &&

--- a/workspaces/arborist/lib/calc-dep-flags.js
+++ b/workspaces/arborist/lib/calc-dep-flags.js
@@ -31,10 +31,6 @@ const calcDepFlagsStep = (node) => {
 
   // for links, map their hierarchy appropriately
   if (node.isLink) {
-    // node.target can be null, we check to ensure it's not null before proceeding
-    if (node.target == null) {
-      return node
-    }
     node.target.dev = node.dev
     node.target.optional = node.optional
     node.target.devOptional = node.devOptional
@@ -102,28 +98,14 @@ const unsetFlag = (node, flag) => {
       visit: node => {
         node.extraneous = node[flag] = false
         if (node.isLink) {
-          // node.target can be null, we check to ensure it's not null before proceeding
-          if (node.target == null) {
-            return []
-          } else {
-            node.target.extraneous = node.target[flag] = false
-          }
+          node.target.extraneous = node.target[flag] = false
         }
       },
       getChildren: node => {
-        if (node.isLink && node.target == null) {
-          return []
-        }
         const children = []
-        const targetNode = node.isLink ? node.target : node
-        if (targetNode == null) {
-          return []
-        }
-        for (const edge of targetNode.edgesOut.values()) {
-          if (
-            edge.to &&
-            edge.to[flag] &&
-            ((flag !== 'peer' && edge.type === 'peer') || edge.type === 'prod')
+        for (const edge of node.target.edgesOut.values()) {
+          if (edge.to && edge.to[flag] &&
+            (flag !== 'peer' && edge.type === 'peer' || edge.type === 'prod')
           ) {
             children.push(edge.to)
           }

--- a/workspaces/arborist/lib/calc-dep-flags.js
+++ b/workspaces/arborist/lib/calc-dep-flags.js
@@ -107,7 +107,7 @@ const unsetFlag = (node, flag) => {
       },
       getChildren: node => {
         const children = []
-        const targetNode = node.isLink && node.target ? node.target : node;
+        const targetNode = node.isLink && node.target ? node.target : node
         for (const edge of targetNode.edgesOut.values()) {
           if (
             edge.to &&

--- a/workspaces/arborist/lib/calc-dep-flags.js
+++ b/workspaces/arborist/lib/calc-dep-flags.js
@@ -31,6 +31,10 @@ const calcDepFlagsStep = (node) => {
 
   // for links, map their hierarchy appropriately
   if (node.isLink) {
+    // node.target can be null, we check to ensure it's not null before proceeding
+    if (node.target == null) {
+      return node
+    }
     node.target.dev = node.dev
     node.target.optional = node.optional
     node.target.devOptional = node.devOptional
@@ -103,9 +107,12 @@ const unsetFlag = (node, flag) => {
       },
       getChildren: node => {
         const children = []
-        for (const edge of node.target.edgesOut.values()) {
-          if (edge.to && edge.to[flag] &&
-            (flag !== 'peer' && edge.type === 'peer' || edge.type === 'prod')
+        const targetNode = node.isLink ? node.target : node
+        for (const edge of targetNode.edgesOut.values()) {
+          if (
+            edge.to &&
+            edge.to[flag] &&
+            ((flag !== 'peer' && edge.type === 'peer') || edge.type === 'prod')
           ) {
             children.push(edge.to)
           }

--- a/workspaces/arborist/lib/calc-dep-flags.js
+++ b/workspaces/arborist/lib/calc-dep-flags.js
@@ -1,119 +1,138 @@
-const { depth } = require('treeverse')
+const { depth } = require("treeverse");
 
 const calcDepFlags = (tree, resetRoot = true) => {
   if (resetRoot) {
-    tree.dev = false
-    tree.optional = false
-    tree.devOptional = false
-    tree.peer = false
+    tree.dev = false;
+    tree.optional = false;
+    tree.devOptional = false;
+    tree.peer = false;
   }
   const ret = depth({
     tree,
-    visit: node => calcDepFlagsStep(node),
-    filter: node => node,
+    visit: (node) => calcDepFlagsStep(node),
+    filter: (node) => node,
     getChildren: (node, tree) =>
-      [...tree.edgesOut.values()].map(edge => edge.to),
-  })
-  return ret
-}
+      [...tree.edgesOut.values()].map((edge) => edge.to),
+  });
+  return ret;
+};
 
 const calcDepFlagsStep = (node) => {
   // This rewalk is necessary to handle cases where devDep and optional
   // or normal dependency graphs overlap deep in the dep graph.
   // Since we're only walking through deps that are not already flagged
   // as non-dev/non-optional, it's typically a very shallow traversal
-  node.extraneous = false
-  resetParents(node, 'extraneous')
-  resetParents(node, 'dev')
-  resetParents(node, 'peer')
-  resetParents(node, 'devOptional')
-  resetParents(node, 'optional')
+  node.extraneous = false;
+  resetParents(node, "extraneous");
+  resetParents(node, "dev");
+  resetParents(node, "peer");
+  resetParents(node, "devOptional");
+  resetParents(node, "optional");
 
   // for links, map their hierarchy appropriately
   if (node.isLink) {
-    node.target.dev = node.dev
-    node.target.optional = node.optional
-    node.target.devOptional = node.devOptional
-    node.target.peer = node.peer
-    return calcDepFlagsStep(node.target)
+    // node.target can be null, we check to ensure it's not null before proceeding
+    if (node.target == null) {
+      return node;
+    }
+    node.target.dev = node.dev;
+    node.target.optional = node.optional;
+    node.target.devOptional = node.devOptional;
+    node.target.peer = node.peer;
+    return calcDepFlagsStep(node.target);
   }
 
   node.edgesOut.forEach(({ peer, optional, dev, to }) => {
     // if the dep is missing, then its flags are already maximally unset
     if (!to) {
-      return
+      return;
     }
 
     // everything with any kind of edge into it is not extraneous
-    to.extraneous = false
+    to.extraneous = false;
 
     // devOptional is the *overlap* of the dev and optional tree.
     // however, for convenience and to save an extra rewalk, we leave
     // it set when we are in *either* tree, and then omit it from the
     // package-lock if either dev or optional are set.
-    const unsetDevOpt = !node.devOptional && !node.dev && !node.optional && !dev && !optional
+    const unsetDevOpt =
+      !node.devOptional && !node.dev && !node.optional && !dev && !optional;
 
     // if we are not in the devOpt tree, then we're also not in
     // either the dev or opt trees
-    const unsetDev = unsetDevOpt || !node.dev && !dev
-    const unsetOpt = unsetDevOpt || !node.optional && !optional
-    const unsetPeer = !node.peer && !peer
+    const unsetDev = unsetDevOpt || (!node.dev && !dev);
+    const unsetOpt = unsetDevOpt || (!node.optional && !optional);
+    const unsetPeer = !node.peer && !peer;
 
     if (unsetPeer) {
-      unsetFlag(to, 'peer')
+      unsetFlag(to, "peer");
     }
 
     if (unsetDevOpt) {
-      unsetFlag(to, 'devOptional')
+      unsetFlag(to, "devOptional");
     }
 
     if (unsetDev) {
-      unsetFlag(to, 'dev')
+      unsetFlag(to, "dev");
     }
 
     if (unsetOpt) {
-      unsetFlag(to, 'optional')
+      unsetFlag(to, "optional");
     }
-  })
+  });
 
-  return node
-}
+  return node;
+};
 
 const resetParents = (node, flag) => {
   if (node[flag]) {
-    return
+    return;
   }
 
   for (let p = node; p && (p === node || p[flag]); p = p.resolveParent) {
-    p[flag] = false
+    p[flag] = false;
   }
-}
+};
 
 // typically a short walk, since it only traverses deps that have the flag set.
 const unsetFlag = (node, flag) => {
   if (node[flag]) {
-    node[flag] = false
+    node[flag] = false;
     depth({
       tree: node,
-      visit: node => {
-        node.extraneous = node[flag] = false
+      visit: (node) => {
+        node.extraneous = node[flag] = false;
         if (node.isLink) {
-          node.target.extraneous = node.target[flag] = false
-        }
-      },
-      getChildren: node => {
-        const children = []
-        for (const edge of node.target.edgesOut.values()) {
-          if (edge.to && edge.to[flag] &&
-            (flag !== 'peer' && edge.type === 'peer' || edge.type === 'prod')
-          ) {
-            children.push(edge.to)
+          // node.target can be null, we check to ensure it's not null before proceeding
+          if (node.target == null) {
+            return [];
+          } else {
+            node.target.extraneous = node.target[flag] = false;
           }
         }
-        return children
       },
-    })
+      getChildren: (node) => {
+        if (node.isLink && node.target == null) {
+          return [];
+        }
+        const children = [];
+        const targetNode = node.isLink ? node.target : node;
+        if (targetNode == null) {
+          return [];
+        }
+        for (const edge of targetNode.edgesOut.values()) {
+          if (
+            edge.to &&
+            edge.to[flag] &&
+            ((flag !== "peer" && edge.type === "peer") || edge.type === "prod")
+          ) {
+            children.push(edge.to);
+          }
+        }
+        return children;
+      },
+    });
   }
-}
+};
 
-module.exports = calcDepFlags
+module.exports = calcDepFlags;

--- a/workspaces/arborist/lib/calc-dep-flags.js
+++ b/workspaces/arborist/lib/calc-dep-flags.js
@@ -1,138 +1,137 @@
-const { depth } = require("treeverse");
+const { depth } = require('treeverse')
 
 const calcDepFlags = (tree, resetRoot = true) => {
   if (resetRoot) {
-    tree.dev = false;
-    tree.optional = false;
-    tree.devOptional = false;
-    tree.peer = false;
+    tree.dev = false
+    tree.optional = false
+    tree.devOptional = false
+    tree.peer = false
   }
   const ret = depth({
     tree,
-    visit: (node) => calcDepFlagsStep(node),
-    filter: (node) => node,
+    visit: node => calcDepFlagsStep(node),
+    filter: node => node,
     getChildren: (node, tree) =>
-      [...tree.edgesOut.values()].map((edge) => edge.to),
-  });
-  return ret;
-};
+      [...tree.edgesOut.values()].map(edge => edge.to),
+  })
+  return ret
+}
 
 const calcDepFlagsStep = (node) => {
   // This rewalk is necessary to handle cases where devDep and optional
   // or normal dependency graphs overlap deep in the dep graph.
   // Since we're only walking through deps that are not already flagged
   // as non-dev/non-optional, it's typically a very shallow traversal
-  node.extraneous = false;
-  resetParents(node, "extraneous");
-  resetParents(node, "dev");
-  resetParents(node, "peer");
-  resetParents(node, "devOptional");
-  resetParents(node, "optional");
+  node.extraneous = false
+  resetParents(node, 'extraneous')
+  resetParents(node, 'dev')
+  resetParents(node, 'peer')
+  resetParents(node, 'devOptional')
+  resetParents(node, 'optional')
 
   // for links, map their hierarchy appropriately
   if (node.isLink) {
     // node.target can be null, we check to ensure it's not null before proceeding
     if (node.target == null) {
-      return node;
+      return node
     }
-    node.target.dev = node.dev;
-    node.target.optional = node.optional;
-    node.target.devOptional = node.devOptional;
-    node.target.peer = node.peer;
-    return calcDepFlagsStep(node.target);
+    node.target.dev = node.dev
+    node.target.optional = node.optional
+    node.target.devOptional = node.devOptional
+    node.target.peer = node.peer
+    return calcDepFlagsStep(node.target)
   }
 
   node.edgesOut.forEach(({ peer, optional, dev, to }) => {
     // if the dep is missing, then its flags are already maximally unset
     if (!to) {
-      return;
+      return
     }
 
     // everything with any kind of edge into it is not extraneous
-    to.extraneous = false;
+    to.extraneous = false
 
     // devOptional is the *overlap* of the dev and optional tree.
     // however, for convenience and to save an extra rewalk, we leave
     // it set when we are in *either* tree, and then omit it from the
     // package-lock if either dev or optional are set.
-    const unsetDevOpt =
-      !node.devOptional && !node.dev && !node.optional && !dev && !optional;
+    const unsetDevOpt = !node.devOptional && !node.dev && !node.optional && !dev && !optional
 
     // if we are not in the devOpt tree, then we're also not in
     // either the dev or opt trees
-    const unsetDev = unsetDevOpt || (!node.dev && !dev);
-    const unsetOpt = unsetDevOpt || (!node.optional && !optional);
-    const unsetPeer = !node.peer && !peer;
+    const unsetDev = unsetDevOpt || !node.dev && !dev
+    const unsetOpt = unsetDevOpt || !node.optional && !optional
+    const unsetPeer = !node.peer && !peer
 
     if (unsetPeer) {
-      unsetFlag(to, "peer");
+      unsetFlag(to, 'peer')
     }
 
     if (unsetDevOpt) {
-      unsetFlag(to, "devOptional");
+      unsetFlag(to, 'devOptional')
     }
 
     if (unsetDev) {
-      unsetFlag(to, "dev");
+      unsetFlag(to, 'dev')
     }
 
     if (unsetOpt) {
-      unsetFlag(to, "optional");
+      unsetFlag(to, 'optional')
     }
-  });
+  })
 
-  return node;
-};
+  return node
+}
 
 const resetParents = (node, flag) => {
   if (node[flag]) {
-    return;
+    return
   }
 
   for (let p = node; p && (p === node || p[flag]); p = p.resolveParent) {
-    p[flag] = false;
+    p[flag] = false
   }
-};
+}
 
 // typically a short walk, since it only traverses deps that have the flag set.
 const unsetFlag = (node, flag) => {
   if (node[flag]) {
-    node[flag] = false;
+    node[flag] = false
     depth({
       tree: node,
-      visit: (node) => {
-        node.extraneous = node[flag] = false;
+      visit: node => {
+        node.extraneous = node[flag] = false
         if (node.isLink) {
           // node.target can be null, we check to ensure it's not null before proceeding
           if (node.target == null) {
-            return [];
+            return []
           } else {
-            node.target.extraneous = node.target[flag] = false;
+            node.target.extraneous = node.target[flag] = false
           }
         }
       },
-      getChildren: (node) => {
+      getChildren: node => {
         if (node.isLink && node.target == null) {
-          return [];
+          return []
         }
-        const children = [];
-        const targetNode = node.isLink ? node.target : node;
+        const children = []
+        const targetNode = node.isLink ? node.target : node
         if (targetNode == null) {
-          return [];
+          return []
         }
         for (const edge of targetNode.edgesOut.values()) {
           if (
             edge.to &&
             edge.to[flag] &&
-            ((flag !== "peer" && edge.type === "peer") || edge.type === "prod")
+            ((flag !== 'peer' && edge.type === 'peer') || edge.type === 'prod')
           ) {
-            children.push(edge.to);
+            children.push(edge.to)
           }
         }
-        return children;
+        return children
       },
-    });
+    })
   }
-};
+}
 
-module.exports = calcDepFlags;
+module.exports = calcDepFlags

--- a/workspaces/arborist/test/calc-dep-flags.js
+++ b/workspaces/arborist/test/calc-dep-flags.js
@@ -266,6 +266,7 @@ t.test('set parents to not extraneous when visiting', t => {
 })
 
 t.test('check null target in link', async t => {
+
   const root = new Link({
     path: '/some/path',
     realpath: '/some/path',
@@ -273,33 +274,6 @@ t.test('check null target in link', async t => {
       dependencies: { foo: '' },
     },
   });
-
-  if (root.target == null) {
-    t.equal(root.target, null, 'root.target should be null');
-    t.equal(root, root, 'should return the node itself if target is null');
-  } else {
-    root.target.peer = true;
-  }
-
-  const nonNullTarget = new Node({
-    name: "notNull",
-    path: '/some/path/node',
-  })
-
-  const rootWithNonNullTarget = new Link({
-    name: "notNull",
-    path: '/some/path/non/null',
-    pkg: {
-      dependencies: { foo: '' },
-    },
-    target: nonNullTarget
-  });
-  if (rootWithNonNullTarget.target == null) {
-    t.equal(rootWithNonNullTarget.target, null, 'rootWithNonNullTarget.target should be null');
-    t.equal(rootWithNonNullTarget, rootWithNonNullTarget, 'should return the node itself if target is null');
-  } else {
-    rootWithNonNullTarget.target.peer = true;
-    t.equal(rootWithNonNullTarget.target.peer, true, 'rootWithNonNullTarget.target.peer should be true');
-  }
+  t.doesNotThrow(()=> calcDepFlags(root))
   t.end();
 });

--- a/workspaces/arborist/test/calc-dep-flags.js
+++ b/workspaces/arborist/test/calc-dep-flags.js
@@ -265,8 +265,7 @@ t.test('set parents to not extraneous when visiting', t => {
   t.end()
 })
 
-t.test('check null target in link', async t => {
-
+t.test('check null target in link', async t => {  
   const root = new Link({
     path: '/some/path',
     realpath: '/some/path',
@@ -274,6 +273,7 @@ t.test('check null target in link', async t => {
       dependencies: { foo: '' },
     },
   });
-  t.doesNotThrow(()=> calcDepFlags(root))
+  t.doesNotThrow(() => calcDepFlags(root))
+  t.doesNotThrow(() => calcDepFlags(root, false))
   t.end();
 });

--- a/workspaces/arborist/test/calc-dep-flags.js
+++ b/workspaces/arborist/test/calc-dep-flags.js
@@ -265,15 +265,15 @@ t.test('set parents to not extraneous when visiting', t => {
   t.end()
 })
 
-t.test('check null target in link', async t => {  
+t.test('check null target in link', async t => {
   const root = new Link({
     path: '/some/path',
     realpath: '/some/path',
     pkg: {
       dependencies: { foo: '' },
     },
-  });
+  })
   t.doesNotThrow(() => calcDepFlags(root))
   t.doesNotThrow(() => calcDepFlags(root, false))
-  t.end();
-});
+  t.end()
+})

--- a/workspaces/arborist/test/calc-dep-flags.js
+++ b/workspaces/arborist/test/calc-dep-flags.js
@@ -264,3 +264,42 @@ t.test('set parents to not extraneous when visiting', t => {
   t.equal(bazLink.devOptional, false, 'bazlink not devOptional')
   t.end()
 })
+
+t.test('check null target in link', async t => {
+  const root = new Link({
+    path: '/some/path',
+    realpath: '/some/path',
+    pkg: {
+      dependencies: { foo: '' },
+    },
+  });
+
+  if (root.target == null) {
+    t.equal(root.target, null, 'root.target should be null');
+    t.equal(root, root, 'should return the node itself if target is null');
+  } else {
+    root.target.peer = true;
+  }
+
+  const nonNullTarget = new Node({
+    name: "notNull",
+    path: '/some/path/node',
+  })
+
+  const rootWithNonNullTarget = new Link({
+    name: "notNull",
+    path: '/some/path/non/null',
+    pkg: {
+      dependencies: { foo: '' },
+    },
+    target: nonNullTarget
+  });
+  if (rootWithNonNullTarget.target == null) {
+    t.equal(rootWithNonNullTarget.target, null, 'rootWithNonNullTarget.target should be null');
+    t.equal(rootWithNonNullTarget, rootWithNonNullTarget, 'should return the node itself if target is null');
+  } else {
+    rootWithNonNullTarget.target.peer = true;
+    t.equal(rootWithNonNullTarget.target.peer, true, 'rootWithNonNullTarget.target.peer should be true');
+  }
+  t.end();
+});


### PR DESCRIPTION
<!-- What / Why -->
If a node represents a symbolic link or a file dep (node.isLink is true), its target is expected to reference another node in the dependency tree. If the linking is not done correctly or is incomplete, node.target might be null.
<!-- Describe the request in detail. What it does and why it's being changed. -->
in this PR, a null check is added to ensure node.target is not null or before proceeding, which will prevent causing errors like:
`npm error Cannot set properties of null (setting 'peer')` 

## References
  Related to #7065, 
  Fixes #6622, #5007,
  Closes #6622, #5007
