### PR TITLE
fix(powershell): improve argument parsing

### DIFF
--- a/bin/npm.ps1
+++ b/bin/npm.ps1
@@ -40,9 +40,9 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
   $NODE_EXE = $NODE_EXE.Replace("``", "````")
   $NPM_CLI_JS = $NPM_CLI_JS.Replace("``", "````")
 
-  $NPM_NO_REDIRECTS_COMMAND = [Management.Automation.Language.Parser]::ParseInput($NPM_ORIGINAL_COMMAND, [ref] $null, [ref] $null).
+  $NPM_COMMAND_ARR = [Management.Automation.Language.Parser]::ParseInput($NPM_ORIGINAL_COMMAND, [ref] $null, [ref] $null).
     EndBlock.Statements.PipelineElements.CommandElements.Extent.Text
-  $NPM_ARGS = ($NPM_NO_REDIRECTS_COMMAND | Select-Object -Skip 1) -join ' '
+  $NPM_ARGS = ($NPM_COMMAND_ARR | Select-Object -Skip 1) -join ' '
 
   Invoke-Expression "& `"$NODE_EXE`" `"$NPM_CLI_JS`" $NPM_ARGS"
 }

--- a/bin/npm.ps1
+++ b/bin/npm.ps1
@@ -40,9 +40,9 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
   $NODE_EXE = $NODE_EXE.Replace("``", "````")
   $NPM_CLI_JS = $NPM_CLI_JS.Replace("``", "````")
 
-  $NPM_COMMAND_ARR = [Management.Automation.Language.Parser]::ParseInput($NPM_ORIGINAL_COMMAND, [ref] $null, [ref] $null).
+  $NPM_COMMAND_ARRAY = [Management.Automation.Language.Parser]::ParseInput($NPM_ORIGINAL_COMMAND, [ref] $null, [ref] $null).
     EndBlock.Statements.PipelineElements.CommandElements.Extent.Text
-  $NPM_ARGS = ($NPM_COMMAND_ARR | Select-Object -Skip 1) -join ' '
+  $NPM_ARGS = ($NPM_COMMAND_ARRAY | Select-Object -Skip 1) -join ' '
 
   Invoke-Expression "& `"$NODE_EXE`" `"$NPM_CLI_JS`" $NPM_ARGS"
 }

--- a/bin/npm.ps1
+++ b/bin/npm.ps1
@@ -42,12 +42,7 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
 
   $NPM_NO_REDIRECTS_COMMAND = [Management.Automation.Language.Parser]::ParseInput($NPM_ORIGINAL_COMMAND, [ref] $null, [ref] $null).
     EndBlock.Statements.PipelineElements.CommandElements.Extent.Text
-
-  if ($NPM_NO_REDIRECTS_COMMAND -is [array] -and $NPM_NO_REDIRECTS_COMMAND.Length -gt 1) {
-    $NPM_ARGS = $NPM_NO_REDIRECTS_COMMAND[1..($NPM_NO_REDIRECTS_COMMAND.Length - 1)] -join ' '
-  } else {
-    $NPM_ARGS = ""
-  }
+  $NPM_ARGS = ($NPM_NO_REDIRECTS_COMMAND | Select-Object -Skip 1) -join ' '
 
   Invoke-Expression "& `"$NODE_EXE`" `"$NPM_CLI_JS`" $NPM_ARGS"
 }

