### PR TITLE
chore(contributing): prepare easier copy-paste contributing commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,13 +13,13 @@ When submitting a new bug report, please first [search](https://github.com/npm/c
 **1. Clone this repository...**
 
 ```bash
-$ git clone git@github.com:npm/cli.git npm
+git clone git@github.com:npm/cli.git npm
 ```
 
 **2. Navigate into project & install development-specific dependencies...**
 
 ```bash
-$ cd ./npm && node ./scripts/resetdeps.js
+cd ./npm && node ./scripts/resetdeps.js
 ```
 
 **3. Write some code &/or add some tests...**
@@ -30,7 +30,7 @@ $ cd ./npm && node ./scripts/resetdeps.js
 
 **4. Run tests & ensure they pass...**
 ```
-$ node . run test
+node . run test
 ```
 
 **5. Open a [Pull Request](https://github.com/npm/cli/pulls) for your work & become the newest contributor to `npm`! 🎉**
@@ -61,9 +61,9 @@ node . exec
 ```
 
 For example instead of:
-```bash 
+```bash
 npm exec -- <package>
-```  
+```
 Use:
 ```bash
 node . exec -- <package>


### PR DESCRIPTION
## Situation

In the [CONTRIBUTING](https://github.com/npm/cli/blob/latest/CONTRIBUTING.md) document, [Development](https://github.com/npm/cli/blob/latest/CONTRIBUTING.md#development) section, commands are shown with a `$` bash prompt.

![image](https://github.com/user-attachments/assets/89759ea8-3cb3-4c5f-8aed-a092dd20b9d8)


This means that if the copy icon is used to copy the command, the prompt character needs to be deleted before executing the command. This is a little inconvenient, and it is inconsistent with the presentation of commands in the [Test Coverage](https://github.com/npm/cli/blob/latest/CONTRIBUTING.md#test-coverage) section, lower down in the same document, where commands are presented without any `$` symbol.

## Change

In the [CONTRIBUTING](https://github.com/npm/cli/blob/latest/CONTRIBUTING.md) document, [Development](https://github.com/npm/cli/blob/latest/CONTRIBUTING.md#development) section, remove the `$` character prepending commands.

Also trailing spaces from a couple of lines have been removed from the Markdown document.