### PR TITLE
feat(install): add package info to json output

### DIFF
--- a/lib/utils/reify-output.js
+++ b/lib/utils/reify-output.js
@@ -33,11 +33,15 @@ const reifyOutput = (npm, arb) => {
   }
 
   const summary = {
+    add: [],
     added: 0,
-    removed: 0,
-    changed: 0,
+    // audit gets added later
     audited: auditReport && !auditReport.error ? actualTree.inventory.size : 0,
+    change: [],
+    changed: 0,
     funding: 0,
+    remove: [],
+    removed: 0,
   }
 
   if (diff) {
@@ -53,18 +57,42 @@ const reifyOutput = (npm, arb) => {
               output.standard(`${chalk.blue('remove')} ${d.actual.name} ${d.actual.package.version}`)
             }
             summary.removed++
+            summary.remove.push({
+              name: d.actual.name,
+              version: d.actual.package.version,
+              path: d.actual.path,
+            })
             break
           case 'ADD':
             if (showDiff) {
               output.standard(`${chalk.green('add')} ${d.ideal.name} ${d.ideal.package.version}`)
             }
-            actualTree.inventory.has(d.ideal) && summary.added++
+            if (actualTree.inventory.has(d.ideal)) {
+              summary.added++
+              summary.add.push({
+                name: d.ideal.name,
+                version: d.ideal.package.version,
+                path: d.ideal.path,
+              })
+            }
             break
           case 'CHANGE':
             if (showDiff) {
               output.standard(`${chalk.cyan('change')} ${d.actual.name} ${d.actual.package.version} => ${d.ideal.package.version}`)
             }
             summary.changed++
+            summary.change.push({
+              from: {
+                name: d.actual.name,
+                version: d.actual.package.version,
+                path: d.actual.path,
+              },
+              to: {
+                name: d.ideal.name,
+                version: d.ideal.package.version,
+                path: d.ideal.path,
+              },
+            })
             break
           default:
             return

--- a/tap-snapshots/test/lib/utils/reify-output.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/reify-output.js.test.cjs
@@ -22,11 +22,14 @@ up to date in {TIME}
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":0,"removed":0,"changed":0,"audited":0,"json":true} 1`] = `
 {
+  "add": [],
   "added": 0,
-  "removed": 0,
-  "changed": 0,
   "audited": 0,
-  "funding": 0
+  "change": [],
+  "changed": 0,
+  "funding": 0,
+  "remove": [],
+  "removed": 0
 }
 `
 
@@ -39,11 +42,14 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":0,"removed":0,"changed":0,"audited":1,"json":true} 1`] = `
 {
+  "add": [],
   "added": 0,
-  "removed": 0,
-  "changed": 0,
   "audited": 1,
+  "change": [],
+  "changed": 0,
   "funding": 0,
+  "remove": [],
+  "removed": 0,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -68,11 +74,14 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":0,"removed":0,"changed":0,"audited":2,"json":true} 1`] = `
 {
+  "add": [],
   "added": 0,
-  "removed": 0,
-  "changed": 0,
   "audited": 2,
+  "change": [],
+  "changed": 0,
   "funding": 0,
+  "remove": [],
+  "removed": 0,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -83,11 +92,14 @@ exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added"
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":0,"removed":0,"changed":0,"audited":2,"json":true} 2`] = `
 {
+  "add": [],
   "added": 0,
-  "removed": 0,
-  "changed": 0,
   "audited": 2,
+  "change": [],
+  "changed": 0,
   "funding": 0,
+  "remove": [],
+  "removed": 0,
   "audit": {
     "vulnerabilities": {},
     "metadata": {
@@ -106,11 +118,27 @@ changed 1 package in {TIME}
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":0,"removed":0,"changed":1,"audited":0,"json":true} 1`] = `
 {
+  "add": [],
   "added": 0,
-  "removed": 0,
-  "changed": 1,
   "audited": 0,
-  "funding": 0
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 1,
+  "funding": 0,
+  "remove": [],
+  "removed": 0
 }
 `
 
