### PR TITLE
docs: Remove `CHANGELOG` from never-ignored list

### DIFF
--- a/docs/lib/content/using-npm/developers.md
+++ b/docs/lib/content/using-npm/developers.md
@@ -139,7 +139,6 @@ The following paths and files are never ignored, so adding them to
 
 * `package.json`
 * `README` (and its variants)
-* `CHANGELOG` (and its variants)
 * `LICENSE` / `LICENCE`
 
 If, given the structure of your project, you find `.npmignore` to be a


### PR DESCRIPTION
It seems that the `CHANGELOG` files are not in the never ignored list since https://github.com/npm/npm-packlist/pull/61

## References

Also see the list at [package.json#files](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#files). 