### PR TITLE
fix: ps1 scripts in powershell 5.1

### DIFF
--- a/bin/npm.ps1
+++ b/bin/npm.ps1
@@ -1,5 +1,7 @@
 #!/usr/bin/env pwsh
 
+Set-StrictMode -Version 'Latest'
+
 $NODE_EXE="$PSScriptRoot/node.exe"
 if (-not (Test-Path $NODE_EXE)) {
   $NODE_EXE="$PSScriptRoot/node"
@@ -27,7 +29,7 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
 } elseif (-not $MyInvocation.Line) { # used "-File" argument
   & $NODE_EXE $NPM_CLI_JS $args
 } else { # used "-Command" argument
-  if ($MyInvocation.Statement) {
+  if (($MyInvocation | Get-Member -Name 'Statement') -and $MyInvocation.Statement) {
     $NPM_ORIGINAL_COMMAND = $MyInvocation.Statement
   } else {
     $NPM_ORIGINAL_COMMAND = (

--- a/bin/npx.ps1
+++ b/bin/npx.ps1
@@ -1,5 +1,7 @@
 #!/usr/bin/env pwsh
 
+Set-StrictMode -Version 'Latest'
+
 $NODE_EXE="$PSScriptRoot/node.exe"
 if (-not (Test-Path $NODE_EXE)) {
   $NODE_EXE="$PSScriptRoot/node"
@@ -27,7 +29,7 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
 } elseif (-not $MyInvocation.Line) { # used "-File" argument
   & $NODE_EXE $NPX_CLI_JS $args
 } else { # used "-Command" argument
-  if ($MyInvocation.Statement) {
+  if (($MyInvocation | Get-Member -Name 'Statement') -and $MyInvocation.Statement) {
     $NPX_ORIGINAL_COMMAND = $MyInvocation.Statement
   } else {
     $NPX_ORIGINAL_COMMAND = (


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

Fixes issue #8468: npm.ps1 and npx.ps1 fail on Windows PowerShell 5.1 when run in strict mode.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