--- a/bin/npm.ps1
+++ b/bin/npm.ps1
@@ -26,7 +26,7 @@ if (Test-Path $NPM_PREFIX_NPM_CLI_JS) {
 
 if ($MyInvocation.ExpectingInput) { # takes pipeline input
   $input | & $NODE_EXE $NPM_CLI_JS $args
-} elseif (-not $MyInvocation.Line -or $MyInvocation.InvocationName -in '&', '.') { # used "-File" argument
+} elseif (-not $MyInvocation.Line) { # used "-File" argument
   & $NODE_EXE $NPM_CLI_JS $args
 } else { # used "-Command" argument
   if (($MyInvocation | Get-Member -Name 'Statement') -and $MyInvocation.Statement) {
@@ -40,9 +40,9 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
   $NODE_EXE = $NODE_EXE.Replace("``", "````")
   $NPM_CLI_JS = $NPM_CLI_JS.Replace("``", "````")
 
-  $NPM_NO_REDIRECTS_COMMAND = [Management.Automation.Language.Parser]::ParseInput($NPM_ORIGINAL_COMMAND, [ref] $null, [ref] $null).
-    EndBlock.Statements.PipelineElements.CommandElements.Extent.Text -join ' '
-  $NPM_ARGS = $NPM_NO_REDIRECTS_COMMAND.Substring($MyInvocation.InvocationName.Length).Trim()
+  $NPM_NO_REDIRECTS_COMMAND_ARR = [Management.Automation.Language.Parser]::ParseInput($NPM_ORIGINAL_COMMAND, [ref] $null, [ref] $null).
+    EndBlock.Statements.PipelineElements.CommandElements.Extent.Text
+  $NPM_ARGS = $NPM_NO_REDIRECTS_COMMAND_ARR[1..($NPM_NO_REDIRECTS_COMMAND_ARR.Length - 1)] -join ' '
 
   Invoke-Expression "& `"$NODE_EXE`" `"$NPM_CLI_JS`" $NPM_ARGS"
 }

--- a/bin/npm.ps1
+++ b/bin/npm.ps1
@@ -40,9 +40,14 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
   $NODE_EXE = $NODE_EXE.Replace("``", "````")
   $NPM_CLI_JS = $NPM_CLI_JS.Replace("``", "````")
 
-  $NPM_NO_REDIRECTS_COMMAND_ARR = [Management.Automation.Language.Parser]::ParseInput($NPM_ORIGINAL_COMMAND, [ref] $null, [ref] $null).
+  $NPM_NO_REDIRECTS_COMMAND = [Management.Automation.Language.Parser]::ParseInput($NPM_ORIGINAL_COMMAND, [ref] $null, [ref] $null).
     EndBlock.Statements.PipelineElements.CommandElements.Extent.Text
-  $NPM_ARGS = $NPM_NO_REDIRECTS_COMMAND_ARR[1..($NPM_NO_REDIRECTS_COMMAND_ARR.Length - 1)] -join ' '
+
+  if ($NPM_NO_REDIRECTS_COMMAND -is [array] -and $NPM_NO_REDIRECTS_COMMAND.Length -gt 1) {
+    $NPM_ARGS = $NPM_NO_REDIRECTS_COMMAND[1..($NPM_NO_REDIRECTS_COMMAND.Length - 1)] -join ' '
+  } else {
+    $NPM_ARGS = ""
+  }
 
   Invoke-Expression "& `"$NODE_EXE`" `"$NPM_CLI_JS`" $NPM_ARGS"
 }

--- a/bin/npx.ps1
+++ b/bin/npx.ps1
@@ -42,12 +42,7 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
 
   $NPX_NO_REDIRECTS_COMMAND = [Management.Automation.Language.Parser]::ParseInput($NPX_ORIGINAL_COMMAND, [ref] $null, [ref] $null).
     EndBlock.Statements.PipelineElements.CommandElements.Extent.Text
-
-  if ($NPX_NO_REDIRECTS_COMMAND -is [array] -and $NPX_NO_REDIRECTS_COMMAND.Length -gt 1) {
-    $NPX_ARGS = $NPX_NO_REDIRECTS_COMMAND[1..($NPX_NO_REDIRECTS_COMMAND.Length - 1)] -join ' '
-  } else {
-    $NPX_ARGS = ""
-  }
+  $NPX_ARGS = ($NPX_NO_REDIRECTS_COMMAND | Select-Object -Skip 1) -join ' '
 
   Invoke-Expression "& `"$NODE_EXE`" `"$NPX_CLI_JS`" $NPX_ARGS"
 }

--- a/bin/npx.ps1
+++ b/bin/npx.ps1
@@ -40,7 +40,7 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
   $NODE_EXE = $NODE_EXE.Replace("``", "````")
   $NPX_CLI_JS = $NPX_CLI_JS.Replace("``", "````")
 
-  $NPX_NO_REDIRECTS_COMMAND_ARR  = [Management.Automation.Language.Parser]::ParseInput($NPX_ORIGINAL_COMMAND, [ref] $null, [ref] $null).
+  $NPX_NO_REDIRECTS_COMMAND_ARR = [Management.Automation.Language.Parser]::ParseInput($NPX_ORIGINAL_COMMAND, [ref] $null, [ref] $null).
     EndBlock.Statements.PipelineElements.CommandElements.Extent.Text
   $NPX_ARGS = $NPX_NO_REDIRECTS_COMMAND_ARR[1..($NPX_NO_REDIRECTS_COMMAND_ARR.Length - 1)] -join ' '
 

--- a/bin/npx.ps1
+++ b/bin/npx.ps1
@@ -40,9 +40,9 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
   $NODE_EXE = $NODE_EXE.Replace("``", "````")
   $NPX_CLI_JS = $NPX_CLI_JS.Replace("``", "````")
 
-  $NPX_COMMAND_ARR = [Management.Automation.Language.Parser]::ParseInput($NPX_ORIGINAL_COMMAND, [ref] $null, [ref] $null).
+  $NPX_COMMAND_ARRAY = [Management.Automation.Language.Parser]::ParseInput($NPX_ORIGINAL_COMMAND, [ref] $null, [ref] $null).
     EndBlock.Statements.PipelineElements.CommandElements.Extent.Text
-  $NPX_ARGS = ($NPX_COMMAND_ARR | Select-Object -Skip 1) -join ' '
+  $NPX_ARGS = ($NPX_COMMAND_ARRAY | Select-Object -Skip 1) -join ' '
 
   Invoke-Expression "& `"$NODE_EXE`" `"$NPX_CLI_JS`" $NPX_ARGS"
 }

