### PR TITLE
Fix: fallback for missing process.env.ComSpec on Windows

### DIFF
--- a/node_modules/@npmcli/promise-spawn/lib/index.js
+++ b/node_modules/@npmcli/promise-spawn/lib/index.js
@@ -70,7 +70,7 @@ const spawnWithShell = (cmd, args, opts, extra) => {
   // ahead of time so that we can escape arguments properly. we don't need coverage here.
   if (command === true) {
     // istanbul ignore next
-    command = process.platform === 'win32' ? process.env.ComSpec : 'sh'
+    command = process.platform === 'win32' ? (process.env.ComSpec || 'cmd.exe') : 'sh'
   }
 
   const options = { ...opts, shell: false }


### PR DESCRIPTION
<!-- What / Why -->
This pull request addresses a bug in the npm run-script chain on Windows when running commands such as `npm start` in a React project under Node.js 22.14.0 LTS. 

In our environment, the environment variable `process.env.ComSpec`—which is typically used to determine the default shell (e.g., "C:\Windows\System32\cmd.exe")—is missing. 

As a result, the code in the `spawnWithShell` function falls back to an undefined value for the shell command. 

This causes the subsequent call to `child_process.spawn()` to receive `undefined` as the file argument, leading to the error:

The "file" argument must be of type string. Received undefined
```
13 verbose stack TypeError [ERR_INVALID_ARG_TYPE]: The "file" argument must be of type string. Received undefined
13 verbose stack     at normalizeSpawnArguments (node:child_process:539:3)
13 verbose stack     at spawn (node:child_process:746:13)
```


The fix implemented in this PR adds a fallback so that if `process.env.ComSpec` is not defined, it defaults to using `"cmd.exe"`. This ensures that the command is properly resolved and that the shell execution chain works as expected.

**Changes made:**
- In the `spawnWithShell` function, the code is modified as follows:
  ```js
  if (command === true) {
    // Use the default shell: if process.env.ComSpec is missing, fallback to 'cmd.exe'
    command = process.platform === 'win32' ? (process.env.ComSpec || 'cmd.exe') : 'sh';
  }


## References

- Fixes internal bug in npm’s shell handling on Windows under Node.js 22.14.0
- similar error #4907 
