### PR TITLE
fix: change error to warning when canceling `npm login` or `adduser`

### DIFF
--- a/lib/commands/adduser.js
+++ b/lib/commands/adduser.js
@@ -34,6 +34,10 @@ class AddUser extends BaseCommand {
       registry,
     })
 
+    if (message === 'canceled') {
+      return
+    }
+
     this.npm.config.delete('_token', 'user') // prevent legacy pollution
     this.npm.config.setCredentialsByURI(registry, newCreds)
 

--- a/lib/commands/login.js
+++ b/lib/commands/login.js
@@ -34,6 +34,10 @@ class Login extends BaseCommand {
       registry,
     })
 
+    if (message === 'canceled') {
+      return
+    }
+
     this.npm.config.delete('_token', 'user') // prevent legacy pollution
     this.npm.config.setCredentialsByURI(registry, newCreds)
 

--- a/lib/utils/auth.js
+++ b/lib/utils/auth.js
@@ -49,13 +49,22 @@ const adduser = async (npm, { creds, ...opts }) => {
 
   // auth type !== web or ENYI error w/ web adduser
   if (!res) {
-    const username = await read.username('Username:', creds.username)
-    const password = await read.password('Password:', creds.password)
-    const email = await read.email('Email: (this IS public) ', creds.email)
-    // npm registry quirk: If you "add" an existing user with their current
-    // password, it's effectively a login, and if that account has otp you'll
-    // be prompted for it.
-    res = await otplease(npm, opts, (reqOpts) => adduserCouch(username, email, password, reqOpts))
+    try {
+      const username = await read.username('Username:', creds.username)
+      const password = await read.password('Password:', creds.password)
+      const email = await read.email('Email: (this IS public) ', creds.email)
+      // npm registry quirk: If you "add" an existing user with their current
+      // password, it's effectively a login, and if that account has otp you'll
+      // be prompted for it.
+      res = await otplease(npm, opts, (reqOpts) => adduserCouch(username, email, password, reqOpts))
+    } catch (er) {
+      if (er.message === 'canceled') {
+        log.warn('adduser', 'canceled')
+        return { message: 'canceled' }
+      } else {
+        throw er
+      }
+    }
   }
 
   // We don't know the username if it was a web login, all we can reliably log is scope and registry
@@ -86,9 +95,18 @@ const login = async (npm, { creds, ...opts }) => {
 
   // auth type !== web or ENYI error w/ web login
   if (!res) {
-    const username = await read.username('Username:', creds.username)
-    const password = await read.password('Password:', creds.password)
-    res = await otplease(npm, opts, (reqOpts) => loginCouch(username, password, reqOpts))
+    try {
+      const username = await read.username('Username:', creds.username)
+      const password = await read.password('Password:', creds.password)
+      res = await otplease(npm, opts, (reqOpts) => loginCouch(username, password, reqOpts))
+    } catch (er) {
+      if (er.message === 'canceled') {
+        log.warn('login', 'canceled')
+        return { message: 'canceled' }
+      } else {
+        throw er
+      }
+    }
   }
 
   // We don't know the username if it was a web login, all we can reliably log is scope and registry

--- a/lib/utils/auth.js
+++ b/lib/utils/auth.js
@@ -41,6 +41,9 @@ const adduser = async (npm, { creds, ...opts }) => {
     } catch (err) {
       if (err.code === 'ENYI') {
         log.verbose('web add user not supported, trying couch')
+      } else if (err.message === 'canceled') {
+        log.warn('adduser', 'canceled')
+        return { message: 'canceled' }
       } else {
         throw err
       }
@@ -87,6 +90,9 @@ const login = async (npm, { creds, ...opts }) => {
     } catch (err) {
       if (err.code === 'ENYI') {
         log.verbose('web login not supported, trying couch')
+      } else if (err.message === 'canceled') {
+        log.warn('login', 'canceled')
+        return { message: 'canceled' }
       } else {
         throw err
       }

--- a/test/lib/commands/adduser.js
+++ b/test/lib/commands/adduser.js
@@ -7,6 +7,7 @@ const { load: loadMockNpm } = require('../../fixtures/mock-npm.js')
 const mockGlobals = require('@npmcli/mock-globals')
 const MockRegistry = require('@npmcli/mock-registry')
 const stream = require('node:stream')
+const { create } = require('node:domain')
 
 const mockAddUser = async (t, { stdin: stdinLines, registry: registryUrl, ...options } = {}) => {
   if (stdinLines) {
@@ -142,8 +143,6 @@ t.test('legacy', async t => {
           username: async () => {
             throw new Error('canceled')
           },
-          password: async () => 'test-password',
-          email: async () => 'test-email@npmjs.org',
         },
       },
     })
@@ -159,8 +158,6 @@ t.test('legacy', async t => {
           username: async () => {
             throw new Error('input error')
           },
-          password: async () => 'test-password',
-          email: async () => 'test-email@npmjs.org',
         },
       },
     })
@@ -212,6 +209,21 @@ t.test('web', t => {
     })
     await adduser.exec([])
     t.same(npm.config.get('//registry.npmjs.org/:_authToken'), 'npm_test-token')
+  })
+
+  t.test('canceled open browser prompt', async t => {
+    const { logs, adduser } = await mockAddUser(t, {
+      config: { 'auth-type': 'web' },
+      mocks: {
+        '{LIB}/utils/open-url.js': {
+          createOpener: () => {
+            throw new Error('canceled')
+          },
+        },
+      },
+    })
+    await adduser.exec([])
+    t.match(logs.warn, ['adduser canceled'], 'should log warning about canceled prompt')
   })
   t.end()
 })

