### PR TITLE
docs: remove reference to deprecated flag in npm-install

### DIFF
--- a/docs/lib/content/commands/npm-install.md
+++ b/docs/lib/content/commands/npm-install.md
@@ -52,13 +52,13 @@ into a tarball (b).
     By default, `npm install` will install all modules listed as
     dependencies in [`package.json`](/configuring-npm/package-json).
 
-    With the `--production` flag (or when the `NODE_ENV` environment
+    With the `--omit=dev` flag (or if the `NODE_ENV` environment
     variable is set to `production`), npm will not install modules listed
     in `devDependencies`. To install all modules listed in both
     `dependencies` and `devDependencies` when `NODE_ENV` environment
-    variable is set to `production`, you can use `--production=false`.
+    variable is set to `production`, you can use `--include=dev`.
 
-    > NOTE: The `--production` flag has no particular meaning when adding a
+    > NOTE: The `--omit=dev` flag has no particular meaning when adding a
     dependency to a project.
 
 * `npm install <folder>`:


### PR DESCRIPTION
Replace `--production` with `--omit=dev`, and `--production=false` with `--include=dev`

## Why
The `--production` flag [is deprecated](https://docs.npmjs.com/cli/v11/using-npm/config#production) so we should avoid mentioning it when we can use `--omit=dev` instead:
> [`production`](https://docs.npmjs.com/cli/v11/using-npm/config#production)
> Default: null
> Type: null or Boolean
> DEPRECATED: Use --omit=dev instead.

## What
This PR helps discourage usage of deprecated commands by using:
- `--omit=dev` instead of `--production`, and
- `--include=dev` instead of `--production=false`. 


## References
  Related to #6987
  Fixes #8025
