### PR TITLE
fix: provenance should only default for oidc

### DIFF
--- a/lib/utils/oidc.js
+++ b/lib/utils/oidc.js
@@ -111,11 +111,11 @@ async function oidc ({ packageName, registry, opts, config }) {
     // this checks if the user configured provenance or it's the default unset value
     const isDefaultProvenance = config.isDefault('provenance')
     const provenanceIntent = config.get('provenance')
+    let enableProvenance = false
 
     // if provenance is the default value or the user explicitly set it
     if (isDefaultProvenance || provenanceIntent) {
       const [headerB64, payloadB64] = idToken.split('.')
-      let enableProvenance = false
       if (headerB64 && payloadB64) {
         const payloadJson = Buffer.from(payloadB64, 'base64').toString('utf8')
         try {
@@ -130,12 +130,6 @@ async function oidc ({ packageName, registry, opts, config }) {
         } catch (e) {
           // Failed to parse idToken payload as JSON
         }
-      }
-
-      if (enableProvenance) {
-        // Repository is public, setting provenance
-        opts.provenance = true
-        config.set('provenance', true, 'user')
       }
     }
 
@@ -160,6 +154,13 @@ async function oidc ({ packageName, registry, opts, config }) {
       log.verbose('oidc', 'Failed because token exchange was missing the token in the response body')
       return undefined
     }
+
+    if (enableProvenance) {
+      // Repository is public, setting provenance
+      opts.provenance = true
+      config.set('provenance', true, 'user')
+    }
+
     /*
      * The "opts" object is a clone of npm.flatOptions and is passed through the `publish` command,
      * eventually reaching `otplease`. To ensure the token is accessible during the publishing process,

--- a/test/lib/commands/publish.js
+++ b/test/lib/commands/publish.js
@@ -1450,5 +1450,30 @@ t.test('oidc token exchange - provenance', (t) => {
     }))
   })
 
+  t.test('token exchange 500 with fallback should not have provenance by default', oidcPublishTest({
+    oidcOptions: { github: true },
+    config: {
+      '//registry.npmjs.org/:_authToken': 'existing-fallback-token',
+    },
+    mockGithubOidcOptions: {
+      audience: 'npm:registry.npmjs.org',
+      idToken: githubPublicIdToken,
+    },
+    mockOidcTokenExchangeOptions: {
+      statusCode: 500,
+      idToken: githubPublicIdToken,
+      body: {
+        message: 'oidc token exchange failed',
+      },
+    },
+    publishOptions: {
+      token: 'existing-fallback-token',
+    },
+    logsContain: [
+      'verbose oidc Failed token exchange request with body message: oidc token exchange failed',
+    ],
+    provenance: false,
+  }))
+
   t.end()
 })


### PR DESCRIPTION
fast follow up for oidc, where currently if criteria is met (where publishing from a workflow with id-token write, and oidc is not configured, and provenance is default (false), this will apply provenance for non-oidc publishes)