### PR TITLE
docs(install): add save-peer flag

### DIFF
--- a/docs/lib/content/commands/npm-install.md
+++ b/docs/lib/content/commands/npm-install.md
@@ -134,6 +134,8 @@ into a tarball (b).
 
     * `-D, --save-dev`: Package will appear in your `devDependencies`.
 
+    * `--save-peer`: Package will appear in your `peerDependencies`.
+
     * `-O, --save-optional`: Package will appear in your
       `optionalDependencies`.
 


### PR DESCRIPTION
<!-- What / Why -->
npm install documentation is missing peer dependency command
<!-- Describe the request in detail. What it does and why it's being changed. -->
Added `--save-peer` flag to npm install documentation.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
