### PR TITLE
fix(publish): honor force for no dist tag and registry version check

### DIFF
--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -159,8 +159,8 @@ class Publish extends BaseCommand {
     }
 
     if (!force) {
-      const { latest: latestVersion, versions } = await this.#registryVersions(resolved, registry)
-      const latestSemverIsGreater = !!latestVersion && semver.gte(latestVersion, manifest.version)
+      const { highestVersion, versions } = await this.#registryVersions(resolved, registry)
+      const latestSemverIsGreater = !!highestVersion && semver.gte(highestVersion, manifest.version)
 
       if (versions.includes(manifest.version)) {
         throw new Error(`You cannot publish over the previously published versions: ${manifest.version}.`)
@@ -168,7 +168,7 @@ class Publish extends BaseCommand {
 
       if (latestSemverIsGreater && isDefaultTag) {
         /* eslint-disable-next-line max-len */
-        throw new Error(`Cannot implicitly apply the "latest" tag because previously published version ${latestVersion} is higher than the new version ${manifest.version}. You must specify a tag using --tag.`)
+        throw new Error(`Cannot implicitly apply the "latest" tag because previously published version ${highestVersion} is higher than the new version ${manifest.version}. You must specify a tag using --tag.`)
       }
     }
 
@@ -230,9 +230,9 @@ class Publish extends BaseCommand {
           return s
         })
         .sort((a, b) => b.compare(a))
-      const latest = ordered.length >= 1 ? ordered[0].version : null
+      const highestVersion = ordered.length >= 1 ? ordered[0].version : null
       const versions = ordered.map(v => v.version)
-      return { versions, latest }
+      return { versions, highestVersion }
     } catch (e) {
       return { versions: [], latest: null }
     }

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -114,12 +114,14 @@ class Publish extends BaseCommand {
     // so that we send the latest and greatest thing to the registry
     // note that publishConfig might have changed as well!
     manifest = await this.#getManifest(spec, opts, true)
-
-    const isPreRelease = Boolean(semver.parse(manifest.version).prerelease.length)
+    const force = this.npm.config.get('force')
     const isDefaultTag = this.npm.config.isDefault('tag') && !manifest.publishConfig?.tag
 
-    if (isPreRelease && isDefaultTag) {
-      throw new Error('You must specify a tag using --tag when publishing a prerelease version.')
+    if (!force) {
+      const isPreRelease = Boolean(semver.parse(manifest.version).prerelease.length)
+      if (isPreRelease && isDefaultTag) {
+        throw new Error('You must specify a tag using --tag when publishing a prerelease version.')
+      }
     }
 
     // If we are not in JSON mode then we show the user the contents of the tarball
@@ -156,11 +158,18 @@ class Publish extends BaseCommand {
       }
     }
 
-    const latestVersion = await this.#highestPublishedVersion(resolved, registry)
-    const latestSemverIsGreater = !!latestVersion && semver.gte(latestVersion, manifest.version)
+    if (!force) {
+      const { latest: latestVersion, versions } = await this.#registryVersions(resolved, registry)
+      const latestSemverIsGreater = !!latestVersion && semver.gte(latestVersion, manifest.version)
 
-    if (latestSemverIsGreater && isDefaultTag) {
-      throw new Error(`Cannot implicitly apply the "latest" tag because published version ${latestVersion} is higher than the new version ${manifest.version}. You must specify a tag using --tag.`)
+      if (versions.includes(manifest.version)) {
+        throw new Error(`You cannot publish over the previously published versions: ${manifest.version}.`)
+      }
+
+      if (latestSemverIsGreater && isDefaultTag) {
+        /* eslint-disable-next-line max-len */
+        throw new Error(`Cannot implicitly apply the "latest" tag because previously published version ${latestVersion} is higher than the new version ${manifest.version}. You must specify a tag using --tag.`)
+      }
     }
 
     const access = opts.access === null ? 'default' : opts.access
@@ -202,7 +211,7 @@ class Publish extends BaseCommand {
     }
   }
 
-  async #highestPublishedVersion (spec, registry) {
+  async #registryVersions (spec, registry) {
     try {
       const packument = await pacote.packument(spec, {
         ...this.npm.flatOptions,
@@ -210,7 +219,7 @@ class Publish extends BaseCommand {
         registry,
       })
       if (typeof packument?.versions === 'undefined') {
-        return null
+        return { versions: [], latest: null }
       }
       const ordered = Object.keys(packument?.versions)
         .flatMap(v => {
@@ -221,9 +230,11 @@ class Publish extends BaseCommand {
           return s
         })
         .sort((a, b) => b.compare(a))
-      return ordered.length >= 1 ? ordered[0].version : null
+      const latest = ordered.length >= 1 ? ordered[0].version : null
+      const versions = ordered.map(v => v.version)
+      return { versions, latest }
     } catch (e) {
-      return null
+      return { versions: [], latest: null }
     }
   }
 

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -219,7 +219,7 @@ class Publish extends BaseCommand {
         registry,
       })
       if (typeof packument?.versions === 'undefined') {
-        return { versions: [], latest: null }
+        return { versions: [], highestVersion: null }
       }
       const ordered = Object.keys(packument?.versions)
         .flatMap(v => {
@@ -234,7 +234,7 @@ class Publish extends BaseCommand {
       const versions = ordered.map(v => v.version)
       return { versions, highestVersion }
     } catch (e) {
-      return { versions: [], latest: null }
+      return { versions: [], highestVersion: null }
     }
   }
 

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -160,14 +160,13 @@ class Publish extends BaseCommand {
 
     if (!force) {
       const { highestVersion, versions } = await this.#registryVersions(resolved, registry)
-      const latestSemverIsGreater = !!highestVersion && semver.gte(highestVersion, manifest.version)
+      const highestVersionIsGreater = !!highestVersion && semver.gte(highestVersion, manifest.version)
 
       if (versions.includes(manifest.version)) {
         throw new Error(`You cannot publish over the previously published versions: ${manifest.version}.`)
       }
 
-      if (latestSemverIsGreater && isDefaultTag) {
-        /* eslint-disable-next-line max-len */
+      if (highestVersionIsGreater && isDefaultTag) {
         throw new Error(`Cannot implicitly apply the "latest" tag because previously published version ${highestVersion} is higher than the new version ${manifest.version}. You must specify a tag using --tag.`)
       }
     }

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -160,6 +160,7 @@ class Publish extends BaseCommand {
 
     if (!force) {
       const { highestVersion, versions } = await this.#registryVersions(resolved, registry)
+      /* eslint-disable-next-line max-len */
       const highestVersionIsGreater = !!highestVersion && semver.gte(highestVersion, manifest.version)
 
       if (versions.includes(manifest.version)) {

--- a/mock-registry/lib/index.js
+++ b/mock-registry/lib/index.js
@@ -359,16 +359,18 @@ class MockRegistry {
   }
 
   publish (name, {
-    packageJson, access, noPut, putCode, manifest, packuments,
+    packageJson, access, noGet, noPut, putCode, manifest, packuments,
   } = {}) {
-    // this getPackage call is used to get the latest semver version before publish
-    if (manifest) {
-      this.getPackage(name, { code: 200, resp: manifest })
-    } else if (packuments) {
-      this.getPackage(name, { code: 200, resp: this.manifest({ name, packuments }) })
-    } else {
-      // assumes the package does not exist yet and will 404 x2 from pacote.manifest
-      this.getPackage(name, { times: 2, code: 404 })
+    if (!noGet) {
+      // this getPackage call is used to get the latest semver version before publish
+      if (manifest) {
+        this.getPackage(name, { code: 200, resp: manifest })
+      } else if (packuments) {
+        this.getPackage(name, { code: 200, resp: this.manifest({ name, packuments }) })
+      } else {
+        // assumes the package does not exist yet and will 404 x2 from pacote.manifest
+        this.getPackage(name, { times: 2, code: 404 })
+      }
     }
     if (!noPut) {
       this.putPackage(name, { code: putCode, packageJson, access })


### PR DESCRIPTION
Merges https://github.com/npm/cli/pull/7993 / https://github.com/npm/cli/pull/7994 / https://github.com/npm/cli/pull/7995

- [x] adds ability to --force publish without latest check
- [x] adds ability to --force publish of prerelease without tag
- [x] consider equality in publish dist tag check error message