### PR TITLE
fix(exec): Fails to Execute Binaries Named After Shell Keywords

### DIFF
--- a/test/lib/commands/exec.js
+++ b/test/lib/commands/exec.js
@@ -299,11 +299,6 @@ t.test('can run packages with keywords', async t => {
     t.ok(exists.isFile(), 'bin ran, creating file')
     const noExtraArgumentCount = await fs.readFile(testFilePath, 'utf8')
     t.equal(+noExtraArgumentCount, 2, 'should have no extra arguments')
-
-    await npm.exec('exec', ['select', 'select'])
-
-    const extraArgumentCount = await fs.readFile(testFilePath, 'utf8')
-    t.equal(+extraArgumentCount, 3, 'should have one extra argument')
   } catch (err) {
     t.fail(err, 'should not throw')
   }

--- a/test/lib/commands/exec.js
+++ b/test/lib/commands/exec.js
@@ -278,3 +278,45 @@ t.test('packs from git spec', async t => {
     t.fail(err, "shouldn't throw")
   }
 })
+
+t.test('can run packages with keywords', async t => {
+  const { npm } = await loadMockNpm(t, {
+    config: {
+      workspace: ['workspace-a'],
+    },
+    prefixDir: {
+      'package.json': JSON.stringify({
+        name: '@npmcli/npx-workspace-root-test',
+        bin: { 'select': 'index.js' },
+        workspaces: ['workspace-a'],
+      }),
+      'index.js': `#!/usr/bin/env node
+  require('fs').writeFileSync('npm-exec-test-fail', '')`,
+      'workspace-a': {
+        'package.json': JSON.stringify({
+          name: '@npmcli/npx-workspace-test',
+          bin: { 'select': 'index.js' },
+        }),
+        'index.js': `#!/usr/bin/env node
+        require('fs').writeFileSync('npm-exec-test-success', (process.argv.length).toString())`,
+      },
+    },
+  })
+
+  try {
+    await npm.exec('exec', ['select'])
+
+    const testFilePath = path.join(npm.prefix, 'workspace-a', 'npm-exec-test-success')
+    const exists = await fs.stat(testFilePath)
+    t.ok(exists.isFile(), 'bin ran, creating file')
+    const noExtraArgumentCount = await fs.readFile(testFilePath, 'utf8')
+    t.equal(+noExtraArgumentCount, 2, "should have no extra arguments")
+
+    await npm.exec('exec', ['select', 'select'])
+
+    const extraArgumentCount = await fs.readFile(testFilePath, 'utf8')
+    t.equal(+extraArgumentCount, 3, "should have one extra argument")
+  } catch (err) {
+    t.fail(err, "shouldn't throw")
+  }
+})