@@ -123,11 +151,27 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":0,"removed":0,"changed":1,"audited":1,"json":true} 1`] = `
 {
+  "add": [],
   "added": 0,
-  "removed": 0,
-  "changed": 1,
   "audited": 1,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 1,
   "funding": 0,
+  "remove": [],
+  "removed": 0,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -145,11 +189,27 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":0,"removed":0,"changed":1,"audited":2,"json":true} 1`] = `
 {
+  "add": [],
   "added": 0,
-  "removed": 0,
-  "changed": 1,
   "audited": 2,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 1,
   "funding": 0,
+  "remove": [],
+  "removed": 0,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -165,11 +225,39 @@ changed 2 packages in {TIME}
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":0,"removed":0,"changed":2,"audited":0,"json":true} 1`] = `
 {
+  "add": [],
   "added": 0,
-  "removed": 0,
-  "changed": 2,
   "audited": 0,
-  "funding": 0
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg1",
+        "version": "1.0.1",
+        "path": "test/a/1"
+      },
+      "to": {
+        "name": "@npmcli/pkg1",
+        "version": "1.1.1",
+        "path": "test/i/1"
+      }
+    },
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 2,
+  "funding": 0,
+  "remove": [],
+  "removed": 0
 }
 `
 
@@ -182,11 +270,39 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":0,"removed":0,"changed":2,"audited":1,"json":true} 1`] = `
 {
+  "add": [],
   "added": 0,
-  "removed": 0,
-  "changed": 2,
   "audited": 1,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg1",
+        "version": "1.0.1",
+        "path": "test/a/1"
+      },
+      "to": {
+        "name": "@npmcli/pkg1",
+        "version": "1.1.1",
+        "path": "test/i/1"
+      }
+    },
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 2,
   "funding": 0,
+  "remove": [],
+  "removed": 0,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -204,11 +320,39 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":0,"removed":0,"changed":2,"audited":2,"json":true} 1`] = `
 {
+  "add": [],
   "added": 0,
-  "removed": 0,
-  "changed": 2,
   "audited": 2,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg1",
+        "version": "1.0.1",
+        "path": "test/a/1"
+      },
+      "to": {
+        "name": "@npmcli/pkg1",
+        "version": "1.1.1",
+        "path": "test/i/1"
+      }
+    },
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 2,
   "funding": 0,
+  "remove": [],
+  "removed": 0,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -224,11 +368,20 @@ removed 1 package in {TIME}
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":0,"removed":1,"changed":0,"audited":0,"json":true} 1`] = `
 {
+  "add": [],
   "added": 0,
-  "removed": 1,
-  "changed": 0,
   "audited": 0,
-  "funding": 0
+  "change": [],
+  "changed": 0,
+  "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 1
 }
 `
 
@@ -241,11 +394,20 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":0,"removed":1,"changed":0,"audited":1,"json":true} 1`] = `
 {
+  "add": [],
   "added": 0,
-  "removed": 1,
-  "changed": 0,
   "audited": 1,
+  "change": [],
+  "changed": 0,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 1,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -263,11 +425,20 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":0,"removed":1,"changed":0,"audited":2,"json":true} 1`] = `
 {
+  "add": [],
   "added": 0,
-  "removed": 1,
-  "changed": 0,
   "audited": 2,
+  "change": [],
+  "changed": 0,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 1,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -283,11 +454,33 @@ removed 1 package, and changed 1 package in {TIME}
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":0,"removed":1,"changed":1,"audited":0,"json":true} 1`] = `
 {
+  "add": [],
   "added": 0,
-  "removed": 1,
-  "changed": 1,
   "audited": 0,
-  "funding": 0
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 1,
+  "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 1
 }
 `
 
@@ -300,11 +493,33 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":0,"removed":1,"changed":1,"audited":1,"json":true} 1`] = `
 {
+  "add": [],
   "added": 0,
-  "removed": 1,
-  "changed": 1,
   "audited": 1,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 1,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 1,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -322,11 +537,33 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":0,"removed":1,"changed":1,"audited":2,"json":true} 1`] = `
 {
+  "add": [],
   "added": 0,
-  "removed": 1,
-  "changed": 1,
   "audited": 2,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 1,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 1,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -342,11 +579,45 @@ removed 1 package, and changed 2 packages in {TIME}
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":0,"removed":1,"changed":2,"audited":0,"json":true} 1`] = `
 {
+  "add": [],
   "added": 0,
-  "removed": 1,
-  "changed": 2,
   "audited": 0,
-  "funding": 0
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg1",
+        "version": "1.0.1",
+        "path": "test/a/1"
+      },
+      "to": {
+        "name": "@npmcli/pkg1",
+        "version": "1.1.1",
+        "path": "test/i/1"
+      }
+    },
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 2,
+  "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 1
 }
 `
 
