### PR TITLE
docs: bring back certfile

### DIFF
--- a/docs/lib/content/configuring-npm/npmrc.md
+++ b/docs/lib/content/configuring-npm/npmrc.md
@@ -96,9 +96,9 @@ to override default configs in a standard and consistent manner.
 
 ### Auth related configuration
 
-The settings `_auth`, `_authToken`, `username` and `_password` must all be
-scoped to a specific registry. This ensures that `npm` will never send
-credentials to the wrong host.
+The settings `_auth`, `_authToken`, `username`, `_password`, `certfile`,
+and `keyfile` must all be scoped to a specific registry. This ensures that
+`npm` will never send credentials to the wrong host.
 
 The full list is:
  - `_auth` (base64 authentication string)
@@ -107,6 +107,7 @@ The full list is:
  - `_password`
  - `email`
  - `cafile` (path to certificate authority file)
+ - `certfile` (path to certificate file)
  - `keyfile` (path to key file)
 
 In order to scope these values, they must be prefixed by a URI fragment.

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -1911,9 +1911,9 @@ When set to \`dev\` or \`development\`, this is an alias for \`--include=dev\`.
 * Default: null
 * Type: null or String
 * DEPRECATED: \`key\` and \`cert\` are no longer used for most registry
-  operations. Use registry scoped \`keyfile\` and \`cafile\` instead. Example:
+  operations. Use registry scoped \`keyfile\` and \`certfile\` instead. Example:
   //other-registry.tld/:keyfile=/path/to/key.pem
-  //other-registry.tld/:cafile=/path/to/cert.crt
+  //other-registry.tld/:certfile=/path/to/cert.crt
 
 A client certificate to pass when accessing the registry. Values should be
 in PEM format (Windows calls it "Base-64 encoded X.509 (.CER)") with
@@ -1924,8 +1924,8 @@ cert="-----BEGIN CERTIFICATE-----\\nXXXX\\nXXXX\\n-----END CERTIFICATE-----"
 \`\`\`
 
 It is _not_ the path to a certificate file, though you can set a
-registry-scoped "cafile" path like
-"//other-registry.tld/:cafile=/path/to/cert.pem".
+registry-scoped "certfile" path like
+"//other-registry.tld/:certfile=/path/to/cert.pem".
 
 
 
@@ -2016,9 +2016,9 @@ Alias for \`--init-version\`
 * Default: null
 * Type: null or String
 * DEPRECATED: \`key\` and \`cert\` are no longer used for most registry
-  operations. Use registry scoped \`keyfile\` and \`cafile\` instead. Example:
+  operations. Use registry scoped \`keyfile\` and \`certfile\` instead. Example:
   //other-registry.tld/:keyfile=/path/to/key.pem
-  //other-registry.tld/:cafile=/path/to/cert.crt
+  //other-registry.tld/:certfile=/path/to/cert.crt
 
 A client key to pass when accessing the registry. Values should be in PEM
 format with newlines replaced by the string "\\n". For example:

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -398,14 +398,14 @@ const definitions = {
       \`\`\`
 
       It is _not_ the path to a certificate file, though you can set a registry-scoped
-      "cafile" path like "//other-registry.tld/:cafile=/path/to/cert.pem".
+      "certfile" path like "//other-registry.tld/:certfile=/path/to/cert.pem".
     `,
     deprecated: `
       \`key\` and \`cert\` are no longer used for most registry operations.
-      Use registry scoped \`keyfile\` and \`cafile\` instead.
+      Use registry scoped \`keyfile\` and \`certfile\` instead.
       Example:
       //other-registry.tld/:keyfile=/path/to/key.pem
-      //other-registry.tld/:cafile=/path/to/cert.crt
+      //other-registry.tld/:certfile=/path/to/cert.crt
     `,
     flatten,
   }),
@@ -1094,10 +1094,10 @@ const definitions = {
     `,
     deprecated: `
       \`key\` and \`cert\` are no longer used for most registry operations.
-      Use registry scoped \`keyfile\` and \`cafile\` instead.
+      Use registry scoped \`keyfile\` and \`certfile\` instead.
       Example:
       //other-registry.tld/:keyfile=/path/to/key.pem
-      //other-registry.tld/:cafile=/path/to/cert.crt
+      //other-registry.tld/:certfile=/path/to/cert.crt
     `,
     flatten,
   }),


### PR DESCRIPTION
Partial revert of #7947

`certfile` and `cafile` are both valid, and are used for different things:

- `certfile` is the path to the certificate file. It's used for mutual TLS and represents the client's certificate (supersedes the deprecated `cert`, and complements `keyfile`).
- `cafile` is the path to the certificate authority file. It's used to verify the authenticity of the registry's certificate.

Also clarify that `keyfile` and `certfile` must be scoped to a registry.
