### PR TITLE
fix: Fix using environment variables to specify prefix

### DIFF
--- a/workspaces/config/lib/index.js
+++ b/workspaces/config/lib/index.js
@@ -683,7 +683,7 @@ class Config {
   }
 
   async loadLocalPrefix () {
-    const cliPrefix = this.#get('prefix', 'cli')
+    const cliPrefix = this.#get('prefix', 'cli') || this.#get('prefix', 'env')
     if (cliPrefix) {
       this.localPrefix = cliPrefix
       return

--- a/workspaces/config/lib/index.js
+++ b/workspaces/config/lib/index.js
@@ -683,9 +683,9 @@ class Config {
   }
 
   async loadLocalPrefix () {
-    const cliPrefix = this.#get('prefix', 'cli') || this.#get('prefix', 'env')
-    if (cliPrefix) {
-      this.localPrefix = cliPrefix
+    const explicitPrefix = this.#get('prefix', 'cli') || this.#get('prefix', 'env')
+    if (explicitPrefix) {
+      this.localPrefix = explicitPrefix
       return
     }
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Previously, the code in `workspaces/config/lib/index.js` didn't take into account the environment variables when determining `Config.localPrefix`. 
This means that commands using `localPrefix` could previously behave unexpectedly or fail (if the current working directory isn't part of a package) when the prefix is specified using `NPM_CONFIG_PREFIX=...` .

This PR fixes this by simply checking the environment variables as well using the `Config.#get('prefix', 'env')`

## References

Fixes #4467.

<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
