### PR TITLE
chore: Remove reference to nonexistent calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ npm <command>
 * [**RFCs**](https://github.com/npm/rfcs) - Contribute ideas & specifications for the API/design of the npm CLI
 * [**Service Status**](https://status.npmjs.org/) - Monitor the current status & see incident reports for the website & registry
 * [**Project Status**](https://npm.github.io/statusboard/) - See the health of all our maintained OSS projects in one view
-* [**Events Calendar**](https://calendar.google.com/calendar/u/0/embed?src=npmjs.com_oonluqt8oftrt0vmgrfbg6q6go@group.calendar.google.com) - Keep track of our Open RFC calls, releases, meetups, conferences & more
 * [**Support**](https://www.npmjs.com/support) - Experiencing problems with the **npm** [website](https://npmjs.com) or [registry](https://registry.npmjs.org)? [File a ticket](https://www.npmjs.com/support)
 
 ### Acknowledgments


### PR DESCRIPTION
This url doesn't appear to represent a real calendar: https://calendar.google.com/calendar/u/0/embed?src=npmjs.com_oonluqt8oftrt0vmgrfbg6q6go@group.calendar.google.com
When I try to import `npmjs.com_oonluqt8oftrt0vmgrfbg6q6go@group.calendar.google.com` with https://calendar.google.com, it says:

> The calendar npmjs.com_oonluqt8oftrt0vmgrfbg6q6go@group.calendar.google.com doesn't exist.

My guess is that it was deleted at some point.

Note that I'm actually looking for information on talking to people so, this was a rather disappointing stale link, but in any event, it seems like the right thing to do is to remove it (unless someone knows of a replacement link... -- I don't)

## References
- Related to #2559 / #2568
