### PR TITLE
fix: use splatting to pass arguments from a powershell scope

### DIFF
--- a/bin/npm.ps1
+++ b/bin/npm.ps1
@@ -24,9 +24,9 @@ if (Test-Path $NPM_PREFIX_NPM_CLI_JS) {
 
 # Support pipeline input
 if ($MyInvocation.ExpectingInput) {
-  $input | & $NODE_EXE $NPM_CLI_JS $args
+  $input | & $NODE_EXE $NPM_CLI_JS @args
 } else {
-  & $NODE_EXE $NPM_CLI_JS $args
+  & $NODE_EXE $NPM_CLI_JS @args
 }
 
 exit $LASTEXITCODE

--- a/bin/npx.ps1
+++ b/bin/npx.ps1
@@ -24,9 +24,9 @@ if (Test-Path $NPM_PREFIX_NPX_CLI_JS) {
 
 # Support pipeline input
 if ($MyInvocation.ExpectingInput) {
-  $input | & $NODE_EXE $NPX_CLI_JS $args
+  $input | & $NODE_EXE $NPX_CLI_JS @args
 } else {
-  & $NODE_EXE $NPX_CLI_JS $args
+  & $NODE_EXE $NPX_CLI_JS @args
 }
 
 exit $LASTEXITCODE


### PR DESCRIPTION
Use splatting when in a powershell context.

From observation, `$args` is being flattened into a single value. Splatting appears to keep the argument structure intact. 

## References
May resolve issue https://github.com/npm/cli/issues/7375
