### PR TITLE
docs(npmrc): add example of URI fragment limitations

### DIFF
--- a/docs/lib/content/configuring-npm/npmrc.md
+++ b/docs/lib/content/configuring-npm/npmrc.md
@@ -94,7 +94,7 @@ to override default configs in a standard and consistent manner.
 ### Auth related configuration
 
 The settings `_auth`, `_authToken`, `username` and `_password` must all be
-scoped to a specific registry. This ensures that `npm` will never send
+scoped to a specific `registry`. This ensures that `npm` will never send
 credentials to the wrong host.
 
 The full list is:
@@ -111,6 +111,30 @@ If the credential is meant for any request to a registry on a single host,
 the scope may look like `//registry.npmjs.org/:`. If it must be scoped to a
 specific path on the host that path may also be provided, such as
 `//my-custom-registry.org/unique/path:`.
+
+#### How NPM matches Registry URL with auth configuration
+
+Let's say you have:
+
+```ini
+@myorg:registry=https://registry.npmjs.org/myorg
+```
+
+npm will look for:
+
+```ini
+//registry.npmjs.org/myorg/:_authToken=...
+```
+
+If instead you put:
+
+```ini
+//registry.npmjs.org/:_authToken=...
+```
+
+That won’t be used, because it **doesn’t match** what npm looks for from the registry URL you defined.
+
+#### Extended configuration example
 
 ```ini
 ; bad config

--- a/docs/lib/content/configuring-npm/npmrc.md
+++ b/docs/lib/content/configuring-npm/npmrc.md
@@ -112,23 +112,30 @@ the scope may look like `//registry.npmjs.org/:`. If it must be scoped to a
 specific path on the host that path may also be provided, such as
 `//my-custom-registry.org/unique/path:`.
 
-```
+```ini
 ; bad config
 _authToken=MYTOKEN
 
 ; good config
-@myorg:registry=https://somewhere-else.com/myorg
-@another:registry=https://somewhere-else.com/another
+@myorg:registry=https://somewhere-else.npmjs.org/myorg
+@another:registry=https://somewhere-else.npmjs.org/another
+@anotherorg:registry=https:///registry.npmjs.org/path/anotherorg
+
+; Applies to any registry at https://registry.npmjs.org/ but not to any sub-path (see @anotherorg)
 //registry.npmjs.org/:_authToken=MYTOKEN
 
-; would apply to both @myorg and @another
-//somewhere-else.com/:_authToken=MYTOKEN
+; Applies to both @myorg and @another but noth @anotherorg
+//somewhere-else.npmjs.org/:_authToken=MYTOKEN
 
-; would apply only to @myorg
-//somewhere-else.com/myorg/:_authToken=MYTOKEN1
+; Only applies to @myorg
+//somewhere-else.npmjs.org/myorg/:_authToken=MYTOKEN1
 
-; would apply only to @another
-//somewhere-else.com/another/:_authToken=MYTOKEN2
+; Only applies to @another
+//somewhere-else.npmjs.org/another/:_authToken=MYTOKEN2
+
+; Only applies to @anotherorg
+//registry.npmjs.org/path/anotherorg:_authToken=MYTOKEN3
+
 ```
 
 ### See also


### PR DESCRIPTION
Attempt to clarify limitations of how URI Fragments are not applied at the host level but at the path level and are not recursively applied to any sub-path.

When attempting to generate valid npmrc configuration files by using //host.name/:_auth=$token to cover any registry available at that host, I could not get npm to use those credentials.

I figured out the hard way that npm would only use the credentials if I specified the entire path up to the registry name i.e. //host.name/artifactory/api/npm/:auth=$token.

I felt the docs could be clarified to help other users realise the same.

Note: This PR replaces #8095 since I messed up the git commits and were unable to clean it up.