### PR TITLE
fix(powershell): don't use Invoke-Expression if `ExpectingInput`

### DIFF
--- a/bin/npm.ps1
+++ b/bin/npm.ps1
@@ -24,7 +24,7 @@ if (Test-Path $NPM_PREFIX_NPM_CLI_JS) {
 
 if ($MyInvocation.ExpectingInput) { # takes pipeline input
   if ($args | Where-Object { $_ -is [array] }) {
-    echo "WARNING: arguments passed to npm contains array"
+    echo "WARNING: arguments passed to NPM contains array"
   }
   $input | & $NODE_EXE $NPM_CLI_JS $args
 } elseif (-not $MyInvocation.Line) { # used "-File" argument

--- a/bin/npm.ps1
+++ b/bin/npm.ps1
@@ -24,7 +24,7 @@ if (Test-Path $NPM_PREFIX_NPM_CLI_JS) {
 
 if ($MyInvocation.ExpectingInput) { # takes pipeline input
   if ($args | Where-Object { $_ -is [array] }) {
-    echo "WARNING: arguments passed contains array"
+    echo "WARNING: arguments passed to npm contains array"
   }
   $input | & $NODE_EXE $NPM_CLI_JS $args
 } elseif (-not $MyInvocation.Line) { # used "-File" argument

--- a/bin/npm.ps1
+++ b/bin/npm.ps1
@@ -23,6 +23,9 @@ if (Test-Path $NPM_PREFIX_NPM_CLI_JS) {
 }
 
 if ($MyInvocation.ExpectingInput) { # takes pipeline input
+  if ($args | Where-Object { $_ -is [array] }) {
+    echo "WARNING: arguments passed contains array"
+  }
   $input | & $NODE_EXE $NPM_CLI_JS $args
 } elseif (-not $MyInvocation.Line) { # used "-File" argument
   & $NODE_EXE $NPM_CLI_JS $args

--- a/bin/npm.ps1
+++ b/bin/npm.ps1
@@ -36,10 +36,14 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
     $NPM_ARGS = $NPM_OG_COMMAND.Substring($MyInvocation.InvocationName.Length).Trim()
   }
 
-  $NODE_EXE = $NODE_EXE.Replace("``", "````")
-  $NPM_CLI_JS = $NPM_CLI_JS.Replace("``", "````")
+  if ($NPM_ARGS.Contains(">")) {
+    & $NODE_EXE $NPM_CLI_JS $args
+  } else {
+    $NODE_EXE = $NODE_EXE.Replace("``", "````")
+    $NPM_CLI_JS = $NPM_CLI_JS.Replace("``", "````")
 
-  Invoke-Expression "& `"$NODE_EXE`" `"$NPM_CLI_JS`" $NPM_ARGS"
+    Invoke-Expression "& `"$NODE_EXE`" `"$NPM_CLI_JS`" $NPM_ARGS"
+  }
 }
 
 exit $LASTEXITCODE

--- a/bin/npm.ps1
+++ b/bin/npm.ps1
@@ -22,7 +22,7 @@ if (Test-Path $NPM_PREFIX_NPM_CLI_JS) {
   $NPM_CLI_JS=$NPM_PREFIX_NPM_CLI_JS
 }
 
-if ($MyInvocation.Line) { # used "-Command" argument
+if (-not $MyInvocation.ExpectingInput -and $MyInvocation.Line) { # used "-Command" argument
   if ($MyInvocation.Statement) {
     $NPM_ARGS = $MyInvocation.Statement.Substring($MyInvocation.InvocationName.Length).Trim()
   } else {
@@ -35,14 +35,7 @@ if ($MyInvocation.Line) { # used "-Command" argument
   $NODE_EXE = $NODE_EXE.Replace("``", "````")
   $NPM_CLI_JS = $NPM_CLI_JS.Replace("``", "````")
 
-  # Support pipeline input
-  if ($MyInvocation.ExpectingInput) {
-    $input = (@($input) -join "`n").Replace("``", "````")
-
-    Invoke-Expression "Write-Output `"$input`" | & `"$NODE_EXE`" `"$NPM_CLI_JS`" $NPM_ARGS"
-  } else {
-    Invoke-Expression "& `"$NODE_EXE`" `"$NPM_CLI_JS`" $NPM_ARGS"
-  }
+  Invoke-Expression "& `"$NODE_EXE`" `"$NPM_CLI_JS`" $NPM_ARGS"
 } else { # used "-File" argument
   # Support pipeline input
   if ($MyInvocation.ExpectingInput) {

--- a/bin/npm.ps1
+++ b/bin/npm.ps1
@@ -23,9 +23,6 @@ if (Test-Path $NPM_PREFIX_NPM_CLI_JS) {
 }
 
 if ($MyInvocation.ExpectingInput) { # takes pipeline input
-  if ($args | Where-Object { $_ -is [array] }) {
-    echo "WARNING: arguments passed to NPM contains array"
-  }
   $input | & $NODE_EXE $NPM_CLI_JS $args
 } elseif (-not $MyInvocation.Line) { # used "-File" argument
   & $NODE_EXE $NPM_CLI_JS $args

--- a/bin/npm.ps1
+++ b/bin/npm.ps1
@@ -22,7 +22,11 @@ if (Test-Path $NPM_PREFIX_NPM_CLI_JS) {
   $NPM_CLI_JS=$NPM_PREFIX_NPM_CLI_JS
 }
 
-if (-not $MyInvocation.ExpectingInput -and $MyInvocation.Line) { # used "-Command" argument
+if ($MyInvocation.ExpectingInput) { # takes pipeline input
+  $input | & $NODE_EXE $NPM_CLI_JS $args
+} elseif (-not $MyInvocation.Line) { # used "-File" argument
+  & $NODE_EXE $NPM_CLI_JS $args
+} else { # used "-Command" argument
   if ($MyInvocation.Statement) {
     $NPM_ARGS = $MyInvocation.Statement.Substring($MyInvocation.InvocationName.Length).Trim()
   } else {
@@ -36,13 +40,6 @@ if (-not $MyInvocation.ExpectingInput -and $MyInvocation.Line) { # used "-Comman
   $NPM_CLI_JS = $NPM_CLI_JS.Replace("``", "````")
 
   Invoke-Expression "& `"$NODE_EXE`" `"$NPM_CLI_JS`" $NPM_ARGS"
-} else { # used "-File" argument
-  # Support pipeline input
-  if ($MyInvocation.ExpectingInput) {
-    $input | & $NODE_EXE $NPM_CLI_JS $args
-  } else {
-    & $NODE_EXE $NPM_CLI_JS $args
-  }
 }
 
 exit $LASTEXITCODE

--- a/bin/npx.ps1
+++ b/bin/npx.ps1
@@ -24,7 +24,7 @@ if (Test-Path $NPM_PREFIX_NPX_CLI_JS) {
 
 if ($MyInvocation.ExpectingInput) { # takes pipeline input
   if ($args | Where-Object { $_ -is [array] }) {
-    echo "WARNING: arguments passed to npx contains array"
+    echo "WARNING: arguments passed to NPX contains array"
   }
   $input | & $NODE_EXE $NPX_CLI_JS $args
 } elseif (-not $MyInvocation.Line) { # used "-File" argument

--- a/bin/npx.ps1
+++ b/bin/npx.ps1
@@ -22,7 +22,7 @@ if (Test-Path $NPM_PREFIX_NPX_CLI_JS) {
   $NPX_CLI_JS=$NPM_PREFIX_NPX_CLI_JS
 }
 
-if ($MyInvocation.Line) { # used "-Command" argument
+if (-not $MyInvocation.ExpectingInput -and $MyInvocation.Line) { # used "-Command" argument
   if ($MyInvocation.Statement) {
     $NPX_ARGS = $MyInvocation.Statement.Substring($MyInvocation.InvocationName.Length).Trim()
   } else {
@@ -35,14 +35,7 @@ if ($MyInvocation.Line) { # used "-Command" argument
   $NODE_EXE = $NODE_EXE.Replace("``", "````")
   $NPX_CLI_JS = $NPX_CLI_JS.Replace("``", "````")
 
-  # Support pipeline input
-  if ($MyInvocation.ExpectingInput) {
-    $input = (@($input) -join "`n").Replace("``", "````")
-
-    Invoke-Expression "Write-Output `"$input`" | & `"$NODE_EXE`" `"$NPX_CLI_JS`" $NPX_ARGS"
-  } else {
-    Invoke-Expression "& `"$NODE_EXE`" `"$NPX_CLI_JS`" $NPX_ARGS"
-  }
+  Invoke-Expression "& `"$NODE_EXE`" `"$NPX_CLI_JS`" $NPX_ARGS"
 } else { # used "-File" argument
   # Support pipeline input
   if ($MyInvocation.ExpectingInput) {

--- a/bin/npx.ps1
+++ b/bin/npx.ps1
@@ -23,6 +23,9 @@ if (Test-Path $NPM_PREFIX_NPX_CLI_JS) {
 }
 
 if ($MyInvocation.ExpectingInput) { # takes pipeline input
+  if ($args | Where-Object { $_ -is [array] }) {
+    echo "WARNING: arguments passed contains array"
+  }
   $input | & $NODE_EXE $NPX_CLI_JS $args
 } elseif (-not $MyInvocation.Line) { # used "-File" argument
   & $NODE_EXE $NPX_CLI_JS $args

--- a/bin/npx.ps1
+++ b/bin/npx.ps1
@@ -24,7 +24,7 @@ if (Test-Path $NPM_PREFIX_NPX_CLI_JS) {
 
 if ($MyInvocation.ExpectingInput) { # takes pipeline input
   if ($args | Where-Object { $_ -is [array] }) {
-    echo "WARNING: arguments passed contains array"
+    echo "WARNING: arguments passed to npx contains array"
   }
   $input | & $NODE_EXE $NPX_CLI_JS $args
 } elseif (-not $MyInvocation.Line) { # used "-File" argument

--- a/bin/npx.ps1
+++ b/bin/npx.ps1
@@ -22,7 +22,11 @@ if (Test-Path $NPM_PREFIX_NPX_CLI_JS) {
   $NPX_CLI_JS=$NPM_PREFIX_NPX_CLI_JS
 }
 
-if (-not $MyInvocation.ExpectingInput -and $MyInvocation.Line) { # used "-Command" argument
+if ($MyInvocation.ExpectingInput) { # takes pipeline input
+  $input | & $NODE_EXE $NPX_CLI_JS $args
+} elseif (-not $MyInvocation.Line) { # used "-File" argument
+  & $NODE_EXE $NPX_CLI_JS $args
+} else { # used "-Command" argument
   if ($MyInvocation.Statement) {
     $NPX_ARGS = $MyInvocation.Statement.Substring($MyInvocation.InvocationName.Length).Trim()
   } else {
@@ -36,13 +40,6 @@ if (-not $MyInvocation.ExpectingInput -and $MyInvocation.Line) { # used "-Comman
   $NPX_CLI_JS = $NPX_CLI_JS.Replace("``", "````")
 
   Invoke-Expression "& `"$NODE_EXE`" `"$NPX_CLI_JS`" $NPX_ARGS"
-} else { # used "-File" argument
-  # Support pipeline input
-  if ($MyInvocation.ExpectingInput) {
-    $input | & $NODE_EXE $NPX_CLI_JS $args
-  } else {
-    & $NODE_EXE $NPX_CLI_JS $args
-  }
 }
 
 exit $LASTEXITCODE

--- a/bin/npx.ps1
+++ b/bin/npx.ps1
@@ -23,9 +23,6 @@ if (Test-Path $NPM_PREFIX_NPX_CLI_JS) {
 }
 
 if ($MyInvocation.ExpectingInput) { # takes pipeline input
-  if ($args | Where-Object { $_ -is [array] }) {
-    echo "WARNING: arguments passed to NPX contains array"
-  }
   $input | & $NODE_EXE $NPX_CLI_JS $args
 } elseif (-not $MyInvocation.Line) { # used "-File" argument
   & $NODE_EXE $NPX_CLI_JS $args

--- a/bin/npx.ps1
+++ b/bin/npx.ps1
@@ -36,10 +36,14 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
     $NPX_ARGS = $NPX_OG_COMMAND.Substring($MyInvocation.InvocationName.Length).Trim()
   }
 
-  $NODE_EXE = $NODE_EXE.Replace("``", "````")
-  $NPX_CLI_JS = $NPX_CLI_JS.Replace("``", "````")
+  if ($NPX_ARGS.Contains(">")) {
+    & $NODE_EXE $NPX_CLI_JS $args
+  } else {
+    $NODE_EXE = $NODE_EXE.Replace("``", "````")
+    $NPX_CLI_JS = $NPX_CLI_JS.Replace("``", "````")
 
-  Invoke-Expression "& `"$NODE_EXE`" `"$NPX_CLI_JS`" $NPX_ARGS"
+    Invoke-Expression "& `"$NODE_EXE`" `"$NPX_CLI_JS`" $NPX_ARGS"
+  }
 }
 
 exit $LASTEXITCODE


### PR DESCRIPTION
dang, my apologies for getting this out after the npm release

this prevents a performance/security regression with piping strings into npm/npx

This should block https://github.com/nodejs/node/pull/58347

---

```
echo "Hello" | npm help a=1,b=2,c=3
```

```
No matches in help for: a=1 b=2 c=3
```

---

```
npm help a=1,b=2,c=3
```

```
No matches in help for: a=1,b=2,c=3
```

---

This is the best compromise between convenience and security