### PR TITLE
docs: fix example package name in `overrides` explainer

### DIFF
--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -979,7 +979,7 @@ also `1.0.0`:
 ```
 
 To only override `@npm/foo` to be `1.0.0` when it's a child (or grandchild, or great
-grandchild, etc) of the package `bar`:
+grandchild, etc) of the package `@npm/bar`:
 
 ```json
 {


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

I'm pretty sure that this should be `@npm/bar`, based on the other usages around it

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
