### PR TITLE
fix: added informative root directory install error

### DIFF
--- a/lib/commands/ci.js
+++ b/lib/commands/ci.js
@@ -37,7 +37,7 @@ class CI extends ArboristWorkspaceCmd {
 
     const where = this.npm.prefix
 
-    if (path.parse(process.cwd()).root === where) {
+    if (path.parse(where).root === where) {
       const msg =
         'The current working directory is the root directory of the filesystem.\n' +
         'Package installs in root directories are not allowed.\n' +

--- a/lib/commands/ci.js
+++ b/lib/commands/ci.js
@@ -36,6 +36,15 @@ class CI extends ArboristWorkspaceCmd {
     }
 
     const where = this.npm.prefix
+
+    if (path.parse(process.cwd()).root === where) {
+      const msg =
+        'The current working directory is the root directory of the filesystem.\n' +
+        'Package installs in root directories are not allowed.\n' +
+        'Please create a new folder and install your packages in there.\n'
+      throw new Error(msg)
+    }
+
     const Arborist = require('@npmcli/arborist')
     const opts = {
       ...this.npm.flatOptions,

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -6,6 +6,7 @@ const pacote = require('pacote')
 const checks = require('npm-install-checks')
 const reifyFinish = require('../utils/reify-finish.js')
 const ArboristWorkspaceCmd = require('../arborist-cmd.js')
+const path = require('node:path')
 
 class Install extends ArboristWorkspaceCmd {
   static description = 'Install a package'
@@ -103,6 +104,14 @@ class Install extends ArboristWorkspaceCmd {
     const where = isGlobalInstall ? globalTop : this.npm.prefix
     const forced = this.npm.config.get('force')
     const scriptShell = this.npm.config.get('script-shell') || undefined
+
+    if (path.parse(process.cwd()).root === where) {
+      const msg =
+        'The current working directory is the root directory of the filesystem.\n' +
+        'Package installs in root directories are not allowed.\n' +
+        'Please create a new folder and install your packages in there.\n'
+      throw new Error(msg)
+    }
 
     // be very strict about engines when trying to update npm itself
     const npmInstall = args.find(arg => arg.startsWith('npm@') || arg === 'npm')

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -105,7 +105,7 @@ class Install extends ArboristWorkspaceCmd {
     const forced = this.npm.config.get('force')
     const scriptShell = this.npm.config.get('script-shell') || undefined
 
-    if (path.parse(process.cwd()).root === where) {
+    if (path.parse(where).root === where) {
       const msg =
         'The current working directory is the root directory of the filesystem.\n' +
         'Package installs in root directories are not allowed.\n' +

--- a/test/lib/commands/ci.js
+++ b/test/lib/commands/ci.js
@@ -309,44 +309,12 @@ t.test('should use --workspace flag', async t => {
   assert.packageInstalled('node_modules/lodash@1.1.1')
 })
 
-t.test('Unix - throw error on ci in root directory', async t => {
-  if (process.platform === 'win32') {
-    return t.skip('Throw on non-Windows root directory ci - test not relevant on platform')
-  }
-
+t.test('throw error on ci in root directory', async t => {
   let npmError = null
 
   const { npm } = await loadMockNpm(t, {
     config: {
-      prefix: '/',
-      'dry-run': true,
-    },
-  })
-
-  try {
-    await npm.exec('ci', ['fizzbuzz'])
-  } catch (error) {
-    npmError = error.message
-  }
-
-  const expectedMessage =
-    'The current working directory is the root directory of the filesystem.\n' +
-    'Package installs in root directories are not allowed.\n' +
-    'Please create a new folder and install your packages in there.\n'
-
-  t.strictSame(npmError, expectedMessage)
-})
-
-t.test('Windows - throw error on ci in root directory', async t => {
-  if (process.platform !== 'win32') {
-    return t.skip('Throw on Windows root directory ci - test not relevant on platform')
-  }
-
-  let npmError = null
-
-  const { npm } = await loadMockNpm(t, {
-    config: {
-      prefix: 'C:\\',
+      prefix: path.parse(process.cwd()).root,
       'dry-run': true,
     },
   })

--- a/test/lib/commands/ci.js
+++ b/test/lib/commands/ci.js
@@ -308,3 +308,59 @@ t.test('should use --workspace flag', async t => {
   assert.packageMissing('node_modules/abbrev@1.1.0')
   assert.packageInstalled('node_modules/lodash@1.1.1')
 })
+
+t.test('Unix - throw error on ci in root directory', async t => {
+  if (process.platform === 'win32') {
+    return t.skip('Throw on non-Windows root directory ci - test not relevant on platform')
+  }
+
+  let npmError = null
+
+  const { npm } = await loadMockNpm(t, {
+    config: {
+      prefix: '/',
+      'dry-run': true,
+    },
+  })
+
+  try {
+    await npm.exec('ci', ['fizzbuzz'])
+  } catch (error) {
+    npmError = error.message
+  }
+
+  const expectedMessage =
+    'The current working directory is the root directory of the filesystem.\n' +
+    'Package installs in root directories are not allowed.\n' +
+    'Please create a new folder and install your packages in there.\n'
+
+  t.strictSame(npmError, expectedMessage)
+})
+
+t.test('Windows - throw error on ci in root directory', async t => {
+  if (process.platform !== 'win32') {
+    return t.skip('Throw on Windows root directory ci - test not relevant on platform')
+  }
+
+  let npmError = null
+
+  const { npm } = await loadMockNpm(t, {
+    config: {
+      prefix: 'C:\\',
+      'dry-run': true,
+    },
+  })
+
+  try {
+    await npm.exec('ci', ['fizzbuzz'])
+  } catch (error) {
+    npmError = error.message
+  }
+
+  const expectedMessage =
+    'The current working directory is the root directory of the filesystem.\n' +
+    'Package installs in root directories are not allowed.\n' +
+    'Please create a new folder and install your packages in there.\n'
+
+  t.strictSame(npmError, expectedMessage)
+})

--- a/test/lib/commands/install.js
+++ b/test/lib/commands/install.js
@@ -400,3 +400,59 @@ t.test('should show install keeps dirty --workspace flag', async t => {
   assert.packageDirty('node_modules/abbrev@1.1.0')
   assert.packageInstalled('node_modules/lodash@1.1.1')
 })
+
+t.test('Unix - throw error on package install in root directory', async t => {
+  if (process.platform === 'win32') {
+    return t.skip('Throw on non-Windows root directory install - test not relevant on platform')
+  }
+
+  let npmError = null
+
+  const { npm } = await loadMockNpm(t, {
+    config: {
+      prefix: '/',
+      'dry-run': true,
+    },
+  })
+
+  try {
+    await npm.exec('install', ['fizzbuzz'])
+  } catch (error) {
+    npmError = error.message
+  }
+
+  const expectedMessage =
+    'The current working directory is the root directory of the filesystem.\n' +
+    'Package installs in root directories are not allowed.\n' +
+    'Please create a new folder and install your packages in there.\n'
+
+  t.strictSame(npmError, expectedMessage)
+})
+
+t.test('Windows - throw error on package install in root directory', async t => {
+  if (process.platform !== 'win32') {
+    return t.skip('Throw on Windows root directory install - test not relevant on platform')
+  }
+
+  let npmError = null
+
+  const { npm } = await loadMockNpm(t, {
+    config: {
+      prefix: 'C:\\',
+      'dry-run': true,
+    },
+  })
+
+  try {
+    await npm.exec('install', ['fizzbuzz'])
+  } catch (error) {
+    npmError = error.message
+  }
+
+  const expectedMessage =
+    'The current working directory is the root directory of the filesystem.\n' +
+    'Package installs in root directories are not allowed.\n' +
+    'Please create a new folder and install your packages in there.\n'
+
+  t.strictSame(npmError, expectedMessage)
+})

--- a/test/lib/commands/install.js
+++ b/test/lib/commands/install.js
@@ -401,44 +401,12 @@ t.test('should show install keeps dirty --workspace flag', async t => {
   assert.packageInstalled('node_modules/lodash@1.1.1')
 })
 
-t.test('Unix - throw error on package install in root directory', async t => {
-  if (process.platform === 'win32') {
-    return t.skip('Throw on non-Windows root directory install - test not relevant on platform')
-  }
-
+t.test('throw error on package install in root directory', async t => {
   let npmError = null
 
   const { npm } = await loadMockNpm(t, {
     config: {
-      prefix: '/',
-      'dry-run': true,
-    },
-  })
-
-  try {
-    await npm.exec('install', ['fizzbuzz'])
-  } catch (error) {
-    npmError = error.message
-  }
-
-  const expectedMessage =
-    'The current working directory is the root directory of the filesystem.\n' +
-    'Package installs in root directories are not allowed.\n' +
-    'Please create a new folder and install your packages in there.\n'
-
-  t.strictSame(npmError, expectedMessage)
-})
-
-t.test('Windows - throw error on package install in root directory', async t => {
-  if (process.platform !== 'win32') {
-    return t.skip('Throw on Windows root directory install - test not relevant on platform')
-  }
-
-  let npmError = null
-
-  const { npm } = await loadMockNpm(t, {
-    config: {
-      prefix: 'C:\\',
+      prefix: path.parse(process.cwd()).root,
       'dry-run': true,
     },
   })


### PR DESCRIPTION
## What & Why
I've seen many instances of people getting this error `Tracker "idealTree" already exists` which is caused by installing packages in a root directory. Examples of where I've seen it:
[Stack Overflow](https://stackoverflow.com/questions/57534295/npm-err-tracker-idealtree-already-exists-while-creating-the-docker-image-for)
https://github.com/docker/for-linux/issues/1207
[Reddit](https://www.reddit.com/r/docker/comments/1b66x8s/tracker_idealtree_already_exists_on_npm_install/)
[lopau.com](https://www.lopau.com/how-to-fix-npm-err-tracker-idealtree-already-exists/)

In those examples, they all come from missing `WORKDIR` in the Dockerfile, but this error could also be caused by creating a new project in the root directory of an external drive in Windows.

## Changes Made

With this PR, an error has been added when trying to run `npm install` or `npm ci` inside of a root directory. It will tell the person that they are running the command in a root directory and that root directory installs are not allowed. It also tells the person to create a new folder and install the packages in there to fix the issue.
