### PR TITLE
fix: ensure global git installs prepare in project

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -147,7 +147,32 @@ class Install extends ArboristWorkspaceCmd {
       workspaces: this.workspaceNames,
     }
     const arb = new Arborist(opts)
-    await arb.reify(opts)
+
+    const originalGlobalEnv = process.env.npm_config_global
+    const originalLocationEnv = process.env.npm_config_location
+
+    if (isGlobalInstall) {
+      process.env.npm_config_global = 'false'
+      process.env.npm_config_location = 'project'
+    }
+
+    try {
+      await arb.reify(opts)
+    } finally {
+      if (isGlobalInstall) {
+        if (originalGlobalEnv === undefined) {
+          delete process.env.npm_config_global
+        } else {
+          process.env.npm_config_global = originalGlobalEnv
+        }
+
+        if (originalLocationEnv === undefined) {
+          delete process.env.npm_config_location
+        } else {
+          process.env.npm_config_location = originalLocationEnv
+        }
+      }
+    }
 
     if (!args.length && !isGlobalInstall && !ignoreScripts) {
       const scripts = [

--- a/test/lib/commands/install.js
+++ b/test/lib/commands/install.js
@@ -158,6 +158,43 @@ t.test('exec commands', async t => {
     )
   })
 
+  await t.test('global install runs git prepare scripts in project location', async t => {
+    const { npm } = await loadMockNpm(t, {
+      config: {
+        audit: false,
+        global: true,
+      },
+      mocks: {
+        '{LIB}/utils/reify-finish.js': async () => {},
+        '@npmcli/arborist': function () {
+          this.reify = async () => {
+            t.equal(
+              process.env.npm_config_global,
+              'false',
+              'npm_config_global is forced to false during reify'
+            )
+            t.equal(
+              process.env.npm_config_location,
+              'project',
+              'npm_config_location points to the project during reify'
+            )
+          }
+        },
+      },
+    })
+
+    const originalGlobal = process.env.npm_config_global
+    const originalLocation = process.env.npm_config_location
+
+    t.equal(process.env.npm_config_global, originalGlobal, 'npm_config_global untouched before install')
+    t.equal(process.env.npm_config_location, originalLocation, 'npm_config_location untouched before install')
+
+    await npm.exec('install', ['abbrev'])
+
+    t.equal(process.env.npm_config_global, originalGlobal, 'npm_config_global restored after install')
+    t.equal(process.env.npm_config_location, originalLocation, 'npm_config_location restored after install')
+  })
+
   await t.test('npm i -g npm engines check success', async t => {
     const { npm, registry } = await loadMockNpm(t, {
       prefixDir: {


### PR DESCRIPTION
## Summary
- ensure git-based global installs run prepare scripts with project-scoped npm configuration
- add a regression test that asserts npm_config flags are forced and restored during global installs

## Testing
- node test/lib/commands/install.js

fixes issue #8440 