### PR TITLE
invalid

### DIFF
--- a/bin/npm.ps1
+++ b/bin/npm.ps1
@@ -37,7 +37,9 @@ if ($MyInvocation.Line) { # used "-Command" argument
 
   # Support pipeline input
   if ($MyInvocation.ExpectingInput) {
-    $input | Invoke-Expression "& `"$NODE_EXE`" `"$NPM_CLI_JS`" $NPM_ARGS"
+    $input = (@($input) -join "`n").Replace("``", "````")
+
+    Invoke-Expression "Write-Output `"$input`" | & `"$NODE_EXE`" `"$NPM_CLI_JS`" $NPM_ARGS"
   } else {
     Invoke-Expression "& `"$NODE_EXE`" `"$NPM_CLI_JS`" $NPM_ARGS"
   }

--- a/bin/npm.ps1
+++ b/bin/npm.ps1
@@ -22,11 +22,32 @@ if (Test-Path $NPM_PREFIX_NPM_CLI_JS) {
   $NPM_CLI_JS=$NPM_PREFIX_NPM_CLI_JS
 }
 
-# Support pipeline input
-if ($MyInvocation.ExpectingInput) {
-  $input | & $NODE_EXE $NPM_CLI_JS $args
-} else {
-  & $NODE_EXE $NPM_CLI_JS $args
+if ($MyInvocation.Line) { # used "-Command" argument
+  if ($MyInvocation.Statement) {
+    $NPM_ARGS = $MyInvocation.Statement.Substring($MyInvocation.InvocationName.Length).Trim()
+  } else {
+    $NPM_OG_COMMAND = (
+      [System.Management.Automation.InvocationInfo].GetProperty('ScriptPosition', [System.Reflection.BindingFlags] 'Instance, NonPublic')
+    ).GetValue($MyInvocation).Text
+    $NPM_ARGS = $NPM_OG_COMMAND.Substring($MyInvocation.InvocationName.Length).Trim()
+  }
+
+  $NODE_EXE = $NODE_EXE.Replace("``", "````")
+  $NPM_CLI_JS = $NPM_CLI_JS.Replace("``", "````")
+
+  # Support pipeline input
+  if ($MyInvocation.ExpectingInput) {
+    $input | Invoke-Expression "& `"$NODE_EXE`" `"$NPM_CLI_JS`" $NPM_ARGS"
+  } else {
+    Invoke-Expression "& `"$NODE_EXE`" `"$NPM_CLI_JS`" $NPM_ARGS"
+  }
+} else { # used "-File" argument
+  # Support pipeline input
+  if ($MyInvocation.ExpectingInput) {
+    $input | & $NODE_EXE $NPM_CLI_JS $args
+  } else {
+    & $NODE_EXE $NPM_CLI_JS $args
+  }
 }
 
 exit $LASTEXITCODE

--- a/bin/npx.ps1
+++ b/bin/npx.ps1
@@ -37,7 +37,9 @@ if ($MyInvocation.Line) { # used "-Command" argument
 
   # Support pipeline input
   if ($MyInvocation.ExpectingInput) {
-    $input | Invoke-Expression "& `"$NODE_EXE`" `"$NPX_CLI_JS`" $NPX_ARGS"
+    $input = (@($input) -join "`n").Replace("``", "````")
+
+    Invoke-Expression "Write-Output `"$input`" | & `"$NODE_EXE`" `"$NPX_CLI_JS`" $NPX_ARGS"
   } else {
     Invoke-Expression "& `"$NODE_EXE`" `"$NPX_CLI_JS`" $NPX_ARGS"
   }

--- a/bin/npx.ps1
+++ b/bin/npx.ps1
@@ -22,11 +22,32 @@ if (Test-Path $NPM_PREFIX_NPX_CLI_JS) {
   $NPX_CLI_JS=$NPM_PREFIX_NPX_CLI_JS
 }
 
-# Support pipeline input
-if ($MyInvocation.ExpectingInput) {
-  $input | & $NODE_EXE $NPX_CLI_JS $args
-} else {
-  & $NODE_EXE $NPX_CLI_JS $args
+if ($MyInvocation.Line) { # used "-Command" argument
+  if ($MyInvocation.Statement) {
+    $NPX_ARGS = $MyInvocation.Statement.Substring($MyInvocation.InvocationName.Length).Trim()
+  } else {
+    $NPX_OG_COMMAND = (
+      [System.Management.Automation.InvocationInfo].GetProperty('ScriptPosition', [System.Reflection.BindingFlags] 'Instance, NonPublic')
+    ).GetValue($MyInvocation).Text
+    $NPX_ARGS = $NPX_OG_COMMAND.Substring($MyInvocation.InvocationName.Length).Trim()
+  }
+
+  $NODE_EXE = $NODE_EXE.Replace("``", "````")
+  $NPX_CLI_JS = $NPX_CLI_JS.Replace("``", "````")
+
+  # Support pipeline input
+  if ($MyInvocation.ExpectingInput) {
+    $input | Invoke-Expression "& `"$NODE_EXE`" `"$NPX_CLI_JS`" $NPX_ARGS"
+  } else {
+    Invoke-Expression "& `"$NODE_EXE`" `"$NPX_CLI_JS`" $NPX_ARGS"
+  }
+} else { # used "-File" argument
+  # Support pipeline input
+  if ($MyInvocation.ExpectingInput) {
+    $input | & $NODE_EXE $NPX_CLI_JS $args
+  } else {
+    & $NODE_EXE $NPX_CLI_JS $args
+  }
 }
 
 exit $LASTEXITCODE


### PR DESCRIPTION
Backport of https://github.com/npm/cli/pull/8278 for npm 10 series

Includes https://github.com/npm/cli/pull/8297

Co-authored-by: @mbtools 59966492+mbtools@users.noreply.github.com

---

From https://github.com/npm/cli/pull/8288#issuecomment-2874072299

> Since npm 10 is in a maintenance mode we're gonna sit on this PR till the next npm 11 release is out and folks have had a chance to test this new script out. If there are any hiccups that'll cut back on the backporting we have to do.

