### PR TITLE
docs: fix `overrides` example in package-json.md

### DIFF
--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -951,7 +951,7 @@ resolution. Published packages may dictate their resolutions by pinning
 dependencies or using an
 [`npm-shrinkwrap.json`](/configuring-npm/npm-shrinkwrap-json) file.
 
-To make sure the package `foo` is always installed as version `1.0.0` no matter
+To make sure the package `@npm/foo` is always installed as version `1.0.0` no matter
 what version your dependencies rely on:
 
 ```json


### PR DESCRIPTION
The example and further discussion are about `@npm/foo` but the first mention just says `foo`, which might mislead people into thinking `@npm/` is a special syntax rather than just part of the package name.
