### PR TITLE
chore: remove stale comment

### DIFF
--- a/lib/cli/update-notifier.js
+++ b/lib/cli/update-notifier.js
@@ -102,7 +102,6 @@ const updateNotifier = async (npm, spec = '*') => {
   return updateCheck(npm, spec, version, current)
 }
 
-// only update the notification timeout if we actually finished checking
 module.exports = npm => {
   if (
     // opted out


### PR DESCRIPTION
Remove stale comment

## References

This comment was originally written like this:
https://github.com/npm/cli/blob/103c8c3ef3ba7ff0483557f32eebc4c6298285e3/lib/utils/update-notifier.js#L118-L123

The code that updates the timeout is no longer anywhere close to this comment:

https://github.com/npm/cli/blob/4c616e9888a564c6236ce446e615fcd5668ddfb6/lib/cli/update-notifier.js#L97-L100