### PR TITLE
fix: don't go into global mode if aliased to npmg

### DIFF
--- a/lib/cli/entry.js
+++ b/lib/cli/entry.js
@@ -6,11 +6,6 @@ module.exports = async (process, validateEngines) => {
   // leak any private CLI configs to other programs
   process.title = 'npm'
 
-  // if npm is called as "npmg" or "npm_g", then run in global mode.
-  if (process.argv[1][process.argv[1].length - 1] === 'g') {
-    process.argv.splice(1, 1, 'npm', '-g')
-  }
-
   // Patch the global fs module here at the app level
   require('graceful-fs').gracefulify(require('node:fs'))
 

--- a/test/lib/cli/entry.js
+++ b/test/lib/cli/entry.js
@@ -35,16 +35,16 @@ const cliMock = async (t, opts) => {
   }
 }
 
-t.test('print the version, and treat npm_g as npm -g', async t => {
+t.test('print the version ', async t => {
   const { logs, cli, Npm, outputs, exitHandlerCalled } = await cliMock(t, {
-    globals: { 'process.argv': ['node', 'npm_g', 'root'] },
+    globals: { 'process.argv': ['node', 'npm', 'root'] },
   })
   await cli(process)
 
-  t.strictSame(process.argv, ['node', 'npm', '-g', 'root'], 'system process.argv was rewritten')
+  t.strictSame(process.argv, ['node', 'npm', 'root'], 'system process.argv was rewritten')
   t.strictSame(logs.verbose.byTitle('cli'), ['cli node npm'])
   t.strictSame(logs.verbose.byTitle('title'), ['title npm root'])
-  t.match(logs.verbose.byTitle('argv'), ['argv "--global" "root"'])
+  t.match(logs.verbose.byTitle('argv'), ['argv "root"'])
   t.strictSame(logs.info, [`using npm@${Npm.version}`, `using node@${process.version}`])
   t.equal(outputs.length, 1)
   t.match(outputs[0], dirname(process.cwd()))


### PR DESCRIPTION
BREAKING CHANGE: npm will no longer switch to global mode if aliased to "npmg" or "npm-g" etc.

[This code](https://github.com/npm/cli/commit/03bd66932c83f4233c9e3fb33bd36a1edf930db9) is a remnant from when npm defined `bin` entries for itself that included `npm_g` and `npm-g`.

npm no longer defines these, and this code should have been removed when those entries were removed.  To utilize this today one would have to manually alias npm themselves.

What this code does today in practice is make local development very tricky, because if you (like me) use git worktrees, and have a worktree directory that ends in "g", npm will be in global mode when you invoke it as `node .`.  This is very "magical" behavior and not at all intuitive.

It's best if this just goes away.  `npm -g` is explicit and does not require npm trying to guess if you really wanted to be in global mode or not.