### PR TITLE
fix: skip redacting URLs printed to console when browser not available

### DIFF
--- a/lib/utils/display.js
+++ b/lib/utils/display.js
@@ -259,7 +259,11 @@ class Display {
   // Write formatted and (non-)colorized output to streams
   #write (stream, options, ...args) {
     const colors = stream === this.#stdout ? this.#stdoutColor : this.#stderrColor
-    const value = formatWithOptions({ colors, ...options }, ...args)
+    const skipRedact = args.length > 0 ? args[args.length - 1]?.skipRedact : false
+    if (skipRedact) {
+      args = args.slice(0, args.length - 1)
+    }
+    const value = formatWithOptions({ colors, ...options, skipRedact }, ...args)
     this.#progress.write(() => stream.write(value))
   }
 

--- a/lib/utils/format.js
+++ b/lib/utils/format.js
@@ -41,9 +41,12 @@ function STRIP_C01 (str) {
   return result
 }
 
-const formatWithOptions = ({ prefix: prefixes = [], eol = '\n', ...options }, ...args) => {
+const formatWithOptions = ({ prefix: prefixes = [], eol = '\n', skipRedact = false, ...options }, ...args) => {
   const prefix = prefixes.filter(p => p != null).join(' ')
-  const formatted = redactLog(STRIP_C01(baseFormatWithOptions(options, ...args)))
+  let formatted = STRIP_C01(baseFormatWithOptions(options, ...args))
+  if (!skipRedact) {
+    formatted = redactLog(formatted)
+  }
   // Splitting could be changed to only `\n` once we are sure we only emit unix newlines.
   // The eol param to this function will put the correct newlines in place for the returned string.
   const lines = formatted.split(/\r?\n/)

--- a/lib/utils/open-url.js
+++ b/lib/utils/open-url.js
@@ -16,9 +16,9 @@ const assertValidUrl = (url) => {
 
 const outputMsg = (json, title, url) => {
   if (json) {
-    output.buffer({ title, url })
+    output.buffer({ title, url }, { skipRedact: true })
   } else {
-    output.standard(`${title}:\n${url}`)
+    output.standard(`${title}:\n${url}`, { skipRedact: true })
   }
 }
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

When a browser is not installed, URLs for logging in and publishing are printed to the console. Since https://github.com/npm/cli/pull/8529, those URLs are now redacted, which is a breaking behavior.

The implementation in this pull request allows for any code going through `proc-log` to skip redaction of the message

## References

Fixes https://github.com/npm/cli/issues/8575