### PR TITLE
invalid

### DIFF
--- a/bin/npm.ps1
+++ b/bin/npm.ps1
@@ -37,7 +37,7 @@ if ($MyInvocation.Line) { # used "-Command" argument
 
   # Support pipeline input
   if ($MyInvocation.ExpectingInput) {
-    $input = (@($input) -join "`n").Replace("``", "````")
+    $input = (@($input) -join "`n").Replace("``", "````").Replace("`"", "```"")
 
     Invoke-Expression "Write-Output `"$input`" | & `"$NODE_EXE`" `"$NPM_CLI_JS`" $NPM_ARGS"
   } else {

--- a/bin/npx.ps1
+++ b/bin/npx.ps1
@@ -37,7 +37,7 @@ if ($MyInvocation.Line) { # used "-Command" argument
 
   # Support pipeline input
   if ($MyInvocation.ExpectingInput) {
-    $input = (@($input) -join "`n").Replace("``", "````")
+    $input = (@($input) -join "`n").Replace("``", "````").Replace("`"", "```"")
 
     Invoke-Expression "Write-Output `"$input`" | & `"$NODE_EXE`" `"$NPX_CLI_JS`" $NPX_ARGS"
   } else {


### PR DESCRIPTION
dang, my apologies for getting this out after the npm release

this should go in for security reasons and it fixes double-quotes from files such as
```
Get-Content .\TEXT.txt | npm start
```