### PR TITLE
docs: rebrand OS X references to macOS

### DIFF
--- a/docs/lib/content/configuring-npm/install.md
+++ b/docs/lib/content/configuring-npm/install.md
@@ -50,9 +50,9 @@ installer to install both Node.js and npm on your system.
 * [NodeSource installer](https://github.com/nodesource/distributions). If
   you use Linux, we recommend that you use a NodeSource installer.
 
-#### OS X or Windows Node installers
+#### macOS or Windows Node installers
 
-If you're using OS X or Windows, use one of the installers from the
+If you're using macOS or Windows, use one of the installers from the
 [Node.js download page](https://nodejs.org/en/download/). Be sure to
 install the version labeled **LTS**. Other versions have not yet been
 tested with npm.

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -290,7 +290,7 @@ systems.
 
 #### \`browser\`
 
-* Default: OS X: \`"open"\`, Windows: \`"start"\`, Others: \`"xdg-open"\`
+* Default: macOS: \`"open"\`, Windows: \`"start"\`, Others: \`"xdg-open"\`
 * Type: null, Boolean, or String
 
 The browser that is called by npm commands to open websites.

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -260,7 +260,7 @@ const definitions = {
   browser: new Definition('browser', {
     default: null,
     defaultDescription: `
-    OS X: \`"open"\`, Windows: \`"start"\`, Others: \`"xdg-open"\`
+    macOS: \`"open"\`, Windows: \`"start"\`, Others: \`"xdg-open"\`
     `,
     type: [null, Boolean, String],
     description: `


### PR DESCRIPTION
## Situation

https://docs.npmjs.com/downloading-and-installing-node-js-and-npm

refers to the operating system "OS X" in the section

[OS X or Windows Node installers](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm#osx-or-linux-node-version-managers)

and

https://docs.npmjs.com/cli/v11/using-npm/config#browser

similarly.

The last version of OS X was OS X 10.11 (El Capitan), released on Sep 30, 2015.

Apple rebranded to macOS with the macOS 10.12 (Sierra) release on Sep 30, 2016.

## Change

Rename "OS X" to "macOS" in user-visible content.

## References

https://en.wikipedia.org/wiki/MacOS_version_history
https://www.apple.com/macos/

Related to https://github.com/npm/documentation/issues/1459
