### PR TITLE
Change default license to `UNLICENSED`

### DIFF
--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -936,7 +936,7 @@ const definitions = {
     `,
   }),
   'init-license': new Definition('init-license', {
-    default: 'ISC',
+    default: 'UNLICENSED',
     hint: '<license>',
     type: String,
     description: `
@@ -995,7 +995,7 @@ const definitions = {
     `,
   }),
   'init.license': new Definition('init.license', {
-    default: 'ISC',
+    default: 'UNLICENSED',
     type: String,
     deprecated: `
       Use \`--init-license\` instead.


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
I've been following [this discussion](https://github.com/npm/rfcs/discussions/678), in which participants have provided many good reasons to change the default license from `ISC` to `UNLICENSED`.

This is a draft PR because I can't find where to change docs so the tests pass. Any help would be appreciated, but I might find it myself on the plane tomorrow. :shrug: 

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
