### PR TITLE
feat: add support for ConEmu indeterminate progress indicator

### DIFF
--- a/lib/utils/display.js
+++ b/lib/utils/display.js
@@ -169,6 +169,7 @@ class Display {
 
   // progress
   #progress
+  #conEmuProgress
 
   // options
   #command
@@ -191,6 +192,7 @@ class Display {
     process.on('output', this.#outputHandler)
     process.on('input', this.#inputHandler)
     this.#progress = new Progress({ stream: stderr })
+    this.#conEmuProgress = new ConEmuProgress({ stream: stderr })
   }
 
   off () {
@@ -200,6 +202,7 @@ class Display {
     this.#outputState.buffer.length = 0
     process.off('input', this.#inputHandler)
     this.#progress.off()
+    this.#conEmuProgress.off()
   }
 
   get chalk () {
@@ -250,6 +253,9 @@ class Display {
     output.flush()
     this.#progress.load({
       unicode,
+      enabled: !!progress && !this.#silent,
+    })
+    this.#conEmuProgress.load({
       enabled: !!progress && !this.#silent,
     })
   }
@@ -533,6 +539,41 @@ class Progress {
     // Move to the start of the line and clear the rest of the line
     this.#stream.cursorTo(0)
     this.#stream.clearLine(1)
+  }
+}
+
+/**
+ * See:
+ * https://conemu.github.io/en/AnsiEscapeCodes.html#OSC_Operating_system_commands
+ */
+class ConEmuProgress {
+  #stream
+  #enabled
+
+  constructor ({ stream }) {
+    this.#stream = stream
+  }
+
+  load ({ enabled }) {
+    this.#enabled = enabled
+    if (enabled) {
+      this.#startProgress()
+    }
+  }
+
+  #startProgress () {
+    this.#stream.write('\x1b]9;4;3;0\x1b\\')
+  }
+
+  #clearProgress () {
+    this.#stream.write('\x1b]9;4;0;0\x1b\\')
+  }
+
+  off () {
+    if (!this.#enabled) {
+      return
+    }
+    this.#clearProgress()
   }
 }
 

--- a/test/lib/utils/display.js
+++ b/test/lib/utils/display.js
@@ -94,7 +94,7 @@ t.test('can do progress', async (t) => {
   log.error('', 'after input')
   output.standard('after input')
 
-  t.strictSame([...new Set(outputErrors)].sort(), ['-', '/', '\\', '|'])
+  t.strictSame([...new Set(outputErrors)].sort(), ['\x1b]9;4;3;0\x1b\\', '-', '/', '\\', '|'])
   t.strictSame(logs, ['error before input', 'error during input', 'error after input'])
   t.strictSame(outputs, ['before input', 'during input', 'after input'])
 })


### PR DESCRIPTION
Adds support for:
https://conemu.github.io/en/AnsiEscapeCodes.html#OSC_Operating_system_commands

The Windows Terminal supports above mentioned Ansi Code extensions. Thoese extensions originate from ConEmu and were also [added to the `dotnet` cli](https://github.com/dotnet/sdk/blob/dc6d68f54aaadae3186f4974be6c381eb4aa4fe1/src/Cli/dotnet/commands/dotnet-test/Terminal/AnsiTerminal.cs#L296)

On windows, this displays a spinner in the current tab. It also marks the respective taskbar item as indeterminate progressing. See it in action:

![indicator2](https://github.com/user-attachments/assets/18a6460a-da5a-4b06-a4ff-b3b182e7c3cf)
([mp4](https://github.com/user-attachments/assets/bc1bfaf4-eb65-4657-bde2-d6d1d52b19c4))

The user is able to minimize the terminal and is still informed about the state of the npm operation.

Note: this code works only on ConEmu terminals, and conflicts with push a notification code on iTerm2.
https://iterm2.com/documentation-escape-codes.html
I could not check what exactly happens in iTerm2, maybe someone else can check this. If that ends up being a problem, we should exclude macOS from this feature.

If this doesn't align with the goals of npm-cli, just close this PR without any comment.
