### PR TITLE
docs: add --save flag to documentation

### DIFF
--- a/lib/commands/version.js
+++ b/lib/commands/version.js
@@ -13,6 +13,7 @@ class Version extends BaseCommand {
     'json',
     'preid',
     'sign-git-tag',
+    'save',
     'workspace',
     'workspaces',
     'workspaces-update',

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -4652,6 +4652,7 @@ npm version [<newversion> | major | minor | patch | premajor | preminor | prepat
 Options:
 [--allow-same-version] [--no-commit-hooks] [--no-git-tag-version] [--json]
 [--preid prerelease-id] [--sign-git-tag]
+[-S|--save|--no-save|--save-prod|--save-dev|--save-optional|--save-peer|--save-bundle]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [--workspaces] [--no-workspaces-update] [--include-workspace-root]
 [--ignore-scripts]
@@ -4672,6 +4673,7 @@ alias: verison
 #### \`json\`
 #### \`preid\`
 #### \`sign-git-tag\`
+#### \`save\`
 #### \`workspace\`
 #### \`workspaces\`
 #### \`workspaces-update\`


### PR DESCRIPTION
The --save flag was already implemented and used in workspaces but was not included in the auto-generated documentation. Adding it to the params array will ensure it appears in the npm version help and documentation.

When used with workspaces, --save updates the root package.json dependencies to match the new workspace versions.

Fixes #8170