### PR TITLE
fix: correctly handle scenario where prefix is the cwd

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -127,7 +127,7 @@ class Install extends ArboristWorkspaceCmd {
     args = args.filter(a => resolve(a) !== this.npm.prefix)
 
     // `npm i -g` => "install this package globally"
-    if (where === globalTop && !args.length) {
+    if (isGlobalInstall && !args.length) {
       args = ['.']
     }
 

--- a/test/fixtures/mock-npm.js
+++ b/test/fixtures/mock-npm.js
@@ -107,6 +107,7 @@ const setupMockNpm = async (t, {
   exec = null, // optionally exec the command before returning
   // test dirs
   prefixDir = {},
+  prefixOverride = null, // sets global and local prefix to this, the same as the `--prefix` flag
   homeDir = {},
   cacheDir = {},
   globalPrefixDir = { node_modules: {} },
@@ -170,9 +171,9 @@ const setupMockNpm = async (t, {
 
   const dirs = {
     testdir: dir,
-    prefix: path.join(dir, 'prefix'),
+    prefix: prefixOverride ?? path.join(dir, 'prefix'),
     cache: path.join(dir, 'cache'),
-    globalPrefix: path.join(dir, 'global'),
+    globalPrefix: prefixOverride ?? path.join(dir, 'global'),
     home: path.join(dir, 'home'),
     other: path.join(dir, 'other'),
   }

--- a/test/lib/commands/install.js
+++ b/test/lib/commands/install.js
@@ -126,6 +126,25 @@ t.test('exec commands', async t => {
     await npm.exec('install')
   })
 
+  await t.test('should not self-install package if prefix is the same as CWD', async t => {
+    let REIFY_CALLED_WITH = null
+    const { npm } = await loadMockNpm(t, {
+      mocks: {
+        '{LIB}/utils/reify-finish.js': async () => {},
+        '@npmcli/run-script': () => {},
+        '@npmcli/arborist': function () {
+          this.reify = (opts) => {
+            REIFY_CALLED_WITH = opts
+          }
+        },
+      },
+      prefixOverride: process.cwd(),
+    })
+
+    await npm.exec('install')
+    t.equal(REIFY_CALLED_WITH.add.length, 0, 'did not install current directory as a dependency')
+  })
+
   await t.test('should not install invalid global package name', async t => {
     const { npm } = await loadMockNpm(t, {
       config: {


### PR DESCRIPTION
closes https://github.com/npm/cli/issues/6960

related https://github.com/npm/cli/pull/7208

resolves feedback from https://github.com/npm/cli/pull/7208#discussion_r2035590840 and https://github.com/npm/cli/pull/7208#pullrequestreview-2561239832

Manually verified the fix on windows