@@ -359,11 +630,45 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":0,"removed":1,"changed":2,"audited":1,"json":true} 1`] = `
 {
+  "add": [],
   "added": 0,
-  "removed": 1,
-  "changed": 2,
   "audited": 1,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg1",
+        "version": "1.0.1",
+        "path": "test/a/1"
+      },
+      "to": {
+        "name": "@npmcli/pkg1",
+        "version": "1.1.1",
+        "path": "test/i/1"
+      }
+    },
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 2,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 1,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -381,11 +686,45 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":0,"removed":1,"changed":2,"audited":2,"json":true} 1`] = `
 {
+  "add": [],
   "added": 0,
-  "removed": 1,
-  "changed": 2,
   "audited": 2,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg1",
+        "version": "1.0.1",
+        "path": "test/a/1"
+      },
+      "to": {
+        "name": "@npmcli/pkg1",
+        "version": "1.1.1",
+        "path": "test/i/1"
+      }
+    },
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 2,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 1,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -401,11 +740,25 @@ removed 2 packages in {TIME}
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":0,"removed":2,"changed":0,"audited":0,"json":true} 1`] = `
 {
+  "add": [],
   "added": 0,
-  "removed": 2,
-  "changed": 0,
   "audited": 0,
-  "funding": 0
+  "change": [],
+  "changed": 0,
+  "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 2
 }
 `
 
@@ -418,11 +771,25 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":0,"removed":2,"changed":0,"audited":1,"json":true} 1`] = `
 {
+  "add": [],
   "added": 0,
-  "removed": 2,
-  "changed": 0,
   "audited": 1,
+  "change": [],
+  "changed": 0,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 2,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -440,11 +807,25 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":0,"removed":2,"changed":0,"audited":2,"json":true} 1`] = `
 {
+  "add": [],
   "added": 0,
-  "removed": 2,
-  "changed": 0,
   "audited": 2,
+  "change": [],
+  "changed": 0,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 2,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -460,11 +841,38 @@ removed 2 packages, and changed 1 package in {TIME}
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":0,"removed":2,"changed":1,"audited":0,"json":true} 1`] = `
 {
+  "add": [],
   "added": 0,
-  "removed": 2,
-  "changed": 1,
   "audited": 0,
-  "funding": 0
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 1,
+  "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 2
 }
 `
 
@@ -477,11 +885,38 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":0,"removed":2,"changed":1,"audited":1,"json":true} 1`] = `
 {
+  "add": [],
   "added": 0,
-  "removed": 2,
-  "changed": 1,
   "audited": 1,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 1,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 2,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -499,11 +934,38 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":0,"removed":2,"changed":1,"audited":2,"json":true} 1`] = `
 {
+  "add": [],
   "added": 0,
-  "removed": 2,
-  "changed": 1,
   "audited": 2,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 1,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 2,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -519,11 +981,50 @@ removed 2 packages, and changed 2 packages in {TIME}
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":0,"removed":2,"changed":2,"audited":0,"json":true} 1`] = `
 {
+  "add": [],
   "added": 0,
-  "removed": 2,
-  "changed": 2,
   "audited": 0,
-  "funding": 0
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg1",
+        "version": "1.0.1",
+        "path": "test/a/1"
+      },
+      "to": {
+        "name": "@npmcli/pkg1",
+        "version": "1.1.1",
+        "path": "test/i/1"
+      }
+    },
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 2,
+  "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 2
 }
 `
 
@@ -536,11 +1037,50 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":0,"removed":2,"changed":2,"audited":1,"json":true} 1`] = `
 {
+  "add": [],
   "added": 0,
-  "removed": 2,
-  "changed": 2,
   "audited": 1,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg1",
+        "version": "1.0.1",
+        "path": "test/a/1"
+      },
+      "to": {
+        "name": "@npmcli/pkg1",
+        "version": "1.1.1",
+        "path": "test/i/1"
+      }
+    },
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 2,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 2,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -558,11 +1098,50 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":0,"removed":2,"changed":2,"audited":2,"json":true} 1`] = `
 {
+  "add": [],
   "added": 0,
-  "removed": 2,
-  "changed": 2,
   "audited": 2,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg1",
+        "version": "1.0.1",
+        "path": "test/a/1"
+      },
+      "to": {
+        "name": "@npmcli/pkg1",
+        "version": "1.1.1",
+        "path": "test/i/1"
+      }
+    },
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 2,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 2,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -578,11 +1157,20 @@ added 1 package in {TIME}
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":1,"removed":0,"changed":0,"audited":0,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 1,
-  "removed": 0,
-  "changed": 0,
   "audited": 0,
-  "funding": 0
+  "change": [],
+  "changed": 0,
+  "funding": 0,
+  "remove": [],
+  "removed": 0
 }
 `
 
@@ -595,11 +1183,20 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":1,"removed":0,"changed":0,"audited":1,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 1,
-  "removed": 0,
-  "changed": 0,
   "audited": 1,
+  "change": [],
+  "changed": 0,
   "funding": 0,
