### PR TITLE
chore(smoke-tests): loosen check on install count

### DIFF
--- a/smoke-tests/test/large-install.js
+++ b/smoke-tests/test/large-install.js
@@ -29,9 +29,7 @@ const runTest = async (t, { lowMemory } = {}) => {
 // should be investigated.
 t.test('large install', async t => {
   const { stdout } = await runTest(t)
-  // As a bonus this test asserts that this package-lock always
-  // installs the same number of packages.
-  t.match(stdout, `added 130${process.platform === 'win32' ? 7 : 6} packages in`)
+  t.match(stdout, /added \d+ packages/)
 })
 
 t.test('large install, no lock and low memory', async t => {


### PR DESCRIPTION
These are not consistent and can change if the packages being installed change.  It's not worth trying to keep up w/ this exact number.

We have other tests that ensure the components of install work properly.  This is just a smoke test.
