### PR TITLE
fix: Fix npm install --prefix on windows

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -97,10 +97,9 @@ class Install extends ArboristWorkspaceCmd {
 
   async exec (args) {
     // the /path/to/node_modules/..
-    const globalTop = resolve(this.npm.globalDir, '..')
     const ignoreScripts = this.npm.config.get('ignore-scripts')
     const isGlobalInstall = this.npm.global
-    const where = isGlobalInstall ? globalTop : this.npm.prefix
+    const where = this.npm.prefix
     const forced = this.npm.config.get('force')
     const scriptShell = this.npm.config.get('script-shell') || undefined
 
@@ -128,13 +127,13 @@ class Install extends ArboristWorkspaceCmd {
     args = args.filter(a => resolve(a) !== this.npm.prefix)
 
     // `npm i -g` => "install this package globally"
-    if (where === globalTop && !args.length) {
+    if (isGlobalInstall && !args.length) {
       args = ['.']
     }
 
     // throw usage error if trying to install empty package
     // name to global space, e.g: `npm i -g ""`
-    if (where === globalTop && !args.every(Boolean)) {
+    if (isGlobalInstall && !args.every(Boolean)) {
       throw this.usageError()
     }
 


### PR DESCRIPTION
I found that globalDir/localDir and globalPrefix/localPrefix end up being the same value when `--prefix` is set. This was surprising to me, but it does appear that `globalPrefix` is set to match `prefix` at the end of loading.

This means that the globalTop logic is actually incorrect here. It accidentally worked on non-windows machines.

For example if running `npm i --prefix scripts`

On non-windows
this.npm.globalDir = $CWD/scripts/lib/node_modules

On windows
this.npm.globalDir = $CWD/scripts/node_modules

IMHO, the logic inside of npmconfig is also incorrect here, since globalDir is being set to this bogus `$CWD/scripts/lib/node_modules`

However, this fix should work regardless - since it stops relying on the specific values of globalDir.

I manually tested `npm install` and `npm install --prefix` on both windows and mac. Everything works now.

## References

Fixes #7722