### PR TITLE
docs: remove outdated roadmap link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ npm <command>
 * [**Documentation**](https://docs.npmjs.com/) - Official docs & how-tos for all things **npm**
     * Note: you can also search docs locally with `npm help-search <query>`
 * [**Bug Tracker**](https://github.com/npm/cli/issues) - Search or submit bugs against the CLI
-* [**Roadmap**](https://github.com/orgs/github/projects/4247/views/1?filterQuery=npm) - Track & follow along with our public roadmap
 * [**Community Feedback and Discussions**](https://github.com/orgs/community/discussions/categories/npm) - Contribute ideas & discussion around the npm registry, website & CLI
 * [**RFCs**](https://github.com/npm/rfcs) - Contribute ideas & specifications for the API/design of the npm CLI
 * [**Service Status**](https://status.npmjs.org/) - Monitor the current status & see incident reports for the website & registry


### PR DESCRIPTION
## Description
Removes the outdated roadmap link from README.md as the GitHub project board hasn't been updated since 2023 and contains no future items.

## Changes
- Removed the Roadmap link from Links & Resources section

## Fixes
Closes #7637

## Rationale
The linked roadmap (https://github.com/orgs/github/projects/4247/views/1?filterQuery=npm) only shows 6 shipped items from 2023 with no future roadmap items. Since there's no active replacement roadmap to link to, removing the outdated link provides a better user experience than keeping a dead link.

## Type of Change
- [x] Documentation update