--- a/test/lib/commands/adduser.js
+++ b/test/lib/commands/adduser.js
@@ -133,6 +133,24 @@ t.test('legacy', async t => {
     })
     await t.rejects(adduser.exec([]))
   })
+
+  t.test('canceled input', async t => {
+    const { logs, adduser } = await mockAddUser(t, {
+      config: { 'auth-type': 'legacy' },
+      mocks: {
+        '{LIB}/utils/read-user-info.js': {
+          username: async () => {
+            const error = new Error('canceled')
+            throw error
+          },
+          password: async () => 'test-password',
+          email: async () => 'test-email@npmjs.org',
+        },
+      },
+    })
+    await adduser.exec([])
+    t.match(logs.warn, ['adduser canceled'], 'should log warning about canceled input')
+  })
   t.end()
 })
 

--- a/test/lib/commands/adduser.js
+++ b/test/lib/commands/adduser.js
@@ -140,8 +140,7 @@ t.test('legacy', async t => {
       mocks: {
         '{LIB}/utils/read-user-info.js': {
           username: async () => {
-            const error = new Error('canceled')
-            throw error
+            throw new Error('canceled')
           },
           password: async () => 'test-password',
           email: async () => 'test-email@npmjs.org',
@@ -150,6 +149,25 @@ t.test('legacy', async t => {
     })
     await adduser.exec([])
     t.match(logs.warn, ['adduser canceled'], 'should log warning about canceled input')
+  })
+
+  t.test('input error', async t => {
+    const { adduser } = await mockAddUser(t, {
+      config: { 'auth-type': 'legacy' },
+      mocks: {
+        '{LIB}/utils/read-user-info.js': {
+          username: async () => {
+            throw new Error('input error')
+          },
+          password: async () => 'test-password',
+          email: async () => 'test-email@npmjs.org',
+        },
+      },
+    })
+    await t.rejects(
+      adduser.exec([]),
+      { message: 'input error' }
+    )
   })
   t.end()
 })

--- a/test/lib/commands/adduser.js
+++ b/test/lib/commands/adduser.js
@@ -7,7 +7,6 @@ const { load: loadMockNpm } = require('../../fixtures/mock-npm.js')
 const mockGlobals = require('@npmcli/mock-globals')
 const MockRegistry = require('@npmcli/mock-registry')
 const stream = require('node:stream')
