### PR TITLE
fix: warn on invalid single-hyphen cli flags

### DIFF
--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -2547,6 +2547,7 @@ exports[`test/lib/docs.js TAP shorthands > docs 1`] = `
 * \`--help\`: \`--usage\`
 * \`-v\`: \`--version\`
 * \`-w\`: \`--workspace\`
+* \`--ws\`: \`--workspaces\`
 * \`-y\`: \`--yes\`
 `
 

--- a/workspaces/config/lib/definitions/index.js
+++ b/workspaces/config/lib/definitions/index.js
@@ -55,6 +55,7 @@ const shorthands = {
   readonly: ['--read-only'],
   reg: ['--registry'],
   iwr: ['--include-workspace-root'],
+  ws: ['--workspaces'],
   ...definitionProps.shorthands,
 }
 

--- a/workspaces/config/test/index.js
+++ b/workspaces/config/test/index.js
@@ -1519,3 +1519,26 @@ t.test('catch project config prefix error', async t => {
     'error', 'config', `prefix cannot be changed from project config: ${path}`,
   ]], 'Expected error logged')
 })
+
+t.test('invalid single hyphen warnings', async t => {
+  const path = t.testdir()
+  const logs = []
+  const logHandler = (...args) => logs.push(args)
+  process.on('log', logHandler)
+  t.teardown(() => process.off('log', logHandler))
+  const config = new Config({
+    npmPath: `${path}/npm`,
+    env: {},
+    argv: [process.execPath, __filename, '-ws', '-iwr'],
+    cwd: path,
+    shorthands,
+    definitions,
+    nerfDarts,
+  })
+  await config.load()
+  const filtered = logs.filter(l => l[0] === 'warn')
+  t.match(filtered, [
+    ['warn', '-iwr is not a valid single-hyphen cli flag and will be removed in the future'],
+    ['warn', '-ws is not a valid single-hyphen cli flag and will be removed in the future'],
+  ], 'Warns about single hyphen configs')
+})


### PR DESCRIPTION
Single hyphen cli flags traditionally are single-character only, so they can be combined.  npm already supports combining single-hyphen flags together, so it eventually needs stop supporting multi-character ones.

Also re-added -ws to undocumented shorthands, it was accidentally removed from the main config and not re-added to the internal one.

Finally, warnings on a few env configs that npm tosses around were suppressed for now.

![Demonstration of the cli warning on some invalid single hyphen flags](https://github.com/user-attachments/assets/e6eeb7ac-7bde-4802-a065-884c5cb0085f)
