### PR TITLE
fix(arborist): workspaces respect overrides on subsequent installs

### DIFF
--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -13,6 +13,7 @@ const { lstat, readlink } = require('node:fs/promises')
 const { depth } = require('treeverse')
 const { log, time } = require('proc-log')
 const { redact } = require('@npmcli/redact')
+const semver = require('semver')
 
 const {
   OK,
@@ -279,14 +280,23 @@ module.exports = cls => class IdealTreeBuilder extends cls {
       // When updating all, we load the shrinkwrap, but don't bother
       // to build out the full virtual tree from it, since we'll be
       // reconstructing it anyway.
-      .then(root => this.options.global ? root
-      : !this[_usePackageLock] || this[_updateAll]
-        ? Shrinkwrap.reset({
-          path: this.path,
-          lockfileVersion: this.options.lockfileVersion,
-          resolveOptions: this.options,
-        }).then(meta => Object.assign(root, { meta }))
-        : this.loadVirtual({ root }))
+      .then(root => {
+        if (this.options.global) {
+          return root
+        } else if (!this[_usePackageLock] || this[_updateAll]) {
+          return Shrinkwrap.reset({
+            path: this.path,
+            lockfileVersion: this.options.lockfileVersion,
+            resolveOptions: this.options,
+          }).then(meta => Object.assign(root, { meta }))
+        } else {
+          return this.loadVirtual({ root })
+            .then(tree => {
+              this.#applyRootOverridesToWorkspaces(tree)
+              return tree
+            })
+        }
+      })
 
       // if we don't have a lockfile to go from, then start with the
       // actual tree, so we only make the minimum required changes.
@@ -1473,6 +1483,32 @@ This is a one-time fix-up, please be patient...
     }
 
     timeEnd()
+  }
+
+  #applyRootOverridesToWorkspaces (tree) {
+    const rootOverrides = tree.root.package.overrides || {}
+
+    for (const node of tree.root.inventory.values()) {
+      if (!node.isWorkspace) {
+        continue
+      }
+
+      for (const depName of Object.keys(rootOverrides)) {
+        const edge = node.edgesOut.get(depName)
+        const rootNode = tree.root.children.get(depName)
+
+        // safely skip if either edge or rootNode doesn't exist yet
+        if (!edge || !rootNode) {
+          continue
+        }
+
+        const resolvedRootVersion = rootNode.package.version
+        if (!semver.satisfies(resolvedRootVersion, edge.spec)) {
+          edge.detach()
+          node.children.delete(depName)
+        }
+      }
+    }
   }
 
   #idealTreePrune () {

--- a/workspaces/arborist/test/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/test/arborist/build-ideal-tree.js
@@ -3984,6 +3984,82 @@ t.test('overrides', async t => {
     t.equal(fooBarEdge.valid, true)
     t.equal(fooBarEdge.to.version, '2.0.0')
   })
+
+  t.test('root overrides should be respected by workspaces on subsequent installs', async t => {
+    // • The root package.json declares a workspaces field, a direct dependency on "abbrev" with version constraint "^1.1.1", and an overrides field for "abbrev" also "^1.1.1".
+    // • The workspace "onepackage" depends on "abbrev" at "1.0.3".
+    const rootPkg = {
+      name: 'root',
+      version: '1.0.0',
+      workspaces: ['onepackage'],
+      dependencies: {
+        abbrev: '^1.1.1',
+        wrappy: '1.0.1',
+      },
+      overrides: {
+        abbrev: '^1.1.1',
+        wrappy: '1.0.1',
+      },
+    }
+    const workspacePkg = {
+      name: 'onepackage',
+      version: '1.0.0',
+      dependencies: {
+        abbrev: '1.0.3',
+        wrappy: '1.0.1',
+      },
+    }
+
+    createRegistry(t, true)
+
+    const dir = t.testdir({
+      'package.json': JSON.stringify(rootPkg, null, 2),
+      onepackage: {
+        'package.json': JSON.stringify(workspacePkg, null, 2),
+      },
+    })
+
+    // fresh install
+    const tree1 = await buildIdeal(dir)
+
+    // The ideal tree should resolve "abbrev" at the root to 1.1.1.
+    t.equal(
+      tree1.children.get('abbrev').package.version,
+      '1.1.1',
+      'first install: root "abbrev" is forced to version 1.1.1'
+    )
+    // The workspace "onepackage" should not have its own nested "abbrev".
+    const onepackageNode1 = tree1.children.get('onepackage').target
+    t.notOk(
+      onepackageNode1.children.has('abbrev'),
+      'first install: workspace does not install "abbrev" separately'
+    )
+
+    // Write out the package-lock.json to disk to mimic a real install.
+    await tree1.meta.save()
+
+    // Simulate re-running install (which reads the package-lock).
+    const tree2 = await buildIdeal(dir)
+
+    // tree2 should NOT have its own abbrev dependency.
+    const onepackageNode2 = tree2.children.get('onepackage').target
+    t.notOk(
+      onepackageNode2.children.has('abbrev'),
+      'workspace should NOT have nested "abbrev" after subsequent install'
+    )
+
+    // The root "abbrev" should still be 1.1.1.
+    t.equal(
+      tree2.children.get('abbrev').package.version,
+      '1.1.1',
+      'second install: root "abbrev" is still forced to version 1.1.1')
+
+    // Overrides should NOT persist unnecessarily
+    t.notOk(
+      onepackageNode2.overrides && onepackageNode2.overrides.has('abbrev'),
+      'workspace node should not unnecessarily retain overrides after subsequent install'
+    )
+  })
 })
 
 t.test('store files with a custom indenting', async t => {


### PR DESCRIPTION
<!-- What / Why -->

Fixes: https://github.com/npm/cli/issues/7660 https://github.com/npm/cli/issues/5443

<!-- Describe the request in detail. What it does and why it's being changed. -->

Currently overrides are applied correctly to workspaces when a user does their initial `npm install`. However, when a user runs `npm install` again, the overrides are not being respected, and versions that the user has specifically overridden because of vulnerabilities or other reasons, are being installed in the node_modules of those workspaces. This ensures that when a package-lock.json is loaded, the overrides are calculated and applied to the workspaces.