### PR TITLE
docs: Explain environment variables from `package.json`, `.npmrc` and `npm`

### DIFF
--- a/docs/lib/content/using-npm/scripts.md
+++ b/docs/lib/content/using-npm/scripts.md
@@ -261,7 +261,7 @@ exported into the `node_modules/.bin` directory on `npm install`.
 
 #### Environment variables from `package.json`
 
-Three fields of the `package.json` file are converted into environment variables prefixed with `npm_package_`. For example, if your `package.json` contains this:
+Several fields of the `package.json` file are converted into environment variables prefixed with `npm_package_`. For example, if your `package.json` contains this:
 ```bash
 {
     "name": "foo",

--- a/docs/lib/content/using-npm/scripts.md
+++ b/docs/lib/content/using-npm/scripts.md
@@ -268,6 +268,12 @@ Three fields of the `package.json` file are converted into environment variables
     "version": "1.2.5",
     "engines": {
         "node": ">20"
+    },
+    "config": {
+        "port": "3000"
+    },
+    "bin": {
+        "cli": "path/to/cli"
     }
 }
 ```
@@ -276,8 +282,10 @@ then these fields can be accessed in your code like so:
 console.log(process.env.npm_package_name) // prints "foo"
 console.log(process.env.npm_package_version) // prints "1.2.5"
 console.log(process.env.npm_package_engines_node) // prints ">20"
+console.log(process.env.npm_package_config_port) // prints "3000"
+console.log(process.env.npm_package_bin_cli) // prints "path/to/cli"
 ```
-Note that the keys in a nested field (such as the node engine) are flattened using `_` as a separator.
+Note that the keys in a nested field (such as `engines`, `bin` or `config`) are flattened using `_` as a separator.
 
 #### Environment variables from `npm`
 


### PR DESCRIPTION
Environment variables explanation was incorrect before.

- [x] fixed capitalisation of headings
- [x] added the env vars populated from package.json
- [x] added the env vars populated from .npmrc
- [x] added the env vars populated from npm

I haven't been able to get any more env vars from the package.json other than the name, version, engines, config and bin. If more env vars are populated, I'll adjust the documentation, but they're the only ones afaict