### PR TITLE
Fix install-strategy=linked package name for workspace packages + workaround for another bug

### DIFF
--- a/workspaces/arborist/lib/arborist/isolated-reifier.js
+++ b/workspaces/arborist/lib/arborist/isolated-reifier.js
@@ -156,7 +156,7 @@ module.exports = cls => class IsolatedReifier extends cls {
     ]
     result.root = this.rootNode
     result.id = this.counter++
-    result.name = node.name
+    result.name = node.packageName || node.name
     result.package = { ...node.package }
     result.package.bundleDependencies = undefined
     result.hasInstallScript = node.hasInstallScript

--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -438,7 +438,7 @@ module.exports = cls => class Reifier extends cls {
       if (includeWorkspaces) {
         // add all ws nodes to filterNodes
         for (const ws of this.options.workspaces) {
-          const ideal = this.idealTree.children.get(ws)
+          const ideal = this.idealTree.children.get && this.idealTree.children.get(ws)
           if (ideal) {
             filterNodes.push(ideal)
           }


### PR DESCRIPTION
Attempts to fix #6122.

I don't know whether the `packageName` to `name` propagation should be limited to `workspaceProxy()` or whether I was correct in placing it in `assignCommonProperties()`. It is based on similar code I found elsewhere.

Also had to add a fix/workaround for `this.idealTree.children.get` being undefined/null sometimes when running `npm install`. Haven't got the slightest clue why.

Additional tests not yet done, requires some test code refactoring to support workspace packages having names not matching their directory name..

Works for me (TM). You can try these changes out locally by implementing the same changes in the files in `<your_node_installation_root>/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/`.

## References
  Fixes #6122