### PR TITLE
docs: add workspace usage examples

### DIFF
--- a/docs/lib/content/commands/npm-publish.md
+++ b/docs/lib/content/commands/npm-publish.md
@@ -12,6 +12,32 @@ description: Publish a package
 
 Publishes a package to the registry so that it can be installed by name.
 
+### Examples
+
+Publish the package in the current directory:
+
+```bash
+npm publish
+```
+
+Publish a specific workspace:
+
+```bash
+npm publish --workspace=<workspace-name>
+```
+
+Publish multiple workspaces:
+
+```bash
+npm publish --workspace=workspace-a --workspace=workspace-b
+```
+
+Publish all workspaces:
+
+```bash
+npm publish --workspaces
+```
+
 By default npm will publish to the public registry.
 This can be overridden by specifying a different default registry or using a [`scope`](/using-npm/scope) in the name, combined with a scope-configured registry (see [`package.json`](/configuring-npm/package-json)).
 


### PR DESCRIPTION
## Summary
This PR adds workspace usage examples to the `npm publish` documentation to address confusion about the proper syntax for publishing workspaces.

## Related issue
Fixes #3543

## What changed
- Added an "Examples" section to `docs/lib/content/commands/npm-publish.md`
- Included clear examples for:
  - Publishing the current directory
  - Publishing a specific workspace
  - Publishing multiple workspaces
  - Publishing all workspaces

## Why this change is needed
Users were confused about the proper syntax for `npm publish --workspace`. The documentation had no examples demonstrating workspace usage, which made it difficult for users to understand how to use this feature.

## Type of change
- [x] Documentation improvement
- [ ] Bug fix
- [ ] New feature

## Testing
- [x] Documentation builds without errors
- [x] Examples are syntactically correct and follow npm CLI conventions

## Checklist
- [x] Examples added to documentation
- [x] Commit message follows Conventional Commits format
- [x] References issue #3543 in commit message
