### PR TITLE
deps: downgrade ci-info to 4.3.0

### DIFF
--- a/node_modules/ci-info/index.js
+++ b/node_modules/ci-info/index.js
@@ -15,24 +15,22 @@ exports.name = null
 exports.isPR = null
 exports.id = null
 
-if (env.CI !== 'false') {
-  vendors.forEach(function (vendor) {
-    const envs = Array.isArray(vendor.env) ? vendor.env : [vendor.env]
-    const isCI = envs.every(function (obj) {
-      return checkEnv(obj)
-    })
-
-    exports[vendor.constant] = isCI
-
-    if (!isCI) {
-      return
-    }
-
-    exports.name = vendor.name
-    exports.isPR = checkPR(vendor)
-    exports.id = vendor.constant
+vendors.forEach(function (vendor) {
+  const envs = Array.isArray(vendor.env) ? vendor.env : [vendor.env]
+  const isCI = envs.every(function (obj) {
+    return checkEnv(obj)
   })
-}
+
+  exports[vendor.constant] = isCI
+
+  if (!isCI) {
+    return
+  }
+
+  exports.name = vendor.name
+  exports.isPR = checkPR(vendor)
+  exports.id = vendor.constant
+})
 
 exports.isCI = !!(
   env.CI !== 'false' && // Bypass all checks if CI env is explicitly set to 'false'

--- a/node_modules/ci-info/package.json
+++ b/node_modules/ci-info/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ci-info",
-  "version": "4.3.1",
+  "version": "4.3.0",
   "description": "Get details about the current Continuous Integration environment",
   "main": "index.js",
   "typings": "index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,7 +97,7 @@
         "archy": "~1.0.0",
         "cacache": "^20.0.1",
         "chalk": "^5.6.2",
-        "ci-info": "^4.3.1",
+        "ci-info": "^4.3.0",
         "cli-columns": "^4.0.0",
         "fastest-levenshtein": "^1.0.16",
         "fs-minipass": "^3.0.3",
@@ -3040,9 +3040,9 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
-      "integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
+      "integrity": "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "archy": "~1.0.0",
     "cacache": "^20.0.1",
     "chalk": "^5.6.2",
-    "ci-info": "^4.3.1",
+    "ci-info": "^4.3.0",
     "cli-columns": "^4.0.0",
     "fastest-levenshtein": "^1.0.16",
     "fs-minipass": "^3.0.3",


### PR DESCRIPTION
Tests for libnpmpublish fail with ci-info@4.3.1

ref: https://github.com/watson/ci-info/pull/140