### PR TITLE
docs: add workspace dependencies example to workspaces

### DIFF
--- a/docs/lib/content/using-npm/workspaces.md
+++ b/docs/lib/content/using-npm/workspaces.md
@@ -86,6 +86,26 @@ If you want to add a dependency named `abbrev` from the registry as a dependency
 npm install abbrev -w a
 ```
 
+**Adding a workspace as a dependency of another workspace:**
+
+If you want to add workspace **b** as a dependency of workspace **a**, you can use the workspace protocol in the dependency specifier:
+
+```
+npm install b@workspace:* -w a
+```
+
+This will add an entry to workspace **a**'s `package.json` like:
+
+```json
+{
+  "dependencies": {
+    "b": "workspace:*"
+  }
+}
+```
+
+The `workspace:` protocol tells npm to link to the local workspace rather than fetching from the registry. The `*` version means it will use whatever version is defined in workspace **b**'s `package.json`.
+
 Note: other installing commands such as `uninstall`, `ci`, etc will also respect the provided `workspace` configuration.
 
 ### Using workspaces


### PR DESCRIPTION
## Description

Adds documentation and examples showing how to add one workspace as a dependency of another workspace using the workspace protocol.

## Changes

- Added a new section explaining how to use workspace:* protocol to add workspace dependencies
- Included example command: npm install b@workspace:* -w a
- Showed the resulting package.json entry
- Explained that workspace: protocol links to local workspace instead of registry

## Fixes

Closes #4742

## Rationale

The workspaces documentation explained how to add registry dependencies to workspaces, but did not explain how to add one workspace as a dependency of another workspace. This is a common use case in monorepos where internal packages depend on each other.

## Type of Change

Documentation enhancement