### PR TITLE
fix(arborist): safely fallback on unresolved $ dependency references

### DIFF
--- a/workspaces/arborist/lib/edge.js
+++ b/workspaces/arborist/lib/edge.js
@@ -206,27 +206,41 @@ class Edge {
     if (this.overrides?.value && this.overrides.value !== '*' && this.overrides.name === this.#name) {
       if (this.overrides.value.startsWith('$')) {
         const ref = this.overrides.value.slice(1)
-        const pkg = this.#from?.sourceReference
+        let pkg = this.#from?.sourceReference
           ? this.#from?.sourceReference.root.package
           : this.#from?.root?.package
-        if (pkg.devDependencies?.[ref]) {
-          return pkg.devDependencies[ref]
-        }
-        if (pkg.optionalDependencies?.[ref]) {
-          return pkg.optionalDependencies[ref]
-        }
-        if (pkg.dependencies?.[ref]) {
-          return pkg.dependencies[ref]
-        }
-        if (pkg.peerDependencies?.[ref]) {
-          return pkg.peerDependencies[ref]
+
+        let specValue = this.#calculateReferentialOverrideSpec(ref, pkg)
+
+        // If the package isn't found in the root package, fall back to the local package.
+        if (!specValue) {
+          pkg = this.#from?.package
+          specValue = this.#calculateReferentialOverrideSpec(ref, pkg)
         }
 
+        if (specValue) {
+          return specValue
+        }
         throw new Error(`Unable to resolve reference ${this.overrides.value}`)
       }
       return this.overrides.value
     }
     return this.#spec
+  }
+
+  #calculateReferentialOverrideSpec (ref, pkg) {
+    if (pkg.devDependencies?.[ref]) {
+      return pkg.devDependencies[ref]
+    }
+    if (pkg.optionalDependencies?.[ref]) {
+      return pkg.optionalDependencies[ref]
+    }
+    if (pkg.dependencies?.[ref]) {
+      return pkg.dependencies[ref]
+    }
+    if (pkg.peerDependencies?.[ref]) {
+      return pkg.peerDependencies[ref]
+    }
   }
 
   get accept () {

--- a/workspaces/arborist/test/edge.js
+++ b/workspaces/arborist/test/edge.js
@@ -1195,3 +1195,52 @@ t.test('overrideset comparison logic', (t) => {
   t.ok(!overrides7.isEqual(overrides1), 'overridesets are different')
   t.end()
 })
+
+t.test('override fallback to local when root missing dependency with from.overrides set', t => {
+  const localFrom = {
+    package: {
+      devDependencies: {
+        foo: '^1.2.3',
+      },
+    },
+    root: {
+      package: {
+        // no 'foo' defined here
+      },
+    },
+    edgesOut: new Map(),
+    edgesIn: new Set(),
+    // dummy overrides object that returns an override with isEqual defined
+    overrides: {
+      getEdgeRule (edge) {
+        return {
+          value: edge.overrides.value,
+          name: edge.overrides.name,
+          isEqual (other) {
+            return other && this.value === other.value && this.name === other.name
+          },
+        }
+      },
+    },
+    addEdgeOut (edge) {
+      this.edgesOut.set(edge.name, edge)
+    },
+    resolve () {
+      return null
+    },
+  }
+
+  const edge = new Edge({
+    from: localFrom,
+    type: 'prod',
+    name: 'foo',
+    spec: '1.x',
+    overrides: {
+      value: '$foo',
+      name: 'foo',
+    },
+  })
+
+  t.equal(edge.spec, '^1.2.3', 'should fallback to local package version from devDependencies')
+  t.end()
+})


### PR DESCRIPTION
fixes https://github.com/npm/cli/issues/5730 

Overrides that use a dollar sign need to resolve to a version string found in one of the package’s dependency fields. We now try two sources in order:

Root Manifest (via sourceReference or this.#from.root.package):
When a node is loaded from a sourceReference or if the node is part of a larger tree, the root package manifest is the first choice because it reflects the “authoritative” set of dependency versions that were installed.

Local Manifest (this.#from.package):
If the root manifest does not contain the key (for example, the dependency version isn’t listed there), we fall back to the local package manifest. This is usually more specific to the individual module and may include dependency fields that the root manifest omits.

This two-step lookup ensures that if the expected dependency isn’t available at the root level—even though it might be defined locally—the override can still resolve correctly. Without this fallback, the override resolution would fail with an error, even though the local package had the required dependency version.