### PR TITLE
fix: handle missing `time` in packument to prevent crash on `npm view`

### DIFF
--- a/lib/commands/view.js
+++ b/lib/commands/view.js
@@ -266,11 +266,13 @@ class View extends BaseCommand {
     const deps = Object.entries(manifest.dependencies || {}).map(([k, dep]) =>
       `${chalk.blue(k)}: ${dep}`
     )
-    // Sort dist-tags by publish time, then tag name, keeping latest at the top of the list
+
+    // Sort dist-tags by publish time when available, then by tag name, keeping `latest` at the top of the list.
     const distTags = Object.entries(packu['dist-tags'])
       .sort(([aTag, aVer], [bTag, bVer]) => {
-        const aTime = aTag === 'latest' ? Infinity : Date.parse(packu.time[aVer])
-        const bTime = bTag === 'latest' ? Infinity : Date.parse(packu.time[bVer])
+        const timeMap = packu.time || {}
+        const aTime = aTag === 'latest' ? Infinity : Date.parse(timeMap[aVer] || 0)
+        const bTime = bTag === 'latest' ? Infinity : Date.parse(timeMap[bVer] || 0)
         if (aTime === bTime) {
           return aTag > bTag ? -1 : 1
         }
@@ -357,7 +359,7 @@ class View extends BaseCommand {
     })
     if (publisher || packu.time) {
       let publishInfo = 'published'
-      if (packu.time) {
+      if (packu.time?.[manifest.version]) {
         publishInfo += ` ${chalk.cyan(relativeDate(packu.time[manifest.version]))}`
       }
       if (publisher) {

--- a/tap-snapshots/test/lib/commands/view.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/view.js.test.cjs
@@ -279,6 +279,22 @@ dist-tags:
 [34mlatest[39m: 1.0.0
 `
 
+exports[`test/lib/commands/view.js TAP package with multiple dist‑tags and no time > must match snapshot 1`] = `
+
+[4m[36mgray@1.1.0[39m[24m | [31mProprietary[39m | deps: [36mnone[39m | versions: [36m1[39m
+
+dist
+.tarball: [34mhttp://gray/1.1.0.tgz[39m
+.shasum: [32mb[39m
+
+dist-tags:
+[34mlatest[39m: 1.1.0
+[34mstable[39m: 1.1.0
+[34mold[39m: 1.0.0
+[34mbeta[39m: 1.2.0-beta
+[34malpha[39m: 1.2.0-alpha
+`
+
 exports[`test/lib/commands/view.js TAP package with no modified time > must match snapshot 1`] = `
 
 [4m[36mcyan@1.0.0[39m[24m | [31mProprietary[39m | deps: [36mnone[39m | versions: [36m2[39m

--- a/test/lib/commands/view.js
+++ b/test/lib/commands/view.js
@@ -79,6 +79,29 @@ const packument = (nv, opts) => {
         },
       },
     },
+    // package with no time attribute
+    gray: {
+      _id: 'gray',
+      name: 'gray',
+      'dist-tags': {
+        latest: '1.1.0',
+        beta: '1.2.0-beta',
+        alpha: '1.2.0-alpha',
+        old: '1.0.0',
+        stable: '1.1.0',
+      },
+      versions: {
+        '1.1.0': {
+          name: 'gray',
+          version: '1.1.0',
+          dist: {
+            shasum: 'b',
+            tarball: 'http://gray/1.1.0.tgz',
+            fileCount: 1,
+          },
+        },
+      },
+    },
     cyan: {
       _npmUser: {
         name: 'claudia',
@@ -768,4 +791,10 @@ t.test('no package completion', async t => {
   const res = await view.completion({ conf: { argv: { remain: ['npm', 'view'] } } })
   t.notOk(res, 'there is no package completion')
   t.end()
+})
+
+t.test('package with multiple dist‑tags and no time', async t => {
+  const { view, joinedOutput } = await loadMockNpm(t, { config: { unicode: false } })
+  await view.exec(['https://github.com/npm/gray'])
+  t.matchSnapshot(joinedOutput())
 })


### PR DESCRIPTION
fixes https://github.com/npm/cli/issues/8132

Before & After

![image](https://github.com/user-attachments/assets/ca92029f-5b43-448c-a75a-0129a72f580c)

Validated that tests start throwing errors without the fix ✅ 