+  "remove": [],
+  "removed": 0,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -617,11 +1214,20 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":1,"removed":0,"changed":0,"audited":2,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 1,
-  "removed": 0,
-  "changed": 0,
   "audited": 2,
+  "change": [],
+  "changed": 0,
   "funding": 0,
+  "remove": [],
+  "removed": 0,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -637,11 +1243,33 @@ added 1 package, and changed 1 package in {TIME}
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":1,"removed":0,"changed":1,"audited":0,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 1,
-  "removed": 0,
-  "changed": 1,
   "audited": 0,
-  "funding": 0
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 1,
+  "funding": 0,
+  "remove": [],
+  "removed": 0
 }
 `
 
@@ -654,11 +1282,33 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":1,"removed":0,"changed":1,"audited":1,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 1,
-  "removed": 0,
-  "changed": 1,
   "audited": 1,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 1,
   "funding": 0,
+  "remove": [],
+  "removed": 0,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -676,11 +1326,33 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":1,"removed":0,"changed":1,"audited":2,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 1,
-  "removed": 0,
-  "changed": 1,
   "audited": 2,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 1,
   "funding": 0,
+  "remove": [],
+  "removed": 0,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -696,11 +1368,45 @@ added 1 package, and changed 2 packages in {TIME}
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":1,"removed":0,"changed":2,"audited":0,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 1,
-  "removed": 0,
-  "changed": 2,
   "audited": 0,
-  "funding": 0
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg1",
+        "version": "1.0.1",
+        "path": "test/a/1"
+      },
+      "to": {
+        "name": "@npmcli/pkg1",
+        "version": "1.1.1",
+        "path": "test/i/1"
+      }
+    },
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 2,
+  "funding": 0,
+  "remove": [],
+  "removed": 0
 }
 `
 
@@ -713,11 +1419,45 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":1,"removed":0,"changed":2,"audited":1,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 1,
-  "removed": 0,
-  "changed": 2,
   "audited": 1,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg1",
+        "version": "1.0.1",
+        "path": "test/a/1"
+      },
+      "to": {
+        "name": "@npmcli/pkg1",
+        "version": "1.1.1",
+        "path": "test/i/1"
+      }
+    },
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 2,
   "funding": 0,
+  "remove": [],
+  "removed": 0,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -735,11 +1475,45 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":1,"removed":0,"changed":2,"audited":2,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 1,
-  "removed": 0,
-  "changed": 2,
   "audited": 2,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg1",
+        "version": "1.0.1",
+        "path": "test/a/1"
+      },
+      "to": {
+        "name": "@npmcli/pkg1",
+        "version": "1.1.1",
+        "path": "test/i/1"
+      }
+    },
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 2,
   "funding": 0,
+  "remove": [],
+  "removed": 0,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -755,11 +1529,26 @@ added 1 package, and removed 1 package in {TIME}
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":1,"removed":1,"changed":0,"audited":0,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 1,
-  "removed": 1,
-  "changed": 0,
   "audited": 0,
-  "funding": 0
+  "change": [],
+  "changed": 0,
+  "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 1
 }
 `
 
@@ -772,11 +1561,26 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":1,"removed":1,"changed":0,"audited":1,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 1,
-  "removed": 1,
-  "changed": 0,
   "audited": 1,
+  "change": [],
+  "changed": 0,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 1,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -794,11 +1598,26 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":1,"removed":1,"changed":0,"audited":2,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 1,
-  "removed": 1,
-  "changed": 0,
   "audited": 2,
+  "change": [],
+  "changed": 0,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 1,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -814,11 +1633,39 @@ added 1 package, removed 1 package, and changed 1 package in {TIME}
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":1,"removed":1,"changed":1,"audited":0,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 1,
-  "removed": 1,
-  "changed": 1,
   "audited": 0,
-  "funding": 0
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 1,
+  "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 1
 }
 `
 
@@ -831,11 +1678,39 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":1,"removed":1,"changed":1,"audited":1,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 1,
-  "removed": 1,
-  "changed": 1,
   "audited": 1,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 1,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 1,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -853,11 +1728,39 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":1,"removed":1,"changed":1,"audited":2,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 1,
-  "removed": 1,
-  "changed": 1,
   "audited": 2,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 1,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 1,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -873,11 +1776,51 @@ added 1 package, removed 1 package, and changed 2 packages in {TIME}
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":1,"removed":1,"changed":2,"audited":0,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 1,
-  "removed": 1,
-  "changed": 2,
   "audited": 0,