-const { create } = require('node:domain')
 
 const mockAddUser = async (t, { stdin: stdinLines, registry: registryUrl, ...options } = {}) => {
   if (stdinLines) {

--- a/test/lib/commands/login.js
+++ b/test/lib/commands/login.js
@@ -114,6 +114,24 @@ t.test('legacy', t => {
       '//diff-registry.npmjs.org/:_authToken': 'npm_test-token',
     }, 'should only have token and scope:registry')
   })
+
+  t.test('canceled input', async t => {
+    const { logs, login } = await mockLogin(t, {
+      config: { 'auth-type': 'legacy' },
+      mocks: {
+        '{LIB}/utils/read-user-info.js': {
+          username: async () => {
+            const error = new Error('canceled')
+            throw error
+          },
+          password: async () => 'test-password',
+          email: async () => 'test-email@npmjs.org',
+        },
+      },
+    })
+    await login.exec([])
+    t.match(logs.warn, ['login canceled'], 'should log warning about canceled input')
+  })
   t.end()
 })
 

--- a/test/lib/commands/login.js
+++ b/test/lib/commands/login.js
@@ -191,5 +191,20 @@ t.test('web', t => {
     await login.exec([])
     t.same(npm.config.get('//registry.npmjs.org/:_authToken'), 'npm_test-token')
   })
+
+  t.test('canceled open browser prompt', async t => {
+    const { logs, login } = await mockLogin(t, {
+      config: { 'auth-type': 'web' },
+      mocks: {
+        '{LIB}/utils/open-url.js': {
+          createOpener: () => {
+            throw new Error('canceled')
+          },
+        },
+      },
+    })
+    await login.exec([])
+    t.match(logs.warn, ['login canceled'], 'should log warning about canceled prompt')
+  })
   t.end()
 })

--- a/test/lib/commands/login.js
+++ b/test/lib/commands/login.js
@@ -121,8 +121,7 @@ t.test('legacy', t => {
       mocks: {
         '{LIB}/utils/read-user-info.js': {
           username: async () => {
-            const error = new Error('canceled')
-            throw error
+            throw new Error('canceled')
           },
           password: async () => 'test-password',
           email: async () => 'test-email@npmjs.org',
@@ -131,6 +130,25 @@ t.test('legacy', t => {
     })
     await login.exec([])
     t.match(logs.warn, ['login canceled'], 'should log warning about canceled input')
+  })
+
+  t.test('input error', async t => {
+    const { login } = await mockLogin(t, {
+      config: { 'auth-type': 'legacy' },
+      mocks: {
+        '{LIB}/utils/read-user-info.js': {
+          username: async () => {
+            throw new Error('input error')
+          },
+          password: async () => 'test-password',
+          email: async () => 'test-email@npmjs.org',
+        },
+      },
+    })
+    await t.rejects(
+      login.exec([]),
+      { message: 'input error' }
+    )
   })
   t.end()
 })

--- a/test/lib/commands/login.js
+++ b/test/lib/commands/login.js
@@ -123,8 +123,6 @@ t.test('legacy', t => {
           username: async () => {
             throw new Error('canceled')
           },
-          password: async () => 'test-password',
-          email: async () => 'test-email@npmjs.org',
         },
       },
     })
@@ -140,8 +138,6 @@ t.test('legacy', t => {
           username: async () => {
             throw new Error('input error')
           },
-          password: async () => 'test-password',
-          email: async () => 'test-email@npmjs.org',
         },
       },
     })


### PR DESCRIPTION
## Problem

Canceling `npm login` or `npm adduser` leads to an error message:

![image](https://github.com/user-attachments/assets/21045106-f2bd-45a6-97aa-9fc1c88e00da)

![image](https://github.com/user-attachments/assets/20afca55-0259-4d66-a06c-423411e9cdbc)

## Solution

npm now issues a simple warning (same as for `npm init`):

![image](https://github.com/user-attachments/assets/ef6f8cc8-4cf5-4e68-b8bb-7a038098b7ef)

![image](https://github.com/user-attachments/assets/a1202157-f098-46a2-bb0d-ff7d258e365b)

![image](https://github.com/user-attachments/assets/1ca07e7c-8868-4842-ab50-a1e53141a2ab)
