### PR TITLE
docs: change certfile to cafile

### DIFF
--- a/docs/lib/content/configuring-npm/npmrc.md
+++ b/docs/lib/content/configuring-npm/npmrc.md
@@ -103,7 +103,7 @@ The full list is:
  - `username`
  - `_password`
  - `email`
- - `certfile` (path to certificate file)
+ - `cafile` (path to certificate authority file)
  - `keyfile` (path to key file)
 
 In order to scope these values, they must be prefixed by a URI fragment.

--- a/tap-snapshots/test/lib/commands/audit.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/audit.js.test.cjs
@@ -331,21 +331,6 @@ audited 2 packages in xxx
 2 packages have verified registry signatures
 `
 
-exports[`test/lib/commands/audit.js TAP fallback audit > must match snapshot 1`] = `
-# npm audit report
-
-test-dep-a  1.0.0
-Severity: high
-Test advisory 100 - https://github.com/advisories/GHSA-100
-fix available via \`npm audit fix\`
-node_modules/test-dep-a
-
-1 high severity vulnerability
-
-To address all issues, run:
-  npm audit fix
-`
-
 exports[`test/lib/commands/audit.js TAP json audit > must match snapshot 1`] = `
 {
   "auditReportVersion": 2,

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -1877,9 +1877,9 @@ When set to \`dev\` or \`development\`, this is an alias for \`--include=dev\`.
 * Default: null
 * Type: null or String
 * DEPRECATED: \`key\` and \`cert\` are no longer used for most registry
-  operations. Use registry scoped \`keyfile\` and \`certfile\` instead. Example:
+  operations. Use registry scoped \`keyfile\` and \`cafile\` instead. Example:
   //other-registry.tld/:keyfile=/path/to/key.pem
-  //other-registry.tld/:certfile=/path/to/cert.crt
+  //other-registry.tld/:cafile=/path/to/cert.crt
 
 A client certificate to pass when accessing the registry. Values should be
 in PEM format (Windows calls it "Base-64 encoded X.509 (.CER)") with
@@ -1890,8 +1890,8 @@ cert="-----BEGIN CERTIFICATE-----\\nXXXX\\nXXXX\\n-----END CERTIFICATE-----"
 \`\`\`
 
 It is _not_ the path to a certificate file, though you can set a
-registry-scoped "certfile" path like
-"//other-registry.tld/:certfile=/path/to/cert.pem".
+registry-scoped "cafile" path like
+"//other-registry.tld/:cafile=/path/to/cert.pem".
 
 
 
@@ -1982,9 +1982,9 @@ Alias for \`--init-version\`
 * Default: null
 * Type: null or String
 * DEPRECATED: \`key\` and \`cert\` are no longer used for most registry
-  operations. Use registry scoped \`keyfile\` and \`certfile\` instead. Example:
+  operations. Use registry scoped \`keyfile\` and \`cafile\` instead. Example:
   //other-registry.tld/:keyfile=/path/to/key.pem
-  //other-registry.tld/:certfile=/path/to/cert.crt
+  //other-registry.tld/:cafile=/path/to/cert.crt
 
 A client key to pass when accessing the registry. Values should be in PEM
 format with newlines replaced by the string "\\n". For example:

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -397,14 +397,14 @@ const definitions = {
       \`\`\`
 
       It is _not_ the path to a certificate file, though you can set a registry-scoped
-      "certfile" path like "//other-registry.tld/:certfile=/path/to/cert.pem".
+      "cafile" path like "//other-registry.tld/:cafile=/path/to/cert.pem".
     `,
     deprecated: `
       \`key\` and \`cert\` are no longer used for most registry operations.
-      Use registry scoped \`keyfile\` and \`certfile\` instead.
+      Use registry scoped \`keyfile\` and \`cafile\` instead.
       Example:
       //other-registry.tld/:keyfile=/path/to/key.pem
-      //other-registry.tld/:certfile=/path/to/cert.crt
+      //other-registry.tld/:cafile=/path/to/cert.crt
     `,
     flatten,
   }),
@@ -1077,10 +1077,10 @@ const definitions = {
     `,
     deprecated: `
       \`key\` and \`cert\` are no longer used for most registry operations.
-      Use registry scoped \`keyfile\` and \`certfile\` instead.
+      Use registry scoped \`keyfile\` and \`cafile\` instead.
       Example:
       //other-registry.tld/:keyfile=/path/to/key.pem
-      //other-registry.tld/:certfile=/path/to/cert.crt
+      //other-registry.tld/:cafile=/path/to/cert.crt
     `,
     flatten,
   }),


### PR DESCRIPTION
cafile is the correct config key

Closes: https://github.com/npm/documentation/issues/1337