### PR TITLE
fix: add warning if bin path includes delimiter

### DIFF
--- a/node_modules/@npmcli/run-script/lib/set-path.js
+++ b/node_modules/@npmcli/run-script/lib/set-path.js
@@ -1,3 +1,4 @@
+const { log } = require('proc-log')
 const { resolve, dirname, delimiter } = require('path')
 // the path here is relative, even though it does not need to be
 // in order to make the posix tests pass in windows
@@ -14,6 +15,12 @@ const setPATH = (projectPath, binPaths, env) => {
 
   const pathArr = []
   if (binPaths) {
+    for (const bin of binPaths) {
+      if (bin.includes(delimiter)) {
+        log.warn('exec', 'Project path contains delimiter (":"), npx may not behave as expected.')
+      }
+    }
+
     pathArr.push(...binPaths)
   }
   // unshift the ./node_modules/.bin from every folder


### PR DESCRIPTION
## Problem:
This pull request aims to resolve #6606. Currently if the project path includes a colon `npx` and `npm exec` will fail to find installed packages with no explanation.

## Solution:
Making npx work properly for package containing deliminators would be too costly, so instead I think adding an warning so that people can understand what is going on would be good enough (I got stuck on this issue for a while!).