### PR TITLE
docs: make npm completion stay in sync with npm updates

### DIFF
--- a/docs/lib/content/commands/npm-completion.md
+++ b/docs/lib/content/commands/npm-completion.md
@@ -18,16 +18,16 @@ To load the completions into your current shell:
 source <(npm completion)
 ```
 
-Adding its output to
+Adding this to
 your ~/.bashrc or ~/.zshrc will make the completions available
 everywhere:
 
 ```bash
-npm completion >> ~/.bashrc
-npm completion >> ~/.zshrc
+echo 'source <(npm completion)' >> ~/.bashrc
+echo 'source <(npm completion)' >> ~/.zshrc
 ```
 
-You may of course also pipe the output of `npm completion` to a file
+You may of course instead add `source <(npm completion)` to a file
 such as `/usr/local/etc/bash_completion.d/npm` or 
 `/etc/bash_completion.d/npm` if you have a system that will read 
 that file for you.

--- a/docs/lib/content/commands/npm-completion.md
+++ b/docs/lib/content/commands/npm-completion.md
@@ -10,10 +10,15 @@ description: Tab Completion for npm
 
 ### Description
 
-Enables tab-completion in all npm commands.
+Generates a shell script to enable tab-completion for all npm commands.
 
-The synopsis above
-loads the completions into your current shell.  Adding it to
+To load the completions into your current shell:
+
+```bash
+source <(npm completion)
+```
+
+Adding its output to
 your ~/.bashrc or ~/.zshrc will make the completions available
 everywhere:
 


### PR DESCRIPTION
The current instructions result in a completion script generated by the currently the installed version of npm to be written to the user's shell configuration. If improvements to the script are made in a later npm version, the user will not get these, nor will they know of this condition.

The updated instructions regenerates the script from the currently installed version of npm each time the shell initializes, thereby staying in sync.

## References

This change builds on top of PR https://github.com/npm/cli/pull/7996 (the first commit of this PR belongs to that PR), so that PR, if acceptable, should be merged first. 
