### PR TITLE
docs: clarify .npmrc naming convention for environment variable overrides

### DIFF
--- a/docs/lib/content/using-npm/config.md
+++ b/docs/lib/content/using-npm/config.md
@@ -31,6 +31,8 @@ For details see [this issue](https://github.com/npm/npm/issues/14528).
 
 Notice that you need to use underscores instead of dashes, so `--allow-same-version` would become `npm_config_allow_same_version=true`.
 
+**Important:** When defining custom configuration keys in `.npmrc` files, use hyphens instead of underscores (e.g., `custom-key=value`). This ensures they can be overridden by environment variables, since npm automatically converts underscores to hyphens when reading environment variables. Keys with underscores in `.npmrc` files cannot be overridden via environment variables.
+
 #### npmrc Files
 
 The four relevant files are:


### PR DESCRIPTION
## Description
Adds important documentation clarifying that custom configuration keys in .npmrc files should use hyphens instead of underscores to ensure they can be overridden by environment variables.

## Changes
- Added a note explaining the naming convention for .npmrc keys
- Clarified that keys with underscores cannot be overridden by environment variables
- Explained that npm converts underscores to hyphens when reading environment variables

## Fixes
Closes #6036

## Rationale
Users were confused because environment variables use underscores (npm_config_some_thing) but if you define 'some_thing' in .npmrc, it can't be overridden. This happens because npm converts underscores to hyphens when reading env vars, so the env var becomes 'some-thing' but the .npmrc key remains 'some_thing'. By using hyphens in .npmrc files, both will resolve to the same key.

## Type of Change
- [x] Documentation update