-  "funding": 0
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg1",
+        "version": "1.0.1",
+        "path": "test/a/1"
+      },
+      "to": {
+        "name": "@npmcli/pkg1",
+        "version": "1.1.1",
+        "path": "test/i/1"
+      }
+    },
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 2,
+  "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 1
 }
 `
 
@@ -890,11 +1833,51 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":1,"removed":1,"changed":2,"audited":1,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 1,
-  "removed": 1,
-  "changed": 2,
   "audited": 1,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg1",
+        "version": "1.0.1",
+        "path": "test/a/1"
+      },
+      "to": {
+        "name": "@npmcli/pkg1",
+        "version": "1.1.1",
+        "path": "test/i/1"
+      }
+    },
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 2,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 1,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -912,11 +1895,51 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":1,"removed":1,"changed":2,"audited":2,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 1,
-  "removed": 1,
-  "changed": 2,
   "audited": 2,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg1",
+        "version": "1.0.1",
+        "path": "test/a/1"
+      },
+      "to": {
+        "name": "@npmcli/pkg1",
+        "version": "1.1.1",
+        "path": "test/i/1"
+      }
+    },
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 2,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 1,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -932,11 +1955,31 @@ added 1 package, and removed 2 packages in {TIME}
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":1,"removed":2,"changed":0,"audited":0,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 1,
-  "removed": 2,
-  "changed": 0,
   "audited": 0,
-  "funding": 0
+  "change": [],
+  "changed": 0,
+  "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 2
 }
 `
 
@@ -949,11 +1992,31 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":1,"removed":2,"changed":0,"audited":1,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 1,
-  "removed": 2,
-  "changed": 0,
   "audited": 1,
+  "change": [],
+  "changed": 0,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 2,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -971,11 +2034,31 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":1,"removed":2,"changed":0,"audited":2,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 1,
-  "removed": 2,
-  "changed": 0,
   "audited": 2,
+  "change": [],
+  "changed": 0,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 2,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -991,11 +2074,44 @@ added 1 package, removed 2 packages, and changed 1 package in {TIME}
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":1,"removed":2,"changed":1,"audited":0,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 1,
-  "removed": 2,
-  "changed": 1,
   "audited": 0,
-  "funding": 0
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 1,
+  "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 2
 }
 `
 
@@ -1008,11 +2124,44 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":1,"removed":2,"changed":1,"audited":1,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 1,
-  "removed": 2,
-  "changed": 1,
   "audited": 1,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 1,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 2,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -1030,11 +2179,44 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":1,"removed":2,"changed":1,"audited":2,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 1,
-  "removed": 2,
-  "changed": 1,
   "audited": 2,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 1,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 2,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -1050,11 +2232,56 @@ added 1 package, removed 2 packages, and changed 2 packages in {TIME}
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":1,"removed":2,"changed":2,"audited":0,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 1,
-  "removed": 2,
-  "changed": 2,
   "audited": 0,
-  "funding": 0
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg1",
+        "version": "1.0.1",
+        "path": "test/a/1"
+      },
+      "to": {
+        "name": "@npmcli/pkg1",
+        "version": "1.1.1",
+        "path": "test/i/1"
+      }
+    },
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 2,
+  "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 2
 }
 `
 
@@ -1067,11 +2294,56 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":1,"removed":2,"changed":2,"audited":1,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 1,
-  "removed": 2,
-  "changed": 2,
   "audited": 1,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg1",
+        "version": "1.0.1",
+        "path": "test/a/1"
+      },
+      "to": {
+        "name": "@npmcli/pkg1",
+        "version": "1.1.1",
+        "path": "test/i/1"
+      }
+    },
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 2,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 2,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -1089,11 +2361,56 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":1,"removed":2,"changed":2,"audited":2,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 1,
-  "removed": 2,
-  "changed": 2,
   "audited": 2,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg1",
+        "version": "1.0.1",
+        "path": "test/a/1"
+      },
+      "to": {
+        "name": "@npmcli/pkg1",
+        "version": "1.1.1",
+        "path": "test/i/1"
+      }
+    },
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 2,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 2,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -1109,11 +2426,25 @@ added 2 packages in {TIME}
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":2,"removed":0,"changed":0,"audited":0,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 2,
-  "removed": 0,
-  "changed": 0,
   "audited": 0,
-  "funding": 0
+  "change": [],
+  "changed": 0,
+  "funding": 0,
+  "remove": [],
+  "removed": 0
 }
 `
 
@@ -1126,11 +2457,25 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":2,"removed":0,"changed":0,"audited":1,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 2,
-  "removed": 0,
-  "changed": 0,
   "audited": 1,
+  "change": [],
+  "changed": 0,
   "funding": 0,
+  "remove": [],
+  "removed": 0,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -1148,11 +2493,25 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":2,"removed":0,"changed":0,"audited":2,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 2,
-  "removed": 0,
-  "changed": 0,
   "audited": 2,
+  "change": [],
+  "changed": 0,
   "funding": 0,
+  "remove": [],
+  "removed": 0,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -1168,11 +2527,38 @@ added 2 packages, and changed 1 package in {TIME}
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":2,"removed":0,"changed":1,"audited":0,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 2,
-  "removed": 0,
-  "changed": 1,
   "audited": 0,
-  "funding": 0
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 1,
+  "funding": 0,
+  "remove": [],
+  "removed": 0
 }
 `
 
