### PR TITLE
docs: remove deprecated section related temp files

### DIFF
--- a/docs/lib/content/configuring-npm/folders.md
+++ b/docs/lib/content/configuring-npm/folders.md
@@ -76,15 +76,6 @@ See [`npm cache`](/commands/npm-cache).  Cache files are stored in `~/.npm` on P
 
 This is controlled by the [`cache` config](/using-npm/config#cache) param.
 
-#### Temp Files
-
-Temporary files are stored by default in the folder specified by the
-[`tmp` config](/using-npm/config#tmp), which defaults to the TMPDIR, TMP, or
-TEMP environment variables, or `/tmp` on Unix and `c:\windows\temp` on Windows.
-
-Temp files are given a unique folder under this root for each run of the
-program, and are deleted upon successful exit.
-
 ### More Information
 
 When installing locally, npm first tries to find an appropriate


### PR DESCRIPTION
Based on this deprecation notice https://docs.npmjs.com/cli/v8/using-npm/config#tmp, Temp files are now stored at cache location and not OS specific temp file locations. 

Fixes: https://github.com/npm/cli/issues/5466
