### PR TITLE
docs: add os, cpu, and funding fields to package-lock.json

### DIFF
--- a/docs/lib/content/configuring-npm/package-lock-json.md
+++ b/docs/lib/content/configuring-npm/package-lock-json.md
@@ -119,6 +119,12 @@ Package descriptors have the following fields:
 
 * bin, license, engines, dependencies, optionalDependencies: fields from `package.json`
 
+* os: An array of operating systems this package is compatible with, as specified in `package.json`. This field is included when the package specifies OS restrictions.
+
+* cpu: An array of CPU architectures this package is compatible with, as specified in `package.json`. This field is included when the package specifies CPU restrictions.
+
+* funding: Funding information for the package, as specified in `package.json`. This field contains details about how to support the package maintainers.
+
 #### dependencies
 
 Legacy data for supporting versions of npm that use `lockfileVersion: 1`.


### PR DESCRIPTION
## Description

Adds documentation for the missing os, cpu, and unding fields in the packages section of package-lock.json.

## Changes

- Added documentation for the os field (array of compatible operating systems)
- Added documentation for the cpu field (array of compatible CPU architectures)
- Added documentation for the unding field (funding information from package.json)

## Fixes

Closes #5849

## Rationale

These fields appear in package-lock.json files for packages that specify OS/CPU restrictions or funding information in their package.json, but were not documented. This caused confusion for users examining their lockfiles.

## Type of Change

Documentation update