### PR TITLE
fix: re-add positional arg and abbrev warnings

### DIFF
--- a/workspaces/config/lib/index.js
+++ b/workspaces/config/lib/index.js
@@ -364,8 +364,11 @@ class Config {
     }
     nopt.invalidHandler = (k, val, type) =>
       this.invalidHandler(k, val, type, 'command line options', 'cli')
+    nopt.unknownHandler = this.unknownHandler
+    nopt.abbrevHandler = this.abbrevHandler
     const conf = nopt(this.types, this.shorthands, this.argv)
     nopt.invalidHandler = null
+    nopt.unknownHandler = null
     this.parsedArgv = conf.argv
     delete conf.argv
     this.#loadObject(conf, 'cli', 'command line options')
@@ -529,6 +532,16 @@ class Config {
     const desc = mustBe.length === 1 ? mustBe[0]
       : [...new Set(mustBe.map(n => typeof n === 'string' ? n : JSON.stringify(n)))].join(', ')
     log.warn('invalid config', msg, desc)
+  }
+
+  abbrevHandler (short, long) {
+    log.warn(`Expanding --${short} to --${long}. This will stop working in the next major version of npm.`)
+  }
+
+  unknownHandler (key, next) {
+    if (next) {
+      log.warn(`"${next}" is being parsed as a normal command line argument.`)
+    }
   }
 
   #getOneOfKeywords (mustBe, typeDesc) {

--- a/workspaces/config/test/index.js
+++ b/workspaces/config/test/index.js
@@ -1542,3 +1542,48 @@ t.test('invalid single hyphen warnings', async t => {
     ['warn', '-ws is not a valid single-hyphen cli flag and will be removed in the future'],
   ], 'Warns about single hyphen configs')
 })
+
+t.test('positional arg warnings', async t => {
+  const path = t.testdir()
+  const logs = []
+  const logHandler = (...args) => logs.push(args)
+  process.on('log', logHandler)
+  t.teardown(() => process.off('log', logHandler))
+  const config = new Config({
+    npmPath: `${path}/npm`,
+    env: {},
+    argv: [process.execPath, __filename, '--something', 'extra'],
+    cwd: path,
+    shorthands,
+    definitions,
+    nerfDarts,
+  })
+  await config.load()
+  const filtered = logs.filter(l => l[0] === 'warn')
+  t.match(filtered, [
+    ['warn', '"extra" is being parsed as a normal command line argument.'],
+    ['warn', 'Unknown cli config "--something". This will stop working in the next major version of npm.'],
+  ], 'Warns about positional cli arg')
+})
+
+t.test('abbreviation expansion warnings', async t => {
+  const path = t.testdir()
+  const logs = []
+  const logHandler = (...args) => logs.push(args)
+  process.on('log', logHandler)
+  t.teardown(() => process.off('log', logHandler))
+  const config = new Config({
+    npmPath: `${path}/npm`,
+    env: {},
+    argv: [process.execPath, __filename, '--bef', '2020-01-01'],
+    cwd: path,
+    shorthands,
+    definitions,
+    nerfDarts,
+  })
+  await config.load()
+  const filtered = logs.filter(l => l[0] === 'warn')
+  t.match(filtered, [
+    ['warn', 'Expanding --bef to --before. This will stop working in the next major version of npm'],
+  ], 'Warns about expanded abbreviations')
+})


### PR DESCRIPTION
PR #8071 originally had this but that appears to have gotten lost along the way.
