### PR TITLE
fix: add option skip-lock-validation to npm ci (#8693)

### DIFF
--- a/lib/commands/ci.js
+++ b/lib/commands/ci.js
@@ -25,6 +25,7 @@ class CI extends ArboristWorkspaceCmd {
     'bin-links',
     'fund',
     'dry-run',
+    'skip-lock-validation',
     ...super.params,
   ]
 
@@ -55,25 +56,31 @@ class CI extends ArboristWorkspaceCmd {
       throw this.usageError(msg)
     })
 
-    // retrieves inventory of packages from loaded virtual tree (lock file)
-    const virtualInventory = new Map(arb.virtualTree.inventory)
+    const skipLockValidation = this.npm.config.get('skip-lock-validation')
+    if (!skipLockValidation) {
+      // retrieves inventory of packages from loaded virtual tree (lock file)
+      const virtualInventory = new Map(arb.virtualTree.inventory)
 
-    // build ideal tree step needs to come right after retrieving the virtual
-    // inventory since it's going to erase the previous ref to virtualTree
-    await arb.buildIdealTree()
+      // build ideal tree step needs to come right after retrieving the virtual
+      // inventory since it's going to erase the previous ref to virtualTree
+      await arb.buildIdealTree()
 
-    // verifies that the packages from the ideal tree will match
-    // the same versions that are present in the virtual tree (lock file)
-    // throws a validation error in case of mismatches
-    const errors = validateLockfile(virtualInventory, arb.idealTree.inventory)
-    if (errors.length) {
-      throw this.usageError(
-        '`npm ci` can only install packages when your package.json and ' +
-        'package-lock.json or npm-shrinkwrap.json are in sync. Please ' +
-        'update your lock file with `npm install` ' +
-        'before continuing.\n\n' +
-        errors.join('\n')
-      )
+      // verifies that the packages from the ideal tree will match
+      // the same versions that are present in the virtual tree (lock file)
+      // throws a validation error in case of mismatches
+      const errors = validateLockfile(virtualInventory, arb.idealTree.inventory)
+      if (errors.length) {
+        throw this.usageError(
+          '`npm ci` can only install packages when your package.json and ' +
+          'package-lock.json or npm-shrinkwrap.json are in sync. Please ' +
+          'update your lock file with `npm install` ' +
+          'before continuing.\n\n' +
+          errors.join('\n')
+        )
+      }
+    } else {
+      // Trust lockfile - use it as the ideal tree
+      arb.idealTree = arb.virtualTree
     }
 
     const dryRun = this.npm.config.get('dry-run')

--- a/tap-snapshots/test/lib/commands/config.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/config.js.test.cjs
@@ -150,6 +150,7 @@ exports[`test/lib/commands/config.js TAP config list --json > output matches sna
   "shrinkwrap": true,
   "sign-git-commit": false,
   "sign-git-tag": false,
+  "skip-lock-validation": false,
   "strict-peer-deps": false,
   "strict-ssl": true,
   "tag": "latest",
@@ -316,6 +317,7 @@ shell = "{SHELL}"
 shrinkwrap = true
 sign-git-commit = false
 sign-git-tag = false
+skip-lock-validation = false
 strict-peer-deps = false
 strict-ssl = true
 tag = "latest"

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -1604,6 +1604,21 @@ this to work properly.
 
 
 
+#### \`skip-lock-validation\`
+
+* Default: false
+* Type: Boolean
+
+When set to \`true\`, \`npm ci\` will install packages directly from the
+lockfile without validating that the lockfile satisfies the dependency
+ranges specified in package.json. This allows the lockfile to be trusted
+completely, ensuring true reproducibility.
+
+By default, \`npm ci\` validates that the packages in the lockfile are an
+exact match for dependencies in package.json.
+
+
+
 #### \`strict-peer-deps\`
 
 * Default: false
@@ -2231,6 +2246,7 @@ Array [
   "shrinkwrap",
   "sign-git-commit",
   "sign-git-tag",
+  "skip-lock-validation",
   "strict-peer-deps",
   "strict-ssl",
   "tag",
@@ -2373,6 +2389,7 @@ Array [
   "shrinkwrap",
   "sign-git-commit",
   "sign-git-tag",
+  "skip-lock-validation",
   "strict-peer-deps",
   "strict-ssl",
   "tag",
@@ -2536,6 +2553,7 @@ Object {
   "signGitCommit": false,
   "signGitTag": false,
   "silent": false,
+  "skipLockValidation": false,
   "strictPeerDeps": false,
   "strictSSL": true,
   "tagVersionPrefix": "v",
@@ -2760,7 +2778,7 @@ Options:
 [--global-style] [--omit <dev|optional|peer> [--omit <dev|optional|peer> ...]]
 [--include <prod|dev|optional|peer> [--include <prod|dev|optional|peer> ...]]
 [--strict-peer-deps] [--foreground-scripts] [--ignore-scripts] [--no-audit]
-[--no-bin-links] [--no-fund] [--dry-run]
+[--no-bin-links] [--no-fund] [--dry-run] [--skip-lock-validation]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [--workspaces] [--include-workspace-root] [--install-links]
 
@@ -2786,6 +2804,7 @@ aliases: clean-install, ic, install-clean, isntall-clean
 #### \`bin-links\`
 #### \`fund\`
 #### \`dry-run\`
+#### \`skip-lock-validation\`
 #### \`workspace\`
 #### \`workspaces\`
 #### \`include-workspace-root\`
@@ -3357,7 +3376,7 @@ Options:
 [--global-style] [--omit <dev|optional|peer> [--omit <dev|optional|peer> ...]]
 [--include <prod|dev|optional|peer> [--include <prod|dev|optional|peer> ...]]
 [--strict-peer-deps] [--foreground-scripts] [--ignore-scripts] [--no-audit]
-[--no-bin-links] [--no-fund] [--dry-run]
+[--no-bin-links] [--no-fund] [--dry-run] [--skip-lock-validation]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [--workspaces] [--include-workspace-root] [--install-links]
 
@@ -3383,6 +3402,7 @@ aliases: cit, clean-install-test, sit
 #### \`bin-links\`
 #### \`fund\`
 #### \`dry-run\`
+#### \`skip-lock-validation\`
 #### \`workspace\`
 #### \`workspaces\`
 #### \`include-workspace-root\`

--- a/test/lib/commands/ci.js
+++ b/test/lib/commands/ci.js
@@ -308,3 +308,33 @@ t.test('should use --workspace flag', async t => {
   assert.packageMissing('node_modules/abbrev@1.1.0')
   assert.packageInstalled('node_modules/lodash@1.1.1')
 })
+
+t.test('should skip validation with --skip-lock-validation', async t => {
+  const { npm, joinedOutput, registry } = await loadMockNpm(t, {
+    config: {
+      'skip-lock-validation': true,
+    },
+    prefixDir: {
+      abbrev: abbrev,
+      // package.json has different dependency than lockfile, but should not error
+      'package.json': JSON.stringify({
+        ...packageJson,
+        dependencies: { notabbrev: '^1.0.0' },
+      }),
+      'package-lock.json': JSON.stringify(packageLock),
+      node_modules: { test: 'test file that will be removed' },
+    },
+  })
+  const manifest = registry.manifest({ name: 'abbrev' })
+  await registry.tarball({
+    manifest: manifest.versions['1.0.0'],
+    tarball: path.join(npm.prefix, 'abbrev'),
+  })
+  registry.nock.post('/-/npm/v1/security/advisories/bulk').reply(200, {})
+  await npm.exec('ci', [])
+  t.match(joinedOutput(), 'added 1 package, and audited 2 packages in')
+  const nmTest = path.join(npm.prefix, 'node_modules', 'test')
+  t.equal(fs.existsSync(nmTest), false, 'existing node_modules is removed')
+  const nmAbbrev = path.join(npm.prefix, 'node_modules', 'abbrev')
+  t.equal(fs.existsSync(nmAbbrev), true, 'installs abbrev from lockfile')
+})

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -2009,6 +2009,20 @@ const definitions = {
     `,
     flatten,
   }),