@@ -1185,11 +2571,38 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":2,"removed":0,"changed":1,"audited":1,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 2,
-  "removed": 0,
-  "changed": 1,
   "audited": 1,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 1,
   "funding": 0,
+  "remove": [],
+  "removed": 0,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -1207,11 +2620,38 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":2,"removed":0,"changed":1,"audited":2,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 2,
-  "removed": 0,
-  "changed": 1,
   "audited": 2,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 1,
   "funding": 0,
+  "remove": [],
+  "removed": 0,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -1227,11 +2667,50 @@ added 2 packages, and changed 2 packages in {TIME}
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":2,"removed":0,"changed":2,"audited":0,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 2,
-  "removed": 0,
-  "changed": 2,
   "audited": 0,
-  "funding": 0
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg1",
+        "version": "1.0.1",
+        "path": "test/a/1"
+      },
+      "to": {
+        "name": "@npmcli/pkg1",
+        "version": "1.1.1",
+        "path": "test/i/1"
+      }
+    },
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 2,
+  "funding": 0,
+  "remove": [],
+  "removed": 0
 }
 `
 
@@ -1244,11 +2723,50 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":2,"removed":0,"changed":2,"audited":1,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 2,
-  "removed": 0,
-  "changed": 2,
   "audited": 1,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg1",
+        "version": "1.0.1",
+        "path": "test/a/1"
+      },
+      "to": {
+        "name": "@npmcli/pkg1",
+        "version": "1.1.1",
+        "path": "test/i/1"
+      }
+    },
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 2,
   "funding": 0,
+  "remove": [],
+  "removed": 0,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -1266,11 +2784,50 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":2,"removed":0,"changed":2,"audited":2,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 2,
-  "removed": 0,
-  "changed": 2,
   "audited": 2,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg1",
+        "version": "1.0.1",
+        "path": "test/a/1"
+      },
+      "to": {
+        "name": "@npmcli/pkg1",
+        "version": "1.1.1",
+        "path": "test/i/1"
+      }
+    },
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 2,
   "funding": 0,
+  "remove": [],
+  "removed": 0,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -1286,11 +2843,31 @@ added 2 packages, and removed 1 package in {TIME}
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":2,"removed":1,"changed":0,"audited":0,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 2,
-  "removed": 1,
-  "changed": 0,
   "audited": 0,
-  "funding": 0
+  "change": [],
+  "changed": 0,
+  "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 1
 }
 `
 
@@ -1303,11 +2880,31 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":2,"removed":1,"changed":0,"audited":1,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 2,
-  "removed": 1,
-  "changed": 0,
   "audited": 1,
+  "change": [],
+  "changed": 0,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 1,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -1325,11 +2922,31 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":2,"removed":1,"changed":0,"audited":2,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 2,
-  "removed": 1,
-  "changed": 0,
   "audited": 2,
+  "change": [],
+  "changed": 0,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 1,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -1345,11 +2962,44 @@ added 2 packages, removed 1 package, and changed 1 package in {TIME}
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":2,"removed":1,"changed":1,"audited":0,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 2,
-  "removed": 1,
-  "changed": 1,
   "audited": 0,
-  "funding": 0
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 1,
+  "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 1
 }
 `
 
@@ -1362,11 +3012,44 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":2,"removed":1,"changed":1,"audited":1,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 2,
-  "removed": 1,
-  "changed": 1,
   "audited": 1,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 1,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 1,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -1384,11 +3067,44 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":2,"removed":1,"changed":1,"audited":2,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 2,
-  "removed": 1,
-  "changed": 1,
   "audited": 2,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 1,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 1,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -1404,11 +3120,56 @@ added 2 packages, removed 1 package, and changed 2 packages in {TIME}
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":2,"removed":1,"changed":2,"audited":0,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 2,
-  "removed": 1,
-  "changed": 2,
   "audited": 0,
-  "funding": 0
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg1",
+        "version": "1.0.1",
+        "path": "test/a/1"
+      },
+      "to": {
+        "name": "@npmcli/pkg1",
+        "version": "1.1.1",
+        "path": "test/i/1"
+      }
+    },
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 2,
+  "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 1
 }
 `
 
