### PR TITLE
fix(docs): corrected github_path

### DIFF
--- a/docs/lib/build.js
+++ b/docs/lib/build.js
@@ -77,7 +77,7 @@ const run = async ({ content, template, nav, man, html, md }) => {
         ...data,
         github_repo: 'npm/cli',
         github_branch: 'latest',
-        github_path: 'docs/content',
+        github_path: 'docs/lib/content',
       },
       frontmatter,
       ...options,


### PR DESCRIPTION
Fixed `github_path` to correctly link to the GitHub edit page.

## References
 Fixes #8212 