### PR TITLE
fix(powershell): multiple Invoke-Expression fixes

### DIFF
--- a/bin/npm.ps1
+++ b/bin/npm.ps1
@@ -31,46 +31,16 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
     $NPM_OG_COMMAND = $MyInvocation.Statement
   } else {
     $NPM_OG_COMMAND = (
-      [System.Management.Automation.InvocationInfo].GetProperty('ScriptPosition', [System.Reflection.BindingFlags] 'Instance, NonPublic')
+      [Management.Automation.InvocationInfo].GetProperty('ScriptPosition', [Reflection.BindingFlags] 'Instance, NonPublic')
     ).GetValue($MyInvocation).Text
   }
 
   $NODE_EXE = $NODE_EXE.Replace("``", "````")
   $NPM_CLI_JS = $NPM_CLI_JS.Replace("``", "````")
 
-  $ast = [System.Management.Automation.Language.Parser]::ParseInput($NPM_OG_COMMAND, [ref]$null, [ref]$null)
-  $redirections = $ast.FindAll({$args[0] -is [System.Management.Automation.Language.FileRedirectionAst]}, $true) | Sort-Object { $_.Extent.StartOffset }
-  $numberOfRedirects = @($redirections).Length
-
-  if ($numberOfRedirects -gt 0) {
-    $NPM_NO_REDIRECTS_COMMAND = ""
-    $prevEndOffset = 0
-    $i = 0
-
-    foreach ($redirection in $redirections) {
-      $parentExtentText = $redirection.Parent.Extent.Text
-      $startOffset = $redirection.Extent.StartOffset
-      $endOffset = $redirection.Extent.EndOffset
-
-      $changed = $parentExtentText.Substring($prevEndOffset, $startOffset - $prevEndOffset)
-      if ($i -eq $numberOfRedirects-1) {
-        if ($endOffset -eq $parentExtentText.Length) {
-          ### make valid powershell syntax when redirect on last line is removed
-          $changed += ";"
-        } else {
-          $changed += $parentExtentText.Substring($endOffset, $parentExtentText.Length - $endOffset)
-        }
-      }
-
-      $NPM_NO_REDIRECTS_COMMAND += $changed
-      $prevEndOffset = $endOffset
-      $i++
-    }
-
-    $NPM_ARGS = $NPM_NO_REDIRECTS_COMMAND.Substring($MyInvocation.InvocationName.Length).Trim()
-  } else {
-    $NPM_ARGS = $NPM_OG_COMMAND.Substring($MyInvocation.InvocationName.Length).Trim()
-  }
+  $NPM_NO_REDIRECTS_COMMAND = [Management.Automation.Language.Parser]::ParseInput($NPM_OG_COMMAND, [ref] $null, [ref] $null).
+    EndBlock.Statements.PipelineElements.CommandElements.Extent.Text -join ' '
+  $NPM_ARGS = $NPM_NO_REDIRECTS_COMMAND.Substring($MyInvocation.InvocationName.Length).Trim()
 
   Invoke-Expression "& `"$NODE_EXE`" `"$NPM_CLI_JS`" $NPM_ARGS"
 }

--- a/bin/npm.ps1
+++ b/bin/npm.ps1
@@ -39,7 +39,7 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
   $NPM_CLI_JS = $NPM_CLI_JS.Replace("``", "````")
 
   $ast = [System.Management.Automation.Language.Parser]::ParseInput($NPM_OG_COMMAND, [ref]$null, [ref]$null)
