### PR TITLE
feat: devEngines

### DIFF
--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -1129,6 +1129,32 @@ Like the `os` option, you can also block architectures:
 
 The host architecture is determined by `process.arch`
 
+### devEngines
+
+The `devEngines` field aids engineers working on a codebase to all be using the same tooling.
+
+You can specify a `devEngines` property in your `package.json` which will run before `install`, `ci`, and `run` commands. 
+
+> Note: `engines` and `devEngines` differ in object shape. They also function very differently. `engines` is designed to alert the user when a dependency uses a differening npm or node version that the project it's being used in, whereas `devEngines` is used to alert people interacting with the source code of a project.
+
+The supported keys under the `devEngines` property are `cpu`, `os`, `libc`, `runtime`, and `packageManager`. Each property can be an object or an array of objects. Objects must contain `name`, and optionally can specify `version`, and `onFail`. `onFail` can be `warn`, `error`, or `ignore`, and if left undefined is of the same value as `error`. `npm` will assume that you're running with `node`.
+Here's an example of a project that will fail if the environment is not `node` and `npm`. If you set `runtime.name` or `packageManager.name` to any other string, it will fail within the npm CLI.
+
+```json
+{
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "onFail": "error"
+    },
+    "packageManager": {
+      "name": "npm",
+      "onFail": "error"
+    }
+  }
+}
+```
+
 ### private
 
 If you set `"private": true` in your package.json, then npm will refuse to