@@ -1421,11 +3182,56 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":2,"removed":1,"changed":2,"audited":1,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 2,
-  "removed": 1,
-  "changed": 2,
   "audited": 1,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg1",
+        "version": "1.0.1",
+        "path": "test/a/1"
+      },
+      "to": {
+        "name": "@npmcli/pkg1",
+        "version": "1.1.1",
+        "path": "test/i/1"
+      }
+    },
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 2,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 1,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -1443,11 +3249,56 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":2,"removed":1,"changed":2,"audited":2,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 2,
-  "removed": 1,
-  "changed": 2,
   "audited": 2,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg1",
+        "version": "1.0.1",
+        "path": "test/a/1"
+      },
+      "to": {
+        "name": "@npmcli/pkg1",
+        "version": "1.1.1",
+        "path": "test/i/1"
+      }
+    },
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 2,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 1,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -1463,11 +3314,36 @@ added 2 packages, and removed 2 packages in {TIME}
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":2,"removed":2,"changed":0,"audited":0,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 2,
-  "removed": 2,
-  "changed": 0,
   "audited": 0,
-  "funding": 0
+  "change": [],
+  "changed": 0,
+  "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 2
 }
 `
 
@@ -1480,11 +3356,36 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":2,"removed":2,"changed":0,"audited":1,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 2,
-  "removed": 2,
-  "changed": 0,
   "audited": 1,
+  "change": [],
+  "changed": 0,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 2,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -1502,11 +3403,36 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":2,"removed":2,"changed":0,"audited":2,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 2,
-  "removed": 2,
-  "changed": 0,
   "audited": 2,
+  "change": [],
+  "changed": 0,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 2,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -1522,11 +3448,49 @@ added 2 packages, removed 2 packages, and changed 1 package in {TIME}
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":2,"removed":2,"changed":1,"audited":0,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 2,
-  "removed": 2,
-  "changed": 1,
   "audited": 0,
-  "funding": 0
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 1,
+  "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 2
 }
 `
 
@@ -1539,11 +3503,49 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":2,"removed":2,"changed":1,"audited":1,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 2,
-  "removed": 2,
-  "changed": 1,
   "audited": 1,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 1,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 2,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -1561,11 +3563,49 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":2,"removed":2,"changed":1,"audited":2,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 2,
-  "removed": 2,
-  "changed": 1,
   "audited": 2,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 1,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 2,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -1581,11 +3621,61 @@ added 2 packages, removed 2 packages, and changed 2 packages in {TIME}
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":2,"removed":2,"changed":2,"audited":0,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 2,
-  "removed": 2,
-  "changed": 2,
   "audited": 0,
