### PR TITLE
fix(outdated): add dependent location in long output

### DIFF
--- a/docs/lib/content/commands/npm-outdated.md
+++ b/docs/lib/content/commands/npm-outdated.md
@@ -37,6 +37,7 @@ In the output:
   included in `package.json` are always marked `dependencies`.
 * `homepage` (when using `--long` / `-l`) is the `homepage` value contained
   in the package's packument
+* `depended by location` (when using `--long` / `-l`) shows location of the package depends on the displayed dependency
 * Red means there's a newer version matching your semver requirements, so
   you should update now.
 * Yellow indicates that there's a newer version _above_ your semver

--- a/docs/lib/content/commands/npm-outdated.md
+++ b/docs/lib/content/commands/npm-outdated.md
@@ -37,7 +37,7 @@ In the output:
   included in `package.json` are always marked `dependencies`.
 * `homepage` (when using `--long` / `-l`) is the `homepage` value contained
   in the package's packument
-* `depended by location` (when using `--long` / `-l`) shows location of the package depends on the displayed dependency
+* `depended by location` (when using `--long` / `-l`) shows location of the package that depends on the displayed dependency
 * Red means there's a newer version matching your semver requirements, so
   you should update now.
 * Yellow indicates that there's a newer version _above_ your semver

--- a/lib/commands/outdated.js
+++ b/lib/commands/outdated.js
@@ -195,6 +195,9 @@ class Outdated extends ArboristWorkspaceCmd {
           wanted: wanted.version,
           latest: latest.version,
           workspaceDependent: edge.from?.isWorkspace ? edge.from.pkgid : null,
+          dependedByLocation: edge.from?.name
+            ? edge.from?.location
+            : 'global',
           dependent: edge.from?.name ?? 'global',
           homepage: packument.homepage,
         })
@@ -226,7 +229,7 @@ class Outdated extends ArboristWorkspaceCmd {
         'Latest',
         'Location',
         'Depended by',
-        ...long ? ['Package Type', 'Homepage'] : [],
+        ...long ? ['Package Type', 'Homepage', 'Depended By Location'] : [],
       ].map(h => bold.underline(h)),
       ...list.map((d) => [
         d.current === d.wanted ? yellow(d.name) : red(d.name),
@@ -235,7 +238,7 @@ class Outdated extends ArboristWorkspaceCmd {
         blue(d.latest),
         d.location ?? '-',
         d.workspaceDependent ? blue(d.workspaceDependent) : d.dependent,
-        ...long ? [d.type, blue(d.homepage ?? '')] : [],
+        ...long ? [d.type, blue(d.homepage ?? ''), d.dependedByLocation] : [],
       ]),
     ], {
       align: ['l', 'r', 'r', 'r', 'l'],
@@ -252,7 +255,7 @@ class Outdated extends ArboristWorkspaceCmd {
       d.current ? `${d.name}@${d.current}` : 'MISSING',
       `${d.name}@${d.latest}`,
       d.dependent,
-      ...this.npm.config.get('long') ? [d.type, d.homepage] : [],
+      ...this.npm.config.get('long') ? [d.type, d.homepage, d.dependedByLocation] : [],
     ].join(':')).join('\n')
   }
 
@@ -268,7 +271,10 @@ class Outdated extends ArboristWorkspaceCmd {
         latest: d.latest,
         dependent: d.dependent,
         location: d.path,
-        ...this.npm.config.get('long') ? { type: d.type, homepage: d.homepage } : {},
+        ...this.npm.config.get('long') ? {
+          type: d.type,
+          homepage: d.homepage,
+          dependedByLocation: d.dependedByLocation } : {},
       }
       acc[d.name] = acc[d.name]
         // If this item alread has an outdated dep then we turn it into an array

--- a/tap-snapshots/test/lib/commands/outdated.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/outdated.js.test.cjs
@@ -15,6 +15,37 @@ Package         Current  Wanted  Latest  Location          Depended by
 cat:dog@^1.0.0    1.0.0   1.0.1   2.0.0  node_modules/cat  prefix
 `
 
+exports[`test/lib/commands/outdated.js TAP dependent location --long --json > should display dependent location when using --long and --json 1`] = `
+{
+  "dog": [
+    {
+      "current": "1.0.0",
+      "wanted": "1.0.1",
+      "latest": "2.0.0",
+      "dependent": "a",
+      "location": "{CWD}/prefix/node_modules/dog",
+      "type": "dependencies",
+      "dependedByLocation": "a"
+    },
+    {
+      "current": "1.0.0",
+      "wanted": "1.0.1",
+      "latest": "2.0.0",
+      "dependent": "a",
+      "location": "{CWD}/prefix/node_modules/dog",
+      "type": "dependencies",
+      "dependedByLocation": "nest/a"
+    }
+  ]
+}
+`
+
+exports[`test/lib/commands/outdated.js TAP dependent location --long > should display dependent location when using --long 1`] = `
+Package  Current  Wanted  Latest  Location          Depended by         Package Type  Homepage  Depended By Location
+dog        1.0.0   1.0.1   2.0.0  node_modules/dog  a@1.0.0             dependencies            a
+dog        1.0.0   1.0.1   2.0.0  node_modules/dog  a@npm:nest-a@1.0.0  dependencies            nest/a
+`
+
 exports[`test/lib/commands/outdated.js TAP should display outdated deps outdated --all > must match snapshot 1`] = `
 Package  Current  Wanted  Latest  Location           Depended by
 cat        1.0.0   1.0.1   1.0.1  node_modules/cat   prefix
