### PR TITLE
fix: checks for sigstore env for gitlab provenance

### DIFF
--- a/lib/utils/oidc.js
+++ b/lib/utils/oidc.js
@@ -131,7 +131,8 @@ async function oidc ({ packageName, registry, opts, config }) {
           if (ciInfo.GITHUB_ACTIONS && payload.repository_visibility === 'public') {
             isPublicRepo = true
           }
-          if (ciInfo.GITLAB && payload.project_visibility === 'public') {
+          // only set provenance for gitlab if SIGSTORE_ID_TOKEN is available
+          if (ciInfo.GITLAB && payload.project_visibility === 'public' && process.env.SIGSTORE_ID_TOKEN) {
             isPublicRepo = true
           }
         } catch (e) {

--- a/lib/utils/oidc.js
+++ b/lib/utils/oidc.js
@@ -123,24 +123,24 @@ async function oidc ({ packageName, registry, opts, config }) {
 
     if (skipProvenance) {
       const [headerB64, payloadB64] = idToken.split('.')
-      let isPublicRepo = false
+      let enableProvenance = false
       if (headerB64 && payloadB64) {
         const payloadJson = Buffer.from(payloadB64, 'base64').toString('utf8')
         try {
           const payload = JSON.parse(payloadJson)
           if (ciInfo.GITHUB_ACTIONS && payload.repository_visibility === 'public') {
-            isPublicRepo = true
+            enableProvenance = true
           }
           // only set provenance for gitlab if SIGSTORE_ID_TOKEN is available
           if (ciInfo.GITLAB && payload.project_visibility === 'public' && process.env.SIGSTORE_ID_TOKEN) {
-            isPublicRepo = true
+            enableProvenance = true
           }
         } catch (e) {
           log.silly('oidc', 'Failed to parse idToken payload as JSON')
         }
       }
 
-      if (isPublicRepo) {
+      if (enableProvenance) {
         log.silly('oidc', 'Repository is public, setting provenance')
         opts.provenance = true
         config.set('provenance', true, 'user')

--- a/test/fixtures/mock-oidc.js
+++ b/test/fixtures/mock-oidc.js
@@ -39,6 +39,7 @@ class MockOidc {
       ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'ACTIONS_ID_TOKEN_REQUEST_TOKEN',
       NPM_ID_TOKEN: 'NPM_ID_TOKEN',
       GITHUB_ID_TOKEN: 'mock-github-id-token',
+      SIGSTORE_ID_TOKEN: undefined,
     }
     const options = { ...defaultOpts, ...opts }
 
@@ -61,6 +62,7 @@ class MockOidc {
       NPM_ID_TOKEN: process.env.NPM_ID_TOKEN,
       SIGSTORE_ID_TOKEN: process.env.SIGSTORE_ID_TOKEN,
     }
+
     this.originalCiInfo = {
       GITLAB: ciInfo.GITLAB,
       GITHUB_ACTIONS: ciInfo.GITHUB_ACTIONS,
@@ -91,14 +93,22 @@ class MockOidc {
     ciInfo.GITLAB = false
 
     if (this.github) {
-      process.env.ACTIONS_ID_TOKEN_REQUEST_URL = this.ACTIONS_ID_TOKEN_REQUEST_URL
-      process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN = this.ACTIONS_ID_TOKEN_REQUEST_TOKEN
+      if (typeof this.ACTIONS_ID_TOKEN_REQUEST_URL === 'string') {
+        process.env.ACTIONS_ID_TOKEN_REQUEST_URL = this.ACTIONS_ID_TOKEN_REQUEST_URL
+      }
+      if (typeof this.ACTIONS_ID_TOKEN_REQUEST_TOKEN === 'string') {
+        process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN = this.ACTIONS_ID_TOKEN_REQUEST_TOKEN
+      }
       ciInfo.GITHUB_ACTIONS = true
     }
 
     if (this.gitlab) {
-      process.env.NPM_ID_TOKEN = this.NPM_ID_TOKEN
-      process.env.SIGSTORE_ID_TOKEN = this.SIGSTORE_ID_TOKEN
+      if (typeof this.NPM_ID_TOKEN === 'string') {
+        process.env.NPM_ID_TOKEN = this.NPM_ID_TOKEN
+      }
+      if (typeof this.SIGSTORE_ID_TOKEN === 'string') {
+        process.env.SIGSTORE_ID_TOKEN = this.SIGSTORE_ID_TOKEN
+      }
       ciInfo.GITLAB = true
     }
   }
@@ -115,8 +125,13 @@ class MockOidc {
 
   reset () {
     // Restore only the backed-up environment variables
+
     for (const key in this.originalEnv) {
-      process.env[key] = this.originalEnv[key]
+      if (typeof this.originalEnv[key] === 'string') {
+        process.env[key] = this.originalEnv[key]
+      } else {
+        delete process.env[key]
+      }
     }
 
     // Restore the original ciInfo values

--- a/test/lib/commands/publish.js
+++ b/test/lib/commands/publish.js
@@ -1347,6 +1347,23 @@ t.test('oidc token exchange -- provenance', (t) => {
     provenance: true,
   }))
 
+  t.test('default registry success gitlab without SIGSTORE_ID_TOKEN', oidcPublishTest({
+    oidcOptions: { gitlab: true, NPM_ID_TOKEN: gitlabPublicIdToken },
+    config: {
+      '//registry.npmjs.org/:_authToken': 'existing-fallback-token',
+    },
+    mockOidcTokenExchangeOptions: {
+      idToken: gitlabPublicIdToken,
+      body: {
+        token: 'exchange-token',
+      },
+    },
+    publishOptions: {
+      token: 'exchange-token',
+    },
+    provenance: false,
+  }))
+
   t.test('setting provenance true in config should enable provenance', oidcPublishTest({
     oidcOptions: { github: true },
     config: {


### PR DESCRIPTION
small update to allow gitlab to NOT REQUIRE provenance 