### PR TITLE
fix(publish): consider package-spec when inside workspace dir

### DIFF
--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -46,7 +46,12 @@ class Publish extends BaseCommand {
     await this.#publish(args)
   }
 
-  async execWorkspaces () {
+  async execWorkspaces (args) {
+    const useWorkspaces = args.length === 0 || args.includes('.')
+    if (!useWorkspaces) {
+      log.warn('Ignoring workspaces for specified package(s)')
+      return this.exec(args)
+    }
     await this.setWorkspaces()
 
     for (const [name, workspace] of this.workspaces.entries()) {

--- a/tap-snapshots/test/lib/commands/publish.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/publish.js.test.cjs
@@ -393,6 +393,10 @@ exports[`test/lib/commands/publish.js TAP workspaces all workspaces - some marke
 + workspace-a@1.2.3-a
 `
 
+exports[`test/lib/commands/publish.js TAP workspaces differet package spec > publish different package spec 1`] = `
++ pkg@1.2.3
+`
+
 exports[`test/lib/commands/publish.js TAP workspaces json > all workspaces in json 1`] = `
 {
   "workspace-a": {


### PR DESCRIPTION
This PR fixes an issue where the `npm publish` command would fail when run from within a workspace directory with package-spec

fixes: https://github.com/npm/cli/issues/7726