### PR TITLE
fix: in canPlaceDep, check if dep is being updated in package.json

### DIFF
--- a/workspaces/arborist/lib/can-place-dep.js
+++ b/workspaces/arborist/lib/can-place-dep.js
@@ -62,6 +62,7 @@ class CanPlaceDep {
       parent = null,
       peerPath = [],
       explicitRequest = false,
+      updateNames = [],
     } = options
 
     debug(() => {
@@ -92,6 +93,7 @@ class CanPlaceDep {
     this.target = target
     this.edge = edge
     this.explicitRequest = explicitRequest
+    this.updateNames = updateNames
 
     // preventing cycles when we check peer sets
     this.peerPath = peerPath
@@ -162,16 +164,43 @@ class CanPlaceDep {
   checkCanPlaceCurrent () {
     const { preferDedupe, explicitRequest, current, target, edge, dep } = this
 
+    // If this package is being explicitly updated (in updateNames),
+    // we should replace it even if it currently satisfies the edge.
+    // This fixes issue #8059 where peer dependencies fail to resolve
+    // during an upgrade because the old version is found in node_modules.
+    const isBeingUpdated = this.updateNames.includes(this.name)
+
+    // Check if there's a root edge to this package that the current doesn't satisfy.
+    // If so, the current will be replaced, so we shouldn't treat it as a blocking conflict.
+    // This fixes issue #8059 where upgrading packages by editing package.json causes
+    // ERESOLVE errors because old versions are found in node_modules.
+    const root = target.root
+    const rootEdge = root && root.edgesOut.get(this.name)
+    const currentInvalidForRoot = rootEdge && !current.satisfies(rootEdge)
+
     if (dep.matches(current)) {
       if (current.satisfies(edge) || this.edgeOverride) {
-        return explicitRequest ? REPLACE : KEEP
+        return explicitRequest || isBeingUpdated ? REPLACE : KEEP
       }
     }
 
     const { version: curVer } = current
     const { version: newVer } = dep
     const tryReplace = curVer && newVer && semver.gte(newVer, curVer)
-    if (tryReplace && dep.canReplace(current)) {
+    // Also try to replace if the current doesn't satisfy root's edge
+    const shouldReplace = tryReplace || currentInvalidForRoot
+
+    // If the current node doesn't satisfy the root package's requirements,
+    // it MUST be replaced. For peer dependencies, we bypass the canReplace check
+    // because the current node may have edges from other packages being replaced.
+    if (currentInvalidForRoot && edge.peer) {
+      const cpp = this.canPlacePeers(REPLACE)
+      if (cpp !== CONFLICT) {
+        return cpp
+      }
+    }
+
+    if (shouldReplace && dep.canReplace(current)) {
       // It's extremely rare that a replaceable node would be a conflict, if
       // the current one wasn't a conflict, but it is theoretically possible
       // if peer deps are pinned.  In that case we treat it like any other
@@ -183,7 +212,8 @@ class CanPlaceDep {
     }
 
     // ok, can't replace the current with new one, but maybe current is ok?
-    if (current.satisfies(edge) && (!explicitRequest || preferDedupe)) {
+    // However, if the package is being explicitly updated, we should replace it
+    if (current.satisfies(edge) && (!explicitRequest || preferDedupe) && !isBeingUpdated) {
       return KEEP
     }
 
@@ -383,6 +413,7 @@ class CanPlaceDep {
         peerPath,
         // always place peers in preferDedupe mode
         preferDedupe: true,
+        updateNames: this.updateNames,
       })
       /* istanbul ignore next */
       debug(() => {

--- a/workspaces/arborist/lib/place-dep.js
+++ b/workspaces/arborist/lib/place-dep.js
@@ -96,6 +96,7 @@ class PlaceDep {
         target,
         preferDedupe: this.preferDedupe,
         explicitRequest: this.explicitRequest,
+        updateNames: this.updateNames,
       })
       this.checks.set(target, cpd)
 

--- a/workspaces/arborist/test/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/test/arborist/build-ideal-tree.js
@@ -4459,4 +4459,116 @@ t.test('installLinks behavior with project-internal file dependencies', async t 
     t.ok(edgeToA.valid, 'the edge from b to a should be valid')
     t.equal(edgeToA.to, packageA, 'the edge from b should point to package a')
   })
+
+  // Regression test for https://github.com/npm/cli/issues/8059
+  // When upgrading packages by editing package.json, npm should not fail with
+  // ERESOLVE errors due to peer dependencies when the old versions are still
+  // in node_modules but will be replaced.
+  t.test('upgrade packages with peer dependencies (issue #8059)', async t => {
+    // Regression test for https://github.com/npm/cli/issues/8059
+    // When upgrading packages by editing package.json, npm should not throw
+    // ERESOLVE errors for peer dependencies that will be upgraded.
+    const registry = createRegistry(t)
+
+    // Create three packages with peer dependencies between them
+    // Simulates the Storybook scenario: react-vite, test, and storybook
+    const mainPackuments = registry.packuments([
+      {
+        version: '1.0.0',
+        peerDependencies: {
+          'pkg-peer': '^1.0.0',
+          'pkg-base': '^1.0.0',
+        },
+      },
+      {
+        version: '2.0.0',
+        peerDependencies: {
+          'pkg-peer': '^2.0.0',
+          'pkg-base': '^2.0.0',
+        },
+      },
+    ], 'pkg-main')
+    const mainManifest = registry.manifest({ name: 'pkg-main', packuments: mainPackuments })
+    await registry.package({ manifest: mainManifest })
+
+    const peerPackuments = registry.packuments([
+      {
+        version: '1.0.0',
+        peerDependencies: {
+          'pkg-base': '^1.0.0',
+        },
+      },
+      {
+        version: '2.0.0',
+        peerDependencies: {
+          'pkg-base': '^2.0.0',
+        },
+      },
+    ], 'pkg-peer')
+    const peerManifest = registry.manifest({ name: 'pkg-peer', packuments: peerPackuments })
+    await registry.package({ manifest: peerManifest })
+
+    const basePackuments = registry.packuments(['1.0.0', '2.0.0'], 'pkg-base')
+    const baseManifest = registry.manifest({ name: 'pkg-base', packuments: basePackuments })
+    await registry.package({ manifest: baseManifest })
+
+    // Simulate a scenario where old versions are already in node_modules
+    // and package.json has been updated to new versions (like editing package.json manually)
+    const path = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'test-project',
+        version: '1.0.0',
+        dependencies: {
+          'pkg-main': '2.0.0',
+          'pkg-peer': '2.0.0',
+          'pkg-base': '2.0.0',
+        },
+      }),
+      node_modules: {
+        'pkg-main': {
+          'package.json': JSON.stringify({
+            name: 'pkg-main',
+            version: '1.0.0',
+            peerDependencies: {
+              'pkg-peer': '^1.0.0',
+              'pkg-base': '^1.0.0',
+            },
+          }),
+        },
+        'pkg-peer': {
+          'package.json': JSON.stringify({
+            name: 'pkg-peer',
+            version: '1.0.0',
+            peerDependencies: {
+              'pkg-base': '^1.0.0',
+            },
+          }),
+        },
+        'pkg-base': {
+          'package.json': JSON.stringify({
+            name: 'pkg-base',
+            version: '1.0.0',
+          }),
+        },
+      },
+    })
+
+    // Build ideal tree - this should NOT fail with ERESOLVE
+    // Before the fix, this would fail because the old versions in node_modules
+    // would be seen as conflicts even though they're being replaced
+    const tree = await buildIdeal(path)
+
+    // Verify all packages were upgraded to 2.0.0
+    t.equal(tree.children.get('pkg-main').version, '2.0.0', 'pkg-main upgraded to 2.0.0')
+    t.equal(tree.children.get('pkg-peer').version, '2.0.0', 'pkg-peer upgraded to 2.0.0')
+    t.equal(tree.children.get('pkg-base').version, '2.0.0', 'pkg-base upgraded to 2.0.0')
+
+    // Verify peer dependencies are satisfied
+    const mainEdgeToPeer = tree.children.get('pkg-main').edgesOut.get('pkg-peer')
+    t.ok(mainEdgeToPeer.valid, 'pkg-main peer dependency on pkg-peer is valid')
+    const mainEdgeToBase = tree.children.get('pkg-main').edgesOut.get('pkg-base')
+    t.ok(mainEdgeToBase.valid, 'pkg-main peer dependency on pkg-base is valid')
+    const peerEdgeToBase = tree.children.get('pkg-peer').edgesOut.get('pkg-base')
+    t.ok(peerEdgeToBase.valid, 'pkg-peer peer dependency on pkg-base is valid')
+  })
 })


### PR DESCRIPTION
This branch was created by throwing Claude Sonnet 4.5 at https://github.com/npm/cli/issues/8059, a bug where `ERESOLVE` is thrown because of a (nonexistent) conflict between peer dependencies. I don't think Claude's fix is the right approach, but I'm hoping it'll give the maintainers some ideas. At the very least, the test case should be useful for further work.

The approach here is to modify `checkCanPlaceCurrent` to see if the current dep is changed in `package.json`; if so, the dep change is treated the same way as an explicit request. That strikes me as an improvement, but not a comprehensive solution, since I've seen incorrect `ERESOLVE` errors in other situations.

## References

Related to #8059