### PR TITLE
Update the tests to reflect the change in the default license value

### DIFF
--- a/test/lib/commands/init.js
+++ b/test/lib/commands/init.js
@@ -43,7 +43,7 @@ t.test('classic npm init -y', async t => {
 
   const pkg = require(resolve(prefix, 'package.json'))
   t.equal(pkg.version, '1.0.0')
-  t.equal(pkg.license, 'ISC')
+  t.equal(pkg.license, 'UNLICENSED')
 })
 
 t.test('classic interactive npm init', async t => {
@@ -273,7 +273,7 @@ t.test('workspaces', async t => {
     const pkg = require(resolve(prefix, 'a/package.json'))
     t.equal(pkg.name, 'a')
     t.equal(pkg.version, '1.0.0')
-    t.equal(pkg.license, 'ISC')
+    t.equal(pkg.license, 'UNLICENSED')
 
     t.matchSnapshot(joinedOutput(), 'should print helper info')
 
@@ -306,7 +306,7 @@ t.test('workspaces', async t => {
     const pkg = require(resolve(prefix, 'packages/a/package.json'))
     t.equal(pkg.name, 'a')
     t.equal(pkg.version, '2.0.0')
-    t.equal(pkg.license, 'ISC')
+    t.equal(pkg.license, 'UNLICENSED')
   })
 
   await t.test('fail parsing top-level package.json to set workspace', async t => {
@@ -422,12 +422,12 @@ t.test('workspaces', async t => {
 
     const pkg = require(resolve(npm.localPrefix, 'package.json'))
     t.equal(pkg.version, '1.0.0')
-    t.equal(pkg.license, 'ISC')
+    t.equal(pkg.license, 'UNLICENSED')
     t.strictSame(pkg.workspaces, ['packages/a'])
 
     const ws = require(resolve(npm.localPrefix, 'packages/a/package.json'))
     t.equal(ws.version, '1.0.0')
-    t.equal(ws.license, 'ISC')
+    t.equal(ws.license, 'UNLICENSED')
   })
   t.test('init pkg - installed workspace package', async t => {
     const { npm } = await mockNpm(t, {


### PR DESCRIPTION
Depends on npm/cli#7727

Eric (@KernelDeimos) has contributed with a change to npm init, so the default license value is changed from 'ISC' to 'UNLICENSED' for reasons that are described in pull request npm/cli#7727 and the linked discussion in said pull request.

The original pull request by Eric missed the npm init tests, hence this addition.

