### PR TITLE
docs: use git+https in package.com url examples

### DIFF
--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -367,11 +367,11 @@ feature to install the "npm" executable.)
 To use this, supply a `bin` field in your package.json which is a map of
 command name to local file name. When this package is installed globally,
 that file will be either linked inside the global bins directory or
-a cmd (Windows Command File) will be created which executes the specified 
+a cmd (Windows Command File) will be created which executes the specified
 file in the `bin` field, so it is available to run by `name` or `name.cmd` (on
-Windows PowerShell). When this package is installed as a dependency in another 
+Windows PowerShell). When this package is installed as a dependency in another
 package, the file will be linked where it will be available to that package
-either directly by `npm exec` or by name in other scripts when invoking them 
+either directly by `npm exec` or by name in other scripts when invoking them
 via `npm run-script`.
 
 
@@ -385,10 +385,10 @@ For example, myapp could have this:
 }
 ```
 
-So, when you install myapp, in case of unix-like OS it'll create a symlink 
-from the `cli.js` script to `/usr/local/bin/myapp` and in case of windows it 
+So, when you install myapp, in case of unix-like OS it'll create a symlink
+from the `cli.js` script to `/usr/local/bin/myapp` and in case of windows it
 will create a cmd file usually at `C:\Users\{Username}\AppData\Roaming\npm\myapp.cmd`
-which runs the `cli.js` script. 
+which runs the `cli.js` script.
 
 If you have a single executable, and its name should be the name of the
 package, then you can just supply it as a string.  For example:
@@ -518,7 +518,7 @@ Do it like this:
 {
   "repository": {
     "type": "git",
-    "url": "https://github.com/npm/cli.git"
+    "url": "git+https://github.com/npm/cli.git"
   }
 }
 ```
@@ -553,8 +553,8 @@ which it lives:
 {
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/react.git",
-    "directory": "packages/react-dom"
+    "url": "git+https://github.com/npm/cli.git",
+    "directory": "workspaces/libnpmpublish"
   }
 }
 ```


### PR DESCRIPTION
- closes #7614

## Issue

Examples in the [repository](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository) section of the [npm CI > Configuring npm > package.json](https://docs.npmjs.com/cli/v10/configuring-npm/package-json) reference page use the protocol `https`. The examples are:

```json
"url": "https://github.com/npm/cli.git"
```
```json
"url": "https://github.com/facebook/react.git"
```

Executing `npm pkg fix` in a repo with a `url` definition and `protocol` using `https` normalizes the protocol to `git+https`.

Examples should be aligned with what `npm pkg fix` considers correct and should also be aligned to the list of valid protocols in the [Git URLs as Dependencies](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#git-urls-as-dependencies) section, which states:

> `<protocol>` is one of `git`, `git+ssh`, `git+http`, `git+https`, or `git+file`.

## Change

1. `npm/cli.git`
    Change to
    ```json
    "url": "git+https://github.com/npm/cli.git"
    ```
2. `facebook/react.git`
    Since the source example of https://github.com/facebook/react/blob/main/packages/react-dom/package.json does not use the correct `git+https` protocol, use instead
    ```json
    "url": "git+https://github.com/npm/cli.git",
    "directory": "workspaces/libnpmpublish"
    ```
