### PR TITLE
fix: Fix typo in package-json module's index.js

### DIFF
--- a/node_modules/@npmcli/package-json/lib/index.js
+++ b/node_modules/@npmcli/package-json/lib/index.js
@@ -225,7 +225,7 @@ class PackageJson {
       this.#manifest = step({ content, originalContent: this.content })
     }
 
-    // unknown properties will just be overwitten
+    // unknown properties will just be overwritten
     for (const [key, value] of Object.entries(content)) {
       if (!knownKeys.has(key)) {
         this.content[key] = value


### PR DESCRIPTION
Fix what is most likely a typo in a comment in the index.js file of the package-json module.