### PR TITLE
fix: remove duplicate loop

### DIFF
--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -1478,11 +1478,6 @@ This is a one-time fix-up, please be patient...
     const needPrune = metaFromDisk && (mutateTree || flagsSuspect)
     if (this.#prune && needPrune) {
       this.#idealTreePrune()
-      for (const node of this.idealTree.inventory.values()) {
-        if (node.extraneous) {
-          node.parent = null
-        }
-      }
     }
 
     timeEnd()


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
This loop is the exact same as `this.#idealTreePrune`:

https://github.com/npm/cli/blob/b7758d73d6b715a62e6d0c48e11b87017ce2b71c/workspaces/arborist/lib/arborist/build-ideal-tree.js#L1517-L1523

I'm 98% sure it's a left-over from a refactor that intended to encapsulate the logic so it can be reused elsewhere

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
