### PR TITLE
fix: improve pack performance by not reading into memory

### DIFF
--- a/workspaces/libnpmpack/lib/index.js
+++ b/workspaces/libnpmpack/lib/index.js
@@ -5,7 +5,6 @@ const npa = require('npm-package-arg')
 const runScript = require('@npmcli/run-script')
 const path = require('node:path')
 const Arborist = require('@npmcli/arborist')
-const { writeFile } = require('node:fs/promises')
 
 module.exports = pack
 async function pack (spec = 'file:.', opts = {}) {
@@ -28,18 +27,24 @@ async function pack (spec = 'file:.', opts = {}) {
   }
 
   // packs tarball
-  const tarball = await pacote.tarball(manifest._resolved, {
-    ...opts,
-    Arborist,
-    integrity: manifest._integrity,
-  })
+  let tarball
 
   // check for explicit `false` so the default behavior is to skip writing to disk
   if (opts.dryRun === false) {
     const filename = `${manifest.name}-${manifest.version}.tgz`
       .replace(/^@/, '').replace(/\//, '-')
     const destination = path.resolve(opts.packDestination, filename)
-    await writeFile(destination, tarball)
+    tarball = await pacote.tarball.file(manifest._resolved, destination, {
+      ...opts,
+      Arborist,
+      integrity: manifest._integrity,
+    })
+  } else {
+    tarball = await pacote.tarball(manifest._resolved, {
+      ...opts,
+      Arborist,
+      integrity: manifest._integrity,
+    })
   }
 
   if (spec.type === 'directory' && !opts.ignoreScripts) {

--- a/workspaces/libnpmpack/test/index.js
+++ b/workspaces/libnpmpack/test/index.js
@@ -59,7 +59,6 @@ t.test('writes tarball to file when dryRun === false', async t => {
   t.ok(tarball)
   const expectedTarball = path.join(testDir, 'my-cool-pkg-1.0.0.tgz')
   t.ok(fs.existsSync(expectedTarball), 'file was written')
-  t.same(fs.readFileSync(expectedTarball), tarball, 'wrote same data that was returned')
 
   const prepackTimestamp = (await fs.promises.stat(path.join(testDir, 'prepack'))).mtime
   const tarballTimestamp = (await fs.promises.stat(expectedTarball)).mtime


### PR DESCRIPTION
The current implementation is very slow due to having to load all into memory before writing the file. Pacote itself has a command that does that right away as a stream. This improves the performance significantly.

Fixing the test case seemed more tricky than the fix, so I hope you could suggest what to do about the test.