### PR TITLE
chore: ignore .github folder in release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -37,7 +37,8 @@
         "smoke-tests",
         "mock-globals",
         "mock-registry",
-        "workspaces"
+        "workspaces",
+        ".github"
       ]
     },
     "workspaces/arborist": {},


### PR DESCRIPTION
ignores the `.github` folder changes in release-please to prevent majors pertaining to this directory.

in prep for devEngines release version https://github.com/npm/statusboard/issues/861