### PR TITLE
docs: remove reference to Node.js download less common os

### DIFF
--- a/docs/lib/content/configuring-npm/install.md
+++ b/docs/lib/content/configuring-npm/install.md
@@ -69,10 +69,3 @@ installers:
 
 Or see [this page](https://nodejs.org/en/download/package-manager/) to
 install npm for Linux in the way many Linux developers prefer.
-
-#### Less-common operating systems
-
-For more information on installing Node.js on a variety of operating
-systems, see [this page][pkg-mgr].
-
-[pkg-mgr]: https://nodejs.org/en/download/package-manager/


### PR DESCRIPTION
## Situation

External URL: https://docs.npmjs.com/downloading-and-installing-node-js-and-npm#less-common-operating-systems
Source URL:  https://github.com/npm/documentation/blob/main/content/getting-started/configuring-your-local-environment/downloading-and-installing-node-js-and-npm.mdx#less-common-operating-systems

- The target URL https://nodejs.org/en/download/package-manager/ redirects to https://nodejs.org/en/download
- The original content, last seen on Mar 18, 2024, viewable on https://web.archive.org/web/20240318015303/https://nodejs.org/en/download/package-manager/ previously contained a list that included operating systems which could be considered as "less common"

The following screenshot shows content that Node.js has already deleted:

![image](https://github.com/user-attachments/assets/68ac3505-fd51-4433-b184-e03d590d2177)

- There is no longer a section on https://nodejs.org/en/download/package-manager/ corresponding to "Less-common operating systems" and the redirected url https://nodejs.org/en/download currently limits itself to:
  - Windows
  - macOS
  - Linux
  - AIX

This is a screenshot of the current contents of https://nodejs.org/en/download:

![image](https://github.com/user-attachments/assets/e936afc3-8ab0-4c49-a02f-820de5836a70)


## Change

In [docs/lib/content/configuring-npm/install.md](https://github.com/npm/cli/blob/latest/docs/lib/content/configuring-npm/install.md):

- remove the section "Less-common operating systems" since there is no longer any corresponding target information available

## References

- related to https://github.com/npm/documentation/issues/1459