### PR TITLE
fix(docs): init usage description corrected

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -31,7 +31,7 @@ class Init extends BaseCommand {
 
   static name = 'init'
   static usage = [
-    '<package-spec> (same as `npx <package-spec>`)',
+    '<package-spec> (same as `npx create-<package-spec>`)',
     '<@scope> (same as `npx <@scope>/create`)',
   ]
 

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -3231,7 +3231,7 @@ exports[`test/lib/docs.js TAP usage init > must match snapshot 1`] = `
 Create a package.json file
 
 Usage:
-npm init <package-spec> (same as \`npx <package-spec>\`)
+npm init <package-spec> (same as \`npx create-<package-spec>\`)
 npm init <@scope> (same as \`npx <@scope>/create\`)
 
 Options:
@@ -3246,7 +3246,7 @@ aliases: create, innit
 Run "npm help init" for more info
 
 \`\`\`bash
-npm init <package-spec> (same as \`npx <package-spec>\`)
+npm init <package-spec> (same as \`npx create-<package-spec>\`)
 npm init <@scope> (same as \`npx <@scope>/create\`)
 
 aliases: create, innit


### PR DESCRIPTION
Updated `npm init <pkg-spec>` command usage documentation for npx equivalent command format `npx create-<pkg-spec>`
Fixes: https://github.com/npm/cli/issues/7011