### PR TITLE
chore: remove references to skimdb.npmjs.com

### DIFF
--- a/docs/lib/content/using-npm/registry.md
+++ b/docs/lib/content/using-npm/registry.md
@@ -22,9 +22,6 @@ npm's package registry implementation supports several
 write APIs as well, to allow for publishing packages and managing user
 account information.
 
-The npm public registry is powered by a CouchDB database,
-of which there is a public mirror at <https://skimdb.npmjs.com/registry>.
-
 The registry URL used is determined by the scope of the package (see
 [`scope`](/using-npm/scope). If no scope is specified, the default registry is
 used, which is supplied by the [`registry` config](/using-npm/config#registry)


### PR DESCRIPTION
# Summary
With the public communication of the replication feed changes, this PR updates all documentation to remove references to skimdb.npmjs.com. All requests will be redirected to replicate.npmjs.com.


## References
- https://github.com/orgs/community/discussions/152515
- https://github.blog/changelog/2025-02-26-changes-and-deprecation-notice-for-npm-replication-apis/