-  $redirections = $ast.FindAll({$args[0] -is [System.Management.Automation.Language.FileRedirectionAst]}, $true)
+  $redirections = $ast.FindAll({$args[0] -is [System.Management.Automation.Language.FileRedirectionAst]}, $true) | Sort-Object { $_.Extent.StartOffset }
   $numberOfRedirects = @($redirections).Length
 
   if ($numberOfRedirects -gt 0) {
@@ -52,15 +52,24 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
       $startOffset = $redirection.Extent.StartOffset
       $endOffset = $redirection.Extent.EndOffset
 
-      if ($i -lt $numberOfRedirects-1) {
-        $changed = $parentExtentText.Substring($prevEndOffset, $startOffset - $prevEndOffset)
+      if ($startOffset - $prevEndOffset -lt 0) {
+        $changed = $parentExtentText.Substring($prevEndOffset, 0)
       } else {
-        $changed = $parentExtentText.Substring($prevEndOffset, $startOffset - $prevEndOffset) + $parentExtentText.Substring($endOffset, $parentExtentText.Length - $endOffset)
+        $changed = $parentExtentText.Substring($prevEndOffset, $startOffset - $prevEndOffset)
+      }
+
+      if ($i -eq $numberOfRedirects-1) {
+        $changed += $parentExtentText.Substring($endOffset, $parentExtentText.Length - $endOffset)
       }
 
       $NPM_NO_REDIRECTS_COMMAND += $changed
       $prevEndOffset = $endOffset
       $i++
+    }
+
+    $NPM_NO_REDIRECTS_COMMAND = $NPM_NO_REDIRECTS_COMMAND.Trim()
+    if ($NPM_NO_REDIRECTS_COMMAND.EndsWith("``")) {
+      $NPM_NO_REDIRECTS_COMMAND = $NPM_NO_REDIRECTS_COMMAND.Substring(0, $NPM_NO_REDIRECTS_COMMAND.Length - 1) + ";"
     }
 
     $NPM_ARGS = $NPM_NO_REDIRECTS_COMMAND.Substring($MyInvocation.InvocationName.Length).Trim()

--- a/bin/npm.ps1
+++ b/bin/npm.ps1
@@ -54,17 +54,17 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
 
       $changed = $parentExtentText.Substring($prevEndOffset, $startOffset - $prevEndOffset)
       if ($i -eq $numberOfRedirects-1) {
-        $changed += $parentExtentText.Substring($endOffset, $parentExtentText.Length - $endOffset)
+        if ($endOffset -eq $parentExtentText.Length) {
+          ### make valid powershell syntax when redirect on last line is removed
+          $changed += ";"
+        } else {
+          $changed += $parentExtentText.Substring($endOffset, $parentExtentText.Length - $endOffset)
+        }
       }
 
       $NPM_NO_REDIRECTS_COMMAND += $changed
       $prevEndOffset = $endOffset
       $i++
-    }
-
-    $NPM_NO_REDIRECTS_COMMAND = $NPM_NO_REDIRECTS_COMMAND.Trim()
-    if ($NPM_NO_REDIRECTS_COMMAND.EndsWith("``")) {
-      $NPM_NO_REDIRECTS_COMMAND = $NPM_NO_REDIRECTS_COMMAND.Substring(0, $NPM_NO_REDIRECTS_COMMAND.Length - 1) + ";"
     }
 
     $NPM_ARGS = $NPM_NO_REDIRECTS_COMMAND.Substring($MyInvocation.InvocationName.Length).Trim()