+  'skip-lock-validation': new Definition('skip-lock-validation', {
+    default: false,
+    type: Boolean,
+    description: `
+      When set to \`true\`, \`npm ci\` will install packages directly from the
+      lockfile without validating that the lockfile satisfies the dependency
+      ranges specified in package.json. This allows the lockfile to be trusted completely,
+      ensuring true reproducibility.
+
+      By default, \`npm ci\` validates that the packages in the
+      lockfile are an exact match for dependencies in package.json.
+    `,
+    flatten,
+  }),
   'strict-peer-deps': new Definition('strict-peer-deps', {
     default: false,
     type: Boolean,


### PR DESCRIPTION
This change adds a new CLI option, --skip-lock-validation, to the npm ci command.

Currently, npm ci fails when package.json and package-lock.json appear “out of sync,” even if the lockfile’s versions still satisfy the declared semver ranges. This can happen when new patch versions of dependencies are published after the lockfile was generated — causing unnecessary CI failures.

The new --skip-lock-validation flag allows users to bypass the strict lockfile validation step, trusting the existing package-lock.json as the single source of truth.
This is particularly useful in reproducible build pipelines where dependency resolution should be deterministic and validation should not block installs when the lockfile is already committed and verified.

Behavior:

When the flag is set, npm ci skips comparing resolved dependency versions against package.json ranges.

Default behavior (without the flag) remains unchanged to preserve backward compatibility.

## References
  Fixes #8693

