### PR TITLE
fix: order of version information in error message

### DIFF
--- a/lib/utils/error-message.js
+++ b/lib/utils/error-message.js
@@ -301,7 +301,7 @@ const errorMessage = (er, npm) => {
         'Not compatible with your version of node/npm: ' + er.pkgid,
         'Required: ' + JSON.stringify(er.required),
         'Actual:   ' +
-        JSON.stringify({ npm: npm.version, node: process.version }),
+        JSON.stringify({ node: process.version, npm: npm.version }),
       ].join('\n')])
       break
 

--- a/tap-snapshots/test/lib/utils/error-message.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/error-message.js.test.cjs
@@ -222,7 +222,7 @@ Object {
       String(
         Not compatible with your version of node/npm: some@package
         Required: undefined
-        Actual:   {"npm":"123.456.789-npm","node":"123.456.789-node"}
+        Actual:   {"node":"123.456.789-node","npm":"123.456.789-npm"}
       ),
     ],
   ],
@@ -1202,7 +1202,7 @@ Object {
       String(
         Not compatible with your version of node/npm: some@package
         Required: undefined
-        Actual:   {"npm":"123.456.789-npm","node":"123.456.789-node"}
+        Actual:   {"node":"123.456.789-node","npm":"123.456.789-npm"}
       ),
     ],
   ],


### PR DESCRIPTION
Reordered one of the lines ("Actual:") of output of `EBADENGINE` error in order to align it with the previous like ("Required"). The output is now easier to comprehend.

Before the change (note 2 last lines):

```sh
$ npm i
npm error code EBADENGINE
npm error engine Unsupported engine
npm error engine Not compatible with your version of node/npm: undefined
npm error notsup Not compatible with your version of node/npm: undefined
npm error notsup Required: {"node":">=22.21.0 <23.0.0","npm":">=10.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.19.5"}
```

After the change:

```sh
[…]
npm error notsup Required: {"node":">=22.21.0 <23.0.0","npm":">=10.0.0"}
npm error notsup Actual:   {"node":"v20.19.5","npm":"10.8.2"}
```

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
