### PR TITLE
docs: update readme for Node.js versions, remove badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,8 @@
 # npm - a JavaScript package manager
 
-[![npm version](https://img.shields.io/npm/v/npm.svg)](https://npm.im/npm)
-[![license](https://img.shields.io/npm/l/npm.svg)](https://npm.im/npm)
-[![CI - cli](https://github.com/npm/cli/actions/workflows/ci.yml/badge.svg)](https://github.com/npm/cli/actions/workflows/ci.yml)
-[![Benchmark Suite](https://github.com/npm/cli/actions/workflows/benchmark.yml/badge.svg)](https://github.com/npm/cli/actions/workflows/benchmark.yml)
-
 ### Requirements
 
-One of the following versions of [Node.js](https://nodejs.org/en/download/) must be installed to run **`npm`**:
-
-* `18.x.x` >= `18.17.0`
-* `20.5.0` or higher
+You should be running a currently supported version of [Node.js](https://nodejs.org/en/download/) to run **`npm`**.  For a list of which versions of Node.js are currently supported, please see the [Node.js releases](https://nodejs.org/en/about/previous-releases) page.
 
 ### Installation
 


### PR DESCRIPTION
Update the copy for "requirements" to specify that it is the Node.js support lifecycle that is key, not a specific version.

Also removed the badges from the readme.  Most of that info is already on the page as parsed by GitHub.
