### PR TITLE
docs: update snapshot generation command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ node . exec -- <package>
 ```
 To update the snapshots run:
 ```bash
-TAP_SNAPSHOT=1 npm test
+TAP_SNAPSHOT=1 node . run test
 ```
 
 ## Performance & Benchmarks


### PR DESCRIPTION
## Situation

In the [CONTRIBUTING](https://github.com/npm/cli/blob/latest/CONTRIBUTING.md) document, [Test Coverage](https://github.com/npm/cli/blob/latest/CONTRIBUTING.md#test-coverage) section, the command to update snapshots is inconsistent with the other npm commands in the same document that run `npm` through `node`, and with the introductory comments in that section.

---
To run your repository's version of the npm cli on your local machine use the following commands:

...

To update the snapshots run:
```bash
TAP_SNAPSHOT=1 npm test
```
---


## Change

In the [CONTRIBUTING](https://github.com/npm/cli/blob/latest/CONTRIBUTING.md) document, [Test Coverage](https://github.com/npm/cli/blob/latest/CONTRIBUTING.md#test-coverage) section, change the command to update snapshots to:

```bash
TAP_SNAPSHOT=1 node . run test
```

## Verification

Ubuntu: `24.04.2` LTS
Node.js: `22.17.1` LTS
npm: `11.15.1`

Execute the following:

```shell
npm install npm@latest -g
node ./scripts/resetdeps.js
node . run test
```

Confirm that there are no errors.

Delete file `tap-snapshots/test/lib/docs.js.test.cjs` and execute:

```shell
node . run test
```

and note that the test result is now:

> Suites:   ​1 failed​, ​101 passed​, ​102 of 102 completed​
> Asserts:  ​​​74 failed​, ​4702 passed​, ​7 skip​, ​of 4783​

Execute:

```bash
TAP_SNAPSHOT=1 node . run test
git status
```

Confirm that all tests now pass and that git shows no pending changes (meaning the deleted snapshot file has been fully restored):

> Suites:   ​102 passed​, ​102 of 102 completed​
> Asserts:  ​​​4781 passed​, ​7 skip​, ​of 4788​

## References

- follows on from https://github.com/npm/cli/pull/8435#issuecomment-3079241292
