### PR TITLE
fix!: don't force `pkg get` json output

### DIFF
--- a/lib/commands/pkg.js
+++ b/lib/commands/pkg.js
@@ -56,7 +56,6 @@ class Pkg extends BaseCommand {
   }
 
   async get (args, { path, workspace }) {
-    this.npm.config.set('json', true)
     const pkgJson = await PackageJson.load(path)
 
     let result = pkgJson.content


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
This pull request removes the hard-coded override setting the `json` configuration option / flag to true. Now, `npm pkg get` commands output JSON only when the `--json` flag is passed (default: false). This is likely considered a breaking change due to people working around the peculiarities of this historical behavior.

## References
Closes #5508.