### PR TITLE
fix(docs): prepare script runs for local package links

### DIFF
--- a/docs/lib/content/using-npm/scripts.md
+++ b/docs/lib/content/using-npm/scripts.md
@@ -46,6 +46,7 @@ situations. These scripts happen in addition to the `pre<event>`, `post<event>`,
     and `npm pack`
 * Runs on local `npm install` without any arguments
 * Runs AFTER `prepublish`, but BEFORE `prepublishOnly`
+* Runs for a package if it's being installed as a link through `npm install <folder>`
 
 * NOTE: If a package being installed through git contains a `prepare`
  script, its `dependencies` and `devDependencies` will be installed, and


### PR DESCRIPTION
Prepare script runs for a package when a package is installed as link `npm install <folder>`. 
https://github.com/npm/cli/blob/3231ee9afefcadce2b17a143fd51d365de4d6dea/workspaces/arborist/lib/arborist/rebuild.js#L155-L160

fixes: https://github.com/npm/cli/issues/8121
