### PR TITLE
docs: fix lifecycle event order for prepare script

### DIFF
--- a/docs/lib/content/using-npm/scripts.md
+++ b/docs/lib/content/using-npm/scripts.md
@@ -43,7 +43,7 @@ These scripts happen in addition to the `pre<event>`, `post<event>`, and
 * Runs BEFORE the package is packed, i.e.
 during `npm publish` and `npm pack`
 * Runs on local `npm install` without any arguments
-* Runs AFTER `prepublish`, but BEFORE `prepublishOnly`
+* Runs AFTER `prepublishOnly` and `prepack`, but BEFORE `postpack`
 * Runs for a package if it's being installed as a link through `npm install <folder>`
 
 * NOTE: If a package being installed through git contains a `prepare` script, its `dependencies` and `devDependencies` will be installed, and the prepare script will be run, before the package is packaged and installed.


### PR DESCRIPTION
## Description

Fixes the documented lifecycle event order for the prepare script to match the actual behavior during npm publish.

## Changes

- Updated the prepare script documentation to correctly state it runs AFTER prepublishOnly and prepack, but BEFORE postpack
- Previously incorrectly stated it runs AFTER prepublish, but BEFORE prepublishOnly

## Fixes

Closes #4893

## Rationale

The documentation contradicted the actual lifecycle event order. The correct order during npm publish is:
1. prepublishOnly
2. prepack
3. prepare
4. postpack
5. publish
6. postpublish

The old documentation stated prepare ran before prepublishOnly, which was incorrect.

## Type of Change

Documentation update