### PR TITLE
deps: brace-expansion@2.0.2 [v10]

### DIFF
--- a/node_modules/brace-expansion/index.js
+++ b/node_modules/brace-expansion/index.js
@@ -116,7 +116,7 @@ function expand(str, isTop) {
     var isOptions = m.body.indexOf(',') >= 0;
     if (!isSequence && !isOptions) {
       // {a},b}
-      if (m.post.match(/,.*\}/)) {
+      if (m.post.match(/,(?!,).*\}/)) {
         str = m.pre + '{' + m.body + escClose + m.post;
         return expand(str);
       }

--- a/node_modules/brace-expansion/package.json
+++ b/node_modules/brace-expansion/package.json
@@ -1,7 +1,7 @@
 {
   "name": "brace-expansion",
   "description": "Brace expansion as known from sh/bash",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "repository": {
     "type": "git",
     "url": "git://github.com/juliangruber/brace-expansion.git"
@@ -42,5 +42,8 @@
       "iphone/6.0..latest",
       "android-browser/4.2..latest"
     ]
+  },
+  "publishConfig": {
+    "tag": "2.x"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3827,9 +3827,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
This PR bumps the vulnerable bundled dependency `brace-expansion` from `2.0.1` to `2.0.2` on the v10 branch (see https://github.com/advisories/GHSA-v6h2-p8h4-qcjw). This has already been addressed on the v11 branch in https://github.com/npm/cli/pull/8358.

There are other vulnerable instances of `brace-expansion` in the lockfile, but they are all related to development dependencies, so this PR doesn't bump them.