### PR TITLE
docs: add example for keywords field

### DIFF
--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -65,6 +65,16 @@ Put keywords in it.
 It's an array of strings.
 This helps people discover your package as it's listed in `npm search`.
 
+Example:
+
+```json
+"keywords": [
+  "node",
+  "javascript",
+  "npm"
+]
+```
+
 ### homepage
 
 The URL to the project homepage.


### PR DESCRIPTION
## Description
Adds an example to the keywords field documentation in package.json to clarify the expected format.

## Changes
- Added JSON example showing keywords as an array of strings

## Fixes
Closes #7070

## Type of Change
- [x] Documentation update