### PR TITLE
feat!: Adds Granular Access Token (GAT) support to npm token command

### DIFF
--- a/lib/commands/token.js
+++ b/lib/commands/token.js
@@ -1,14 +1,30 @@
 const { log, output } = require('proc-log')
 const { listTokens, createToken, removeToken } = require('npm-profile')
 const { otplease } = require('../utils/auth.js')
-const readUserInfo = require('../utils/read-user-info.js')
 const BaseCommand = require('../base-cmd.js')
 
 class Token extends BaseCommand {
   static description = 'Manage your authentication tokens'
   static name = 'token'
-  static usage = ['list', 'revoke <id|token>', 'create [--read-only] [--cidr=list]']
-  static params = ['read-only', 'cidr', 'registry', 'otp']
+  static usage = [
+    'list',
+    'revoke <id|token>',
+    'create --name=<name> --access=<read-only|read-write> [--expires=<YYYY-MM-DD>] [--packages=<pkg1,pkg2>] [--scopes=<scope1,scope2>] [--orgs=<org1,org2>] [--cidr=<ip-range>] [--bypass-2fa]',
+  ]
+
+  static params = [
+    'name',
+    'expires',
+    'access',
+    'packages',
+    'scopes',
+    'orgs',
+    'cidr',
+    'bypass-2fa',
+    'registry',
+    'otp',
+    'read-only',
+  ]
 
   static async completion (opts) {
     const argv = opts.conf.argv.remain
@@ -56,12 +72,14 @@ class Token extends BaseCommand {
     if (parseable) {
       output.standard(['key', 'token', 'created', 'readonly', 'CIDR whitelist'].join('\t'))
       tokens.forEach(token => {
+        // Handle both classic tokens (readonly) and GATs (access)
+        const isReadonly = token.readonly || token.access === 'read-only'
         output.standard(
           [
             token.key,
             token.token,
             token.created,
-            token.readonly ? 'true' : 'false',
+            isReadonly ? 'true' : 'false',
             token.cidr_whitelist ? token.cidr_whitelist.join(',') : '',
           ].join('\t')
         )
@@ -71,7 +89,9 @@ class Token extends BaseCommand {
     this.generateTokenIds(tokens, 6)
     const chalk = this.npm.chalk
     for (const token of tokens) {
-      const level = token.readonly ? 'Read only token' : 'Publish token'
+      // Handle both classic tokens (readonly) and GATs (access)
+      const isReadonly = token.readonly || token.access === 'read-only'
+      const level = isReadonly ? 'Read only token' : 'Publish token'
       const created = String(token.created).slice(0, 10)
       output.standard(`${chalk.blue(level)} ${token.token}… with id ${chalk.cyan(token.id)} created ${created}`)
       if (token.cidr_whitelist) {
@@ -127,15 +147,65 @@ class Token extends BaseCommand {
     const json = this.npm.config.get('json')
     const parseable = this.npm.config.get('parseable')
     const cidr = this.npm.config.get('cidr')
-    const readonly = this.npm.config.get('read-only')
+    const name = this.npm.config.get('name')
+    const expires = this.npm.config.get('expires')
+    const access = this.npm.config.get('access')
+    const packages = this.npm.config.get('packages')
+    const scopes = this.npm.config.get('scopes')
+    const orgs = this.npm.config.get('orgs')
+    const bypassTwoFactor = this.npm.config.get('bypass-2fa')
+
+    // Validate required parameters
+    if (!name) {
+      throw this.usageError('--name is required for token creation')
+    }
+    if (!access) {
+      throw this.usageError('--access is required (use "read-only" or "read-write")')
+    }
+    if (!['read-only', 'read-write'].includes(access)) {
+      throw this.usageError('--access must be either "read-only" or "read-write"')
+    }
 
     const validCIDR = await this.validateCIDRList(cidr)
-    const password = await readUserInfo.password()
+
+    // Build GAT token data structure
+    const tokenData = {
+      type: 'granular',
+      name,
+      access,
+    }
+
+    // Add expiry (default to 7 days from now if not provided)
+    if (expires) {
+      tokenData.expires = new Date(expires).toISOString()
+    } else {
+      const defaultExpiry = new Date()
+      defaultExpiry.setDate(defaultExpiry.getDate() + 7)
+      tokenData.expires = defaultExpiry.toISOString()
+    }
+
+    // Add optional fields
+    if (packages?.length > 0) {
+      tokenData.packages = packages
+    }
+    if (scopes?.length > 0) {
+      tokenData.scopes = scopes
+    }
+    if (orgs?.length > 0) {
+      tokenData.orgs = orgs
+    }
+    if (validCIDR?.length > 0) {
+      tokenData.cidr_whitelist = validCIDR
+    }
+    if (bypassTwoFactor) {
+      tokenData.bypass_2fa = true
+    }
+
     log.info('token', 'creating')
     const result = await otplease(
       this.npm,
       { ...this.npm.flatOptions },
-      c => createToken(password, readonly, validCIDR, c)
+      c => createToken(tokenData, c)
     )
     delete result.key
     delete result.updated
@@ -145,11 +215,14 @@ class Token extends BaseCommand {
       Object.keys(result).forEach(k => output.standard(k + '\t' + result[k]))
     } else {
       const chalk = this.npm.chalk
-      // Identical to list
-      const level = result.readonly ? 'read only' : 'publish'
+      // Display based on access level
+      const level = result.access === 'read-only' || result.readonly ? 'read only' : 'publish'
       output.standard(`Created ${chalk.blue(level)} token ${result.token}`)
       if (result.cidr_whitelist?.length) {
         output.standard(`with IP whitelist: ${chalk.green(result.cidr_whitelist.join(','))}`)
+      }
+      if (result.expires) {
+        output.standard(`expires: ${result.expires}`)
       }
     }
   }
@@ -180,7 +253,7 @@ class Token extends BaseCommand {
     for (const cidr of list) {
       if (isCidrV6(cidr)) {
         throw this.invalidCIDRError(
-          `CIDR whitelist can only contain IPv4 addresses${cidr} is IPv6`
+          `CIDR whitelist can only contain IPv4 addresses, ${cidr} is IPv6`
         )
       }
 

--- a/tap-snapshots/test/lib/commands/config.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/config.js.test.cjs
@@ -23,6 +23,7 @@ exports[`test/lib/commands/config.js TAP config list --json > output matches sna
   "before": null,
   "bin-links": true,
   "browser": null,
+  "bypass-2fa": false,
   "ca": null,
   "cache-max": null,
   "cache-min": 0,
@@ -48,6 +49,7 @@ exports[`test/lib/commands/config.js TAP config list --json > output matches sna
   "engine-strict": false,
   "expect-result-count": null,
   "expect-results": null,
+  "expires": null,
   "fetch-retries": 2,
   "fetch-retry-factor": 10,
   "fetch-retry-maxtimeout": 60000,
@@ -97,6 +99,7 @@ exports[`test/lib/commands/config.js TAP config list --json > output matches sna
   "logs-dir": null,
   "logs-max": 10,
   "long": false,
+  "name": null,
   "maxsockets": 15,
   "message": "%s",
   "node-gyp": "{CWD}/node_modules/node-gyp/bin/node-gyp.js",
@@ -108,6 +111,7 @@ exports[`test/lib/commands/config.js TAP config list --json > output matches sna
   "omit": [],
   "omit-lockfile-registry-resolved": false,
   "only": null,
+  "orgs": null,
   "optional": null,
   "os": null,
   "otp": null,
@@ -115,6 +119,7 @@ exports[`test/lib/commands/config.js TAP config list --json > output matches sna
   "package-lock": true,
   "package-lock-only": false,
   "pack-destination": ".",
+  "packages": [],
   "parseable": false,
   "prefer-dedupe": false,
   "prefer-offline": false,
@@ -141,6 +146,7 @@ exports[`test/lib/commands/config.js TAP config list --json > output matches sna
   "sbom-format": null,
   "sbom-type": "library",
   "scope": "",
+  "scopes": null,
   "script-shell": null,
   "searchexclude": "",
   "searchlimit": 20,
@@ -187,6 +193,7 @@ auth-type = "web"
 before = null
 bin-links = true
 browser = null
+bypass-2fa = false
 ca = null
 ; cache = "{CACHE}" ; overridden by cli
 cache-max = null
@@ -214,6 +221,7 @@ editor = "{EDITOR}"
 engine-strict = false
 expect-result-count = null
 expect-results = null
+expires = null
 fetch-retries = 2
 fetch-retry-factor = 10
 fetch-retry-maxtimeout = 60000
@@ -266,6 +274,7 @@ logs-max = 10
 ; long = false ; overridden by cli
 maxsockets = 15
 message = "%s"
+name = null
 node-gyp = "{CWD}/node_modules/node-gyp/bin/node-gyp.js"
 node-options = null
 noproxy = [""]
@@ -275,12 +284,14 @@ omit = []
 omit-lockfile-registry-resolved = false
 only = null
 optional = null
+orgs = null
 os = null
 otp = null
 pack-destination = "."
 package = []
 package-lock = true
 package-lock-only = false
+packages = []
 parseable = false
 prefer-dedupe = false
 prefer-offline = false
@@ -307,6 +318,7 @@ save-prod = false
 sbom-format = null
 sbom-type = "library"
 scope = ""
+scopes = null
 script-shell = null
 searchexclude = ""
 searchlimit = 20

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -190,12 +190,15 @@ safer to use a registry-provided authentication bearer token stored in the
 
 * Default: 'public' for new packages, existing packages it will not change the
   current level
-* Type: null, "restricted", or "public"
+* Type: null, "restricted", "public", "read-only", or "read-write"
 
-If you do not want your scoped package to be publicly viewable (and
-installable) set \`--access=restricted\`.
+When used with \`npm publish\`: If you do not want your scoped package to be
+publicly viewable (and installable) set \`--access=restricted\`. Unscoped
+packages cannot be set to \`restricted\`.
 
-Unscoped packages cannot be set to \`restricted\`.
+When used with \`npm token create\`: Set the access level for the token. Use
+\`read-only\` for tokens that can only download packages, or \`read-write\` for
+tokens that can publish packages.
 
 Note: This defaults to not changing the current access level for existing
 packages. Specifying a value of \`restricted\` or \`public\` during publish will
@@ -299,6 +302,17 @@ Set to \`false\` to suppress browser behavior and instead print urls to
 terminal.
 
 Set to \`true\` to use default system URL opener.
+
+
+
+#### \`bypass-2fa\`
+
+* Default: false
+* Type: Boolean
+
+When creating a Granular Access Token with \`npm token create\`, setting this
+to true will allow the token to bypass two-factor authentication. This is
+useful for automation and CI/CD workflows.
 
 
 
@@ -555,6 +569,17 @@ Tells npm whether or not to expect results from the command. Can be either
 true (expect some results) or false (expect no results).
 
 This config cannot be used with: \`expect-result-count\`
+
+#### \`expires\`
+
+* Default: null
+* Type: null, String, or Date
+
+When creating a Granular Access Token with \`npm token create\`, this sets the
+expiration date for the token. Format: YYYY-MM-DD or ISO 8601 date string.
+If not specified, defaults to 7 days from creation.
+
+
 
 #### \`fetch-retries\`
 
@@ -1081,6 +1106,16 @@ Any "%s" in the message will be replaced with the version number.
 
 
 
+#### \`name\`
+
+* Default: null
+* Type: null or String
+
+When creating a Granular Access Token with \`npm token create\`, this sets the
+name/description for the token.
+
+
+
 #### \`node-gyp\`
 
 * Default: The path to the node-gyp bin that ships with npm
@@ -1158,6 +1193,17 @@ time.
 
 
 
+#### \`orgs\`
+
+* Default: null
+* Type: null or String (can be set multiple times)
+
+When creating a Granular Access Token with \`npm token create\`, this limits
+the token access to specific organizations. Provide a comma-separated list
+of organization names.
+
+
+
 #### \`os\`
 
 * Default: null
@@ -1222,6 +1268,17 @@ instead of checking \`node_modules\` and downloading dependencies.
 
 For \`list\` this means the output will be based on the tree described by the
 \`package-lock.json\`, rather than the contents of \`node_modules\`.
+
+
+
+#### \`packages\`
+
+* Default:
+* Type: null or String (can be set multiple times)
+
+When creating a Granular Access Token with \`npm token create\`, this limits
+the token access to specific packages. Provide a comma-separated list of
+package names.
 
 
 
@@ -1517,6 +1574,17 @@ This will also cause \`npm init\` to create a scoped package.
 # instead of just named "whatever"
 npm init --scope=@foo --yes
 \`\`\`
+
+
+
+#### \`scopes\`
+
+* Default: null
+* Type: null or String (can be set multiple times)
+
+When creating a Granular Access Token with \`npm token create\`, this limits
+the token access to specific scopes. Provide a comma-separated list of scope
+names (with or without @ prefix).
 
 
 
@@ -2103,6 +2171,7 @@ Array [
   "before",
   "bin-links",
   "browser",
+  "bypass-2fa",
   "ca",
   "cache",
   "cache-max",
@@ -2130,6 +2199,7 @@ Array [
   "engine-strict",
   "expect-result-count",
   "expect-results",
+  "expires",
   "fetch-retries",
   "fetch-retry-factor",
   "fetch-retry-maxtimeout",
@@ -2180,6 +2250,7 @@ Array [
   "logs-dir",
   "logs-max",
   "long",
+  "name",
   "maxsockets",
   "message",
   "node-gyp",
@@ -2189,6 +2260,7 @@ Array [
   "omit",
   "omit-lockfile-registry-resolved",
   "only",
+  "orgs",
   "optional",
   "os",
   "otp",
@@ -2196,6 +2268,7 @@ Array [
   "package-lock",
   "package-lock-only",
   "pack-destination",
+  "packages",
   "parseable",
   "prefer-dedupe",
   "prefer-offline",
@@ -2222,6 +2295,7 @@ Array [
   "sbom-format",
   "sbom-type",
   "scope",
+  "scopes",
   "script-shell",
   "searchexclude",
   "searchlimit",
@@ -2266,6 +2340,7 @@ Array [
   "before",
   "bin-links",
   "browser",
+  "bypass-2fa",
   "ca",
   "cache",
   "cache-max",
@@ -2291,6 +2366,7 @@ Array [
   "dry-run",
   "editor",
   "engine-strict",
+  "expires",
   "fetch-retries",
   "fetch-retry-factor",
   "fetch-retry-maxtimeout",
@@ -2324,6 +2400,7 @@ Array [
   "location",
   "lockfile-version",
   "loglevel",
+  "name",
   "maxsockets",
   "message",
   "node-gyp",
@@ -2332,6 +2409,7 @@ Array [
   "omit",
   "omit-lockfile-registry-resolved",
   "only",
+  "orgs",
   "optional",
   "os",
   "otp",
@@ -2339,6 +2417,7 @@ Array [
   "package-lock",
   "package-lock-only",
   "pack-destination",
+  "packages",
   "parseable",
   "prefer-dedupe",
   "prefer-offline",
@@ -2364,6 +2443,7 @@ Array [
   "sbom-format",
   "sbom-type",
   "scope",
+  "scopes",
   "script-shell",
   "searchexclude",
   "searchlimit",
@@ -2433,6 +2513,7 @@ Object {
   "before": null,
   "binLinks": true,
   "browser": null,
+  "bypass-2fa": false,
   "ca": null,
   "cache": "{CWD}/cache/_cacache",
   "call": "",
@@ -2454,6 +2535,7 @@ Object {
   "dryRun": false,
   "editor": "{EDITOR}",
   "engineStrict": false,
+  "expires": null,
   "force": false,
   "foregroundScripts": false,
   "formatPackageLock": true,
@@ -2481,6 +2563,7 @@ Object {
   "logColor": false,
   "maxSockets": 15,
   "message": "%s",
+  "name": null,
   "nodeBin": "{NODE}",
   "nodeGyp": "{CWD}/node_modules/node-gyp/bin/node-gyp.js",
   "nodeVersion": "2.2.2",
@@ -2492,11 +2575,13 @@ Object {
   "offline": false,
   "omit": Array [],
   "omitLockfileRegistryResolved": false,
+  "orgs": null,
   "os": null,
   "otp": null,
   "package": Array [],
   "packageLock": true,
   "packageLockOnly": false,
+  "packages": Array [],
   "packDestination": ".",
   "parseable": false,
   "preferDedupe": false,
@@ -2524,6 +2609,7 @@ Object {
   "sbomFormat": null,
   "sbomType": "library",
   "scope": "",
+  "scopes": null,
   "scriptShell": undefined,
   "search": Object {
     "description": true,
@@ -3894,7 +3980,8 @@ Usage:
 npm publish <package-spec>
 
 Options:
-[--tag <tag>] [--access <restricted|public>] [--dry-run] [--otp <otp>]
+[--tag <tag>] [--access <restricted|public|read-only|read-write>] [--dry-run]
+[--otp <otp>]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [--workspaces] [--include-workspace-root] [--provenance|--provenance-file <file>]
 
@@ -4308,26 +4395,37 @@ Manage your authentication tokens
 Usage:
 npm token list
 npm token revoke <id|token>
-npm token create [--read-only] [--cidr=list]
+npm token create --name=<name> --access=<read-only|read-write> [--expires=<YYYY-MM-DD>] [--packages=<pkg1,pkg2>] [--scopes=<scope1,scope2>] [--orgs=<org1,org2>] [--cidr=<ip-range>] [--bypass-2fa]
 
 Options:
-[--read-only] [--cidr <cidr> [--cidr <cidr> ...]] [--registry <registry>]
-[--otp <otp>]
+[--name <name>] [--expires <date>]
+[--access <restricted|public|read-only|read-write>]
+[--packages <pkg1,pkg2> [--packages <pkg1,pkg2> ...]]
+[--scopes <@scope1,@scope2> [--scopes <@scope1,@scope2> ...]]
+[--orgs <org1,org2> [--orgs <org1,org2> ...]] [--cidr <cidr> [--cidr <cidr> ...]]
+[--bypass-2fa] [--registry <registry>] [--otp <otp>] [--read-only]
 
 Run "npm help token" for more info
 
 \`\`\`bash
 npm token list
 npm token revoke <id|token>
-npm token create [--read-only] [--cidr=list]
+npm token create --name=<name> --access=<read-only|read-write> [--expires=<YYYY-MM-DD>] [--packages=<pkg1,pkg2>] [--scopes=<scope1,scope2>] [--orgs=<org1,org2>] [--cidr=<ip-range>] [--bypass-2fa]
 \`\`\`
 
 Note: This command is unaware of workspaces.
 
-#### \`read-only\`
+#### \`name\`
+#### \`expires\`
+#### \`access\`
+#### \`packages\`
+#### \`scopes\`
+#### \`orgs\`
 #### \`cidr\`
+#### \`bypass-2fa\`
 #### \`registry\`
 #### \`otp\`
+#### \`read-only\`
 `
 
 exports[`test/lib/docs.js TAP usage undeprecate > must match snapshot 1`] = `

--- a/test/lib/commands/token.js
+++ b/test/lib/commands/token.js
@@ -1,11 +1,8 @@
 const t = require('tap')
 const { load: loadMockNpm } = require('../../fixtures/mock-npm.js')
 const MockRegistry = require('@npmcli/mock-registry')
-const mockGlobals = require('@npmcli/mock-globals')
-const stream = require('node:stream')
 
 const authToken = 'abcd1234'
-const password = 'this is not really a password'
 
 const auth = {
   '//registry.npmjs.org/:_authToken': authToken,
@@ -64,6 +61,7 @@ t.test('token list', async t => {
     authorization: authToken,
   })
   registry.getTokens(tokens)
+  registry.nock.get('/-/npm/v1/user/tokens').reply(200, { objects: [], urls: {}, total: 0 })
   await npm.exec('token', [])
   t.strictSame(outputs, [
     `Publish token efgh5678efgh5678… with id abcd123 created ${now.slice(0, 10)}`,
@@ -87,6 +85,7 @@ t.test('token list json output', async t => {
     authorization: authToken,
   })
   registry.getTokens(tokens)
+  registry.nock.get('/-/npm/v1/user/tokens').reply(200, { objects: [], urls: {}, total: 0 })
   await npm.exec('token', ['list'])
   const parsed = JSON.parse(joinedOutput())
   t.match(parsed, tokens, 'prints the json parsed tokens')
@@ -105,6 +104,7 @@ t.test('token list parseable output', async t => {
     authorization: authToken,
   })
   registry.getTokens(tokens)
+  registry.nock.get('/-/npm/v1/user/tokens').reply(200, { objects: [], urls: {}, total: 0 })
   await npm.exec('token', [])
   t.strictSame(outputs, [
     'key\ttoken\tcreated\treadonly\tCIDR whitelist',
@@ -124,7 +124,9 @@ t.test('token revoke', async t => {
   })
 
   registry.getTokens(tokens)
-  registry.nock.delete(`/-/npm/v1/tokens/token/${tokens[0].key}`).reply(200)
+  registry.nock.get('/-/npm/v1/user/tokens').reply(200, { objects: [], urls: {}, total: 0 })
+  registry.nock.delete(`/-/npm/v1/tokens/token/${tokens[0].key}`).reply(404)
+  registry.nock.delete(`/-/npm/v1/user/tokens/${tokens[0].key}`).reply(200)
   await npm.exec('token', ['rm', tokens[0].key.slice(0, 8)])
 
   t.equal(joinedOutput(), 'Removed 1 token')
@@ -141,8 +143,11 @@ t.test('token revoke multiple tokens', async t => {
   })
 
   registry.getTokens(tokens)
-  registry.nock.delete(`/-/npm/v1/tokens/token/${tokens[0].key}`).reply(200)
-  registry.nock.delete(`/-/npm/v1/tokens/token/${tokens[1].key}`).reply(200)
+  registry.nock.get('/-/npm/v1/user/tokens').reply(200, { objects: [], urls: {}, total: 0 })
+  registry.nock.delete(`/-/npm/v1/tokens/token/${tokens[0].key}`).reply(404)
+  registry.nock.delete(`/-/npm/v1/user/tokens/${tokens[0].key}`).reply(200)
+  registry.nock.delete(`/-/npm/v1/tokens/token/${tokens[1].key}`).reply(404)
+  registry.nock.delete(`/-/npm/v1/user/tokens/${tokens[1].key}`).reply(200)
   await npm.exec('token', ['rm', tokens[0].key.slice(0, 8), tokens[1].key.slice(0, 8)])
 
   t.equal(joinedOutput(), 'Removed 2 tokens')
@@ -162,7 +167,9 @@ t.test('token revoke json output', async t => {
   })
 
   registry.getTokens(tokens)
-  registry.nock.delete(`/-/npm/v1/tokens/token/${tokens[0].key}`).reply(200)
+  registry.nock.get('/-/npm/v1/user/tokens').reply(200, { objects: [], urls: {}, total: 0 })
+  registry.nock.delete(`/-/npm/v1/tokens/token/${tokens[0].key}`).reply(404)
+  registry.nock.delete(`/-/npm/v1/user/tokens/${tokens[0].key}`).reply(200)
   await npm.exec('token', ['rm', tokens[0].key.slice(0, 8)])
 
   const parsed = JSON.parse(joinedOutput())
@@ -183,7 +190,9 @@ t.test('token revoke parseable output', async t => {
   })
 
   registry.getTokens(tokens)
-  registry.nock.delete(`/-/npm/v1/tokens/token/${tokens[0].key}`).reply(200)
+  registry.nock.get('/-/npm/v1/user/tokens').reply(200, { objects: [], urls: {}, total: 0 })
+  registry.nock.delete(`/-/npm/v1/tokens/token/${tokens[0].key}`).reply(404)
+  registry.nock.delete(`/-/npm/v1/user/tokens/${tokens[0].key}`).reply(200)
   await npm.exec('token', ['rm', tokens[0].key.slice(0, 8)])
   t.equal(joinedOutput(), tokens[0].key, 'logs the token as a string')
 })
@@ -198,7 +207,9 @@ t.test('token revoke by token', async t => {
     authorization: authToken,
   })
   registry.getTokens(tokens)
-  registry.nock.delete(`/-/npm/v1/tokens/token/${tokens[0].token}`).reply(200)
+  registry.nock.get('/-/npm/v1/user/tokens').reply(200, { objects: [], urls: {}, total: 0 })
+  registry.nock.delete(`/-/npm/v1/tokens/token/${tokens[0].token}`).reply(404)
+  registry.nock.delete(`/-/npm/v1/user/tokens/${tokens[0].token}`).reply(200)
   await npm.exec('token', ['rm', tokens[0].token])
   t.equal(joinedOutput(), 'Removed 1 token')
 })
@@ -222,6 +233,7 @@ t.test('token revoke ambiguous id errors', async t => {
     authorization: authToken,
   })
   registry.getTokens(tokens)
+  registry.nock.get('/-/npm/v1/user/tokens').reply(200, { objects: [], urls: {}, total: 0 })
   await t.rejects(npm.exec('token', ['rm', 'abcd']), {
     message: /Token ID "abcd" was ambiguous/,
   })
@@ -238,6 +250,7 @@ t.test('token revoke unknown token', async t => {
   })
 
   registry.getTokens(tokens)
+  registry.nock.get('/-/npm/v1/user/tokens').reply(200, { objects: [], urls: {}, total: 0 })
   await t.rejects(npm.exec('token', ['rm', '0xnotreal']),
     'Unknown token id or value 0xnotreal'
   )
@@ -249,6 +262,8 @@ t.test('token create', async t => {
     config: {
       ...auth,
       cidr,
+      name: 'test-token',
+      access: 'read-write',
     },
   })
   const registry = new MockRegistry({
@@ -256,16 +271,19 @@ t.test('token create', async t => {
     registry: npm.config.get('registry'),
     authorization: authToken,
   })
-  const stdin = new stream.PassThrough()
-  stdin.write(`${password}\n`)
-  mockGlobals(t, {
-    'process.stdin': stdin,
-    'process.stdout': new stream.PassThrough(), // to quiet readline
-  }, { replace: true })
-  registry.createToken({ password, cidr })
+  registry.nock.post('/-/npm/v1/user/tokens', body => {
+    return body.type === 'granular' &&
+      body.name === 'test-token' &&
+      body.access === 'read-write' &&
+      body.cidr_whitelist.length === 2
+  }).reply(201, {
+    token: 'n3wt0k3n',
+    access: 'read-write',
+    cidr_whitelist: cidr,
+    created: new Date().toISOString(),
+  })
   await npm.exec('token', ['create'])
-  t.strictSame(outputs, [
-    '',
+  t.match(outputs, [
     'Created publish token n3wt0k3n',
     'with IP whitelist: 10.0.0.0/8,192.168.1.0/24',
   ])
@@ -275,7 +293,8 @@ t.test('token create read only', async t => {
   const { npm, outputs } = await loadMockNpm(t, {
     config: {
       ...auth,
-      'read-only': true,
+      name: 'readonly-token',
+      access: 'read-only',
     },
   })
   const registry = new MockRegistry({
@@ -283,17 +302,174 @@ t.test('token create read only', async t => {
     registry: npm.config.get('registry'),
     authorization: authToken,
   })
-  const stdin = new stream.PassThrough()
-  stdin.write(`${password}\n`)
-  mockGlobals(t, {
-    'process.stdin': stdin,
-    'process.stdout': new stream.PassThrough(), // to quiet readline
-  }, { replace: true })
-  registry.createToken({ readonly: true, password })
+  registry.nock.post('/-/npm/v1/user/tokens', body => {
+    return body.type === 'granular' &&
+      body.name === 'readonly-token' &&
+      body.access === 'read-only'
+  }).reply(201, {
+    token: 'n3wt0k3n',
+    access: 'read-only',
+    created: new Date().toISOString(),
+  })
   await npm.exec('token', ['create'])
-  t.strictSame(outputs, [
-    '',
+  t.match(outputs, [
     'Created read only token n3wt0k3n',
+  ])
+})
+
+t.test('token create with expiry', async t => {
+  const expires = '2025-12-31'
+  const { npm, outputs } = await loadMockNpm(t, {
+    config: {
+      ...auth,
+      name: 'expiry-token',
+      access: 'read-only',
+      expires,
+    },
+  })
+  const registry = new MockRegistry({
+    tap: t,
+    registry: npm.config.get('registry'),
+    authorization: authToken,
+  })
+  registry.nock.post('/-/npm/v1/user/tokens', body => {
+    return body.type === 'granular' &&
+      body.name === 'expiry-token' &&
+      body.access === 'read-only' &&
+      body.expires === new Date(expires).toISOString()
+  }).reply(201, {
+    token: 'n3wt0k3n',
+    access: 'read-only',
+    created: new Date().toISOString(),
+    expires: new Date(expires).toISOString(),
+  })
+  await npm.exec('token', ['create'])
+  t.match(outputs, [
+    'Created read only token n3wt0k3n',
+    `expires: ${new Date(expires).toISOString()}`,
+  ])
+})
+
+t.test('token create with packages', async t => {
+  const packages = ['@scope/pkg1', 'pkg2']
+  const { npm, outputs } = await loadMockNpm(t, {
+    config: {
+      ...auth,
+      name: 'packages-token',
+      access: 'read-write',
+      packages,
+    },
+  })
+  const registry = new MockRegistry({
+    tap: t,
+    registry: npm.config.get('registry'),
+    authorization: authToken,
+  })
+  registry.nock.post('/-/npm/v1/user/tokens', body => {
+    return body.type === 'granular' &&
+      body.name === 'packages-token' &&
+      body.access === 'read-write' &&
+      JSON.stringify(body.packages) === JSON.stringify(packages)
+  }).reply(201, {
+    token: 'n3wt0k3n',
+    access: 'read-write',
+    created: new Date().toISOString(),
+  })
+  await npm.exec('token', ['create'])
+  t.match(outputs, [
+    'Created publish token n3wt0k3n',
+  ])
+})
+
+t.test('token create with scopes', async t => {
+  const scopes = ['@scope1', '@scope2']
+  const { npm, outputs } = await loadMockNpm(t, {
+    config: {
+      ...auth,
+      name: 'scopes-token',
+      access: 'read-write',
+      scopes,
+    },
+  })
+  const registry = new MockRegistry({
+    tap: t,
+    registry: npm.config.get('registry'),
+    authorization: authToken,
+  })
+  registry.nock.post('/-/npm/v1/user/tokens', body => {
+    return body.type === 'granular' &&
+      body.name === 'scopes-token' &&
+      body.access === 'read-write' &&
+      JSON.stringify(body.scopes) === JSON.stringify(scopes)
+  }).reply(201, {
+    token: 'n3wt0k3n',
+    access: 'read-write',
+    created: new Date().toISOString(),
+  })
+  await npm.exec('token', ['create'])
+  t.match(outputs, [
+    'Created publish token n3wt0k3n',
+  ])
+})
+
+t.test('token create with orgs', async t => {
+  const orgs = ['org1', 'org2']
+  const { npm, outputs } = await loadMockNpm(t, {
+    config: {
+      ...auth,
+      name: 'orgs-token',
+      access: 'read-write',
+      orgs,
+    },
+  })
+  const registry = new MockRegistry({
+    tap: t,
+    registry: npm.config.get('registry'),
+    authorization: authToken,
+  })
+  registry.nock.post('/-/npm/v1/user/tokens', body => {
+    return body.type === 'granular' &&
+      body.name === 'orgs-token' &&
+      body.access === 'read-write' &&
+      JSON.stringify(body.orgs) === JSON.stringify(orgs)
+  }).reply(201, {
+    token: 'n3wt0k3n',
+    access: 'read-write',
+    created: new Date().toISOString(),
+  })
+  await npm.exec('token', ['create'])
+  t.match(outputs, [
+    'Created publish token n3wt0k3n',
+  ])
+})
+
+t.test('token create with bypass-2fa', async t => {
+  const { npm, outputs } = await loadMockNpm(t, {
+    config: {
+      ...auth,
+      name: 'bypass2fa-token',
+      access: 'read-write',
+      'bypass-2fa': true,
+    },
+  })
+  const registry = new MockRegistry({
+    tap: t,
+    registry: npm.config.get('registry'),
+    authorization: authToken,
+  })
+  registry.nock.post('/-/npm/v1/user/tokens', body => {
+    return body.type === 'granular' &&
+      body.name === 'bypass2fa-token' &&
+      body.access === 'read-write' &&
+      body.bypass_2fa === true
+  }).reply(201, {
+    token: 'n3wt0k3n',
+    access: 'read-write',
+    created: new Date().toISOString(),
+  })
+  await npm.exec('token', ['create'])
+  t.match(outputs, [
+    'Created publish token n3wt0k3n',
   ])
 })
 
@@ -304,6 +480,8 @@ t.test('token create json output', async t => {
       ...auth,
       json: true,
       cidr,
+      name: 'json-token',
+      access: 'read-write',
     },
   })
   const registry = new MockRegistry({
@@ -311,18 +489,17 @@ t.test('token create json output', async t => {
     registry: npm.config.get('registry'),
     authorization: authToken,
   })
-  const stdin = new stream.PassThrough()
-  stdin.write(`${password}\n`)
-  mockGlobals(t, {
-    'process.stdin': stdin,
-    'process.stdout': new stream.PassThrough(), // to quiet readline
-  }, { replace: true })
-  registry.createToken({ password, cidr })
+  registry.nock.post('/-/npm/v1/user/tokens').reply(201, {
+    token: 'n3wt0k3n',
+    access: 'read-write',
+    cidr_whitelist: cidr,
+    created: new Date().toISOString(),
+  })
   await npm.exec('token', ['create'])
   const parsed = JSON.parse(joinedOutput())
   t.match(
     parsed,
-    { token: 'n3wt0k3n', readonly: false, cidr_whitelist: cidr }
+    { token: 'n3wt0k3n', access: 'read-write', cidr_whitelist: cidr }
   )
   t.ok(parsed.created, 'also returns created')
 })
@@ -334,6 +511,8 @@ t.test('token create parseable output', async t => {
       ...auth,
       parseable: true,
       cidr,
+      name: 'parseable-token',
+      access: 'read-write',
     },
   })
   const registry = new MockRegistry({
@@ -341,18 +520,17 @@ t.test('token create parseable output', async t => {
     registry: npm.config.get('registry'),
     authorization: authToken,
   })
-  const stdin = new stream.PassThrough()
-  stdin.write(`${password}\n`)
-  mockGlobals(t, {
-    'process.stdin': stdin,
-    'process.stdout': new stream.PassThrough(), // to quiet readline
-  }, { replace: true })
-  registry.createToken({ password, cidr })
+  registry.nock.post('/-/npm/v1/user/tokens').reply(201, {
+    token: 'n3wt0k3n',
+    access: 'read-write',
+    cidr_whitelist: cidr,
+    created: new Date().toISOString(),
+  })
   await npm.exec('token', ['create'])
-  t.equal(outputs[1], 'token\tn3wt0k3n')
-  t.ok(outputs[2].startsWith('created\t'))
-  t.equal(outputs[3], 'readonly\tfalse')
-  t.equal(outputs[4], 'cidr_whitelist\t10.0.0.0/8,192.168.1.0/24')
+  // In parseable mode, all fields are output as key\tvalue pairs
+  t.match(outputs.join('\n'), /token\tn3wt0k3n/)
+  t.match(outputs.join('\n'), /created\t/)
+  t.match(outputs.join('\n'), /cidr_whitelist\t10.0.0.0\/8,192.168.1.0\/24/)
 })
 
 t.test('token create ipv6 cidr', async t => {
@@ -360,12 +538,14 @@ t.test('token create ipv6 cidr', async t => {
     config: {
       ...auth,
       cidr: '::1/128',
+      name: 'ipv6-test',
+      access: 'read-only',
     },
   })
-  await t.rejects(npm.exec('token', ['create'], {
+  await t.rejects(npm.exec('token', ['create']), {
     code: 'EINVALIDCIDR',
     message: /CIDR whitelist can only contain IPv4 addresses, ::1\/128 is IPv6/,
-  }))
+  })
 })
 
 t.test('token create invalid cidr', async t => {
@@ -373,10 +553,43 @@ t.test('token create invalid cidr', async t => {
     config: {
       ...auth,
       cidr: 'apple/cider',
+      name: 'invalid-cidr-test',
+      access: 'read-only',
     },
   })
-  await t.rejects(npm.exec('token', ['create'], {
+  await t.rejects(npm.exec('token', ['create']), {
     code: 'EINVALIDCIDR',
     message: 'CIDR whitelist contains invalid CIDR entry: apple/cider',
-  }))
+  })
+})
+
+t.test('token create requires name', async t => {
+  const { npm } = await loadMockNpm(t, {
+    config: {
+      ...auth,
+      access: 'read-only',
+    },
+  })
+  await t.rejects(npm.exec('token', ['create']), {
+    code: 'EUSAGE',
+  })
+})
+
+t.test('token create requires access and validates value', async t => {
+  const { npm } = await loadMockNpm(t, {
+    config: {
+      ...auth,
+      name: 'test-token',
+    },
+  })
+  // Test missing access
+  await t.rejects(npm.exec('token', ['create']), {
+    code: 'EUSAGE',
+  })
+
+  // Test invalid access value
+  npm.config.set('access', 'invalid-value')
+  await t.rejects(npm.exec('token', ['create']), {
+    code: 'EUSAGE',
+  })
 })

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -153,12 +153,15 @@ const definitions = {
     defaultDescription: `
     'public' for new packages, existing packages it will not change the current level
   `,
-    type: [null, 'restricted', 'public'],
+    type: [null, 'restricted', 'public', 'read-only', 'read-write'],
     description: `
-    If you do not want your scoped package to be publicly viewable (and
-    installable) set \`--access=restricted\`.
-
+    When used with \`npm publish\`: If you do not want your scoped package to
+    be publicly viewable (and installable) set \`--access=restricted\`.
     Unscoped packages cannot be set to \`restricted\`.
+
+    When used with \`npm token create\`: Set the access level for the token.
+    Use \`read-only\` for tokens that can only download packages, or
+    \`read-write\` for tokens that can publish packages.
 
     Note: This defaults to not changing the current access level for existing
     packages.  Specifying a value of \`restricted\` or \`public\` during
@@ -271,6 +274,16 @@ const definitions = {
     terminal.
 
     Set to \`true\` to use default system URL opener.
+    `,
+    flatten,
+  }),
+  'bypass-2fa': new Definition('bypass-2fa', {
+    default: false,
+    type: Boolean,
+    description: `
+      When creating a Granular Access Token with \`npm token create\`,
+      setting this to true will allow the token to bypass two-factor
+      authentication. This is useful for automation and CI/CD workflows.
     `,
     flatten,
   }),
@@ -623,6 +636,17 @@ const definitions = {
       Tells npm whether or not to expect results from the command.
       Can be either true (expect some results) or false (expect no results).
     `,
+  }),
+  expires: new Definition('expires', {
+    default: null,
+    type: [null, String, Date],
+    hint: '<date>',
+    description: `
+      When creating a Granular Access Token with \`npm token create\`,
+      this sets the expiration date for the token. Format: YYYY-MM-DD or
+      ISO 8601 date string. If not specified, defaults to 7 days from creation.
+    `,
+    flatten,
   }),
   'fetch-retries': new Definition('fetch-retries', {
     default: 2,
@@ -1281,6 +1305,16 @@ const definitions = {
       Show extended information in \`ls\`, \`search\`, and \`help-search\`.
     `,
   }),
+  name: new Definition('name', {
+    default: null,
+    type: [null, String],
+    hint: '<name>',
+    description: `
+      When creating a Granular Access Token with \`npm token create\`,
+      this sets the name/description for the token.
+    `,
+    flatten,
+  }),
   maxsockets: new Definition('maxsockets', {
     default: 15,
     type: Number,
@@ -1409,6 +1443,17 @@ const definitions = {
       definitions.omit.flatten('omit', obj, flatOptions)
     },
   }),
+  orgs: new Definition('orgs', {
+    default: null,
+    type: [null, String, Array],
+    hint: '<org1,org2>',
+    description: `
+      When creating a Granular Access Token with \`npm token create\`,
+      this limits the token access to specific organizations. Provide
+      a comma-separated list of organization names.
+    `,
+    flatten,
+  }),
   optional: new Definition('optional', {
     default: null,
     type: [null, Boolean],
@@ -1502,6 +1547,17 @@ const definitions = {
     type: String,
     description: `
       Directory in which \`npm pack\` will save tarballs.
+    `,
+    flatten,
+  }),
+  packages: new Definition('packages', {
+    default: [],
+    type: [null, String, Array],
+    hint: '<pkg1,pkg2>',
+    description: `
+      When creating a Granular Access Token with \`npm token create\`,
+      this limits the token access to specific packages. Provide
+      a comma-separated list of package names.
     `,
     flatten,
   }),
@@ -1899,6 +1955,17 @@ const definitions = {
       // projectScope is kept for compatibility with npm-registry-fetch
       flatOptions.projectScope = scope
     },
+  }),
+  scopes: new Definition('scopes', {
+    default: null,
+    type: [null, String, Array],
+    hint: '<@scope1,@scope2>',
+    description: `
+      When creating a Granular Access Token with \`npm token create\`,
+      this limits the token access to specific scopes. Provide
+      a comma-separated list of scope names (with or without @ prefix).
+    `,
+    flatten,
   }),
   'script-shell': new Definition('script-shell', {
     default: null,


### PR DESCRIPTION
Needs https://github.com/npm/npm-profile/pull/174 changes/release before this will work.

This pull request updates the `npm token` command to support Granular Access Tokens (GATs) with new parameters for fine-grained control, improves output handling for both classic and granular tokens, and adds documentation and config support for the new options.