### PR TITLE
fix `npm docs` bug when running with no arguments

### DIFF
--- a/lib/commands/docs.js
+++ b/lib/commands/docs.js
@@ -13,7 +13,9 @@ class Docs extends PackageUrlCmd {
     if (info) {
       return info.docs()
     }
-
+    if (mani.name === undefined) {
+      return `https://www.docs.npmjs.com`
+    }
     return `https://www.npmjs.com/package/${mani.name}`
   }
 }


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
`npm docs` is a command that opens the documentation for a specified package. However, when running it without any arguments, it converts the pkgname argument, which in this case is undefined, to a string, and returns/opens the URL `https://www.npmjs.com/package/undefined`. Now, when running `npm docs` with no arguments, it returns/opens the URL to [NPM's docs](https://docs.npmjs.com/).
<!-- No references, I found the bug -->
