### PR TITLE
fix: optional set calculation

### DIFF
--- a/workspaces/arborist/lib/optional-set.js
+++ b/workspaces/arborist/lib/optional-set.js
@@ -29,10 +29,8 @@ const optionalSet = node => {
   }
 
   // now that we've hit the boundary, gather the rest of the nodes in
-  // the optional section.  that's the set of dependencies that are only
-  // depended upon by other nodes within the set, or optional dependencies
-  // from outside the set.
-  return gatherDepSet(set, edge => !edge.optional)
+  // the optional section that don't have dependents outside the set.
+  return gatherDepSet(set, edge => !set.has(edge.to))
 }
 
 module.exports = optionalSet

--- a/workspaces/arborist/test/optional-set.js
+++ b/workspaces/arborist/test/optional-set.js
@@ -9,17 +9,18 @@ tree (PROD a, PROD c, OPT i)
 +-- a (OPT o)
 +-- b (PROD c)
 +-- c (OPT b)
-+-- o (PROD m)
-+-- m (PROD n)
++-- o (PROD m, OPT i)
++-- m (OPT n)
 +-- n ()
 +-- OPT i (PROD j)
 +-- j ()
 
 Gathering the optional set from:
-j: [i],
+j: [j, i],
 a: [],
-o: [m, n],
-b: []
+o: [o, m, n],
+m: [o, m, n],
+b: [b],
 */
 
 const tree = new Node({
@@ -38,8 +39,8 @@ const tree = new Node({
     ['a', [], ['o']],
     ['b', ['c'], []],
     ['c', [], ['b']],
-    ['o', ['m'], []],
-    ['m', ['n'], []],
+    ['o', ['m'], ['i']],
+    ['m', [], ['n']],
     ['n', [], []],
     ['i', ['j'], []],
     ['j', [], []],
@@ -83,11 +84,11 @@ t.equal(setO.has(nodeO), true, 'set o includes o')
 t.equal(setO.has(nodeM), true, 'set o includes m')
 t.equal(setO.has(nodeN), true, 'set o includes n')
 
-const setN = optionalSet(nodeO)
-t.equal(setN.size, 3, 'three nodes in n set')
-t.equal(setN.has(nodeO), true, 'set n includes o')
-t.equal(setN.has(nodeM), true, 'set n includes m')
-t.equal(setN.has(nodeN), true, 'set n includes n')
+const setM = optionalSet(nodeM)
+t.equal(setM.size, 3, 'three nodes in m set')
+t.equal(setM.has(nodeO), true, 'set m includes o')
+t.equal(setM.has(nodeM), true, 'set m includes m')
+t.equal(setM.has(nodeN), true, 'set m includes n')
 
 const setB = optionalSet(nodeB)
 t.equal(setB.size, 1, 'gathering from b is only b')


### PR DESCRIPTION
Discovered while investigating https://github.com/npm/cli/issues/8535#issuecomment-3232484915.
I noticed that not all deps of a failed optional dep were added to the trash list.

I modified the tests to expose this and changed the implementation to fix it.

Best illustrated with this graph showing the results of the test case `const setO = optionalSet(nodeO)`:

[<img width="422" height="499" alt="image" src="https://github.com/user-attachments/assets/2f1778d7-4cd5-4728-b063-d2f218be5fd8" />](https://mermaid.live/edit#pako:eNp9k8tuwyAQRX_FmmwdC-fhB4tu2m1_oEKKCCYJETAWwWrTJP9ex05U4bpmxcyde2ZAmgsIrCRQ2Gn8FAfuPLMnf9Yy8k7KTbRTWtNZlmWxQI2OzgghzHbafP5yrR1W0ZVv0oQkf_MizCetgLVXaLmOruop9u0ejH8aPtQBAkPEdhLxUEem691i0i1GB9iGCAwQQoQIHA5gnm4chQ8-yEzCzSjChggbPnGA6GvU5Deo4RuOYYfjpBti2DtVAfWukTEY6Qy_h3BhNooY-IM0kgFtr1Y23nHNgNlba6u5_UA0T6fDZn8AuuP61EZNXXEv3xTfO_5bIm0l3Ss21gNNi7zoIEAv8AV0Va6TfJGWKSmL5WK5XsRwBppnyaq8n2y5KjKS57cYvruuJCnyXloXbXlOyhhkpTy69357uiW6_QAjeANq)

Yellow nodes were returned by the prev implementation. Yellow + green nodes are returned by the fixed implementation.

<details>

<summary>Code to produce graph</summary>

```js
const oldS = gatherDepSet(set, edge => !edge.optional)
const newS = gatherDepSet(set, edge => !set.has(edge.to))
if (!oldS.size !== newS.size) {
  graph(oldS, newS)
}
```

```js
function graph (...sets) {
  const safe = (id) => id.replaceAll('@', '_')
  let code = 'flowchart\n'
  for (const node of sets[0].values().next().value.root.inventory.values()) {
    const rgb = sets.map(s => s.has(node) ? 'c' : '6').concat(...'666').slice(0, 3).join('')
    code += `style ${safe(node.pkgid)} fill:#${rgb},color:#000\n`
    for (const edge of node.edgesOut.values()) {
      code += `${safe(node.pkgid)}-${edge.optional ? '.' : ''}->|${edge.type} ${edge.error || ''}|${safe(edge.to?.pkgid || `${edge.name}@${edge.spec}`)}\n`
    }
  }
  const mermaid = JSON.stringify({ theme: 'neutral' })
  console.log(`https://mermaid.live/edit#pako:${require('zlib').deflateSync(JSON.stringify({ code, mermaid })).toString('base64')}`)
}
```

</details>
