### PR TITLE
docs: depth flag default value

### DIFF
--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -405,7 +405,7 @@ are same as \`cpu\` field of package.json, which comes from \`process.arch\`.
 
 #### \`depth\`
 
-* Default: \`Infinity\` if \`--all\` is set, otherwise \`1\`
+* Default: \`Infinity\` if \`--all\` is set, otherwise \`0\`
 * Type: null or Number
 
 The depth to go when recursing packages for \`npm ls\`.

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -461,7 +461,7 @@ const definitions = {
   depth: new Definition('depth', {
     default: null,
     defaultDescription: `
-      \`Infinity\` if \`--all\` is set, otherwise \`1\`
+      \`Infinity\` if \`--all\` is set, otherwise \`0\`
     `,
     type: [null, Number],
     description: `


### PR DESCRIPTION
documentation of `ls` command specifies that `depth` flag if not set defaults to `1` but as per code it uses 0 as default value. https://github.com/npm/cli/blob/dc31c1bdc6658ab69554adcf2988ee99a615c409/lib/commands/ls.js#L113-L116

fixes: https://github.com/npm/cli/issues/7979
