### PR TITLE
docs: clarify legacy token creation in npm login and adduser commands

### DIFF
--- a/docs/lib/content/commands/npm-adduser.md
+++ b/docs/lib/content/commands/npm-adduser.md
@@ -14,7 +14,7 @@ Create a new user in the specified registry, and save the credentials to
 the `.npmrc` file. If no registry is specified, the default registry
 will be used (see [`registry`](/using-npm/registry)).
 
-When you run `npm adduser`, the CLI automatically generates a legacy token of publish type. For more information, see [About legacy tokens](/about-access-tokens#about-legacy-tokens).
+When you run `npm adduser`, the CLI automatically generates a legacy token of `publish` type. For more information, see [About legacy tokens](/about-access-tokens#about-legacy-tokens).
 
 When using `legacy` for your `auth-type`, the username, password, and
 email are read in from prompts.

--- a/docs/lib/content/commands/npm-adduser.md
+++ b/docs/lib/content/commands/npm-adduser.md
@@ -14,6 +14,8 @@ Create a new user in the specified registry, and save the credentials to
 the `.npmrc` file. If no registry is specified, the default registry
 will be used (see [`registry`](/using-npm/registry)).
 
+When you run `npm adduser`, the CLI automatically generates a legacy token of publish type. For more information, see [About legacy tokens](/about-access-tokens#about-legacy-tokens).
+
 When using `legacy` for your `auth-type`, the username, password, and
 email are read in from prompts.
 

--- a/docs/lib/content/commands/npm-login.md
+++ b/docs/lib/content/commands/npm-login.md
@@ -14,6 +14,8 @@ Verify a user in the specified registry, and save the credentials to the
 `.npmrc` file. If no registry is specified, the default registry will be
 used (see [`config`](/using-npm/config)).
 
+When you run `npm login`, the CLI automatically generates a legacy token of publish type. For more information, see [About legacy tokens](/about-access-tokens#about-legacy-tokens).
+
 When using `legacy` for your `auth-type`, the username and password, are
 read in from prompts.
 

--- a/docs/lib/content/commands/npm-login.md
+++ b/docs/lib/content/commands/npm-login.md
@@ -14,7 +14,7 @@ Verify a user in the specified registry, and save the credentials to the
 `.npmrc` file. If no registry is specified, the default registry will be
 used (see [`config`](/using-npm/config)).
 
-When you run `npm login`, the CLI automatically generates a legacy token of publish type. For more information, see [About legacy tokens](/about-access-tokens#about-legacy-tokens).
+When you run `npm login`, the CLI automatically generates a legacy token of `publish` type. For more information, see [About legacy tokens](/about-access-tokens#about-legacy-tokens).
 
 When using `legacy` for your `auth-type`, the username and password, are
 read in from prompts.


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

This is simple PR for adjust `npm login` and `npm adduser` doc.

### Problem Description:
When using `npm login`/`npm adduser`, users are not aware that this command generates a legacy token with publish permissions. This information is not evident in the `npm login`/`npm adduser` cli documentation.

After a while searching. found that this context and detail hiding in the [About legacy tokens](https://docs.npmjs.com/about-access-tokens#about-legacy-tokens) documentation.

### Solution:
Add a clear description in the `npm login`/`npm adduser` documentation in this PR so that users can understand publish token would be created after `npm login` in the future.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

Related to this PR: https://github.com/npm/documentation/pull/1550
