### PR TITLE
fix: --dry-run with --json output

### DIFF
--- a/lib/utils/reify-output.js
+++ b/lib/utils/reify-output.js
@@ -45,7 +45,7 @@ const reifyOutput = (npm, arb) => {
   }
 
   if (diff) {
-    const showDiff = npm.config.get('dry-run') || npm.config.get('long')
+    const showDiff = (npm.config.get('dry-run') || npm.config.get('long')) && !npm.flatOptions.json
     const chalk = npm.chalk
 
     depth({


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

This broke in 10.4. Before 10.4 `npm install --dry-run --json` would return JSON. After 10.4 it no longer returns JSON.

https://github.com/npm/cli/commit/c209e989b405fa3e86df7015c22e6840e18313b8#r165769221

Note: This is the smallest change and I didn't update any tests. Nor was I sure where to one. The fact that it broke means there was no test for this before.

If it was up to me I think I'd add a `summary.diff = []` and push the diffs on there. And then only at the end where it outputs `summary`, if you want diff output to stdout then map over `summary.diff`. That would put the checks for output in a single place.

## References

Fixeds #8565
