### PR TITLE
fix: prevent infinite recursion when looking up real paths

### DIFF
--- a/workspaces/arborist/lib/realpath.js
+++ b/workspaces/arborist/lib/realpath.js
@@ -28,7 +28,7 @@ const realpathCached = (path, rpcache, stcache, depth) => {
   }
 
   // if it's the root, then we know it's real
-  if (!base || dir == path) {
+  if (!base || dir === path) {
     rpcache.set(dir, dir)
     return Promise.resolve(dir)
   }

--- a/workspaces/arborist/lib/realpath.js
+++ b/workspaces/arborist/lib/realpath.js
@@ -28,7 +28,7 @@ const realpathCached = (path, rpcache, stcache, depth) => {
   }
 
   // if it's the root, then we know it's real
-  if (!base) {
+  if (!base || dir == path) {
     rpcache.set(dir, dir)
     return Promise.resolve(dir)
   }


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
This fixes https://github.com/npm/cli/issues/7309 which causes a "RangeError: Maximum call stack size exceeded" on line 38 on Windows 11 without this change.

## References
@danFbach found the fix.
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
