### PR TITLE
fix(powershell): support pipeline input with Invoke-Expression

### DIFF
--- a/bin/npm.ps1
+++ b/bin/npm.ps1
@@ -37,7 +37,9 @@ if ($MyInvocation.Line) { # used "-Command" argument
 
   # Support pipeline input
   if ($MyInvocation.ExpectingInput) {
-    $input | Invoke-Expression "& `"$NODE_EXE`" `"$NPM_CLI_JS`" $NPM_ARGS"
+    $input = (@($input) -join "`n").Replace("``", "````")
+
+    Invoke-Expression "Write-Output `"$input`" | & `"$NODE_EXE`" `"$NPM_CLI_JS`" $NPM_ARGS"
   } else {
     Invoke-Expression "& `"$NODE_EXE`" `"$NPM_CLI_JS`" $NPM_ARGS"
   }

--- a/bin/npx.ps1
+++ b/bin/npx.ps1
@@ -37,7 +37,9 @@ if ($MyInvocation.Line) { # used "-Command" argument
 
   # Support pipeline input
   if ($MyInvocation.ExpectingInput) {
-    $input | Invoke-Expression "& `"$NODE_EXE`" `"$NPX_CLI_JS`" $NPX_ARGS"
+    $input = (@($input) -join "`n").Replace("``", "````")
+
+    Invoke-Expression "Write-Output `"$input`" | & `"$NODE_EXE`" `"$NPX_CLI_JS`" $NPX_ARGS"
   } else {
     Invoke-Expression "& `"$NODE_EXE`" `"$NPX_CLI_JS`" $NPX_ARGS"
   }


### PR DESCRIPTION
requires https://github.com/npm/cli/pull/8318 after

---

needs this PR first: https://github.com/npm/cli/pull/8278

---

fixes the case with Invoke-Expression and pipeline input to work

```
"Line 1", "Line 2", "Line 3" | npm start
```

above syntax **ONLY** works in PowerShell

**OUTPUT**
```

> start
> node script.js

Processed: Line 1
Processed: Line 2
Processed: Line 3
```

---

given.....

**[package.json]**
```json
{
  "scripts": {
    "start": "node script.js"
  }
}
```

**[script.js]**
```js
const readline = require('readline')

const rl = readline.createInterface({
  input: process.stdin,
  output: process.stdout,
  terminal: false
})

rl.on('line', (line) => {
  console.log(`Processed: ${line}`)
})
```

---

manually tested with PowerShell