### PR TITLE
fix: don't mkdir directories that already exist

### DIFF
--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -12,6 +12,7 @@ const hgi = require('hosted-git-info')
 const rpj = require('read-package-json-fast')
 
 const { dirname, resolve, relative, join } = require('node:path')
+const { existsSync } = require("node:fs")
 const { depth: dfwalk } = require('treeverse')
 const {
   lstat,
@@ -123,10 +124,12 @@ module.exports = cls => class Reifier extends cls {
       // we do NOT want to set ownership on this folder, especially
       // recursively, because it can have other side effects to do that
       // in a project directory.  We just want to make it if it's missing.
-      await mkdir(resolve(this.path), { recursive: true })
+      let resolvedPath = resolve(this.path);
+      if(!existsSync(resolvedPath))
+        await mkdir(resolvedPath, { recursive: true })
 
       // do not allow the top-level node_modules to be a symlink
-      await this.#validateNodeModules(resolve(this.path, 'node_modules'))
+      await this.#validateNodeModules(resolve(resolvedPath, 'node_modules'))
     }
     await this[_loadTrees](options)
 

--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -128,7 +128,7 @@ module.exports = cls => class Reifier extends cls {
       try {
         await access(resolvedPath)
       } catch (accessError) {
-        if (accessError.code === "ENOENT") {
+        if (accessError.code === 'ENOENT') {
           await mkdir(resolvedPath, { recursive: true })
         } else {
           throw accessError

--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -12,8 +12,8 @@ const hgi = require('hosted-git-info')
 const rpj = require('read-package-json-fast')
 
 const { dirname, resolve, relative, join } = require('node:path')
-const { existsSync } = require("node:fs")
 const { depth: dfwalk } = require('treeverse')
+const { existsSync } = require('node:fs')
 const {
   lstat,
   mkdir,
@@ -124,9 +124,11 @@ module.exports = cls => class Reifier extends cls {
       // we do NOT want to set ownership on this folder, especially
       // recursively, because it can have other side effects to do that
       // in a project directory.  We just want to make it if it's missing.
-      let resolvedPath = resolve(this.path);
-      if(!existsSync(resolvedPath))
+      const resolvedPath = resolve(this.path)
+      if (!existsSync(resolvedPath))
+      {
         await mkdir(resolvedPath, { recursive: true })
+      }
 
       // do not allow the top-level node_modules to be a symlink
       await this.#validateNodeModules(resolve(resolvedPath, 'node_modules'))


### PR DESCRIPTION
This pull request aims to resolve #6412, by making checks for whether a project's working directory already exists, before attempting to `mkdir` it.  
This effectively prevents `reify.js` from accidentally executing `mkdir` on root drive letters on Windows, like `mkdir "D:/"` for example, as the Windows operating system prohibits such operations.  

The resolution of #6412 will inevitably introduce the `npm error Tracker "idealTree" already exists` issue, however I believe that is an issue separate from #6412, and that separate issue was already documented before, #7596 being a good example of one of those documentations (in my opinion).

As can be seen in #6412, this pull request makes changes to [the following line of code](https://github.com/npm/cli/blob/780afc50e3a345feb1871a28e33fa48235bc3bd5/workspaces/arborist/lib/arborist/reify.js#L126) in `reify.js`.

Of course, should one attempt to execute `npm i` in a drive letter that does not exist, then this error in my opinion **should** take place, informing the user that said drive letter and the path within cannot be created, and that error **will** take place. However this error in my opinion **should not** take place on existing drives, hence this pull request.

### Additional info
- **Affected file:** `/workspaces/arborist/lib/arborist/reify.js` line `126`
- **Relevant issue:** #6412
- **Other related issues/prs:** #7596