### PR TITLE
fix: update lifecycle script list in run-script

### DIFF
--- a/lib/commands/run-script.js
+++ b/lib/commands/run-script.js
@@ -165,8 +165,10 @@ class RunScript extends BaseCommand {
       return
     }
 
-    // TODO this is missing things like prepare, prepublishOnly, and dependencies
     const cmdList = [
+      'prepare', 'prepublishOnly',
+      'prepack', 'postpack',
+      'dependencies',
       'preinstall', 'install', 'postinstall',
       'prepublish', 'publish', 'postpublish',
       'prerestart', 'restart', 'postrestart',


### PR DESCRIPTION
This change updates the list of lifecycle scripts in the RunScript class to include important npm scripts that were previously missing.

- add `prepare`, `prepublishOnly` scripts
- add `dependencies` scripts
- add `prepack` and `postpack` scripts
- todo comments removed due to changes reflected

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
The documents I referenced are as follows:
- https://docs.npmjs.com/cli/v10/using-npm/scripts

<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