--- a/lib/arborist-cmd.js
+++ b/lib/arborist-cmd.js
@@ -18,6 +18,7 @@ class ArboristCmd extends BaseCommand {
 
   static workspaces = true
   static ignoreImplicitWorkspace = false
+  static checkDevEngines = true
 
   constructor (npm) {
     super(npm)

--- a/lib/commands/run-script.js
+++ b/lib/commands/run-script.js
@@ -21,6 +21,7 @@ class RunScript extends BaseCommand {
   static workspaces = true
   static ignoreImplicitWorkspace = false
   static isShellout = true
+  static checkDevEngines = true
 
   static async completion (opts, npm) {
     const argv = opts.conf.argv.remain

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -247,6 +247,10 @@ class Npm {
       execWorkspaces = true
     }
 
+    if (command.checkDevEngines && !this.global) {
+      await command.checkDevEngines()
+    }
+
     return time.start(`command:${cmd}`, () =>
       execWorkspaces ? command.execWorkspaces(args) : command.exec(args))
   }

--- a/lib/utils/error-message.js
+++ b/lib/utils/error-message.js
@@ -200,6 +200,13 @@ const errorMessage = (er, npm) => {
       ].join('\n')])
       break
 
+    case 'EBADDEVENGINES': {
+      const { current, required } = er
+      summary.push(['EBADDEVENGINES', er.message])
+      detail.push(['EBADDEVENGINES', { current, required }])
+      break
+    }
+
     case 'EBADPLATFORM': {
       const actual = er.current
       const expected = { ...er.required }

--- a/tap-snapshots/test/lib/commands/install.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/install.js.test.cjs
@@ -1,0 +1,291 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/lib/commands/install.js TAP devEngines should not utilize engines in root if devEngines is provided > must match snapshot 1`] = `
+silly config load:file:{CWD}/npmrc
+silly config load:file:{CWD}/prefix/.npmrc
+silly config load:file:{CWD}/home/.npmrc
+silly config load:file:{CWD}/global/etc/npmrc
+verbose title npm
+verbose argv "--fetch-retries" "0" "--cache" "{CWD}/cache" "--loglevel" "silly" "--color" "false"
+verbose logfile logs-max:10 dir:{CWD}/cache/_logs/{DATE}-
+verbose logfile {CWD}/cache/_logs/{DATE}-debug-0.log
+silly logfile done cleaning log files
+warn EBADDEVENGINES The developer of this package has specified the following through devEngines
+warn EBADDEVENGINES Invalid engine "runtime"
+warn EBADDEVENGINES Invalid semver version "0.0.1" does not match "v1337.0.0" for "runtime"
+warn EBADDEVENGINES {
+warn EBADDEVENGINES   current: { name: 'node', version: 'v1337.0.0' },
+warn EBADDEVENGINES   required: { name: 'node', version: '0.0.1', onFail: 'warn' }
+warn EBADDEVENGINES }
+silly packumentCache heap:{heap} maxSize:{maxSize} maxEntrySize:{maxEntrySize}
+silly idealTree buildDeps
+silly reify moves {}
+silly audit report null
+
+up to date, audited 1 package in {TIME}
+found 0 vulnerabilities
+`
+
+exports[`test/lib/commands/install.js TAP devEngines should show devEngines doesnt break engines > must match snapshot 1`] = `
+silly config load:file:{CWD}/npmrc
+silly config load:file:{CWD}/home/.npmrc
+silly config load:file:{CWD}/global/etc/npmrc
+verbose title npm
+verbose argv "--fetch-retries" "0" "--cache" "{CWD}/cache" "--loglevel" "silly" "--color" "false" "--global" "true"
+verbose logfile logs-max:10 dir:{CWD}/cache/_logs/{DATE}-
+verbose logfile {CWD}/cache/_logs/{DATE}-debug-0.log
+silly logfile done cleaning log files
+silly packumentCache heap:{heap} maxSize:{maxSize} maxEntrySize:{maxEntrySize}
+silly idealTree buildDeps
+silly placeDep ROOT alpha@ OK for:  want: file:../../prefix/alpha
+warn EBADENGINE Unsupported engine {
+warn EBADENGINE   package: undefined,
+warn EBADENGINE   required: { node: '1.0.0' },
+warn EBADENGINE   current: { node: 'v1337.0.0', npm: '42.0.0' }
+warn EBADENGINE }
+warn EBADENGINE Unsupported engine {
+warn EBADENGINE   package: undefined,
+warn EBADENGINE   required: { node: '1.0.0' },
+warn EBADENGINE   current: { node: 'v1337.0.0', npm: '42.0.0' }
+warn EBADENGINE }
+silly reify moves {}
+silly ADD node_modules/alpha
+
+added 1 package in {TIME}
+`
+
+exports[`test/lib/commands/install.js TAP devEngines should show devEngines has no effect on dev package install > must match snapshot 1`] = `
+silly config load:file:{CWD}/npmrc
+silly config load:file:{CWD}/prefix/.npmrc
+silly config load:file:{CWD}/home/.npmrc
+silly config load:file:{CWD}/global/etc/npmrc
+verbose title npm
+verbose argv "--fetch-retries" "0" "--cache" "{CWD}/cache" "--loglevel" "silly" "--color" "false" "--save-dev" "true"
+verbose logfile logs-max:10 dir:{CWD}/cache/_logs/{DATE}-
+verbose logfile {CWD}/cache/_logs/{DATE}-debug-0.log
+silly logfile done cleaning log files
+silly packumentCache heap:{heap} maxSize:{maxSize} maxEntrySize:{maxEntrySize}
+silly idealTree buildDeps
+silly placeDep ROOT alpha@ OK for:  want: file:alpha
+silly reify moves {}
+silly audit bulk request {}
+silly audit report null
+silly ADD node_modules/alpha
+
+added 1 package, and audited 3 packages in {TIME}
+found 0 vulnerabilities
+`
+
+exports[`test/lib/commands/install.js TAP devEngines should show devEngines has no effect on package install > must match snapshot 1`] = `
+silly config load:file:{CWD}/npmrc
+silly config load:file:{CWD}/prefix/.npmrc
+silly config load:file:{CWD}/home/.npmrc
+silly config load:file:{CWD}/global/etc/npmrc
+verbose title npm
+verbose argv "--fetch-retries" "0" "--cache" "{CWD}/cache" "--loglevel" "silly" "--color" "false"
+verbose logfile logs-max:10 dir:{CWD}/cache/_logs/{DATE}-
+verbose logfile {CWD}/cache/_logs/{DATE}-debug-0.log
+silly logfile done cleaning log files
+silly packumentCache heap:{heap} maxSize:{maxSize} maxEntrySize:{maxEntrySize}
+silly idealTree buildDeps
+silly placeDep ROOT alpha@ OK for:  want: file:alpha
+silly reify moves {}
+silly audit bulk request {}
+silly audit report null
+silly ADD node_modules/alpha
+
+added 1 package, and audited 3 packages in {TIME}
+found 0 vulnerabilities
+`
+
+exports[`test/lib/commands/install.js TAP devEngines should utilize devEngines 2x error case > must match snapshot 1`] = `
+silly config load:file:{CWD}/npmrc
+silly config load:file:{CWD}/prefix/.npmrc
+silly config load:file:{CWD}/home/.npmrc
+silly config load:file:{CWD}/global/etc/npmrc
+verbose title npm
+verbose argv "--fetch-retries" "0" "--cache" "{CWD}/cache" "--loglevel" "silly" "--color" "false"
+verbose logfile logs-max:10 dir:{CWD}/cache/_logs/{DATE}-
+verbose logfile {CWD}/cache/_logs/{DATE}-debug-0.log
+silly logfile done cleaning log files
+verbose stack Error: The developer of this package has specified the following through devEngines
+verbose stack Invalid engine "runtime"
+verbose stack Invalid name "nondescript" does not match "node" for "runtime"
+verbose stack     at Install.checkDevEngines ({CWD}/lib/base-cmd.js:182:27)
+verbose stack     at MockNpm.#exec ({CWD}/lib/npm.js:251:7)
+verbose stack     at MockNpm.exec ({CWD}/lib/npm.js:207:9)
+error code EBADDEVENGINES
+error EBADDEVENGINES The developer of this package has specified the following through devEngines
+error EBADDEVENGINES Invalid engine "runtime"
+error EBADDEVENGINES Invalid name "nondescript" does not match "node" for "runtime"
+error EBADDEVENGINES {
+error EBADDEVENGINES   current: { name: 'node', version: 'v1337.0.0' },
+error EBADDEVENGINES   required: { name: 'nondescript', onFail: 'error' }
+error EBADDEVENGINES }
+`
+
+exports[`test/lib/commands/install.js TAP devEngines should utilize devEngines 2x warning case > must match snapshot 1`] = `
+silly config load:file:{CWD}/npmrc
+silly config load:file:{CWD}/prefix/.npmrc
+silly config load:file:{CWD}/home/.npmrc
+silly config load:file:{CWD}/global/etc/npmrc
+verbose title npm
+verbose argv "--fetch-retries" "0" "--cache" "{CWD}/cache" "--loglevel" "silly" "--color" "false"
+verbose logfile logs-max:10 dir:{CWD}/cache/_logs/{DATE}-
+verbose logfile {CWD}/cache/_logs/{DATE}-debug-0.log
+silly logfile done cleaning log files
+warn EBADDEVENGINES The developer of this package has specified the following through devEngines
+warn EBADDEVENGINES Invalid engine "runtime"
+warn EBADDEVENGINES Invalid name "nondescript" does not match "node" for "runtime"
+warn EBADDEVENGINES {
+warn EBADDEVENGINES   current: { name: 'node', version: 'v1337.0.0' },
+warn EBADDEVENGINES   required: { name: 'nondescript', onFail: 'warn' }
+warn EBADDEVENGINES }
+warn EBADDEVENGINES Invalid engine "cpu"
+warn EBADDEVENGINES Invalid name "risv" does not match "x86" for "cpu"
+warn EBADDEVENGINES {
+warn EBADDEVENGINES   current: { name: 'x86' },
+warn EBADDEVENGINES   required: { name: 'risv', onFail: 'warn' }
+warn EBADDEVENGINES }
+silly packumentCache heap:{heap} maxSize:{maxSize} maxEntrySize:{maxEntrySize}
+silly idealTree buildDeps
+silly reify moves {}
+silly audit report null
+
+up to date, audited 1 package in {TIME}
+found 0 vulnerabilities
+`
+
+exports[`test/lib/commands/install.js TAP devEngines should utilize devEngines failure and warning case > must match snapshot 1`] = `
+silly config load:file:{CWD}/npmrc
+silly config load:file:{CWD}/prefix/.npmrc
+silly config load:file:{CWD}/home/.npmrc
+silly config load:file:{CWD}/global/etc/npmrc
+verbose title npm
+verbose argv "--fetch-retries" "0" "--cache" "{CWD}/cache" "--loglevel" "silly" "--color" "false"
+verbose logfile logs-max:10 dir:{CWD}/cache/_logs/{DATE}-
+verbose logfile {CWD}/cache/_logs/{DATE}-debug-0.log
+silly logfile done cleaning log files
+warn EBADDEVENGINES The developer of this package has specified the following through devEngines
+warn EBADDEVENGINES Invalid engine "cpu"
+warn EBADDEVENGINES Invalid name "risv" does not match "x86" for "cpu"
+warn EBADDEVENGINES {
+warn EBADDEVENGINES   current: { name: 'x86' },
+warn EBADDEVENGINES   required: { name: 'risv', onFail: 'warn' }
+warn EBADDEVENGINES }
+verbose stack Error: The developer of this package has specified the following through devEngines
+verbose stack Invalid engine "runtime"
+verbose stack Invalid name "nondescript" does not match "node" for "runtime"
+verbose stack     at Install.checkDevEngines ({CWD}/lib/base-cmd.js:182:27)
+verbose stack     at MockNpm.#exec ({CWD}/lib/npm.js:251:7)
+verbose stack     at MockNpm.exec ({CWD}/lib/npm.js:207:9)
+error code EBADDEVENGINES
+error EBADDEVENGINES The developer of this package has specified the following through devEngines
+error EBADDEVENGINES Invalid engine "runtime"
+error EBADDEVENGINES Invalid name "nondescript" does not match "node" for "runtime"
+error EBADDEVENGINES {
+error EBADDEVENGINES   current: { name: 'node', version: 'v1337.0.0' },
+error EBADDEVENGINES   required: { name: 'nondescript' }
+error EBADDEVENGINES }
+`
+
+exports[`test/lib/commands/install.js TAP devEngines should utilize devEngines failure case > must match snapshot 1`] = `
+silly config load:file:{CWD}/npmrc
+silly config load:file:{CWD}/prefix/.npmrc
+silly config load:file:{CWD}/home/.npmrc
+silly config load:file:{CWD}/global/etc/npmrc
+verbose title npm
+verbose argv "--fetch-retries" "0" "--cache" "{CWD}/cache" "--loglevel" "silly" "--color" "false"
+verbose logfile logs-max:10 dir:{CWD}/cache/_logs/{DATE}-
+verbose logfile {CWD}/cache/_logs/{DATE}-debug-0.log
+silly logfile done cleaning log files
+verbose stack Error: The developer of this package has specified the following through devEngines
+verbose stack Invalid engine "runtime"
+verbose stack Invalid name "nondescript" does not match "node" for "runtime"
+verbose stack     at Install.checkDevEngines ({CWD}/lib/base-cmd.js:182:27)
+verbose stack     at MockNpm.#exec ({CWD}/lib/npm.js:251:7)
+verbose stack     at MockNpm.exec ({CWD}/lib/npm.js:207:9)
+error code EBADDEVENGINES
+error EBADDEVENGINES The developer of this package has specified the following through devEngines
+error EBADDEVENGINES Invalid engine "runtime"
+error EBADDEVENGINES Invalid name "nondescript" does not match "node" for "runtime"
+error EBADDEVENGINES {
+error EBADDEVENGINES   current: { name: 'node', version: 'v1337.0.0' },
+error EBADDEVENGINES   required: { name: 'nondescript' }
+error EBADDEVENGINES }
+`
+
+exports[`test/lib/commands/install.js TAP devEngines should utilize devEngines failure force case > must match snapshot 1`] = `
+silly config load:file:{CWD}/npmrc
+silly config load:file:{CWD}/prefix/.npmrc
+silly config load:file:{CWD}/home/.npmrc
+silly config load:file:{CWD}/global/etc/npmrc
+verbose title npm
+verbose argv "--fetch-retries" "0" "--cache" "{CWD}/cache" "--loglevel" "silly" "--color" "false" "--force" "true"
+verbose logfile logs-max:10 dir:{CWD}/cache/_logs/{DATE}-
+verbose logfile {CWD}/cache/_logs/{DATE}-debug-0.log
+warn using --force Recommended protections disabled.
+silly logfile done cleaning log files
+warn EBADDEVENGINES The developer of this package has specified the following through devEngines
+warn EBADDEVENGINES Invalid engine "runtime"
+warn EBADDEVENGINES Invalid name "nondescript" does not match "node" for "runtime"
+warn EBADDEVENGINES {
+warn EBADDEVENGINES   current: { name: 'node', version: 'v1337.0.0' },
+warn EBADDEVENGINES   required: { name: 'nondescript' }
+warn EBADDEVENGINES }
+silly packumentCache heap:{heap} maxSize:{maxSize} maxEntrySize:{maxEntrySize}
+silly idealTree buildDeps
+silly reify moves {}
+silly audit report null
+
+up to date, audited 1 package in {TIME}
+found 0 vulnerabilities
+`
+
+exports[`test/lib/commands/install.js TAP devEngines should utilize devEngines success case > must match snapshot 1`] = `
+silly config load:file:{CWD}/npmrc
+silly config load:file:{CWD}/prefix/.npmrc
+silly config load:file:{CWD}/home/.npmrc
+silly config load:file:{CWD}/global/etc/npmrc
+verbose title npm
+verbose argv "--fetch-retries" "0" "--cache" "{CWD}/cache" "--loglevel" "silly" "--color" "false"
+verbose logfile logs-max:10 dir:{CWD}/cache/_logs/{DATE}-
+verbose logfile {CWD}/cache/_logs/{DATE}-debug-0.log
+silly logfile done cleaning log files
+silly packumentCache heap:{heap} maxSize:{maxSize} maxEntrySize:{maxEntrySize}
+silly idealTree buildDeps
+silly reify moves {}
+silly audit report null
+
+up to date, audited 1 package in {TIME}
+found 0 vulnerabilities
+`
+
+exports[`test/lib/commands/install.js TAP devEngines should utilize engines in root if devEngines is not provided > must match snapshot 1`] = `
+silly config load:file:{CWD}/npmrc
+silly config load:file:{CWD}/prefix/.npmrc
+silly config load:file:{CWD}/home/.npmrc
+silly config load:file:{CWD}/global/etc/npmrc
+verbose title npm
+verbose argv "--fetch-retries" "0" "--cache" "{CWD}/cache" "--loglevel" "silly" "--color" "false"
+verbose logfile logs-max:10 dir:{CWD}/cache/_logs/{DATE}-
+verbose logfile {CWD}/cache/_logs/{DATE}-debug-0.log
+silly logfile done cleaning log files
+silly packumentCache heap:{heap} maxSize:{maxSize} maxEntrySize:{maxEntrySize}
+silly idealTree buildDeps
+warn EBADENGINE Unsupported engine {
+warn EBADENGINE   package: undefined,
+warn EBADENGINE   required: { node: '0.0.1' },
+warn EBADENGINE   current: { node: 'v1337.0.0', npm: '42.0.0' }
+warn EBADENGINE }
+silly reify moves {}
+silly audit report null
+
+up to date, audited 1 package in {TIME}
+found 0 vulnerabilities
+`

--- a/tap-snapshots/test/lib/commands/install.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/install.js.test.cjs
@@ -5,6 +5,24 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/lib/commands/install.js TAP devEngines should not utilize devEngines if global install > must match snapshot 1`] = `
+silly config load:file:{CWD}/npmrc
+silly config load:file:{CWD}/home/.npmrc
+silly config load:file:{CWD}/global/etc/npmrc
+verbose title npm
+verbose argv "--fetch-retries" "0" "--cache" "{CWD}/cache" "--loglevel" "silly" "--color" "false" "--global" "true"
+verbose logfile logs-max:10 dir:{CWD}/cache/_logs/{DATE}-
+verbose logfile {CWD}/cache/_logs/{DATE}-debug-0.log
+silly logfile done cleaning log files
+silly packumentCache heap:{heap} maxSize:{maxSize} maxEntrySize:{maxEntrySize}
+silly idealTree buildDeps
+silly placeDep ROOT alpha@ OK for:  want: file:../../prefix
+silly reify moves {}
+silly ADD node_modules/alpha
+
+added 1 package in {TIME}
+`
+
 exports[`test/lib/commands/install.js TAP devEngines should not utilize engines in root if devEngines is provided > must match snapshot 1`] = `
 silly config load:file:{CWD}/npmrc
 silly config load:file:{CWD}/prefix/.npmrc

--- a/tap-snapshots/test/lib/commands/install.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/install.js.test.cjs
@@ -5,24 +5,6 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/lib/commands/install.js TAP devEngines should not utilize devEngines if global install > must match snapshot 1`] = `
-silly config load:file:{CWD}/npmrc
-silly config load:file:{CWD}/home/.npmrc
-silly config load:file:{CWD}/global/etc/npmrc
-verbose title npm
-verbose argv "--fetch-retries" "0" "--cache" "{CWD}/cache" "--loglevel" "silly" "--color" "false" "--global" "true"
-verbose logfile logs-max:10 dir:{CWD}/cache/_logs/{DATE}-
-verbose logfile {CWD}/cache/_logs/{DATE}-debug-0.log
-silly logfile done cleaning log files
-silly packumentCache heap:{heap} maxSize:{maxSize} maxEntrySize:{maxEntrySize}
-silly idealTree buildDeps
-silly placeDep ROOT alpha@ OK for:  want: file:../../prefix
-silly reify moves {}
-silly ADD node_modules/alpha
-
-added 1 package in {TIME}
-`
-
 exports[`test/lib/commands/install.js TAP devEngines should not utilize engines in root if devEngines is provided > must match snapshot 1`] = `
 silly config load:file:{CWD}/npmrc
 silly config load:file:{CWD}/prefix/.npmrc
@@ -97,6 +79,24 @@ silly ADD node_modules/alpha
 
 added 1 package, and audited 3 packages in {TIME}
 found 0 vulnerabilities
+`
+
+exports[`test/lib/commands/install.js TAP devEngines should show devEngines has no effect on global package install > must match snapshot 1`] = `
+silly config load:file:{CWD}/npmrc
+silly config load:file:{CWD}/home/.npmrc
+silly config load:file:{CWD}/global/etc/npmrc
+verbose title npm
+verbose argv "--fetch-retries" "0" "--cache" "{CWD}/cache" "--loglevel" "silly" "--color" "false" "--global" "true"
+verbose logfile logs-max:10 dir:{CWD}/cache/_logs/{DATE}-
+verbose logfile {CWD}/cache/_logs/{DATE}-debug-0.log
+silly logfile done cleaning log files
+silly packumentCache heap:{heap} maxSize:{maxSize} maxEntrySize:{maxEntrySize}
+silly idealTree buildDeps
+silly placeDep ROOT alpha@ OK for:  want: file:../../prefix
+silly reify moves {}
+silly ADD node_modules/alpha
+
+added 1 package in {TIME}
 `
 
 exports[`test/lib/commands/install.js TAP devEngines should show devEngines has no effect on package install > must match snapshot 1`] = `

--- a/test/fixtures/clean-snapshot.js
+++ b/test/fixtures/clean-snapshot.js
@@ -42,12 +42,18 @@ const cleanZlib = str => str
   .replace(/"integrity": ".*",/g, '"integrity": "{integrity}",')
   .replace(/"size": [0-9]*,/g, '"size": "{size}",')
 
+const cleanPackumentCache = str => str
+  .replace(/heap:[0-9]*/g, 'heap:{heap}')
+  .replace(/maxSize:[0-9]*/g, 'maxSize:{maxSize}')
+  .replace(/maxEntrySize:[0-9]*/g, 'maxEntrySize:{maxEntrySize}')
+
 module.exports = {
   cleanCwd,
   cleanDate,
   cleanNewlines,
   cleanTime,
   cleanZlib,
+  cleanPackumentCache,
   normalizePath,
   pathRegex,
 }

--- a/test/lib/commands/install.js
+++ b/test/lib/commands/install.js
@@ -687,4 +687,33 @@ t.test('devEngines', async t => {
     t.ok(output.includes('EBADENGINE'))
     t.ok(!output.includes('EBADDEVENGINES'))
   })
+
+  t.test('should not utilize devEngines if global install', async t => {
+    const { npm, joinedFullOutput } = await loadMockNpm(t, {
+      ...mockArguments,
+      config: {
+        global: true,
+      },
+      prefixDir: {
+        'package.json': JSON.stringify({
+          name: 'alpha',
+          bin: {
+            alpha: 'index.js',
+          },
+          devEngines: {
+            runtime: {
+              name: 'node',
+              version: '0.0.1',
+            },
+          },
+        }),
+        'index.js': 'console.log("this is alpha index")',
+      },
+    })
+    await npm.exec('install', ['.'])
+    const output = joinedFullOutput()
+    t.matchSnapshot(output)
+    t.ok(!output.includes('EBADENGINE'))
+    t.ok(!output.includes('EBADDEVENGINES'))
+  })
 })

--- a/test/lib/commands/install.js
+++ b/test/lib/commands/install.js
@@ -1,7 +1,15 @@
 const tspawk = require('../../fixtures/tspawk')
+const {
+  cleanCwd,
+  cleanTime,
+  cleanDate,
+  cleanPackumentCache,
+} = require('../../fixtures/clean-snapshot.js')
 
 const path = require('node:path')
 const t = require('tap')
+
+t.cleanSnapshot = (str) => cleanPackumentCache(cleanDate(cleanTime(cleanCwd(str))))
 
 const {
   loadNpmWithRegistry: loadMockNpm,
@@ -399,4 +407,284 @@ t.test('should show install keeps dirty --workspace flag', async t => {
   await npm.exec('install', [])
   assert.packageDirty('node_modules/abbrev@1.1.0')
   assert.packageInstalled('node_modules/lodash@1.1.1')
+})
+
+t.test('devEngines', async t => {
+  const mockArguments = {
+    globals: {
+      'process.platform': 'linux',
+      'process.arch': 'x86',
+      'process.version': 'v1337.0.0',
+    },
+    mocks: {
+      '{ROOT}/package.json': { version: '42.0.0' },
+    },
+  }
+
+  t.test('should utilize devEngines success case', async t => {
+    const { npm, joinedFullOutput } = await loadMockNpm(t, {
+      ...mockArguments,
+      prefixDir: {
+        'package.json': JSON.stringify({
+          name: 'test-package',
+          version: '1.0.0',
+          devEngines: {
+            runtime: {
+              name: 'node',
+            },
+          },
+        }),
+      },
+    })
+    await npm.exec('install', [])
+    const output = joinedFullOutput()
+    t.matchSnapshot(output)
+    t.ok(!output.includes('EBADDEVENGINES'))
+  })
+
+  t.test('should utilize devEngines failure case', async t => {
+    const { npm, joinedFullOutput } = await loadMockNpm(t, {
+      ...mockArguments,
+      prefixDir: {
+        'package.json': JSON.stringify({
+          name: 'test-package',
+          version: '1.0.0',
+          devEngines: {
+            runtime: {
+              name: 'nondescript',
+            },
+          },
+        }),
+      },
+    })
+    await t.rejects(
+      npm.exec('install', [])
+    )
+    const output = joinedFullOutput()
+    t.matchSnapshot(output)
+    t.ok(output.includes('error EBADDEVENGINES'))
+  })
+
+  t.test('should utilize devEngines failure force case', async t => {
+    const { npm, joinedFullOutput } = await loadMockNpm(t, {
+      ...mockArguments,
+      config: {
+        force: true,
+      },
+      prefixDir: {
+        'package.json': JSON.stringify({
+          name: 'test-package',
+          version: '1.0.0',
+          devEngines: {
+            runtime: {
+              name: 'nondescript',
+            },
+          },
+        }),
+      },
+    })
+    await npm.exec('install', [])
+    const output = joinedFullOutput()
+    t.matchSnapshot(output)
+    t.ok(output.includes('warn EBADDEVENGINES'))
+  })
+
+  t.test('should utilize devEngines 2x warning case', async t => {
+    const { npm, joinedFullOutput } = await loadMockNpm(t, {
+      ...mockArguments,
+      prefixDir: {
+        'package.json': JSON.stringify({
+          name: 'test-package',
+          version: '1.0.0',
+          devEngines: {
+            runtime: {
+              name: 'nondescript',
+              onFail: 'warn',
+            },
+            cpu: {
+              name: 'risv',
+              onFail: 'warn',
+            },
+          },
+        }),
+      },
+    })
+    await npm.exec('install', [])
+    const output = joinedFullOutput()
+    t.matchSnapshot(output)
+    t.ok(output.includes('warn EBADDEVENGINES'))
+  })
+
+  t.test('should utilize devEngines 2x error case', async t => {
+    const { npm, joinedFullOutput } = await loadMockNpm(t, {
+      ...mockArguments,
+      prefixDir: {
+        'package.json': JSON.stringify({
+          name: 'test-package',
+          version: '1.0.0',
+          devEngines: {
+            runtime: {
+              name: 'nondescript',
+              onFail: 'error',
+            },
+            cpu: {
+              name: 'risv',
+              onFail: 'error',
+            },
+          },
+        }),
+      },
+    })
+    await t.rejects(
+      npm.exec('install', [])
+    )
+    const output = joinedFullOutput()
+    t.matchSnapshot(output)
+    t.ok(output.includes('error EBADDEVENGINES'))
+  })
+
+  t.test('should utilize devEngines failure and warning case', async t => {
+    const { npm, joinedFullOutput } = await loadMockNpm(t, {
+      ...mockArguments,
+      prefixDir: {
+        'package.json': JSON.stringify({
+          name: 'test-package',
+          version: '1.0.0',
+          devEngines: {
+            runtime: {
+              name: 'nondescript',
+            },
+            cpu: {
+              name: 'risv',
+              onFail: 'warn',
+            },
+          },
+        }),
+      },
+    })
+    await t.rejects(
+      npm.exec('install', [])
+    )
+    const output = joinedFullOutput()
+    t.matchSnapshot(output)
+    t.ok(output.includes('EBADDEVENGINES'))
+  })
+
+  t.test('should show devEngines has no effect on package install', async t => {
+    const { npm, joinedFullOutput } = await loadMockNpm(t, {
+      ...mockArguments,
+      prefixDir: {
+        alpha: {
+          'package.json': JSON.stringify({
+            name: 'alpha',
+            devEngines: { runtime: { name: 'node', version: '1.0.0' } },
+          }),
+          'index.js': 'console.log("this is alpha index")',
+        },
+        'package.json': JSON.stringify({
+          name: 'project',
+        }),
+      },
+    })
+    await npm.exec('install', ['./alpha'])
+    const output = joinedFullOutput()
+    t.matchSnapshot(output)
+    t.ok(!output.includes('EBADDEVENGINES'))
+  })
+
+  t.test('should show devEngines has no effect on dev package install', async t => {
+    const { npm, joinedFullOutput } = await loadMockNpm(t, {
+      ...mockArguments,
+      prefixDir: {
+        alpha: {
+          'package.json': JSON.stringify({
+            name: 'alpha',
+            devEngines: { runtime: { name: 'node', version: '1.0.0' } },
+          }),
+          'index.js': 'console.log("this is alpha index")',
+        },
+        'package.json': JSON.stringify({
+          name: 'project',
+        }),
+      },
+      config: {
+        'save-dev': true,
+      },
+    })
+    await npm.exec('install', ['./alpha'])
+    const output = joinedFullOutput()
+    t.matchSnapshot(output)
+    t.ok(!output.includes('EBADDEVENGINES'))
+  })
+
+  t.test('should show devEngines doesnt break engines', async t => {
+    const { npm, joinedFullOutput } = await loadMockNpm(t, {
+      ...mockArguments,
+      prefixDir: {
+        alpha: {
+          'package.json': JSON.stringify({
+            name: 'alpha',
+            devEngines: { runtime: { name: 'node', version: '1.0.0' } },
+            engines: { node: '1.0.0' },
+          }),
+          'index.js': 'console.log("this is alpha index")',
+        },
+        'package.json': JSON.stringify({
+          name: 'project',
+        }),
+      },
+      config: { global: true },
+    })
+    await npm.exec('install', ['./alpha'])
+    const output = joinedFullOutput()
+    t.matchSnapshot(output)
+    t.ok(output.includes('warn EBADENGINE'))
+  })
+
+  t.test('should not utilize engines in root if devEngines is provided', async t => {
+    const { npm, joinedFullOutput } = await loadMockNpm(t, {
+      ...mockArguments,
+      prefixDir: {
+        'package.json': JSON.stringify({
+          name: 'alpha',
+          engines: {
+            node: '0.0.1',
+          },
+          devEngines: {
+            runtime: {
+              name: 'node',
+              version: '0.0.1',
+              onFail: 'warn',
+            },
+          },
+        }),
+        'index.js': 'console.log("this is alpha index")',
+      },
+    })
+    await npm.exec('install')
+    const output = joinedFullOutput()
+    t.matchSnapshot(output)
+    t.ok(!output.includes('EBADENGINE'))
+    t.ok(output.includes('warn EBADDEVENGINES'))
+  })
+
+  t.test('should utilize engines in root if devEngines is not provided', async t => {
+    const { npm, joinedFullOutput } = await loadMockNpm(t, {
+      ...mockArguments,
+      prefixDir: {
+        'package.json': JSON.stringify({
+          name: 'alpha',
+          engines: {
+            node: '0.0.1',
+          },
+        }),
+        'index.js': 'console.log("this is alpha index")',
+      },
+    })
+    await npm.exec('install')
+    const output = joinedFullOutput()
+    t.matchSnapshot(output)
+    t.ok(output.includes('EBADENGINE'))
+    t.ok(!output.includes('EBADDEVENGINES'))
+  })
 })

--- a/test/lib/commands/install.js
+++ b/test/lib/commands/install.js
@@ -688,12 +688,9 @@ t.test('devEngines', async t => {
     t.ok(!output.includes('EBADDEVENGINES'))
   })
 
-  t.test('should not utilize devEngines if global install', async t => {
+  t.test('should show devEngines has no effect on global package install', async t => {
     const { npm, joinedFullOutput } = await loadMockNpm(t, {
       ...mockArguments,
-      config: {
-        global: true,
-      },
       prefixDir: {
         'package.json': JSON.stringify({
           name: 'alpha',
@@ -708,6 +705,9 @@ t.test('devEngines', async t => {
           },
         }),
         'index.js': 'console.log("this is alpha index")',
+      },
+      config: {
+        global: true,
       },
     })
     await npm.exec('install', ['.'])

--- a/test/lib/npm.js
+++ b/test/lib/npm.js
@@ -149,8 +149,8 @@ t.test('npm.load', async t => {
       'does not change npm.command when another command is called')
 
     t.match(logs, [
+      /timing config:load:flatten Completed in [0-9.]+ms/,
       /timing command:config Completed in [0-9.]+ms/,
-      /timing command:get Completed in [0-9.]+ms/,
     ])
     t.same(outputs, ['scope=@foo\nusage=false'])
   })

--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -195,7 +195,10 @@ module.exports = cls => class IdealTreeBuilder extends cls {
     for (const node of this.idealTree.inventory.values()) {
       if (!node.optional) {
         try {
-          checkEngine(node.package, npmVersion, nodeVersion, this.options.force)
+          // if devEngines is present in the root node we ignore the engines check
+          if (!(node.isRoot && node.package.devEngines)) {
+            checkEngine(node.package, npmVersion, nodeVersion, this.options.force)
+          }
         } catch (err) {
           if (engineStrict) {
             throw err

--- a/workspaces/arborist/test/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/test/arborist/build-ideal-tree.js
@@ -3979,3 +3979,18 @@ t.test('store files with a custom indenting', async t => {
   const tree = await buildIdeal(path)
   t.matchSnapshot(String(tree.meta))
 })
+
+t.test('should take devEngines in account', async t => {
+  const path = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'empty-update',
+      devEngines: {
+        runtime: {
+          name: 'node',
+        },
+      },
+    }),
+  })
+  const tree = await buildIdeal(path)
+  t.matchSnapshot(String(tree.meta))
+})


### PR DESCRIPTION
This PR adds a check for `devEngines` in the current projects `package.json` as defined in the spec here:
https://github.com/openjs-foundation/package-metadata-interoperability-collab-space/issues/15

This PR utilizes a `checkDevEngines` function defined within `npm-install-checks` open here: 
https://github.com/npm/npm-install-checks/pull/116

The goal of this pr is to have a check for specific npm commands `install`,  and `run` consult the `devEngines` property before execution and check if the current system / environment. For `npm ` the runtime will always be `node` and the `packageManager` will always be `npm`, if a project is defined as not those two envs and it's required we'll throw.

> Note the current `engines` property is checked when you install your dependencies. Each packages `engines` are checked with your environment. However, `devEngines` operates on commands for maintainers of a package, service, project when install and run commands are executed and is meant to enforce / guide maintainers to all be using the same engine / env and or versions.