### PR TITLE
docs: clean up deprecated `npm access` commands

### DIFF
--- a/docs/lib/content/commands/npm-access.md
+++ b/docs/lib/content/commands/npm-access.md
@@ -16,7 +16,7 @@ For all of the subcommands, `npm access` will perform actions on the packages
 in the current working directory if no package name is passed to the
 subcommand.
 
-* grant / revoke (deprecated):
+* grant / revoke:
   Add or remove the ability of users and teams to have read-only or read-write
   access to a package.
 

--- a/docs/lib/content/commands/npm-access.md
+++ b/docs/lib/content/commands/npm-access.md
@@ -29,7 +29,7 @@ Unscoped packages are *always public*.
 
 Scoped packages *default to restricted*, but you can either publish them as
 public using `npm publish --access=public`, or set their access as public using
-`npm access public` after the initial publish.
+`npm access set status=public` after the initial publish.
 
 You must have privileges to set the access of a package:
 

--- a/docs/lib/content/commands/npm-access.md
+++ b/docs/lib/content/commands/npm-access.md
@@ -16,28 +16,9 @@ For all of the subcommands, `npm access` will perform actions on the packages
 in the current working directory if no package name is passed to the
 subcommand.
 
-* public / restricted (deprecated):
-  Set a package to be either publicly accessible or restricted.
-
 * grant / revoke (deprecated):
   Add or remove the ability of users and teams to have read-only or read-write
   access to a package.
-
-* 2fa-required / 2fa-not-required (deprecated):
-  Configure whether a package requires that anyone publishing it have two-factor
-  authentication enabled on their account.
-
-* ls-packages (deprecated):
-  Show all of the packages a user or a team is able to access, along with the
-  access level, except for read-only public packages (it won't print the whole
-  registry listing)
-
-* ls-collaborators (deprecated):
-  Show all of the access privileges for a package. Will only show permissions
-  for packages to which you have at least read access. If `<user>` is passed in,
-  the list is filtered only to teams _that_ user happens to belong to.
-
-* edit (not implemented)
 
 ### Details
 

--- a/docs/lib/content/using-npm/orgs.md
+++ b/docs/lib/content/using-npm/orgs.md
@@ -71,19 +71,19 @@ npm access revoke <org:team> [<package>]
 * See what org packages a team member can access:
 
 ```bash
-npm access ls-packages <org> <user>
+npm access list packages <org> <user>
 ```
 
 * See packages available to a specific team:
 
 ```bash
-npm access ls-packages <org:team>
+npm access list packages <org:team>
 ```
 
 * Check which teams are collaborating on a package:
 
 ```bash
-npm access ls-collaborators <pkg>
+npm access list collaborators <pkg>
 ```
 
 ### See also


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
- Related to #5445
