### PR TITLE
docs: Add --ignore-scripts option to npm version help and docs

### DIFF
--- a/lib/commands/version.js
+++ b/lib/commands/version.js
@@ -17,6 +17,7 @@ class Version extends BaseCommand {
     'workspaces',
     'workspaces-update',
     'include-workspace-root',
+    'ignore-scripts',
   ]
 
   static workspaces = true

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -4488,6 +4488,7 @@ Options:
 [--preid prerelease-id] [--sign-git-tag]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [--workspaces] [--no-workspaces-update] [--include-workspace-root]
+[--ignore-scripts]
 
 alias: verison
 
@@ -4509,6 +4510,7 @@ alias: verison
 #### \`workspaces\`
 #### \`workspaces-update\`
 #### \`include-workspace-root\`
+#### \`ignore-scripts\`
 `
 
 exports[`test/lib/docs.js TAP usage view > must match snapshot 1`] = `


### PR DESCRIPTION
This PR adds the missing `--ignore-scripts` option to the `npm version` command's help output and documentation. The option allows users to skip running lifecycle scripts (`preversion`, `version`, `postversion`) during version bumps, which is important for CI environments or cases where scripts might fail or be unwanted. This ensures consistency with other npm commands that support `--ignore-scripts`.

### Changes Made
1. `version.js`: Added `'ignore-scripts'` to the `static params` array to include it in the command's accepted parameters.

### Testing
- Verified that `npm version -h` now shows `[--ignore-scripts]` in the options.
<img width="755" height="225" alt="image" src="https://github.com/user-attachments/assets/e97271a5-9866-4d19-8de6-90cd45d62c90" />

- Confirmed that `npm help version` includes the `--ignore-scripts` configuration section.
<img width="1300" height="153" alt="image" src="https://github.com/user-attachments/assets/9c27194f-3120-4959-9475-ad02d125b7a6" />

- Ran docs generation to ensure man pages and HTML docs are updated.

### References
Fixes #8668 