### PR TITLE
fix: Error due to missing null check

### DIFF
--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -571,7 +571,7 @@ module.exports = cls => class Reifier extends cls {
       const { top } = node
 
       // if the top is not the root or workspace then we do not want to omit it
-      if (!top.isProjectRoot && !top.isWorkspace) {
+      if (top && !top.isProjectRoot && !top.isWorkspace) {
         continue
       }
 


### PR DESCRIPTION
**PROBLEM**:
The PR enhances to address the issue "TypeError:cannot read properties of undefined (reading `isProjectRoot`) 
identified the root cause of the issue and implemented the solution. The changes in `reify.js` handle cases where `isProjectRoot` is undefined.The code assumes all nodes in the dependency tree have the `isProjectRoot` property. However, in some cases(e.g, when a dependency is missing or improperly linked) the node object is undefined, leading to the error.

**Solution**:
- Added a null/undefined check before accessing the `isProjectRoot` property.
- Updated the logic in `reify.js` to ensure that the code gracefully handles cases where the node object is undefined.

**Reference**:
#7067
