### PR TITLE
docs: make `main` field monospaced

### DIFF
--- a/docs/content/configuring-npm/package-json.md
+++ b/docs/content/configuring-npm/package-json.md
@@ -328,7 +328,7 @@ If `main` is not set it defaults to `index.js` in the packages root folder.
 ### browser
 
 If your module is meant to be used client-side the browser field should be
-used instead of the main field. This is helpful to hint users that it might
+used instead of the `main` field. This is helpful to hint users that it might
 rely on primitives that aren't available in Node.js modules. (e.g.
 `window`)
 


### PR DESCRIPTION
## What 

A small cosmetic/syntactic improvement, making the `main` field monospaced.

