### PR TITLE
fix(cache): add limit for PackumentCache.heapLimit

### DIFF
--- a/workspaces/arborist/lib/packument-cache.js
+++ b/workspaces/arborist/lib/packument-cache.js
@@ -7,7 +7,10 @@ const { log } = require('proc-log')
 // of the same packument to bypass disk reads.  The tradeoff here is memory
 // usage for disk reads.
 class PackumentCache extends LRUCache {
-  static #heapLimit = Math.floor(getHeapStatistics().heap_size_limit)
+  static #heapLimit = Math.min(
+    Math.floor(getHeapStatistics().heap_size_limit),
+    16 * 1024 * 1024 * 1024 // 16GB
+  )
 
   #sizeKey
   #disposed = new Set()


### PR DESCRIPTION
### The problem
The current implementation of PackumentCache gets `heapLimit` value from the node runtime. But, in bun, the  `heap_size_limit: Infinity` by default, and it seems there is no way to limit it.
Then, the `heapLimit` value passes to lru-cache cache with doesn't work with unlimited cache size at all.

Trace from `lru-cache`:
```
361 |         // NB: maxEntrySize is set to maxSize if it's set
362 |         if (this.maxEntrySize !== 0) {
363 |             if (this.#maxSize !== 0) {
364 |                 console.log('this.#maxSize', this.#maxSize)
365 |                 if (!isPosInt(this.#maxSize)) {
366 |                     throw new TypeError('maxSize must be a positive integer if specified');
```
### Solution
Let's set a reasonable maximum to the `heapLimit` to avoid this.