### PR TITLE
fix(arborist): Add better error message when lockfile is malformed

### DIFF
--- a/workspaces/arborist/lib/arborist/load-virtual.js
+++ b/workspaces/arborist/lib/arborist/load-virtual.js
@@ -200,6 +200,18 @@ module.exports = cls => class VirtualLoader extends cls {
       const targetPath = resolve(this.path, meta.resolved)
       const targetLoc = relpath(this.path, targetPath)
       const target = nodes.get(targetLoc)
+
+      if (!target) {
+        const err = new Error(
+`Missing target in lock file: "${targetLoc}" is referenced by "${location}" but does not exist.
+To fix:
+1. rm package-lock.json
+2. npm install`
+        )
+        err.code = 'EMISSINGTARGET'
+        throw err
+      }
+
       const link = this.#loadLink(location, targetLoc, target, meta)
       nodes.set(location, link)
       nodes.set(targetLoc, link.target)

--- a/workspaces/arborist/test/arborist/load-virtual.js
+++ b/workspaces/arborist/test/arborist/load-virtual.js
@@ -245,3 +245,44 @@ t.test('do not bundle the entire universe', async t => {
     'yaml',
   ].sort())
 })
+
+t.test('error when link target is missing', async t => {
+  const path = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'root',
+      workspaces: ['packages/*'],
+    }),
+    'package-lock.json': JSON.stringify({
+      name: 'root',
+      lockfileVersion: 3,
+      packages: {
+        '': {
+          workspaces: ['packages/*'],
+        },
+        // This is the problematic entry - a link with no corresponding target
+        'node_modules/@my-scope/my-package': {
+          resolved: 'packages/some-folder/my-package',
+          link: true,
+        },
+        // Missing entry for 'packages/some-folder/my-package'
+      },
+    }),
+    packages: {
+      'some-folder': {
+        'my-package': {
+          'package.json': JSON.stringify({
+            name: '@my-scope/my-package',
+            version: '1.0.0',
+          }),
+        },
+      },
+    },
+  })
+
+  const arb = new Arborist({ path })
+
+  await t.rejects(arb.loadVirtual(), {
+    code: 'EMISSINGTARGET',
+    message: /Missing target in lock file:.*but does not exist/,
+  })
+})


### PR DESCRIPTION
Overrides #6997 with a more standard way of expressing errors in the cli and has a test for it.