### PR TITLE
[draft] fix(aborist): reify should not create links to non-existent paths

### DIFF
--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -807,8 +807,14 @@ module.exports = cls => class Reifier extends cls {
     const dir = dirname(node.path)
     const target = node.realpath
     const rel = relative(dir, target)
-    await mkdir(dir, { recursive: true })
-    return symlink(rel, node.path, 'junction')
+    if (await lstat(target).catch(() => false)) {
+      await mkdir(dir, { recursive: true })
+      return symlink(rel, node.path, 'junction')
+    } else {
+      const er = new Error(`Target for link to ${node.name} (from ${[...node.edgesIn].map(e => e.from.name).join(', ')}) not found`)
+      er.code = 'ENOLINK'
+      throw er
+    }
   }
 
   // if the node is optional, then the failure of the promise is nonfatal


### PR DESCRIPTION
This throws an error when we try to link to a target that doesn't exist. It would help users catch errors where they have set up links to non-existent packages.

## References

Related to #8199, but does not work due to the race condition from #8201
