### PR TITLE
docs: Fix grammar in package-json.md

### DIFF
--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -749,7 +749,7 @@ that require npm installing where you don't want to hit an external server,
 but should not be used when publishing your package to the public registry.
 
 *note*: Packages linked by local path will not have their own
-dependencies installed when `npm install` is ran in this case.  You must
+dependencies installed when `npm install` is run.  You must
 run `npm install` from inside the local path itself.
 
 ### devDependencies


### PR DESCRIPTION
"is ran" is not correct. "in this case" seems to add nothing so I removed that also.
