### PR TITLE
chore: smoke tests using a preid

### DIFF
--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -126,6 +126,8 @@ const main = async (opts) => {
   for (const publish of publishes) {
     const workspace = publish.workspace && `--workspace=${publish.name}`
     const publishPkg = (...args) => npm('publish', workspace, `--tag=${publish.tag}`, ...args)
+
+    await npm('version prerelease', workspace, '--preid=smoke')
     if (isPack) {
       await npm(
         'pack',


### PR DESCRIPTION
https://github.com/npm/cli/pull/8054 broke the smoke test because were publishing the current version in a test