### PR TITLE
fix: the information time object output by `npm view` should sorted b…

### DIFF
--- a/lib/commands/view.js
+++ b/lib/commands/view.js
@@ -166,6 +166,15 @@ class View extends BaseCommand {
       log.info('view', `Ignoring invalid version: ${v}`)
       return false
     }).sort(semver.compareLoose)
+    const pckmntTime = {}
+    const invalidVersions = Object.keys(pckmnt.time).filter(v => !semver.valid(v))
+    invalidVersions.forEach(v => {
+      pckmntTime[v] = pckmnt.time[v]
+    })
+    pckmnt.versions.forEach(v => {
+      pckmntTime[v] = pckmnt.time[v]
+    })
+    pckmnt.time = pckmntTime
 
     // remove readme unless we asked for it
     if (args.indexOf('readme') === -1) {

--- a/lib/commands/view.js
+++ b/lib/commands/view.js
@@ -166,15 +166,7 @@ class View extends BaseCommand {
       log.info('view', `Ignoring invalid version: ${v}`)
       return false
     }).sort(semver.compareLoose)
-    const pckmntTime = {}
-    const invalidVersions = Object.keys(pckmnt.time).filter(v => !semver.valid(v))
-    invalidVersions.forEach(v => {
-      pckmntTime[v] = pckmnt.time[v]
-    })
-    pckmnt.versions.forEach(v => {
-      pckmntTime[v] = pckmnt.time[v]
-    })
-    pckmnt.time = pckmntTime
+    pckmnt.time = Object.fromEntries(Object.entries(pckmnt.time).sort(semver.compare))
 
     // remove readme unless we asked for it
     if (args.indexOf('readme') === -1) {


### PR DESCRIPTION
…y version

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
When I execute `npm view --json` in my local project, the output is as follows:

<table>
<tr>
<td>before</td>
<td>after</td>
</tr>
<tr>
<td>

<img width="484" alt="image" src="https://github.com/user-attachments/assets/e22f7c19-4c68-498b-bffb-f5e58ce3a20f">

</td>
<td>
 
<img width="494" alt="image" src="https://github.com/user-attachments/assets/3a6e48da-196f-43ce-b374-dee1caa54859">

</td>
</tr>
</table>

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
