### PR TITLE
fix: limit concurrent open files during 'npm cache verify'

### DIFF
--- a/node_modules/cacache/lib/entry-index.js
+++ b/node_modules/cacache/lib/entry-index.js
@@ -20,9 +20,7 @@ const indexV = require('../package.json')['cache-version'].index
 const { moveFile } = require('@npmcli/fs')
 
 const pMap = require('p-map')
-const lsStreamOpts = {
-  concurrency: 5,
-}
+const lsStreamConcurrency = 5
 
 
 module.exports.NotFoundError = class NotFoundError extends Error {
@@ -220,11 +218,11 @@ function lsStream (cache) {
             throw err
           }
         },
-        { concurrency: lsStreamOpts.concurrency })
+        { concurrency: lsStreamConcurrency })
       },
-      { concurrency: lsStreamOpts.concurrency })
+      { concurrency: lsStreamConcurrency })
     },
-    { concurrency: lsStreamOpts.concurrency })
+    { concurrency: lsStreamConcurrency })
     stream.end()
     return stream
   }).catch(err => stream.emit('error', err))

--- a/node_modules/cacache/lib/entry-index.js
+++ b/node_modules/cacache/lib/entry-index.js
@@ -19,6 +19,12 @@ const hashToSegments = require('./util/hash-to-segments')
 const indexV = require('../package.json')['cache-version'].index
 const { moveFile } = require('@npmcli/fs')
 
+const pMap = require('p-map')
+const lsStreamOpts = {
+  concurrency: 5,
+}
+
+
 module.exports.NotFoundError = class NotFoundError extends Error {
   constructor (cache, key) {
     super(`No cache entry for ${key} found in ${cache}`)
@@ -182,15 +188,15 @@ function lsStream (cache) {
   // Set all this up to run on the stream and then just return the stream
   Promise.resolve().then(async () => {
     const buckets = await readdirOrEmpty(indexDir)
-    await Promise.all(buckets.map(async (bucket) => {
+    await pMap(buckets, async (bucket) => {
       const bucketPath = path.join(indexDir, bucket)
       const subbuckets = await readdirOrEmpty(bucketPath)
-      await Promise.all(subbuckets.map(async (subbucket) => {
+      await pMap(subbuckets, async (subbucket) => {
         const subbucketPath = path.join(bucketPath, subbucket)
 
         // "/cachename/<bucket 0xFF>/<bucket 0xFF>./*"
         const subbucketEntries = await readdirOrEmpty(subbucketPath)
-        await Promise.all(subbucketEntries.map(async (entry) => {
+        await pMap(subbucketEntries, async (entry) => {
           const entryPath = path.join(subbucketPath, entry)
           try {
             const entries = await bucketEntries(entryPath)
@@ -213,9 +219,12 @@ function lsStream (cache) {
             }
             throw err
           }
-        }))
-      }))
-    }))
+        },
+        { concurrency: lsStreamOpts.concurrency })
+      },
+      { concurrency: lsStreamOpts.concurrency })
+    },
+    { concurrency: lsStreamOpts.concurrency })
     stream.end()
     return stream
   }).catch(err => stream.emit('error', err))


### PR DESCRIPTION
This change solves https://github.com/npm/cli/issues/4783

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
During 'npm cache verify', currently all the cache files are open at the same time, which will bring EMFILE error in an environment that limit max open files.
This change limits the concurrent open files in garbageCollect() with p-map module to avoid this problem.

## References
  Fixes #4783
