### PR TITLE
fix: move warning to new line when `npm init` is canceled

### DIFF
--- a/lib/commands/init.js
+++ b/lib/commands/init.js
@@ -177,6 +177,7 @@ class Init extends BaseCommand {
       return data
     } catch (er) {
       if (er.message === 'canceled') {
+        output.flush()
         log.warn('init', 'canceled')
       } else {
         throw er


### PR DESCRIPTION
This makes sure that the log warning is not shown behind the prompt but on new line afterwards when canceling the input.

Before:

![image](https://github.com/user-attachments/assets/5efdda20-b7cb-4c8e-89fe-2e04d45dd465)

After:

![image](https://github.com/user-attachments/assets/a185705a-4239-41f4-a335-b7be096f4c5d)
