### PR TITLE
fix(perf): enable compile cache

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,3 +1,11 @@
+try {
+  const { enableCompileCache } = require('node:module')
+  /* istanbul ignore next */
+  if (enableCompileCache) {
+    enableCompileCache()
+  }
+} catch (e) { /* istanbul ignore next */ }
+
 const validateEngines = require('./cli/validate-engines.js')
 const cliEntry = require('node:path').resolve(__dirname, 'cli/entry.js')
 


### PR DESCRIPTION
Adding support to [module.enableCompileCache](https://nodejs.org/docs/v22.11.0/api/module.html#moduleenablecompilecachecachedir), added by  https://github.com/nodejs/node/pull/54501, Typescript got [2.5x perf on tsc](https://devblogs.microsoft.com/typescript/announcing-typescript-5-7-beta/#support-for-v8-compile-caching-in-node.js).

On my machine, for the command `--version`, I got the following results:

```bash
Benchmark 1: node bin/npm-cli.js --version
  Time (mean ± σ):      58.0 ms ±   1.1 ms    [User: 51.8 ms, System: 16.8 ms]
  Range (min … max):    56.5 ms …  62.6 ms    51 runs
 
Benchmark 2: node bin/npm-cli-with-cache.js --version
  Time (mean ± σ):      52.9 ms ±   1.0 ms    [User: 46.5 ms, System: 16.8 ms]
  Range (min … max):    51.4 ms …  55.5 ms    56 runs
 
Summary
  'node bin/npm-cli-with-cache.js --version' ran
    1.10 ± 0.03 times faster than 'node bin/npm-cli.js --version'
```

I run the same test with `npm run empty` and I got the same 10% improvement. 