### PR TITLE
fix: use look behind regex for trailing slash stripping

### DIFF
--- a/lib/commands/explain.js
+++ b/lib/commands/explain.js
@@ -92,7 +92,7 @@ class Explain extends ArboristWorkspaceCmd {
     }
 
     // if it's a location, get that node
-    const maybeLoc = arg.replace(/\\/g, '/').replace(/\/+$/, '')
+    const maybeLoc = arg.replace(/\\/g, '/').replace(/(?<!\/)\/+$/, '')
     const nodeByLoc = tree.inventory.get(maybeLoc)
     if (nodeByLoc) {
       return [nodeByLoc]
@@ -100,7 +100,7 @@ class Explain extends ArboristWorkspaceCmd {
 
     // maybe a path to a node_modules folder
     const maybePath = relative(this.npm.prefix, resolve(maybeLoc))
-      .replace(/\\/g, '/').replace(/\/+$/, '')
+      .replace(/\\/g, '/').replace(/(?<!\/)\/+$/, '')
     const nodeByPath = tree.inventory.get(maybePath)
     if (nodeByPath) {
       return [nodeByPath]

--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -103,7 +103,7 @@ module.exports = cls => class IdealTreeBuilder extends cls {
 
     // normalize trailing slash
     const registry = options.registry || 'https://registry.npmjs.org'
-    options.registry = this.registry = registry.replace(/\/+$/, '') + '/'
+    options.registry = this.registry = registry.replace(/(?<!\/)\/+$/, '') + '/'
 
     const {
       follow = false,


### PR DESCRIPTION
In context this isn't a big deal, the extra slash is usually an artifact of path and url parsing.  Linting will not warn about this now though.
