### PR TITLE
fix-npm --workspaces does not update the dependencies

### DIFF
--- a/lib/commands/version.js
+++ b/lib/commands/version.js
@@ -97,7 +97,7 @@ class Version extends BaseCommand {
         'git-tag-version': false,
         path,
       })
-      updatedWorkspaces.push(name)
+      updatedWorkspaces.push([name, path]) // Modified to include the path
       output.standard(`${prefix}${version}`)
     }
     return updateWorkspaces({

--- a/lib/utils/update-workspaces.js
+++ b/lib/utils/update-workspaces.js
@@ -1,40 +1,74 @@
 'use strict'
 
-const reifyFinish = require('../utils/reify-finish.js')
+const fs = require('fs')
+const path = require('path')
+const Arborist = require('@npmcli/arborist')
 
 async function updateWorkspaces ({
-  config,
   flatOptions,
   localPrefix,
-  npm,
   workspaces,
 }) {
   if (!flatOptions.workspacesUpdate || !workspaces.length) {
     return
   }
 
-  // default behavior is to not save by default in order to avoid
-  // race condition problems when publishing multiple workspaces
-  // that have dependencies on one another, it might still be useful
-  // in some cases, which then need to set --save
-  const save = config.isDefault('save')
-    ? false
-    : config.get('save')
+  // collect updated workspace package versions
+  const workspacePackages = new Map()
 
-  // runs a minimalistic reify update, targeting only the workspaces
-  // that had version updates and skipping fund/audit/save
+  // get the updated versions of workspace packages
+  for (const [, workspacePath] of workspaces) {
+    const pkgPath = path.join(workspacePath, 'package.json')
+    const pkgData = await fs.promises.readFile(pkgPath, 'utf8')
+    const pkg = JSON.parse(pkgData)
+    workspacePackages.set(pkg.name, pkg.version)
+  }
+
+  // update dependencies in all workspace packages
+  for (const [, workspacePath] of workspaces) {
+    const pkgPath = path.join(workspacePath, 'package.json')
+    const pkgData = await fs.promises.readFile(pkgPath, 'utf8')
+    const pkg = JSON.parse(pkgData)
+
+    // list of dependency fields to update
+    const depFields = [
+      'dependencies',
+      'devDependencies',
+      'peerDependencies',
+      'optionalDependencies',
+    ]
+
+    let updated = false
+
+    for (const field of depFields) {
+      if (pkg[field]) {
+        for (const depName of Object.keys(pkg[field])) {
+          if (workspacePackages.has(depName)) {
+            // update the version spec to match the new version
+            pkg[field][depName] = workspacePackages.get(depName)
+            updated = true
+          }
+        }
+      }
+    }
+
+    if (updated) {
+      // write the updated package.json back to disk
+      const updatedPkgData = JSON.stringify(pkg, null, 2) + '\n'
+      await fs.promises.writeFile(pkgPath, updatedPkgData, 'utf8')
+    }
+  }
+
+  // after done with updating package.json files, use arborist.reify() to update node_modules
   const opts = {
     ...flatOptions,
     audit: false,
     fund: false,
     path: localPrefix,
-    save,
+    save: false, // since the package.json is already updated, so no need to save changes again
   }
-  const Arborist = require('@npmcli/arborist')
   const arb = new Arborist(opts)
-
-  await arb.reify({ ...opts, update: workspaces })
-  await reifyFinish(npm, arb)
+  await arb.reify()
 }
 
 module.exports = updateWorkspaces


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
This PR addresses an issue where running npm version --workspaces updates the version fields in the package.json files of workspace packages but does not update the internal dependencies (dependencies, devDependencies, etc.) that reference other workspace packages. 

Background

In npm workspaces, it's expected that updating the version of workspace packages should also update internal dependencies to match the new version numbers. This ensures consistency across the monorepo and prevents potential issues during installation, publishing, or runtime.

Previously, issue #3403 highlighted this problem, and although a fix was attempted, the issue persists as reported in issue #7843.

Problem with the Current Implementation

Reliance on arborist.reify(): The existing updateWorkspaces function relies on arborist.reify() to update workspaces. However, reify focuses on aligning the node_modules directory with the package tree defined by package.json and package-lock.json, and does not modify the dependencies fields in package.json.

save Option Set to false: The save option is set to false by default to prevent potential race conditions when publishing multiple workspaces. This means that even if reify could update package.json, it would not do so because save is false.

Resulting Issue: As a result, internal dependencies remain pointing to old versions after a version bump, leading to inconsistencies within the workspace.

Solution

To resolve this issue, I've modified the updateWorkspaces function to directly update the package.json files of workspace packages, ensuring that internal dependencies are updated to match the new version numbers.

Changes Made

Modified lib/commands/version.js

Updated changeWorkspaces Method:

Changed the way updated workspaces are collected by including both the package name and its path:
updatedWorkspaces.push([name, path])
This provides the necessary information to locate and update each package.json file.
Passed Detailed Workspace Information:

The updateWorkspaces function now receives the updatedWorkspaces array containing both names and paths.
Updated lib/utils/update-workspaces.js

Removed Reliance on arborist.reify():

Instead of relying on reify, which does not update package.json dependencies, the function now directly reads and writes to package.json files.

Implemented Direct File Manipulation:

Reads Each package.json: Uses fs.promises.readFile to read the contents of each workspace's package.json.
Updates Internal Dependencies:
Iterates over the dependency fields (dependencies, devDependencies, peerDependencies, optionalDependencies).
Checks if any dependencies are workspace packages that have been version-bumped.
Updates the version specifier to the new version.
Writes Changes Back to Disk: Uses fs.promises.writeFile to save the updated package.json files.
Optionally Integrated arborist.reify() to Update node_modules

After updating the package.json files, arborist.reify() is called to update the node_modules directories to match the new dependencies.


This PR provides solution to ensure that npm version --workspaces updates both the version fields and the internal dependencies in package.json files of workspace packages. By directly manipulating the package.json files and updating node_modules and maintain consistency across the workspace and prevent potential issues arising from outdated internal dependencies.

This change resolves the issue reported in Issue #7843 and aligns with the expected behavior discussed in Issue #3403.

## References
  Related to #7843 
  Depends on #3403
  Blocked by #0
  Fixes #7843 
  Closes #7843 
