### PR TITLE
chore: fix spelling in workspaces/arborist

### DIFF
--- a/workspaces/arborist/docs/audit-bundled.md
+++ b/workspaces/arborist/docs/audit-bundled.md
@@ -12,7 +12,7 @@ advisory.
 
 However, with `bundleDependencies`, any version of `x` whose dependency on
 `y` _intersects_ with the vulnerable range on the `y` advisory should be
-considered potentally vulnerable.
+considered potentially vulnerable.
 
 When considering the meta-vulnerability of any version of `x`, thus:
 

--- a/workspaces/arborist/docs/ideal-tree.md
+++ b/workspaces/arborist/docs/ideal-tree.md
@@ -72,7 +72,7 @@ dependency can go without causing conflicts.
     2. If not CONFLICT, set result in CAN PLACE
     3. set TARGET to TARGET parent
 4. If no satisfying target found, throw Unresolvable Dep Tree error
-5. set TARGET to last non-conclict target checked
+5. set TARGET to last non-conflict target checked
 6. If CAN PLACE is KEEP, do not place
 7. add dep to placed list
 8. If an existing child by that name at TARGET,

--- a/workspaces/arborist/docs/ideal-tree.md
+++ b/workspaces/arborist/docs/ideal-tree.md
@@ -52,7 +52,7 @@ Options:
             3. Attempt to PLACE the dep in the tree
         3. Add each placed node to the queue to be checked for updates
 6. If the shrinkwrap was loaded from disk, and the tree was mutated, reset
-   all dependency flags to true (dev, optional, devOptionl, extraneous)
+   all dependency flags to true (dev, optional, devOptional, extraneous)
 7. If the shrinkwrap was not loaded from disk, or the tree was mutated,
    calculate dependency flags appropriately (like for a `loadActual` walk)
 8. If options.prune is not false, and we started from a shrinkwrap and then

--- a/workspaces/arborist/docs/parent.md
+++ b/workspaces/arborist/docs/parent.md
@@ -32,7 +32,7 @@ In this tree, `x` is `y`'s parent.
 
 `y` can resolve its dependents either within its own `node_modules` folder
 (ie, it's `children` nodes), or its parent's `node_modules` folder (ie,
-it's parent's `children`), or its parent's parent's, and so on up the tree.
+its parent's `children`), or its parent's parent's, and so on up the tree.
 
 Setting `node.parent` to another Node object will move it into that
 location in the tree, automatically adding it to `parent.children`,

--- a/workspaces/arborist/docs/parent.md
+++ b/workspaces/arborist/docs/parent.md
@@ -18,7 +18,7 @@ consistent.
 ## parent
 
 If a package is located in a `node_modules` folder, then its `parent`
-represents the the package that contains that `node_modules` folder.
+represents the package that contains that `node_modules` folder.
 
 For example:
 

--- a/workspaces/arborist/docs/reify.md
+++ b/workspaces/arborist/docs/reify.md
@@ -197,7 +197,7 @@ a
 ```
 
 This actually means that we move each unchanging node's _contents_ (other
-than `node_mdules`) into the new location.  (Maybe we ought to _only_ ever
+than `node_modules`) into the new location.  (Maybe we ought to _only_ ever
 move files, not directories?)
 
 Fail: move unchanging nodes back to retired tree, fail step 2

--- a/workspaces/arborist/docs/tree-types.md
+++ b/workspaces/arborist/docs/tree-types.md
@@ -10,7 +10,7 @@ Arborist handles three different types of tree:
   `arborist.loadVirtual()`.
 
     This method _may_ be called with an argument
-    specifyig the node to use as the `root` of the tree, like
+    specifying the node to use as the `root` of the tree, like
     `arborist.loadVirtual({ root: nodeObject })`.  If a root is not specified
     then a missing shrinkwrap is treated as a failure.  If a root is not
     specified, then a shrinkwrap file must be present, or the virtual load

--- a/workspaces/arborist/docs/workspace.md
+++ b/workspaces/arborist/docs/workspace.md
@@ -168,7 +168,7 @@ NOTE:
 
 ### Reify
 
-1. Correctly symlink workspaces to its dependants `node_modules`
+1. Correctly symlink workspaces to its dependents `node_modules`
 
 ## Open Ended Questions
 

--- a/workspaces/arborist/docs/workspace.md
+++ b/workspaces/arborist/docs/workspace.md
@@ -156,7 +156,7 @@ NOTE:
 
 ### Load Virtual
 
-1. How to figure out all the structure of workspaces form a pakcage-lock
+1. How to figure out all the structure of workspaces form a package-lock
   1. How it gets saved?
   2. How to build the virtual tree out of reading package-lock
 2. maybe support a subset of glob? we need to optimize mapWorkspace regardless

--- a/workspaces/arborist/docs/workspace.md
+++ b/workspaces/arborist/docs/workspace.md
@@ -141,9 +141,9 @@ workspaces will try to install deps from registry if no satisfying semver versio
 
 ### Build Ideal Tree
 
-1. Read list of "workpaces" from `package.json`
+1. Read list of "workspaces" from `package.json`
 2. Turn globs into actual locations, retrieve the final list of workspaces paths
-3. Arborist needs to be made aware of the list of worskpaces paths
+3. Arborist needs to be made aware of the list of workspaces paths
   1. Workspace info parsed (steps 1 and 2) needs to be attached before build ideal tree
   2. On building ideal tree, checks against existing workspaces to append them as child nodes
   3. Edge needs to support a `workspace` type

--- a/workspaces/arborist/scripts/README.md
+++ b/workspaces/arborist/scripts/README.md
@@ -5,7 +5,7 @@ around.
 
 They're untested (or, in some sense, some of them _are_ tests, albeit ad
 hoc ones for use when figuring out what a thing should even be), and really
-moroe like spikes or examples than anything dependable or useful.
+more like spikes or examples than anything dependable or useful.
 
 At some point it would be good to gather up some of this and turn it into a
 proper `arb` executable.


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Spelling errors hurt usability/readability

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
