### PR TITLE
docs: update docs for npmrc and package-json 

### DIFF
--- a/docs/lib/content/configuring-npm/npmrc.md
+++ b/docs/lib/content/configuring-npm/npmrc.md
@@ -29,7 +29,7 @@ Environment variables can be replaced using `${VARIABLE_NAME}`. For
 example:
 
 ```bash
-prefix = ${HOME}/.npm-packages
+cache = ${HOME}/.npm-packages
 ```
 
 Each of these files is loaded, and config options are resolved in priority

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -617,6 +617,7 @@ See [semver](https://github.com/npm/node-semver#versions) for more details about
 * `tag` A specific version tagged and published as `tag`  See [`npm
   dist-tag`](/commands/npm-dist-tag)
 * `path/path/path` See [Local Paths](#local-paths) below
+* `npm:@scope/pkg@version` Custom alias for a pacakge See [`package-spec`](/using-npm/package-spec#aliases) 
 
 For example, these are all valid:
 
@@ -634,7 +635,8 @@ For example, these are all valid:
     "two": "2.x",
     "thr": "3.3.x",
     "lat": "latest",
-    "dyl": "file:../dyl"
+    "dyl": "file:../dyl",
+    "kpg": "npm:pkg@1.0.0"
   }
 }
 ```


### PR DESCRIPTION
Updating Docs for 
`npmrc` 
 - Updated example config, instead of `prefix` which can not be changed for project, instead added `cache` which can be used for all three config types project, user and global 
 
 `package-json` 
- added alias example in package-json docs, which can be used to define alias for a package

fixes: https://github.com/npm/cli/issues/6839, https://github.com/npm/cli/issues/7188
