### PR TITLE
fix: oidc visibility check for provenance

### DIFF
--- a/lib/utils/oidc.js
+++ b/lib/utils/oidc.js
@@ -150,7 +150,7 @@ async function oidc ({ packageName, registry, opts, config }) {
           const payload = JSON.parse(payloadJson)
           if (
             (ciInfo.GITHUB_ACTIONS && payload.repository_visibility === 'public') ||
-            // only set provenance for gitlab if SIGSTORE_ID_TOKEN is available
+            // only set provenance for gitlab if the repo is public and SIGSTORE_ID_TOKEN is available
             (ciInfo.GITLAB && payload.project_visibility === 'public' && process.env.SIGSTORE_ID_TOKEN)
           ) {
             const visibility = await libaccess.getVisibility(packageName, opts)

--- a/lib/utils/oidc.js
+++ b/lib/utils/oidc.js
@@ -154,7 +154,7 @@ async function oidc ({ packageName, registry, opts, config }) {
             (ciInfo.GITLAB && payload.project_visibility === 'public' && process.env.SIGSTORE_ID_TOKEN)
           ) {
             const visibility = await libaccess.getVisibility(packageName, opts)
-            if (visibility && visibility.public) {
+            if (visibility?.public) {
               log.verbose('oidc', `Enabling provenance`)
               opts.provenance = true
               config.set('provenance', true, 'user')

--- a/lib/utils/oidc.js
+++ b/lib/utils/oidc.js
@@ -3,6 +3,7 @@ const npmFetch = require('npm-registry-fetch')
 const ciInfo = require('ci-info')
 const fetch = require('make-fetch-happen')
 const npa = require('npm-package-arg')
+const libaccess = require('libnpmaccess')
 
 /**
  * Handles OpenID Connect (OIDC) token retrieval and exchange for CI environments.
@@ -108,31 +109,6 @@ async function oidc ({ packageName, registry, opts, config }) {
       return undefined
     }
 
-    // this checks if the user configured provenance or it's the default unset value
-    const isDefaultProvenance = config.isDefault('provenance')
-    const provenanceIntent = config.get('provenance')
-    let enableProvenance = false
-
-    // if provenance is the default value or the user explicitly set it
-    if (isDefaultProvenance || provenanceIntent) {
-      const [headerB64, payloadB64] = idToken.split('.')
-      if (headerB64 && payloadB64) {
-        const payloadJson = Buffer.from(payloadB64, 'base64').toString('utf8')
-        try {
-          const payload = JSON.parse(payloadJson)
-          if (ciInfo.GITHUB_ACTIONS && payload.repository_visibility === 'public') {
-            enableProvenance = true
-          }
-          // only set provenance for gitlab if SIGSTORE_ID_TOKEN is available
-          if (ciInfo.GITLAB && payload.project_visibility === 'public' && process.env.SIGSTORE_ID_TOKEN) {
-            enableProvenance = true
-          }
-        } catch (e) {
-          // Failed to parse idToken payload as JSON
-        }
-      }
-    }
-
     const parsedRegistry = new URL(registry)
     const regKey = `//${parsedRegistry.host}${parsedRegistry.pathname}`
     const authTokenKey = `${regKey}:_authToken`
@@ -155,12 +131,6 @@ async function oidc ({ packageName, registry, opts, config }) {
       return undefined
     }
 
-    if (enableProvenance) {
-      // Repository is public, setting provenance
-      opts.provenance = true
-      config.set('provenance', true, 'user')
-    }
-
     /*
      * The "opts" object is a clone of npm.flatOptions and is passed through the `publish` command,
      * eventually reaching `otplease`. To ensure the token is accessible during the publishing process,
@@ -170,6 +140,31 @@ async function oidc ({ packageName, registry, opts, config }) {
     opts[authTokenKey] = response.token
     config.set(authTokenKey, response.token, 'user')
     log.verbose('oidc', `Successfully retrieved and set token`)
+
+    try {
+      const isDefaultProvenance = config.isDefault('provenance')
+      if (isDefaultProvenance) {
+        const [headerB64, payloadB64] = idToken.split('.')
+        if (headerB64 && payloadB64) {
+          const payloadJson = Buffer.from(payloadB64, 'base64').toString('utf8')
+          const payload = JSON.parse(payloadJson)
+          if (
+            (ciInfo.GITHUB_ACTIONS && payload.repository_visibility === 'public') ||
+            // only set provenance for gitlab if SIGSTORE_ID_TOKEN is available
+            (ciInfo.GITLAB && payload.project_visibility === 'public' && process.env.SIGSTORE_ID_TOKEN)
+          ) {
+            const visibility = await libaccess.getVisibility(packageName, opts)
+            if (visibility && visibility.public) {
+              log.verbose('oidc', `Enabling provenance`)
+              opts.provenance = true
+              config.set('provenance', true, 'user')
+            }
+          }
+        }
+      }
+    } catch (error) {
+      log.verbose('oidc', `Failed to set provenance with message: ${error?.message || 'Unknown error'}`)
+    }
   } catch (error) {
     log.verbose('oidc', `Failure with message: ${error?.message || 'Unknown error'}`)
   }

--- a/test/fixtures/mock-oidc.js
+++ b/test/fixtures/mock-oidc.js
@@ -39,10 +39,11 @@ const mockOidc = async (t, {
   config = {},
   packageJson = {},
   load = {},
-  mockGithubOidcOptions = null,
-  mockOidcTokenExchangeOptions = null,
+  mockGithubOidcOptions = false,
+  mockOidcTokenExchangeOptions = false,
   publishOptions = {},
   provenance = false,
+  oidcVisibilityOptions = false,
 }) => {
   const github = oidcOptions.github ?? false
   const gitlab = oidcOptions.gitlab ?? false
@@ -113,9 +114,17 @@ const mockOidc = async (t, {
     })
   }
 
+  if (oidcVisibilityOptions) {
+    registry.getVisibility({ spec: packageName, visibility: oidcVisibilityOptions })
+  }
+
   registry.publish(packageName, publishOptions)
 
-  if ((github || gitlab) && provenance) {
+  /**
+   * this will nock / mock all the successful requirements for provenance and
+   * assumes when a test has "provenance true" that these calls are expected
+   */
+  if (provenance) {
     registry.getVisibility({ spec: packageName, visibility: { public: true } })
     mockProvenance(t, {
       oidcURL: ACTIONS_ID_TOKEN_REQUEST_URL,

--- a/test/lib/commands/publish.js
+++ b/test/lib/commands/publish.js
@@ -1317,6 +1317,7 @@ t.test('oidc token exchange - no provenance', t => {
 })
 
 t.test('oidc token exchange - provenance', (t) => {
+  const githubPrivateIdToken = githubIdToken({ visibility: 'private' })
   const githubPublicIdToken = githubIdToken({ visibility: 'public' })
   const gitlabPublicIdToken = gitlabIdToken({ visibility: 'public' })
   const SIGSTORE_ID_TOKEN = sigstoreIdToken()
@@ -1340,6 +1341,7 @@ t.test('oidc token exchange - provenance', (t) => {
       token: 'exchange-token',
     },
     provenance: true,
+    oidcVisibilityOptions: { public: true },
   }))
 
   t.test('default registry success gitlab', oidcPublishTest({
@@ -1357,6 +1359,7 @@ t.test('oidc token exchange - provenance', (t) => {
       token: 'exchange-token',
     },
     provenance: true,
+    oidcVisibilityOptions: { public: true },
   }))
 
   t.test('default registry success gitlab without SIGSTORE_ID_TOKEN', oidcPublishTest({
@@ -1376,6 +1379,10 @@ t.test('oidc token exchange - provenance', (t) => {
     provenance: false,
   }))
 
+  /**
+   * when the user sets provenance to true or false
+   * the OIDC flow should not concern itself with provenance at all
+   */
   t.test('setting provenance true in config should enable provenance', oidcPublishTest({
     oidcOptions: { github: true },
     config: {
@@ -1472,6 +1479,50 @@ t.test('oidc token exchange - provenance', (t) => {
     logsContain: [
       'verbose oidc Failed token exchange request with body message: oidc token exchange failed',
     ],
+    provenance: false,
+  }))
+
+  t.test('attempt to publish a private package with OIDC provenance should be false', oidcPublishTest({
+    oidcOptions: { github: true },
+    config: {
+      '//registry.npmjs.org/:_authToken': 'existing-fallback-token',
+    },
+    mockGithubOidcOptions: {
+      audience: 'npm:registry.npmjs.org',
+      idToken: githubPublicIdToken,
+    },
+    mockOidcTokenExchangeOptions: {
+      idToken: githubPublicIdToken,
+      body: {
+        token: 'exchange-token',
+      },
+    },
+    publishOptions: {
+      token: 'exchange-token',
+    },
+    provenance: false,
+    oidcVisibilityOptions: { public: false },
+  }))
+
+  /** this call shows that if the repo is private, the visibility check will not be called */
+  t.test('attempt to publish a private repository with OIDC provenance should be false', oidcPublishTest({
+    oidcOptions: { github: true },
+    config: {
+      '//registry.npmjs.org/:_authToken': 'existing-fallback-token',
+    },
+    mockGithubOidcOptions: {
+      audience: 'npm:registry.npmjs.org',
+      idToken: githubPrivateIdToken,
+    },
+    mockOidcTokenExchangeOptions: {
+      idToken: githubPrivateIdToken,
+      body: {
+        token: 'exchange-token',
+      },
+    },
+    publishOptions: {
+      token: 'exchange-token',
+    },
     provenance: false,
   }))
 

--- a/test/lib/commands/publish.js
+++ b/test/lib/commands/publish.js
@@ -1526,13 +1526,15 @@ t.test('oidc token exchange - provenance', (t) => {
     provenance: false,
   }))
 
-  ;[[
+  const provenanceFailures = [[
     new Error('Valid error'),
     'verbose oidc Failed to set provenance with message: Valid error',
   ], [
     'Valid error',
     'verbose oidc Failed to set provenance with message: Unknown error',
-  ]].forEach(([error, logMessage], index) => {
+  ]]
+
+  provenanceFailures.forEach(([error, logMessage], index) => {
     t.test(`provenance visibility check failure, coverage for try-catch ${index}`, async t => {
       const { npm, logs, joinedOutput } = await mockOidc(t, {
         load: {

--- a/test/lib/commands/publish.js
+++ b/test/lib/commands/publish.js
@@ -1526,5 +1526,49 @@ t.test('oidc token exchange - provenance', (t) => {
     provenance: false,
   }))
 
+  ;[[
+    new Error('Valid error'),
+    'verbose oidc Failed to set provenance with message: Valid error',
+  ], [
+    'Valid error',
+    'verbose oidc Failed to set provenance with message: Unknown error',
+  ]].forEach(([error, logMessage], index) => {
+    t.test(`provenance visibility check failure, coverage for try-catch ${index}`, async t => {
+      const { npm, logs, joinedOutput } = await mockOidc(t, {
+        load: {
+          mocks: {
+            libnpmaccess: {
+              getVisibility: () => {
+                throw error
+              },
+            },
+          },
+        },
+        oidcOptions: { github: true },
+        config: {
+          '//registry.npmjs.org/:_authToken': 'existing-fallback-token',
+        },
+        mockGithubOidcOptions: {
+          audience: 'npm:registry.npmjs.org',
+          idToken: githubPublicIdToken,
+        },
+        mockOidcTokenExchangeOptions: {
+          idToken: githubPublicIdToken,
+          body: {
+            token: 'exchange-token',
+          },
+        },
+        publishOptions: {
+          token: 'exchange-token',
+        },
+        provenance: false,
+      })
+
+      await npm.exec('publish', [])
+      t.match(joinedOutput(), '+ @npmcli/test-package@1.0.0')
+      t.ok(logs.includes(logMessage))
+    })
+  })
+
   t.end()
 })


### PR DESCRIPTION
When someone with a public repository and a private package attempts to publish with OIDC, the publish command will fail because provenance is enabled, there is currently no visibility check before auto enabling provenance. 

This is a very rare edge case, but it's still incorrect. OIDC will always gracefully fail, but provenance does not.

* This fix adds all the provenance related code after the OIDC auth token is set.
* This requires provenance to be in the default config state (not set by the user) for OIDC to even consider auto-enabling provannece.