@@ -31,7 +62,8 @@ exports[`test/lib/commands/outdated.js TAP should display outdated deps outdated
     "latest": "1.0.1",
     "dependent": "prefix",
     "location": "{CWD}/prefix/node_modules/cat",
-    "type": "dependencies"
+    "type": "dependencies",
+    "dependedByLocation": ""
   },
   "chai": {
     "current": "1.0.0",
@@ -39,7 +71,8 @@ exports[`test/lib/commands/outdated.js TAP should display outdated deps outdated
     "latest": "1.0.1",
     "dependent": "prefix",
     "location": "{CWD}/prefix/node_modules/chai",
-    "type": "peerDependencies"
+    "type": "peerDependencies",
+    "dependedByLocation": ""
   },
   "dog": {
     "current": "1.0.1",
@@ -47,13 +80,15 @@ exports[`test/lib/commands/outdated.js TAP should display outdated deps outdated
     "latest": "2.0.0",
     "dependent": "prefix",
     "location": "{CWD}/prefix/node_modules/dog",
-    "type": "dependencies"
+    "type": "dependencies",
+    "dependedByLocation": ""
   },
   "theta": {
     "wanted": "1.0.1",
     "latest": "1.0.1",
     "dependent": "prefix",
-    "type": "dependencies"
+    "type": "dependencies",
+    "dependedByLocation": ""
   }
 }
 `
@@ -90,7 +125,7 @@ exports[`test/lib/commands/outdated.js TAP should display outdated deps outdated
 `
 
 exports[`test/lib/commands/outdated.js TAP should display outdated deps outdated --long > must match snapshot 1`] = `
-Package  Current  Wanted  Latest  Location           Depended by  Package Type      Homepage
+Package  Current  Wanted  Latest  Location           Depended by  Package Type      Homepage  Depended By Location
 cat        1.0.0   1.0.1   1.0.1  node_modules/cat   prefix       dependencies
 chai       1.0.0   1.0.1   1.0.1  node_modules/chai  prefix       peerDependencies
 dog        1.0.1   1.0.1   2.0.0  node_modules/dog   prefix       dependencies
@@ -120,10 +155,10 @@ exports[`test/lib/commands/outdated.js TAP should display outdated deps outdated
 `
 
 exports[`test/lib/commands/outdated.js TAP should display outdated deps outdated --parseable --long > must match snapshot 1`] = `
-{CWD}/prefix/node_modules/cat:cat@1.0.1:cat@1.0.0:cat@1.0.1:prefix:dependencies:
-{CWD}/prefix/node_modules/chai:chai@1.0.1:chai@1.0.0:chai@1.0.1:prefix:peerDependencies:
-{CWD}/prefix/node_modules/dog:dog@1.0.1:dog@1.0.1:dog@2.0.0:prefix:dependencies:
-:theta@1.0.1:MISSING:theta@1.0.1:prefix:dependencies:
+{CWD}/prefix/node_modules/cat:cat@1.0.1:cat@1.0.0:cat@1.0.1:prefix:dependencies::
+{CWD}/prefix/node_modules/chai:chai@1.0.1:chai@1.0.0:chai@1.0.1:prefix:peerDependencies::
+{CWD}/prefix/node_modules/dog:dog@1.0.1:dog@1.0.1:dog@2.0.0:prefix:dependencies::
+:theta@1.0.1:MISSING:theta@1.0.1:prefix:dependencies::
 `
 
 exports[`test/lib/commands/outdated.js TAP should display outdated deps outdated --parseable > must match snapshot 1`] = `

--- a/test/lib/commands/outdated.js
+++ b/test/lib/commands/outdated.js
@@ -662,3 +662,72 @@ t.test('aliases with version range', async t => {
   )
   t.equal(process.exitCode, 1)
 })
+
+t.test('dependent location', async t => {
+  const testDir = {
+    'package.json': JSON.stringify({
+      name: 'similer-name',
+      version: '1.0.0',
+      workspaces: ['a', 'nest/a'],
+    }),
+    a: {
+      'package.json': JSON.stringify({
+        name: 'a',
+        version: '1.0.0',
+        dependencies: {
+          dog: '^1.0.0',
+        },
+      }),
+    },
+    nest: {
+      a: {
+        'package.json': JSON.stringify({
+          name: 'nest-a',
+          version: '1.0.0',
+          dependencies: {
+            dog: '^1.0.0',
+          },
+        }),
+      },
+    },
+    node_modules: {
+      dog: {
+        'package.json': JSON.stringify({
+          name: 'dog',
+          version: '1.0.0',
+        }),
+      },
+      a: t.fixture('symlink', '../a'),
+      'nest-a': t.fixture('symlink', '../nest/a'),
+    },
+
+  }
+  t.test(`--long`, async t => {
+    const { outdated, joinedOutput } = await mockNpm(t, {
+      prefixDir: testDir,
+      config: {
+        long: true,
+      },
+    })
+    await outdated.exec([])
+    t.matchSnapshot(
+      joinedOutput(),
+      'should display dependent location when using --long'
+    )
+  })
+
+  t.test('--long --json', async t => {
+    const { outdated, joinedOutput } = await mockNpm(t, {
+      prefixDir: testDir,
+      config: {
+        long: true,
+        json: true,
+      },
+    })
+    await outdated.exec([])
+    t.matchSnapshot(
+      joinedOutput(),
+      'should display dependent location when using --long and --json'
+    )
+  })
+})


### PR DESCRIPTION
Add dependent location details when using `--long` version of the output to identify who is the dependent of the outdated dependencies. 
Fixes: https://github.com/npm/cli/issues/7736

Test output
<img width="1443" alt="Screenshot 2025-04-02 at 1 27 02 PM" src="https://github.com/user-attachments/assets/cf9cd91e-06c1-403b-a57e-53fa9d80ef01" />

