### PR TITLE
fix: spelling in workspaces/libnpmexec

### DIFF
--- a/workspaces/libnpmexec/lib/get-bin-from-manifest.js
+++ b/workspaces/libnpmexec/lib/get-bin-from-manifest.js
@@ -1,7 +1,7 @@
 const getBinFromManifest = (mani) => {
   // if we have a bin matching (unscoped portion of) packagename, use that
   // otherwise if there's 1 bin or all bin value is the same (alias), use
-  // that, otherwise fail
+  // that; otherwise, fail
   const bin = mani.bin || {}
   if (new Set(Object.values(bin)).size === 1) {
     return Object.keys(bin)[0]

--- a/workspaces/libnpmexec/test/get-bin-from-manifest.js
+++ b/workspaces/libnpmexec/test/get-bin-from-manifest.js
@@ -15,7 +15,7 @@ t.test('extract scope from manifest name with multiple bins', t => {
   t.end()
 })
 
-t.test('can not figure out what executable to run', t => {
+t.test('cannot figure out what executable to run', t => {
   t.throws(
     () => getBinFromManifest({
       name: 'lorem',

--- a/workspaces/libnpmexec/test/local.js
+++ b/workspaces/libnpmexec/test/local.js
@@ -58,7 +58,7 @@ t.test('bin in local pkg', async t => {
   await chmod('node_modules/pkg-with-conflicting-bin/index.js')
 
   // Note that we have to resetSeenLinks after each exec since otherwise
-  // our non-existent file will fail when it gets attempted to get chmod'ed
+  // our nonexistent file will fail when it gets attempted to get chmod'ed
   // in a real world situation these would happen during different
   // processes where these is no shared cache
   const exec = async (...args) => {


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
Spelling errors hurt usability/readability



## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
- Related to https://github.com/npm/cli/pull/8620#issuecomment-3357382740