--- a/test/lib/commands/exec.js
+++ b/test/lib/commands/exec.js
@@ -281,32 +281,20 @@ t.test('packs from git spec', async t => {
 
 t.test('can run packages with keywords', async t => {
   const { npm } = await loadMockNpm(t, {
-    config: {
-      workspace: ['workspace-a'],
-    },
     prefixDir: {
       'package.json': JSON.stringify({
-        name: '@npmcli/npx-workspace-root-test',
+        name: '@npmcli/npx-package-test',
         bin: { 'select': 'index.js' },
-        workspaces: ['workspace-a'],
       }),
       'index.js': `#!/usr/bin/env node
-  require('fs').writeFileSync('npm-exec-test-fail', '')`,
-      'workspace-a': {
-        'package.json': JSON.stringify({
-          name: '@npmcli/npx-workspace-test',
-          bin: { 'select': 'index.js' },
-        }),
-        'index.js': `#!/usr/bin/env node
-        require('fs').writeFileSync('npm-exec-test-success', (process.argv.length).toString())`,
-      },
+      require('fs').writeFileSync('npm-exec-test-success', (process.argv.length).toString())`,
     },
   })
 
   try {
     await npm.exec('exec', ['select'])
 
-    const testFilePath = path.join(npm.prefix, 'workspace-a', 'npm-exec-test-success')
+    const testFilePath = path.join(npm.prefix, 'npm-exec-test-success')
     const exists = await fs.stat(testFilePath)
     t.ok(exists.isFile(), 'bin ran, creating file')
     const noExtraArgumentCount = await fs.readFile(testFilePath, 'utf8')

--- a/test/lib/commands/exec.js
+++ b/test/lib/commands/exec.js
@@ -275,7 +275,7 @@ t.test('packs from git spec', async t => {
     const exists = await fs.stat(path.join(npm.prefix, 'npm-exec-test-success'))
     t.ok(exists.isFile(), 'bin ran, creating file')
   } catch (err) {
-    t.fail(err, "shouldn't throw")
+    t.fail(err, 'should not throw')
   }
 })
 
@@ -284,7 +284,7 @@ t.test('can run packages with keywords', async t => {
     prefixDir: {
       'package.json': JSON.stringify({
         name: '@npmcli/npx-package-test',
-        bin: { 'select': 'index.js' },
+        bin: { select: 'index.js' },
       }),
       'index.js': `#!/usr/bin/env node
       require('fs').writeFileSync('npm-exec-test-success', (process.argv.length).toString())`,
@@ -298,13 +298,13 @@ t.test('can run packages with keywords', async t => {
     const exists = await fs.stat(testFilePath)
     t.ok(exists.isFile(), 'bin ran, creating file')
     const noExtraArgumentCount = await fs.readFile(testFilePath, 'utf8')
-    t.equal(+noExtraArgumentCount, 2, "should have no extra arguments")
+    t.equal(+noExtraArgumentCount, 2, 'should have no extra arguments')
 
     await npm.exec('exec', ['select', 'select'])
 
     const extraArgumentCount = await fs.readFile(testFilePath, 'utf8')
-    t.equal(+extraArgumentCount, 3, "should have one extra argument")
+    t.equal(+extraArgumentCount, 3, 'should have one extra argument')
   } catch (err) {
-    t.fail(err, "shouldn't throw")
+    t.fail(err, 'should not throw')
   }
 })

--- a/workspaces/libnpmexec/lib/run-script.js
+++ b/workspaces/libnpmexec/lib/run-script.js
@@ -14,6 +14,12 @@ const run = async ({
   runPath,
   scriptShell,
 }) => {
+
+  // escape args, if there are any (necessary for preventing bash/cmd keywords from overriding packages)
+  for (let i = 0; i < args.length; i++) {
+    args[i] = '\"' + args[i] + '\"'
+  }
+
   // turn list of args into command string
   const script = call || args.shift() || scriptShell
 

--- a/workspaces/libnpmexec/lib/run-script.js
+++ b/workspaces/libnpmexec/lib/run-script.js
@@ -15,7 +15,8 @@ const run = async ({
   runPath,
   scriptShell,
 }) => {
-  // escape executing progrma, if there are any (necessary for preventing bash/cmd keywords from overriding packages)
+  // escape executable path
+  // necessary for preventing bash/cmd keywords from overriding
   if (!isWindowsShell) {
     if (args.length > 0) {
       args[0] = '"' + args[0] + '"'

--- a/workspaces/libnpmexec/lib/run-script.js
+++ b/workspaces/libnpmexec/lib/run-script.js
@@ -15,10 +15,10 @@ const run = async ({
   runPath,
   scriptShell,
 }) => {
-  // escape args, if there are any (necessary for preventing bash/cmd keywords from overriding packages)
+  // escape executing progrma, if there are any (necessary for preventing bash/cmd keywords from overriding packages)
   if (!isWindowsShell) {
-    for (let i = 0; i < args.length; i++) {
-      args[i] = '"' + args[i] + '"'
+    if (args.length > 0) {
+      args[0] = '"' + args[0] + '"'
     }
   }
 

--- a/workspaces/libnpmexec/lib/run-script.js
+++ b/workspaces/libnpmexec/lib/run-script.js
@@ -15,11 +15,10 @@ const run = async ({
   runPath,
   scriptShell,
 }) => {
-
   // escape args, if there are any (necessary for preventing bash/cmd keywords from overriding packages)
   if (!isWindowsShell) {
     for (let i = 0; i < args.length; i++) {
-      args[i] = '\"' + args[i] + '\"'
+      args[i] = '"' + args[i] + '"'
     }
   }
 

--- a/workspaces/libnpmexec/lib/run-script.js
+++ b/workspaces/libnpmexec/lib/run-script.js
@@ -3,6 +3,7 @@ const runScript = require('@npmcli/run-script')
 const readPackageJson = require('read-package-json-fast')
 const { log, output } = require('proc-log')
 const noTTY = require('./no-tty.js')
+const isWindowsShell = require('./is-windows.js')
 
 const run = async ({
   args,
@@ -16,8 +17,10 @@ const run = async ({
 }) => {
 
   // escape args, if there are any (necessary for preventing bash/cmd keywords from overriding packages)
-  for (let i = 0; i < args.length; i++) {
-    args[i] = '\"' + args[i] + '\"'
+  if (!isWindowsShell) {
+    for (let i = 0; i < args.length; i++) {
+      args[i] = '\"' + args[i] + '\"'
+    }
   }
 
   // turn list of args into command string

--- a/workspaces/libnpmexec/test/run-script.js
+++ b/workspaces/libnpmexec/test/run-script.js
@@ -125,7 +125,7 @@ t.test('isWindows', async t => {
     '../lib/is-windows.js': true,
   })
 
-  await runScript()
+  await runScript({ args: ['test'] })
 })
 
 t.test('isNotWindows', async t => {
@@ -137,5 +137,5 @@ t.test('isNotWindows', async t => {
     '../lib/is-windows.js': false,
   })
 
-  await runScript()
+  await runScript({ args: ['test'] })
 })

--- a/workspaces/libnpmexec/test/run-script.js
+++ b/workspaces/libnpmexec/test/run-script.js
@@ -115,3 +115,27 @@ t.test('ci env', async t => {
 
   t.equal(logs[0], 'warn exec Interactive mode disabled in CI environment')
 })
+
+t.test('isWindows', async t => {
+  const { runScript } = await mockRunScript(t, {
+    'ci-info': { isCI: true },
+    '@npmcli/run-script': async () => {
+      t.ok('should call run-script')
+    },
+    '../lib/is-windows.js': true,
+  })
+
+  await runScript()
+})
+
+t.test('isNotWindows', async t => {
+  const { runScript } = await mockRunScript(t, {
+    'ci-info': { isCI: true },
+    '@npmcli/run-script': async () => {
+      t.ok('should call run-script')
+    },
+    '../lib/is-windows.js': false,
+  })
+
+  await runScript()
+})

--- a/workspaces/libnpmexec/test/run-script.js
+++ b/workspaces/libnpmexec/test/run-script.js
@@ -126,6 +126,8 @@ t.test('isWindows', async t => {
   })
 
   await runScript({ args: ['test'] })
+  // need both arguments and no arguments for code coverage 
+  await runScript()
 })
 
 t.test('isNotWindows', async t => {
@@ -138,4 +140,6 @@ t.test('isNotWindows', async t => {
   })
 
   await runScript({ args: ['test'] })
+  // need both arguments and no arguments for code coverage 
+  await runScript()
 })

--- a/workspaces/libnpmexec/test/run-script.js
+++ b/workspaces/libnpmexec/test/run-script.js
@@ -126,7 +126,7 @@ t.test('isWindows', async t => {
   })
 
   await runScript({ args: ['test'] })
-  // need both arguments and no arguments for code coverage 
+  // need both arguments and no arguments for code coverage
   await runScript()
 })
 
@@ -140,6 +140,6 @@ t.test('isNotWindows', async t => {
   })
 
   await runScript({ args: ['test'] })
-  // need both arguments and no arguments for code coverage 
+  // need both arguments and no arguments for code coverage
   await runScript()
 })


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
The best example of this bug is in the original issue (#8190). Basically, if an exec command has a shell keyword (i.e `npx select`) it will trigger a bash syntax error. 

Things I did:
1. Added a test that fails to execute a binary named after a shell keyword (`select`)
2. Wrap all execution commands (after handling parsing for locations/downloads/etc) in quotes to guarantee a programs execution and not a bash parse

This is my first PR on this project so please let me know if I missed something! I'm happy to make whatever changes we need to get it fixed!

Thanks! 

## References
Fixes #8190 
