### PR TITLE
fix(arborist): workspaces correctly path to file: packages from over…

### DIFF
--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -825,7 +825,14 @@ module.exports = cls => class Reifier extends cls {
     // symlink
     const dir = dirname(node.path)
     const target = node.realpath
-    const rel = relative(dir, target)
+
+    let rel
+    if (node.resolved?.startsWith('file:')) {
+      rel = this.#calculateRelativePath(node, dir, target, nm)
+    } else {
+      rel = relative(dir, target)
+    }
+
     await mkdir(dir, { recursive: true })
     return symlink(rel, node.path, 'junction')
   }
@@ -841,6 +848,36 @@ module.exports = cls => class Reifier extends cls {
         this[_addNodeToTrashList](node)
       }
     }) : p).then(() => node)
+  }
+
+  #calculateRelativePath (node, dir, target) {
+    // Check if the node is affected by a root override
+    let hasRootOverride = [...node.edgesIn].some(edge => edge.from.isRoot && edge.overrides)
+    // If not set via edges, see if the root package.json explicitly lists an override
+    if (!hasRootOverride && node.root) {
+      const rootPackage = node.root.target
+      hasRootOverride = !!(rootPackage &&
+        rootPackage.package.overrides &&
+        rootPackage.package.overrides[node.name])
+    }
+    if (!hasRootOverride) {
+      return relative(dir, target)
+    }
+    // If an override is detected, attempt to retrieve the override spec from the root package.json
+    const overrideSpec = node.root?.target?.package?.overrides?.[node.name]
+    if (typeof overrideSpec === 'string' && overrideSpec.startsWith('file:')) {
+      const overridePath = overrideSpec.replace(/^file:/, '')
+      const rootDir = node.root.target.path
+      return relative(dir, resolve(rootDir, overridePath))
+    }
+
+    // Fallback: derive the package name from node.resolved in a platform-agnostic way
+    const filePath = node.resolved.replace(/^file:/, '')
+    // A node.package.name could be different than the folder name
+    const pathParts = filePath.split(/[\\/]/)
+    const packageName = pathParts[pathParts.length - 1]
+
+    return join('..', packageName)
   }
 
   #registryResolved (resolved) {

--- a/workspaces/arborist/test/arborist/reify.js
+++ b/workspaces/arborist/test/arborist/reify.js
@@ -8,6 +8,7 @@ const fs = require('node:fs')
 const fsp = require('node:fs/promises')
 const npmFs = require('@npmcli/fs')
 const MockRegistry = require('@npmcli/mock-registry')
+const { dirname, relative } = require('node:path')
 
 let failRm = false
 let failRename = null
@@ -3202,6 +3203,57 @@ t.test('installLinks', (t) => {
   })
 
   t.end()
+})
+
+t.test('root overrides with file: paths are visible to workspaces', async t => {
+  const path = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'root',
+      workspaces: ['hello'],
+      dependencies: {},
+      overrides: {
+        print: 'file:./print',
+      },
+    }),
+    hello: {
+      'package.json': JSON.stringify({
+        name: 'hello',
+        version: '1.0.0',
+        dependencies: {
+          print: '../print',
+        },
+      }),
+    },
+    print: {
+      'package.json': JSON.stringify({
+        name: 'print',
+        version: '1.0.0',
+        main: 'index.js',
+      }),
+    },
+  })
+
+  createRegistry(t, false)
+  await reify(path)
+
+  const printSymlink = fs.readlinkSync(resolve(path, 'node_modules/print'))
+
+  // Create a platform-agnostic way to compare symlink targets
+  const normalizeLinkTarget = target => {
+    if (process.platform === 'win32') {
+      // For Windows: convert absolute paths to relative and normalize slashes
+      const linkDir = dirname(resolve(path, 'node_modules/print'))
+      return relative(linkDir, target).replace(/\\/g, '/')
+    }
+    // For Unix: already a relative path
+    return target
+  }
+
+  t.equal(
+    normalizeLinkTarget(printSymlink),
+    '../print',
+    'print symlink points to ../print (normalized for platform)'
+  )
 })
 
 t.test('should preserve exact ranges, missing actual tree', async (t) => {


### PR DESCRIPTION
Fixes: https://github.com/npm/cli/issues/5584

This pull request introduces changes to the `Reifier` class in `workspaces/arborist/lib/arborist/reify.js` to handle root overrides with `file:` paths and adds a corresponding test case. The most important changes include the addition of a new method to calculate relative paths and the inclusion of a test to verify the new functionality.

I learned about how windows does symlinks in this (junctions). Interesting difference.
