### PR TITLE
fix(version): include prerelease when retriving tag

### DIFF
--- a/workspaces/libnpmversion/lib/retrieve-tag.js
+++ b/workspaces/libnpmversion/lib/retrieve-tag.js
@@ -5,7 +5,7 @@ module.exports = async opts => {
   const tag = (await spawn(
     ['describe', '--tags', '--abbrev=0', '--match=*.*.*'],
     opts)).stdout.trim()
-  const ver = semver.coerce(tag, { loose: true })
+  const ver = semver.coerce(tag, { loose: true, includePrerelease: true })
   if (ver) {
     return ver.version
   }

--- a/workspaces/libnpmversion/test/retrieve-tag.js
+++ b/workspaces/libnpmversion/test/retrieve-tag.js
@@ -18,3 +18,8 @@ t.test('yes a valid semver tag', async t => {
   tag = 'this is a version tho: Release-1.2.3 candidate'
   t.equal(await retrieveTag(), '1.2.3')
 })
+
+t.test('yes a valid semver pre-release tag', async t => {
+  tag = 'this is a prerelease version tho: Release-1.2.3-pre.1 candidate'
+  t.equal(await retrieveTag(), '1.2.3-pre.1')
+})


### PR DESCRIPTION
Include pre-release when retrieving tags to use as version. 

fixes: https://github.com/npm/cli/issues/8275
