### PR TITLE
fix: update notifier to consider node version

### DIFF
--- a/lib/cli/update-notifier.js
+++ b/lib/cli/update-notifier.js
@@ -8,10 +8,21 @@ const gte = require('semver/functions/gte')
 const parse = require('semver/functions/parse')
 const { stat, writeFile } = require('node:fs/promises')
 const { resolve } = require('node:path')
+const { checkEngine } = require('npm-install-checks')
+const semver = require('semver')
 
 // update check frequency
 const DAILY = 1000 * 60 * 60 * 24
 const WEEKLY = DAILY * 7
+
+const engineOk = (manifest, npmVersion, nodeVersion) => {
+  try {
+    checkEngine(manifest, npmVersion, nodeVersion)
+    return true
+  } catch (_) {
+    return false
+  }
+}
 
 // don't put it in the _cacache folder, just in npm's cache
 const lastCheckedFile = npm =>
@@ -22,19 +33,23 @@ const lastCheckedFile = npm =>
 const updateCheck = async (npm, spec, version, current) => {
   const pacote = require('pacote')
 
-  const mani = await pacote.manifest(`npm@${spec}`, {
+  const pacu = await pacote.packument(`npm@${spec}`, {
     // always prefer latest, even if doing --tag=whatever on the cmd
     defaultTag: 'latest',
     ...npm.flatOptions,
     cache: false,
   }).catch(() => null)
 
+  const npmVersions = Object.keys(pacu.versions).sort(semver.rcompare)
+  const compatibleLatest = npmVersions.find(v => {
+    return engineOk(pacu.versions[v], npm.version, process.version)
+  })
   // if pacote failed, give up
-  if (!mani) {
+  if (!compatibleLatest) {
     return null
   }
-
-  const latest = mani.version
+  const mani = pacu.versions[compatibleLatest]
+  const latest = compatibleLatest
 
   // if the current version is *greater* than latest, we're on a 'next'
   // and should get the updates from that release train.


### PR DESCRIPTION
npm update notifier currently suggests latest npm version regardless of node version compatibility. This PR attempts to choose latest compatible version when suggesting npm update. 

 appropriate to fix it in pacote or pick-manifest while requesting manifest for npm, 