--- a/bin/npx.ps1
+++ b/bin/npx.ps1
@@ -40,9 +40,14 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
   $NODE_EXE = $NODE_EXE.Replace("``", "````")
   $NPX_CLI_JS = $NPX_CLI_JS.Replace("``", "````")
 
-  $NPX_NO_REDIRECTS_COMMAND_ARR = [Management.Automation.Language.Parser]::ParseInput($NPX_ORIGINAL_COMMAND, [ref] $null, [ref] $null).
+  $NPX_NO_REDIRECTS_COMMAND = [Management.Automation.Language.Parser]::ParseInput($NPX_ORIGINAL_COMMAND, [ref] $null, [ref] $null).
     EndBlock.Statements.PipelineElements.CommandElements.Extent.Text
-  $NPX_ARGS = $NPX_NO_REDIRECTS_COMMAND_ARR[1..($NPX_NO_REDIRECTS_COMMAND_ARR.Length - 1)] -join ' '
+
+  if ($NPX_NO_REDIRECTS_COMMAND -is [array] -and $NPX_NO_REDIRECTS_COMMAND.Length -gt 1) {
+    $NPX_ARGS = $NPX_NO_REDIRECTS_COMMAND[1..($NPX_NO_REDIRECTS_COMMAND.Length - 1)] -join ' '
+  } else {
+    $NPX_ARGS = ""
+  }
 
   Invoke-Expression "& `"$NODE_EXE`" `"$NPX_CLI_JS`" $NPX_ARGS"
 }

--- a/bin/npx.ps1
+++ b/bin/npx.ps1
@@ -40,9 +40,9 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
   $NODE_EXE = $NODE_EXE.Replace("``", "````")
   $NPX_CLI_JS = $NPX_CLI_JS.Replace("``", "````")
 
-  $NPX_NO_REDIRECTS_COMMAND = [Management.Automation.Language.Parser]::ParseInput($NPX_ORIGINAL_COMMAND, [ref] $null, [ref] $null).
+  $NPX_COMMAND_ARR = [Management.Automation.Language.Parser]::ParseInput($NPX_ORIGINAL_COMMAND, [ref] $null, [ref] $null).
     EndBlock.Statements.PipelineElements.CommandElements.Extent.Text
-  $NPX_ARGS = ($NPX_NO_REDIRECTS_COMMAND | Select-Object -Skip 1) -join ' '
+  $NPX_ARGS = ($NPX_COMMAND_ARR | Select-Object -Skip 1) -join ' '
 
   Invoke-Expression "& `"$NODE_EXE`" `"$NPX_CLI_JS`" $NPX_ARGS"
 }

--- a/bin/npx.ps1
+++ b/bin/npx.ps1
@@ -26,7 +26,7 @@ if (Test-Path $NPM_PREFIX_NPX_CLI_JS) {
 
 if ($MyInvocation.ExpectingInput) { # takes pipeline input
   $input | & $NODE_EXE $NPX_CLI_JS $args
-} elseif (-not $MyInvocation.Line -or $MyInvocation.InvocationName -in '&', '.') { # used "-File" argument
+} elseif (-not $MyInvocation.Line) { # used "-File" argument
   & $NODE_EXE $NPX_CLI_JS $args
 } else { # used "-Command" argument
   if (($MyInvocation | Get-Member -Name 'Statement') -and $MyInvocation.Statement) {
@@ -40,9 +40,9 @@ if ($MyInvocation.ExpectingInput) { # takes pipeline input
   $NODE_EXE = $NODE_EXE.Replace("``", "````")
   $NPX_CLI_JS = $NPX_CLI_JS.Replace("``", "````")
 
-  $NPX_NO_REDIRECTS_COMMAND = [Management.Automation.Language.Parser]::ParseInput($NPX_ORIGINAL_COMMAND, [ref] $null, [ref] $null).
-    EndBlock.Statements.PipelineElements.CommandElements.Extent.Text -join ' '
-  $NPX_ARGS = $NPX_NO_REDIRECTS_COMMAND.Substring($MyInvocation.InvocationName.Length).Trim()
+  $NPX_NO_REDIRECTS_COMMAND_ARR  = [Management.Automation.Language.Parser]::ParseInput($NPX_ORIGINAL_COMMAND, [ref] $null, [ref] $null).
+    EndBlock.Statements.PipelineElements.CommandElements.Extent.Text
+  $NPX_ARGS = $NPX_NO_REDIRECTS_COMMAND_ARR[1..($NPX_NO_REDIRECTS_COMMAND_ARR.Length - 1)] -join ' '
 
   Invoke-Expression "& `"$NODE_EXE`" `"$NPX_CLI_JS`" $NPX_ARGS"
 }


### PR DESCRIPTION
improve the argument parsing PS1 logic
- support `& npm args` and `. npm args` properly
- support syntax such as `C:\"Program Files"\nodejs\npm.ps1 args`

**of course ^ for both npm and npx version of the script**

Code Explanation: instead of getting the `CommandElements.Extent.Text` array and joining it with spaces right away, now it's getting the same array and only capturing everything after the first element

---

@wraithgar @mbtools sorry about this right after the other PR