### PR TITLE
feat: adds pkg sort command

### DIFF
--- a/lib/commands/pkg.js
+++ b/lib/commands/pkg.js
@@ -13,6 +13,7 @@ class Pkg extends BaseCommand {
     'set [<array>[<index>].<key>=<value> ...]',
     'set [<array>[].<key>=<value> ...]',
     'fix',
+    'sort',
   ]
 
   static params = [
@@ -43,6 +44,8 @@ class Pkg extends BaseCommand {
         return this.delete(_args, { path, workspace }).then(p => p.save())
       case 'fix':
         return PackageJson.fix(path).then(p => p.save())
+      case 'sort':
+        return PackageJson.load(path).then(p => p.save({ sort: true }))
       default:
         throw this.usageError()
     }

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -3727,6 +3727,7 @@ npm pkg delete <key> [<key> ...]
 npm pkg set [<array>[<index>].<key>=<value> ...]
 npm pkg set [<array>[].<key>=<value> ...]
 npm pkg fix
+npm pkg sort
 
 Options:
 [-f|--force] [--json]
@@ -3742,6 +3743,7 @@ npm pkg delete <key> [<key> ...]
 npm pkg set [<array>[<index>].<key>=<value> ...]
 npm pkg set [<array>[].<key>=<value> ...]
 npm pkg fix
+npm pkg sort
 \`\`\`
 
 #### \`force\`

--- a/test/lib/commands/pkg.js
+++ b/test/lib/commands/pkg.js
@@ -759,3 +759,21 @@ t.test('fix', async t => {
     'fixes package.json issues'
   )
 })
+
+t.test('sort', async t => {
+  const { pkg, readPackageJson } = await mockNpm(t, {
+    prefixDir: {
+      'package.json': JSON.stringify({
+        version: '1.1.1',
+        name: 'foo',
+      }),
+    },
+  })
+
+  await pkg('sort')
+  t.strictSame(
+    readPackageJson(),
+    { name: 'foo', version: '1.1.1' },
+    'sorts package.json fields'
+  )
+})


### PR DESCRIPTION
adds `npm pkg sort` command to sort package.json fields

* in init-package-json [sorting was added](https://github.com/npm/init-package-json/commit/5eeea50f70412968d8e16b390da43cab5de02954) 
*  from npm/package-json [here](https://github.com/npm/package-json/commit/4c22738d919e29a32ae20472f48837b65181c309)
