### PR TITLE
chore: remove references to benchmarks workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,16 +73,6 @@ To update the snapshots run:
 TAP_SNAPSHOT=1 node . run test
 ```
 
-## Performance & Benchmarks
-
-We've set up an automated [benchmark](https://github.com/npm/benchmarks) integration that will run against all Pull Requests; Posting back a comment with the results of the run.
-
-**Example:**
-
-![image](https://user-images.githubusercontent.com/2818462/72312698-e2e57f80-3656-11ea-9fcf-4a8f6b97b0d1.png)
-
-You can learn more about this tool, including how to run & configure it manually, [here](https://github.com/npm/benchmarks)
-
 ## What _not_ to contribute?
 
 ### Dependencies


### PR DESCRIPTION
Remove references to benchmarks workflow

https://github.com/npm/benchmarks
> This repository was archived by the owner on Jul 1, 2024. It is now read-only.


## References
- Related to #7621
