### PR TITLE
chore: Fix spelling in workspaces/config

### DIFF
--- a/workspaces/config/README.md
+++ b/workspaces/config/README.md
@@ -121,7 +121,7 @@ Options:
 - `cwd` Optional, defaults to `process.cwd()`, used for inferring the
   `localPrefix` and loading the `project` config.
 - `platform` Optional, defaults to `process.platform`.  Used when inferring
-  the `globalPrefix` from the `execPath`, since this is done diferently on
+  the `globalPrefix` from the `execPath`, since this is done differently on
   Windows.
 - `execPath` Optional, defaults to `process.execPath`.  Used to infer the
   `globalPrefix`.

--- a/workspaces/config/README.md
+++ b/workspaces/config/README.md
@@ -65,7 +65,7 @@ const conf = new Config({
   flatten,
   // optional, defaults to process.argv
   // argv: [] <- if you are using this package in your own cli
-  //             and dont want to have colliding argv
+  //             and don't want to have colliding argv
   argv: process.argv,
   // optional, defaults to process.env
   env: process.env,


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Spelling errors hurt usability/readability



## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
