### PR TITLE
fix!: publishing prerelease requires explicit tag

### DIFF
--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -116,6 +116,13 @@ class Publish extends BaseCommand {
     // note that publishConfig might have changed as well!
     manifest = await this.#getManifest(spec, opts, true)
 
+    const isPreRelease = Boolean(semver.parse(manifest.version).prerelease.length)
+    const isDefaultTag = this.npm.config.isDefault('tag')
+
+    if (isPreRelease && isDefaultTag) {
+      throw new Error('You must specify a tag using --tag when publishing a prerelease version')
+    }
+
     // If we are not in JSON mode then we show the user the contents of the tarball
     // before it is published so they can see it while their otp is pending
     if (!json) {


### PR DESCRIPTION
BREAKING CHANGE: When publishing a package with a pre-release version, you must explicitly specify a tag.
 
ref: https://github.com/npm/statusboard/issues/898