### PR TITLE
chore(tests): account for when npm is a prerelease

### DIFF
--- a/smoke-tests/test/npm-replace-global.js
+++ b/smoke-tests/test/npm-replace-global.js
@@ -143,7 +143,7 @@ t.test('publish and replace global self', async t => {
     }
     return false
   }).reply(201, {})
-  await npmLocal('publish', { proxy: true, force: true })
+  await npmLocal('publish', '--tag=smoke-test', { proxy: true, force: true })
 
   t.comment(JSON.stringify(publishedPackument, null, 2))
 

--- a/test/lib/commands/publish.js
+++ b/test/lib/commands/publish.js
@@ -962,6 +962,7 @@ t.test('manifest', async t => {
   const { npm } = await loadMockNpm(t, {
     config: {
       ...auth,
+      tag: 'latest',
       'foreground-scripts': false,
     },
     chdir: () => root,


### PR DESCRIPTION
A few of our tests necessarily use npm's own local version in its package.json, and those tests need to be fixed for the new breaking change that requires an explicit dist tag.
