### PR TITLE
docs: Remove ", instead of updating the package lock"

### DIFF
--- a/docs/lib/content/commands/npm-ci.md
+++ b/docs/lib/content/commands/npm-ci.md
@@ -20,7 +20,7 @@ The main differences between using `npm install` and `npm ci` are:
 * The project **must** have an existing `package-lock.json` or
   `npm-shrinkwrap.json`.
 * If dependencies in the package lock do not match those in `package.json`,
-  `npm ci` will exit with an error, instead of updating the package lock.
+  `npm ci` will exit with an error.
 * `npm ci` can only install entire projects at a time: individual
   dependencies cannot be added with this command.
 * If a `node_modules` is already present, it will be automatically removed


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

Remove ", instead of updating the package lock" from the docs because, AFAIK, that never occurs anyway. The last bullet point states this, too.


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
