### PR TITLE
fix: remove duplicate var

### DIFF
--- a/workspaces/arborist/lib/consistent-resolve.js
+++ b/workspaces/arborist/lib/consistent-resolve.js
@@ -20,11 +20,10 @@ const consistentResolve = (resolved, fromPath, toPath, relPaths = false) => {
       raw,
     } = npa(resolved, fromPath)
     if (type === 'file' || type === 'directory') {
-      const cleanFetchSpec = fetchSpec
       if (relPaths && toPath) {
-        return `file:${relpath(toPath, cleanFetchSpec)}`
+        return `file:${relpath(toPath, fetchSpec)}`
       }
-      return `file:${cleanFetchSpec}`
+      return `file:${fetchSpec}`
     }
     if (hosted) {
       return `git+${hosted.auth ? hosted.https(hostedOpt) : hosted.sshurl(hostedOpt)}`


### PR DESCRIPTION
**Note to reviewers:** The CI failures are unrelated to the code changes in this CR. They're caused by `git dirty` complaining because there was a release of `@npmcli/git` that hasn't been merged in yet: https://github.com/npm/git/pull/224

---

Following up on #8115. Since `cleanFetchSpec` no longer differs from `fetchSpec`, it's no longer needed. cc @wraithgar 