### PR TITLE
docs: Rename "command" to "script"

### DIFF
--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -589,7 +589,7 @@ had the following:
 }
 ```
 
-It could also have a "start" command that referenced the
+It could also have a "start" script that referenced the
 `npm_package_config_port` environment variable.
 
 ### dependencies


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
- The intention of this PR is to add clarity and fix a (potential?) typo
- If this change is in error, and "command" was the appropriate word to use, can someone explain to me what this sentence is trying to convey?

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
