### PR TITLE
feat: env install node

### DIFF
--- a/workspaces/arborist/lib/arborist/index.js
+++ b/workspaces/arborist/lib/arborist/index.js
@@ -69,7 +69,7 @@ class Arborist extends Base {
     const timeEnd = time.start('arborist:ctor')
     super(options)
     this.options = {
-      nodeVersion: process.version,
+      nodeVersion: process.env.nodeVersion || process.version,
       ...options,
       Arborist: this.constructor,
       binLinks: 'binLinks' in options ? !!options.binLinks : true,


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

Hi, we're looking to dynamically configure Node.js versions within a `single install process` by [nodejs npm package](https://www.npmjs.com/package/node) 

Currently, `Arborist` read the read-only `process.version`. Could we please merge the dynamic nodeVersion setting from [npm-install-checks](https://github.com/npm/npm-install-checks/blob/main/lib/current-env.js#L53) into Arborist?

This would allow us to avoid extra subprocesses and align with the configurability of other properties like `os` and `cpu`.

🙏🏻🙏🏻🙏🏻

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