--- a/bin/npm.ps1
+++ b/bin/npm.ps1
@@ -28,9 +28,9 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
   & $NODE_EXE $NPM_CLI_JS $args
 } else { # used "-Command" argument
   if ($MyInvocation.Statement) {
-    $NPM_OG_COMMAND = $MyInvocation.Statement
+    $NPM_ORIGINAL_COMMAND = $MyInvocation.Statement
   } else {
-    $NPM_OG_COMMAND = (
+    $NPM_ORIGINAL_COMMAND = (
       [Management.Automation.InvocationInfo].GetProperty('ScriptPosition', [Reflection.BindingFlags] 'Instance, NonPublic')
     ).GetValue($MyInvocation).Text
   }
@@ -38,7 +38,7 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
   $NODE_EXE = $NODE_EXE.Replace("``", "````")
   $NPM_CLI_JS = $NPM_CLI_JS.Replace("``", "````")
 
-  $NPM_NO_REDIRECTS_COMMAND = [Management.Automation.Language.Parser]::ParseInput($NPM_OG_COMMAND, [ref] $null, [ref] $null).
+  $NPM_NO_REDIRECTS_COMMAND = [Management.Automation.Language.Parser]::ParseInput($NPM_ORIGINAL_COMMAND, [ref] $null, [ref] $null).
     EndBlock.Statements.PipelineElements.CommandElements.Extent.Text -join ' '
   $NPM_ARGS = $NPM_NO_REDIRECTS_COMMAND.Substring($MyInvocation.InvocationName.Length).Trim()
 

--- a/bin/npm.ps1
+++ b/bin/npm.ps1
@@ -22,34 +22,55 @@ if (Test-Path $NPM_PREFIX_NPM_CLI_JS) {
   $NPM_CLI_JS=$NPM_PREFIX_NPM_CLI_JS
 }
 
-if ($MyInvocation.Line) { # used "-Command" argument
+if ($MyInvocation.ExpectingInput) { # takes pipeline input
+  $input | & $NODE_EXE $NPM_CLI_JS $args
+} elseif (-not $MyInvocation.Line) { # used "-File" argument
+  & $NODE_EXE $NPM_CLI_JS $args
+} else { # used "-Command" argument
   if ($MyInvocation.Statement) {
-    $NPM_ARGS = $MyInvocation.Statement.Substring($MyInvocation.InvocationName.Length).Trim()
+    $NPM_OG_COMMAND = $MyInvocation.Statement
   } else {
     $NPM_OG_COMMAND = (
       [System.Management.Automation.InvocationInfo].GetProperty('ScriptPosition', [System.Reflection.BindingFlags] 'Instance, NonPublic')
     ).GetValue($MyInvocation).Text
-    $NPM_ARGS = $NPM_OG_COMMAND.Substring($MyInvocation.InvocationName.Length).Trim()
   }
 
   $NODE_EXE = $NODE_EXE.Replace("``", "````")
   $NPM_CLI_JS = $NPM_CLI_JS.Replace("``", "````")
 
-  # Support pipeline input
-  if ($MyInvocation.ExpectingInput) {
-    $input = (@($input) -join "`n").Replace("``", "````")
+  $ast = [System.Management.Automation.Language.Parser]::ParseInput($NPM_OG_COMMAND, [ref]$null, [ref]$null)
+  $redirections = $ast.FindAll({$args[0] -is [System.Management.Automation.Language.FileRedirectionAst]}, $true)
 
-    Invoke-Expression "Write-Output `"$input`" | & `"$NODE_EXE`" `"$NPM_CLI_JS`" $NPM_ARGS"
+  $prevEndOffset = 0
+  $i = 0
+  $numberOfRedirects = @($redirections).Length
+
+  if ($numberOfRedirects -gt 0) {
+    $NPM_NO_REDIRECTS_COMMAND = ""
+
+    foreach ($redirection in $redirections) {
+      $parentExtentText = $redirection.Parent.Extent.Text
+      $startOffset = $redirection.Extent.StartOffset
+      $endOffset = $redirection.Extent.EndOffset
+
+      if ($i -lt $numberOfRedirects-1) {
+        $changed = $parentExtentText.Substring($prevEndOffset, $startOffset - $prevEndOffset)
+      } else {
+        $changed = $parentExtentText.Substring($prevEndOffset, $startOffset - $prevEndOffset) + $parentExtentText.Substring($endOffset, $parentExtentText.Length - $endOffset)
+      }
+
+      $NPM_NO_REDIRECTS_COMMAND += $changed
+
+      $prevEndOffset = $endOffset
+      $i++
+    }
+
+    $NPM_ARGS = $NPM_NO_REDIRECTS_COMMAND.Substring($MyInvocation.InvocationName.Length).Trim()
   } else {
-    Invoke-Expression "& `"$NODE_EXE`" `"$NPM_CLI_JS`" $NPM_ARGS"
+    $NPM_ARGS = $NPM_OG_COMMAND.Substring($MyInvocation.InvocationName.Length).Trim()
   }
-} else { # used "-File" argument
-  # Support pipeline input
-  if ($MyInvocation.ExpectingInput) {
-    $input | & $NODE_EXE $NPM_CLI_JS $args
-  } else {
-    & $NODE_EXE $NPM_CLI_JS $args
-  }
+
+  Invoke-Expression "& `"$NODE_EXE`" `"$NPM_CLI_JS`" $NPM_ARGS"
 }
 
 exit $LASTEXITCODE

--- a/bin/npm.ps1
+++ b/bin/npm.ps1
@@ -52,12 +52,7 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
       $startOffset = $redirection.Extent.StartOffset
       $endOffset = $redirection.Extent.EndOffset
 
-      if ($startOffset - $prevEndOffset -lt 0) {
-        $changed = $parentExtentText.Substring($prevEndOffset, 0)
-      } else {
-        $changed = $parentExtentText.Substring($prevEndOffset, $startOffset - $prevEndOffset)
-      }
-
+      $changed = $parentExtentText.Substring($prevEndOffset, $startOffset - $prevEndOffset)
       if ($i -eq $numberOfRedirects-1) {
         $changed += $parentExtentText.Substring($endOffset, $parentExtentText.Length - $endOffset)
       }

--- a/bin/npm.ps1
+++ b/bin/npm.ps1
@@ -40,13 +40,12 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
 
   $ast = [System.Management.Automation.Language.Parser]::ParseInput($NPM_OG_COMMAND, [ref]$null, [ref]$null)
   $redirections = $ast.FindAll({$args[0] -is [System.Management.Automation.Language.FileRedirectionAst]}, $true)
-
-  $prevEndOffset = 0
-  $i = 0
   $numberOfRedirects = @($redirections).Length
 
   if ($numberOfRedirects -gt 0) {
     $NPM_NO_REDIRECTS_COMMAND = ""
+    $prevEndOffset = 0
+    $i = 0
 
     foreach ($redirection in $redirections) {
       $parentExtentText = $redirection.Parent.Extent.Text
@@ -60,7 +59,6 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
       }
 
       $NPM_NO_REDIRECTS_COMMAND += $changed
-
       $prevEndOffset = $endOffset
       $i++
     }

--- a/bin/npx.ps1
+++ b/bin/npx.ps1
@@ -31,46 +31,16 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
     $NPX_OG_COMMAND = $MyInvocation.Statement
   } else {
     $NPX_OG_COMMAND = (
-      [System.Management.Automation.InvocationInfo].GetProperty('ScriptPosition', [System.Reflection.BindingFlags] 'Instance, NonPublic')
+      [Management.Automation.InvocationInfo].GetProperty('ScriptPosition', [Reflection.BindingFlags] 'Instance, NonPublic')
     ).GetValue($MyInvocation).Text
   }
 
   $NODE_EXE = $NODE_EXE.Replace("``", "````")
   $NPX_CLI_JS = $NPX_CLI_JS.Replace("``", "````")
 
-  $ast = [System.Management.Automation.Language.Parser]::ParseInput($NPX_OG_COMMAND, [ref]$null, [ref]$null)
-  $redirections = $ast.FindAll({$args[0] -is [System.Management.Automation.Language.FileRedirectionAst]}, $true) | Sort-Object { $_.Extent.StartOffset }
-  $numberOfRedirects = @($redirections).Length
-
-  if ($numberOfRedirects -gt 0) {
-    $NPX_NO_REDIRECTS_COMMAND = ""
-    $prevEndOffset = 0
-    $i = 0
-
-    foreach ($redirection in $redirections) {
-      $parentExtentText = $redirection.Parent.Extent.Text
-      $startOffset = $redirection.Extent.StartOffset
-      $endOffset = $redirection.Extent.EndOffset
-
-      $changed = $parentExtentText.Substring($prevEndOffset, $startOffset - $prevEndOffset)
-      if ($i -eq $numberOfRedirects-1) {
-        if ($endOffset -eq $parentExtentText.Length) {
-          ### make valid powershell syntax when redirect on last line is removed
-          $changed += ";"
-        } else {
-          $changed += $parentExtentText.Substring($endOffset, $parentExtentText.Length - $endOffset)
-        }
-      }
-
-      $NPX_NO_REDIRECTS_COMMAND += $changed
-      $prevEndOffset = $endOffset
-      $i++
-    }
-
-    $NPX_ARGS = $NPX_NO_REDIRECTS_COMMAND.Substring($MyInvocation.InvocationName.Length).Trim()
-  } else {
-    $NPX_ARGS = $NPX_OG_COMMAND.Substring($MyInvocation.InvocationName.Length).Trim()
-  }
+  $NPX_NO_REDIRECTS_COMMAND = [Management.Automation.Language.Parser]::ParseInput($NPX_OG_COMMAND, [ref] $null, [ref] $null).
+    EndBlock.Statements.PipelineElements.CommandElements.Extent.Text -join ' '
+  $NPX_ARGS = $NPX_NO_REDIRECTS_COMMAND.Substring($MyInvocation.InvocationName.Length).Trim()
 
   Invoke-Expression "& `"$NODE_EXE`" `"$NPX_CLI_JS`" $NPX_ARGS"
 }

--- a/bin/npx.ps1
+++ b/bin/npx.ps1
@@ -54,17 +54,17 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
 
       $changed = $parentExtentText.Substring($prevEndOffset, $startOffset - $prevEndOffset)
       if ($i -eq $numberOfRedirects-1) {
-        $changed += $parentExtentText.Substring($endOffset, $parentExtentText.Length - $endOffset)
+        if ($endOffset -eq $parentExtentText.Length) {
+          ### make valid powershell syntax when redirect on last line is removed
+          $changed += ";"
+        } else {
+          $changed += $parentExtentText.Substring($endOffset, $parentExtentText.Length - $endOffset)
+        }
       }
 
       $NPX_NO_REDIRECTS_COMMAND += $changed
       $prevEndOffset = $endOffset
       $i++
-    }
-
-    $NPX_NO_REDIRECTS_COMMAND = $NPX_NO_REDIRECTS_COMMAND.Trim()
-    if ($NPX_NO_REDIRECTS_COMMAND.EndsWith("``")) {
-      $NPX_NO_REDIRECTS_COMMAND = $NPX_NO_REDIRECTS_COMMAND.Substring(0, $NPX_NO_REDIRECTS_COMMAND.Length - 1) + ";"
     }
 
     $NPX_ARGS = $NPX_NO_REDIRECTS_COMMAND.Substring($MyInvocation.InvocationName.Length).Trim()

--- a/bin/npx.ps1
+++ b/bin/npx.ps1
@@ -39,7 +39,7 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
   $NPX_CLI_JS = $NPX_CLI_JS.Replace("``", "````")
 
   $ast = [System.Management.Automation.Language.Parser]::ParseInput($NPX_OG_COMMAND, [ref]$null, [ref]$null)
-  $redirections = $ast.FindAll({$args[0] -is [System.Management.Automation.Language.FileRedirectionAst]}, $true)
+  $redirections = $ast.FindAll({$args[0] -is [System.Management.Automation.Language.FileRedirectionAst]}, $true) | Sort-Object { $_.Extent.StartOffset }
   $numberOfRedirects = @($redirections).Length
 
   if ($numberOfRedirects -gt 0) {
@@ -52,15 +52,24 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
       $startOffset = $redirection.Extent.StartOffset
       $endOffset = $redirection.Extent.EndOffset
 
-      if ($i -lt $numberOfRedirects-1) {
-        $changed = $parentExtentText.Substring($prevEndOffset, $startOffset - $prevEndOffset)
+      if ($startOffset - $prevEndOffset -lt 0) {
+        $changed = $parentExtentText.Substring($prevEndOffset, 0)
       } else {
-        $changed = $parentExtentText.Substring($prevEndOffset, $startOffset - $prevEndOffset) + $parentExtentText.Substring($endOffset, $parentExtentText.Length - $endOffset)
+        $changed = $parentExtentText.Substring($prevEndOffset, $startOffset - $prevEndOffset)
+      }
+
+      if ($i -eq $numberOfRedirects-1) {
+        $changed += $parentExtentText.Substring($endOffset, $parentExtentText.Length - $endOffset)
       }
 
       $NPX_NO_REDIRECTS_COMMAND += $changed
       $prevEndOffset = $endOffset
       $i++
+    }
+
+    $NPX_NO_REDIRECTS_COMMAND = $NPX_NO_REDIRECTS_COMMAND.Trim()
+    if ($NPX_NO_REDIRECTS_COMMAND.EndsWith("``")) {
+      $NPX_NO_REDIRECTS_COMMAND = $NPX_NO_REDIRECTS_COMMAND.Substring(0, $NPX_NO_REDIRECTS_COMMAND.Length - 1) + ";"
     }
 
     $NPX_ARGS = $NPX_NO_REDIRECTS_COMMAND.Substring($MyInvocation.InvocationName.Length).Trim()

--- a/bin/npx.ps1
+++ b/bin/npx.ps1
@@ -52,12 +52,7 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
       $startOffset = $redirection.Extent.StartOffset
       $endOffset = $redirection.Extent.EndOffset
 
-      if ($startOffset - $prevEndOffset -lt 0) {
-        $changed = $parentExtentText.Substring($prevEndOffset, 0)
-      } else {
-        $changed = $parentExtentText.Substring($prevEndOffset, $startOffset - $prevEndOffset)
-      }
-
+      $changed = $parentExtentText.Substring($prevEndOffset, $startOffset - $prevEndOffset)
       if ($i -eq $numberOfRedirects-1) {
         $changed += $parentExtentText.Substring($endOffset, $parentExtentText.Length - $endOffset)
       }

--- a/bin/npx.ps1
+++ b/bin/npx.ps1
@@ -28,9 +28,9 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
   & $NODE_EXE $NPX_CLI_JS $args
 } else { # used "-Command" argument
   if ($MyInvocation.Statement) {
-    $NPX_OG_COMMAND = $MyInvocation.Statement
+    $NPX_ORIGINAL_COMMAND = $MyInvocation.Statement
   } else {
-    $NPX_OG_COMMAND = (
+    $NPX_ORIGINAL_COMMAND = (
       [Management.Automation.InvocationInfo].GetProperty('ScriptPosition', [Reflection.BindingFlags] 'Instance, NonPublic')
     ).GetValue($MyInvocation).Text
   }
@@ -38,7 +38,7 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
   $NODE_EXE = $NODE_EXE.Replace("``", "````")
   $NPX_CLI_JS = $NPX_CLI_JS.Replace("``", "````")
 
-  $NPX_NO_REDIRECTS_COMMAND = [Management.Automation.Language.Parser]::ParseInput($NPX_OG_COMMAND, [ref] $null, [ref] $null).
+  $NPX_NO_REDIRECTS_COMMAND = [Management.Automation.Language.Parser]::ParseInput($NPX_ORIGINAL_COMMAND, [ref] $null, [ref] $null).
     EndBlock.Statements.PipelineElements.CommandElements.Extent.Text -join ' '
   $NPX_ARGS = $NPX_NO_REDIRECTS_COMMAND.Substring($MyInvocation.InvocationName.Length).Trim()
 

--- a/bin/npx.ps1
+++ b/bin/npx.ps1
@@ -40,13 +40,12 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
 
   $ast = [System.Management.Automation.Language.Parser]::ParseInput($NPX_OG_COMMAND, [ref]$null, [ref]$null)
   $redirections = $ast.FindAll({$args[0] -is [System.Management.Automation.Language.FileRedirectionAst]}, $true)
-
-  $prevEndOffset = 0
-  $i = 0
   $numberOfRedirects = @($redirections).Length
 
   if ($numberOfRedirects -gt 0) {
     $NPX_NO_REDIRECTS_COMMAND = ""
+    $prevEndOffset = 0
+    $i = 0
 
     foreach ($redirection in $redirections) {
       $parentExtentText = $redirection.Parent.Extent.Text
@@ -60,7 +59,6 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
       }
 
       $NPX_NO_REDIRECTS_COMMAND += $changed
-
       $prevEndOffset = $endOffset
       $i++
     }

--- a/bin/npx.ps1
+++ b/bin/npx.ps1
@@ -22,34 +22,55 @@ if (Test-Path $NPM_PREFIX_NPX_CLI_JS) {
   $NPX_CLI_JS=$NPM_PREFIX_NPX_CLI_JS
 }
 
-if ($MyInvocation.Line) { # used "-Command" argument
+if ($MyInvocation.ExpectingInput) { # takes pipeline input
+  $input | & $NODE_EXE $NPX_CLI_JS $args
+} elseif (-not $MyInvocation.Line) { # used "-File" argument
+  & $NODE_EXE $NPX_CLI_JS $args
+} else { # used "-Command" argument
   if ($MyInvocation.Statement) {
-    $NPX_ARGS = $MyInvocation.Statement.Substring($MyInvocation.InvocationName.Length).Trim()
+    $NPX_OG_COMMAND = $MyInvocation.Statement
   } else {
     $NPX_OG_COMMAND = (
       [System.Management.Automation.InvocationInfo].GetProperty('ScriptPosition', [System.Reflection.BindingFlags] 'Instance, NonPublic')
     ).GetValue($MyInvocation).Text
-    $NPX_ARGS = $NPX_OG_COMMAND.Substring($MyInvocation.InvocationName.Length).Trim()
   }
 
   $NODE_EXE = $NODE_EXE.Replace("``", "````")
   $NPX_CLI_JS = $NPX_CLI_JS.Replace("``", "````")
 
-  # Support pipeline input
-  if ($MyInvocation.ExpectingInput) {
-    $input = (@($input) -join "`n").Replace("``", "````")
+  $ast = [System.Management.Automation.Language.Parser]::ParseInput($NPX_OG_COMMAND, [ref]$null, [ref]$null)
+  $redirections = $ast.FindAll({$args[0] -is [System.Management.Automation.Language.FileRedirectionAst]}, $true)
 
-    Invoke-Expression "Write-Output `"$input`" | & `"$NODE_EXE`" `"$NPX_CLI_JS`" $NPX_ARGS"
+  $prevEndOffset = 0
+  $i = 0
+  $numberOfRedirects = @($redirections).Length
+
+  if ($numberOfRedirects -gt 0) {
+    $NPX_NO_REDIRECTS_COMMAND = ""
+
+    foreach ($redirection in $redirections) {
+      $parentExtentText = $redirection.Parent.Extent.Text
+      $startOffset = $redirection.Extent.StartOffset
+      $endOffset = $redirection.Extent.EndOffset
+
+      if ($i -lt $numberOfRedirects-1) {
+        $changed = $parentExtentText.Substring($prevEndOffset, $startOffset - $prevEndOffset)
+      } else {
+        $changed = $parentExtentText.Substring($prevEndOffset, $startOffset - $prevEndOffset) + $parentExtentText.Substring($endOffset, $parentExtentText.Length - $endOffset)
+      }
+
+      $NPX_NO_REDIRECTS_COMMAND += $changed
+
+      $prevEndOffset = $endOffset
+      $i++
+    }
+
+    $NPX_ARGS = $NPX_NO_REDIRECTS_COMMAND.Substring($MyInvocation.InvocationName.Length).Trim()
   } else {
-    Invoke-Expression "& `"$NODE_EXE`" `"$NPX_CLI_JS`" $NPX_ARGS"
+    $NPX_ARGS = $NPX_OG_COMMAND.Substring($MyInvocation.InvocationName.Length).Trim()
   }
-} else { # used "-File" argument
-  # Support pipeline input
-  if ($MyInvocation.ExpectingInput) {
-    $input | & $NODE_EXE $NPX_CLI_JS $args
-  } else {
-    & $NODE_EXE $NPX_CLI_JS $args
-  }
+
+  Invoke-Expression "& `"$NODE_EXE`" `"$NPX_CLI_JS`" $NPX_ARGS"
 }
 
 exit $LASTEXITCODE


### PR DESCRIPTION
- prevent pipeline input from using Invoke-Expression
- allow redirect operator to behave again by stripping redirects out from Invoke-Expression