### PR TITLE
docs(logging): replace proceeding with preceding in loglevels details

### DIFF
--- a/docs/lib/content/using-npm/logging.md
+++ b/docs/lib/content/using-npm/logging.md
@@ -38,7 +38,7 @@ The default value of `loglevel` is `"notice"` but there are several levels/types
 - `"verbose"`
 - `"silly"`
 
-All logs pertaining to a level proceeding the current setting will be shown.
+All logs pertaining to a level preceding the current setting will be shown.
 
 ##### Aliases
 


### PR DESCRIPTION
Grammar fix for the docs regarding the loglevel hierarchy in the CLI logging docs.

## References

Closes #8161
