### PR TITLE
chore: Improve link accessibility for screen reader users

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm <command>
 * [**Service Status**](https://status.npmjs.org/) - Monitor the current status & see incident reports for the website & registry
 * [**Project Status**](https://npm.github.io/statusboard/) - See the health of all our maintained OSS projects in one view
 * [**Events Calendar**](https://calendar.google.com/calendar/u/0/embed?src=npmjs.com_oonluqt8oftrt0vmgrfbg6q6go@group.calendar.google.com) - Keep track of our Open RFC calls, releases, meetups, conferences & more
-* [**Support**](https://www.npmjs.com/support) - Experiencing problems with the **npm** [website](https://npmjs.com) or [registry](https://registry.npmjs.org)? File a ticket [here](https://www.npmjs.com/support)
+* [**Support**](https://www.npmjs.com/support) - Experiencing problems with the **npm** [website](https://npmjs.com) or [registry](https://registry.npmjs.org)? [File a ticket](https://www.npmjs.com/support)
 
 ### Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm <command>
 ### Acknowledgments
 
 * `npm` is configured to use the **npm Public Registry** at [https://registry.npmjs.org](https://registry.npmjs.org) by default; Usage of this registry is subject to **Terms of Use** available at [https://npmjs.com/policies/terms](https://npmjs.com/policies/terms)
-* You can configure `npm` to use any other compatible registry you prefer. You can read more about configuring third-party registries [here](https://docs.npmjs.com/cli/v7/using-npm/registry)
+* You can configure `npm` to use any other compatible registry you prefer. You can read more about [configuring third-party registries](https://docs.npmjs.com/cli/v7/using-npm/registry)
 
 ### FAQ on Branding
 

--- a/docs/test/index.js
+++ b/docs/test/index.js
@@ -83,7 +83,7 @@ t.test('html', async t => {
   // but we test for coverage
   t.test('files can link to root pages', async t => {
     await testBuildDocs(t, {
-      content: { 'test.md': '[link](/test)' },
+      content: { 'test.md': '[Test](/test)' },
       nav: '- url: /test',
     })
   })


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
#### Do not use `(click) here` links

For more information, see:
* https://www.w3.org/QA/Tips/noClickHere
* https://webaim.org/techniques/hypertext/link_text
* https://granicus.com/blog/why-click-here-links-are-bad/
* https://heyoka.medium.com/dont-use-click-here-f32f445d1021


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
