### PR TITLE
fix: make `npm run` autocomplete work with workspaces

### DIFF
--- a/lib/commands/run-script.js
+++ b/lib/commands/run-script.js
@@ -26,7 +26,11 @@ class RunScript extends BaseCommand {
   static async completion (opts, npm) {
     const argv = opts.conf.argv.remain
     if (argv.length === 2) {
-      const { content: { scripts = {} } } = await pkgJson.normalize(npm.localPrefix)
+      const workspacePrefixes = npm.config.get('workspace', 'default')
+      const localPrefix = workspacePrefixes.length
+        ? workspacePrefixes[0]
+        : npm.localPrefix
+      const { content: { scripts = {} } } = await pkgJson.normalize(localPrefix)
         .catch(() => ({ content: {} }))
       if (opts.isFish) {
         return Object.keys(scripts).map(s => `${s}\t${scripts[s].slice(0, 30)}`)

--- a/test/lib/commands/run-script.js
+++ b/test/lib/commands/run-script.js
@@ -3,6 +3,7 @@ const { resolve } = require('node:path')
 const realRunScript = require('@npmcli/run-script')
 const mockNpm = require('../../fixtures/mock-npm')
 const { cleanCwd } = require('../../fixtures/clean-snapshot')
+const path = require('node:path')
 
 const mockRs = async (t, { windows = false, runScript, ...opts } = {}) => {
   let RUN_SCRIPTS = []
@@ -491,6 +492,7 @@ t.test('workspaces', async t => {
     prefixDir,
     workspaces = true,
     exec = [],
+    chdir = ({ prefix }) => prefix,
     ...config
   } = {}) => {
     const mock = await mockRs(t, {
@@ -554,6 +556,7 @@ t.test('workspaces', async t => {
         ...Array.isArray(workspaces) ? { workspace: workspaces } : { workspaces },
         ...config,
       },
+      chdir,
       runScript,
     })
     if (exec) {
@@ -561,6 +564,22 @@ t.test('workspaces', async t => {
     }
     return mock
   }
+
+  t.test('completion', async t => {
+    t.test('in root dir', async t => {
+      const { runScript } = await mockWorkspaces(t)
+      const res = await runScript.completion({ conf: { argv: { remain: ['npm', 'run'] } } })
+      t.strictSame(res, [])
+    })
+
+    t.test('in workspace dir', async t => {
+      const { runScript } = await mockWorkspaces(t, {
+        chdir: ({ prefix }) => path.join(prefix, 'packages/c'),
+      })
+      const res = await runScript.completion({ conf: { argv: { remain: ['npm', 'run'] } } })
+      t.strictSame(res, ['test', 'posttest', 'lorem'])
+    })
+  })
 
   t.test('list all scripts', async t => {
     const { joinedOutput } = await mockWorkspaces(t)


### PR DESCRIPTION
PR makes `npm run` completion to take workspaces into account in case of cwd is inside workspace dir it will autocompletes from `scripts` section of nearest workspace's package.

Former behavoiur was to autocomplete everything from workspace root package, it has no sense since when you are in workspace directory script which will be suggested in such manner will not work. So there was a mismatch between the script launch and the autocomplete hint areas.

## References
Fixes [#7114](https://github.com/npm/cli/issues/7114)