### PR TITLE
docs: fix udpate typo in alias examples

### DIFF
--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -4437,14 +4437,14 @@ Options:
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [--workspaces] [--include-workspace-root] [--install-links]
 
-aliases: up, upgrade, udpate
+aliases: up, upgrade, update
 
 Run "npm help update" for more info
 
 \`\`\`bash
 npm update [<pkg>...]
 
-aliases: up, upgrade, udpate
+aliases: up, upgrade, update
 \`\`\`
 
 #### \`save\`


### PR DESCRIPTION
There's a typo in the synopsis of the `npm-update` page, here: https://docs.npmjs.com/cli/v11/commands/npm-update#synopsis

`udpate` is correct in the codebase for some instances as it's bound to `update` in case a user makes a type, but the user-facing documentation shows the incorrect spelling under aliases. This PR fixes that,
