### PR TITLE
docs: deprecate npm token create and npm profile enable-2fa commands

### DIFF
--- a/docs/lib/content/commands/npm-profile.md
+++ b/docs/lib/content/commands/npm-profile.md
@@ -36,8 +36,11 @@ You can set the following properties this way: email, fullname, homepage, freeno
 This is interactive, you'll be prompted for your current password and a new password.
 You'll also be prompted for an OTP if you have two-factor authentication enabled.
 
-* `npm profile enable-2fa [auth-and-writes|auth-only]`: Enables two-factor authentication.
+* `npm profile enable-2fa [auth-and-writes|auth-only] (DEPRECATED)`: Enables two-factor authentication.
 Defaults to `auth-and-writes` mode.
+
+> **⚠️ Warning:** Enabling two-factor authentication via the cli is deprecated as of **November 2025**. 
+
 Modes are:
   * `auth-only`: Require an OTP when logging in or making changes to your account's authentication.
 The OTP will be required on both the website and the command line.

--- a/docs/lib/content/commands/npm-token.md
+++ b/docs/lib/content/commands/npm-token.md
@@ -26,10 +26,12 @@ Publish token npm_… with id e0cf92 created 2017-10-02
 
 ```
 
-* `npm token create [--read-only] [--cidr=<cidr-ranges>]`:
+* `npm token create [--read-only] [--cidr=<cidr-ranges>] (DEPRECATED)`:
   Create a new authentication token.
   It can be `--read-only`, or accept a list of [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) ranges with which to limit use of this token.
   This will prompt you for your password, and, if you have two-factor authentication enabled, an otp.
+
+  > **⚠️ Warning:** Creating tokens via the cli are deprecated as of **November 2025**.
 
   Currently, the cli cannot generate automation tokens.
   Please refer to the [docs website](https://docs.npmjs.com/creating-and-viewing-access-tokens) for more information on generating automation tokens.


### PR DESCRIPTION
## Summary
Add deprecation notices to the documentation for two CLI authentication features that will be deprecated as of November 2025.

## Changes
- Add deprecation warning to `npm token create` command documentation
- Add deprecation warning to `npm profile enable-2fa` command documentation

## Affected Files
- `docs/lib/content/commands/npm-token.md`
- `docs/lib/content/commands/npm-profile.md`

## Before changes
<img width="1353" height="448" alt="Screenshot 2025-10-30 at 11 38 14 AM" src="https://github.com/user-attachments/assets/e7d45150-0468-467f-8ff2-70e91f7bdfde" />
<img width="1365" height="468" alt="Screenshot 2025-10-30 at 11 11 55 AM" src="https://github.com/user-attachments/assets/22ff77fd-2b73-469e-b796-ca708dc6ff1b" />

## After changes
<img width="1426" height="440" alt="Screenshot 2025-10-30 at 11 50 34 AM" src="https://github.com/user-attachments/assets/d201f743-3bda-4a34-9087-d5ac74ac5baf" />
<img width="1313" height="369" alt="Screenshot 2025-10-30 at 11 52 14 AM" src="https://github.com/user-attachments/assets/fd1e1634-caa3-46ca-9be3-198c72b66394" />

