### PR TITLE
fix: display full token when creating authentication tokens 

### DIFF
--- a/lib/commands/token.js
+++ b/lib/commands/token.js
@@ -1,4 +1,4 @@
-const { log, output } = require('proc-log')
+const { log, output, META } = require('proc-log')
 const { listTokens, createToken, removeToken } = require('npm-profile')
 const { otplease } = require('../utils/auth.js')
 const readUserInfo = require('../utils/read-user-info.js')
@@ -147,7 +147,7 @@ class Token extends BaseCommand {
       const chalk = this.npm.chalk
       // Identical to list
       const level = result.readonly ? 'read only' : 'publish'
-      output.standard(`Created ${chalk.blue(level)} token ${result.token}`)
+      output.standard(`Created ${chalk.blue(level)} token ${result.token}`, { [META]: true, redact: false })
       if (result.cidr_whitelist?.length) {
         output.standard(`with IP whitelist: ${chalk.green(result.cidr_whitelist.join(','))}`)
       }


### PR DESCRIPTION
Fixes [#8684](https://github.com/npm/cli/issues/8684)

### What / Why
When running `npm token create`, the created authentication token was being redacted in the output, making it difficult for users to copy and use the token. This happened because npm's output system automatically applies redaction to sensitive information like tokens.

### How
- Import `META` from `proc-log` to access output metadata options
- Use `{ [META]: true, redact: false }` option in `output.standard()` to disable redaction for the token display line
- This follows the established pattern used in other parts of the codebase (e.g., `lib/utils/open-url.js`) for displaying sensitive information that users need to see

### Testing
- All existing tests pass
- The fix preserves the existing output format and test expectations
- Token is now displayed in full while maintaining proper formatting and colors

### Before

Created publish token npm_***

### After

Created publish token npm_1a2b3c4d5e6f7g8h9i0j

The token can now be copied and used directly without being obscured by npm's redaction system. 