-  "funding": 0
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg1",
+        "version": "1.0.1",
+        "path": "test/a/1"
+      },
+      "to": {
+        "name": "@npmcli/pkg1",
+        "version": "1.1.1",
+        "path": "test/i/1"
+      }
+    },
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 2,
+  "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 2
 }
 `
 
@@ -1598,11 +3688,61 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":2,"removed":2,"changed":2,"audited":1,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 2,
-  "removed": 2,
-  "changed": 2,
   "audited": 1,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg1",
+        "version": "1.0.1",
+        "path": "test/a/1"
+      },
+      "to": {
+        "name": "@npmcli/pkg1",
+        "version": "1.1.1",
+        "path": "test/i/1"
+      }
+    },
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 2,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 2,
   "audit": {
     "vulnerabilities": {
       "total": 0
@@ -1620,11 +3760,61 @@ found 0 vulnerabilities
 
 exports[`test/lib/utils/reify-output.js TAP packages changed message  > {"added":2,"removed":2,"changed":2,"audited":2,"json":true} 1`] = `
 {
+  "add": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
   "added": 2,
-  "removed": 2,
-  "changed": 2,
   "audited": 2,
+  "change": [
+    {
+      "from": {
+        "name": "@npmcli/pkg1",
+        "version": "1.0.1",
+        "path": "test/a/1"
+      },
+      "to": {
+        "name": "@npmcli/pkg1",
+        "version": "1.1.1",
+        "path": "test/i/1"
+      }
+    },
+    {
+      "from": {
+        "name": "@npmcli/pkg0",
+        "version": "1.0.0",
+        "path": "test/a/0"
+      },
+      "to": {
+        "name": "@npmcli/pkg0",
+        "version": "1.1.0",
+        "path": "test/i/0"
+      }
+    }
+  ],
+  "changed": 2,
   "funding": 0,
+  "remove": [
+    {
+      "name": "@npmcli/pkg1",
+      "version": "1.0.1",
+      "path": "test/1"
+    },
+    {
+      "name": "@npmcli/pkg0",
+      "version": "1.0.0",
+      "path": "test/0"
+    }
+  ],
+  "removed": 2,
   "audit": {
     "vulnerabilities": {
       "total": 0

--- a/test/lib/utils/reify-output.js
+++ b/test/lib/utils/reify-output.js
@@ -310,16 +310,16 @@ t.test('packages changed message', async t => {
       },
     }
     for (let i = 0; i < added; i++) {
-      mock.diff.children.push({ action: 'ADD', ideal: { location: 'loc' } })
+      mock.diff.children.push({ action: 'ADD', ideal: { path: `test/${i}`, name: `@npmcli/pkg${i}`, location: 'loc', package: { version: `1.0.${i}` } } })
     }
 
     for (let i = 0; i < removed; i++) {
-      mock.diff.children.push({ action: 'REMOVE', actual: { location: 'loc' } })
+      mock.diff.children.push({ action: 'REMOVE', actual: { path: `test/${i}`, name: `@npmcli/pkg${i}`, location: 'loc', package: { version: `1.0.${i}` } } })
     }
 
     for (let i = 0; i < changed; i++) {
-      const actual = { location: 'loc' }
-      const ideal = { location: 'loc' }
+      const actual = { path: `test/a/${i}`, name: `@npmcli/pkg${i}`, location: 'loc', package: { version: `1.0.${i}` } }
+      const ideal = { path: `test/i/${i}`, name: `@npmcli/pkg${i}`, location: 'loc', package: { version: `1.1.${i}` } }
       mock.diff.children.push({ action: 'CHANGE', actual, ideal })
     }
 
@@ -366,7 +366,7 @@ t.test('added packages should be looked up within returned tree', async t => {
       },
       diff: {
         children: [
-          { action: 'ADD', ideal: { name: 'baz' } },
+          { action: 'ADD', ideal: { path: 'test/baz', name: 'baz', package: { version: '1.0.0' } } },
         ],
       },
     })
@@ -384,7 +384,7 @@ t.test('added packages should be looked up within returned tree', async t => {
       },
       diff: {
         children: [
-          { action: 'ADD', ideal: { name: 'baz' } },
+          { action: 'ADD', ideal: { path: 'test/baz', name: 'baz', package: { version: '1.0.0' } } },
         ],
       },
     })
@@ -403,12 +403,12 @@ t.test('prints dedupe difference on dry-run', async t => {
     },
     diff: {
       children: [
-        { action: 'ADD', ideal: { name: 'foo', package: { version: '1.0.0' } } },
-        { action: 'REMOVE', actual: { name: 'bar', package: { version: '1.0.0' } } },
+        { action: 'ADD', ideal: { path: 'test/foo', name: 'foo', package: { version: '1.0.0' } } },
+        { action: 'REMOVE', actual: { path: 'test/foo', name: 'bar', package: { version: '1.0.0' } } },
         {
           action: 'CHANGE',
-          actual: { name: 'bar', package: { version: '1.0.0' } },
-          ideal: { package: { version: '2.1.0' } },
+          actual: { path: 'test/a/bar', name: 'bar', package: { version: '1.0.0' } },
+          ideal: { path: 'test/i/bar', name: 'bar', package: { version: '2.1.0' } },
         },
       ],
     },
@@ -431,12 +431,12 @@ t.test('prints dedupe difference on long', async t => {
     },
     diff: {
       children: [
-        { action: 'ADD', ideal: { name: 'foo', package: { version: '1.0.0' } } },
-        { action: 'REMOVE', actual: { name: 'bar', package: { version: '1.0.0' } } },
+        { action: 'ADD', ideal: { path: 'test/foo', name: 'foo', package: { version: '1.0.0' } } },
+        { action: 'REMOVE', actual: { path: 'test/bar', name: 'bar', package: { version: '1.0.0' } } },
         {
           action: 'CHANGE',
-          actual: { name: 'bar', package: { version: '1.0.0' } },
-          ideal: { package: { version: '2.1.0' } },
+          actual: { path: 'test/a/bar', name: 'bar', package: { version: '1.0.0' } },
+          ideal: { path: 'test/i/bar', name: 'bar', package: { version: '2.1.0' } },
         },
       ],
     },


### PR DESCRIPTION
This was removed in npm 7 and never got re-added.  In order for this not to be a breaking change the info was added to new fields, since the old fields are already being used to return counts.

This differs slightly from the npm 6 output, as "changed" now has a "from" and "to" field instead of a tacked on "previousVersion" field.

Closes: https://github.com/npm/cli/issues/6558
