### PR TITLE
docs: Improve manpage section for `package.json` `funding` properties

### DIFF
--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -226,7 +226,7 @@ npm also sets a top-level "maintainers" field with your npm user info.
 
 You can specify an object containing a URL that provides up-to-date
 information about ways to help fund development of your package, a
-string URL, or an array of objects and strings:
+string URL, or an array of objects and string URLs:
 
 ```json
 {
@@ -270,7 +270,7 @@ string URL, or an array of objects and strings:
 
 Users can use the `npm fund` subcommand to list the `funding` URLs of all
 dependencies of their project, direct and indirect. A shortcut to visit
-each funding url is also available when providing the project name such as:
+each funding URL is also available when providing the project name such as:
 `npm fund <projectname>` (when there are multiple URLs, the first one will
 be visited)
 

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -225,23 +225,35 @@ npm also sets a top-level "maintainers" field with your npm user info.
 ### funding
 
 You can specify an object containing a URL that provides up-to-date
-information about ways to help fund development of your package, or a
-string URL, or an array of these:
+information about ways to help fund development of your package, a
+string URL, or an array of objects and strings:
 
 ```json
 {
   "funding": {
     "type" : "individual",
     "url" : "http://example.com/donate"
-  },
+  }
+}
+```
 
+```json
+{
   "funding": {
     "type" : "patreon",
     "url" : "https://www.patreon.com/my-account"
-  },
+  }
+}
+```
 
-  "funding": "http://example.com/donate",
+```json
+{
+  "funding": "http://example.com/donate"
+}
+```
 
+```json
+{
   "funding": [
     {
       "type" : "individual",


### PR DESCRIPTION
Small doc fix. Reviewing the section on `funding` on docs.npmjs.com, I noticed some odd code-block formatting, as well as some opportunities to clarify.

The current weirdness:

![2024-06-02-214100_3840x2160_scrot](https://github.com/npm/cli/assets/205760/5f0a436f-5812-4a97-b4b9-b4183219d4dd)

Glad to see string-or-object worked out.