### PR TITLE
fix(npx): always save true when installing to npx cache

### DIFF
--- a/workspaces/libnpmexec/lib/index.js
+++ b/workspaces/libnpmexec/lib/index.js
@@ -292,6 +292,7 @@ const exec = async (opts) => {
       }
       await npxArb.reify({
         ...flatOptions,
+        save: true,
         add,
       })
     }

--- a/workspaces/libnpmexec/test/registry.js
+++ b/workspaces/libnpmexec/test/registry.js
@@ -297,3 +297,25 @@ t.test('npx tree triggers manifest fetch when local version does satisfy range u
     value: 'packages-2.0.1',
   })
 })
+
+t.test('override save to true when installing to npx cache', async t => {
+  const { fixtures, package } = createPkg({ versions: ['2.0.0'] })
+
+  const { exec, path, registry, readOutput } = setup(t, {
+    testdir: merge(fixtures, {
+      global: {},
+    }),
+  })
+
+  await package({ registry, path })
+
+  await exec({
+    args: ['@npmcli/create-index'],
+    globalPath: resolve(path, 'global'),
+    save: false,
+  })
+
+  t.match(await readOutput('@npmcli-create-index'), {
+    value: 'packages-2.0.0',
+  })
+})

--- a/workspaces/libnpmexec/test/registry.js
+++ b/workspaces/libnpmexec/test/registry.js
@@ -2,6 +2,7 @@ const { resolve } = require('node:path')
 const t = require('tap')
 const { setup, createPkg, merge } = require('./fixtures/setup.js')
 const crypto = require('node:crypto')
+const { existsSync } = require('node:fs')
 
 t.test('run from registry - no local packages', async t => {
   const { fixtures, package } = createPkg({ versions: ['2.0.0'] })
@@ -301,6 +302,11 @@ t.test('npx tree triggers manifest fetch when local version does satisfy range u
 t.test('override save to true when installing to npx cache', async t => {
   const { fixtures, package } = createPkg({ versions: ['2.0.0'] })
 
+  const hash = crypto.createHash('sha512')
+    .update('@npmcli/create-index')
+    .digest('hex')
+    .slice(0, 16)
+
   const { exec, path, registry, readOutput } = setup(t, {
     testdir: merge(fixtures, {
       global: {},
@@ -314,6 +320,9 @@ t.test('override save to true when installing to npx cache', async t => {
     globalPath: resolve(path, 'global'),
     save: false,
   })
+
+  const packageJsonPath = resolve(path, 'npxCache', hash, 'package.json')
+  t.ok(existsSync(packageJsonPath), 'package.json should exist at npmCache')
 
   t.match(await readOutput('@npmcli-create-index'), {
     value: 'packages-2.0.0',


### PR DESCRIPTION
Override config `save` to always be `true` when installing to the npx cache.

fixes: https://github.com/npm/cli/issues/8151