### PR TITLE
docs: standardize env vars to uppercase convention

### DIFF
--- a/docs/lib/content/commands/npm.md
+++ b/docs/lib/content/commands/npm.md
@@ -60,7 +60,7 @@ In particular, npm has two modes of operation:
   npm installs packages into the current project directory, which defaults to the current working directory.
   Packages install to `./node_modules`, and bins to `./node_modules/.bin`.
 * global mode:
-  npm installs packages into the install prefix at `$npm_config_prefix/lib/node_modules` and bins to `$npm_config_prefix/bin`.
+  npm installs packages into the install prefix at `$NPM_CONFIG_PREFIX/lib/node_modules` and bins to `$NPM_CONFIG_PREFIX/bin`.
 
 Local mode is the default.
 Use `-g` or `--global` on any command to run in global mode instead.
@@ -94,8 +94,8 @@ It reads its configuration options from 5 places.
   All keys take a value, even if they are booleans (the config parser doesn't know what the options are at the time of parsing).
   If you do not provide a value (`--key`) then the option is set to boolean `true`.
 * Environment Variables:
-  Set any config by prefixing the name in an environment variable with `npm_config_`.
-  For example, `export npm_config_key=val`.
+  Set any config by prefixing the name in an environment variable with `NPM_CONFIG_`.
+  For example, `export NPM_CONFIG_KEY=val`.
 * User Configs:
   The file at `$HOME/.npmrc` is an ini-formatted list of configs.
   If present, it is parsed.

--- a/docs/lib/content/using-npm/scripts.md
+++ b/docs/lib/content/using-npm/scripts.md
@@ -333,7 +333,7 @@ They just have to be some kind of executable file.
 Read through [`package.json`](/configuring-npm/package-json) to see all the things that you can specify and enable by simply describing your package appropriately.
 In general, this will lead to a more robust and consistent state.
 * Inspect the env to determine where to put things.
-For instance, if the `npm_config_binroot` environment variable is set to `/home/user/bin`, then don't try to install executables into `/usr/local/bin`.
+For instance, if the `NPM_CONFIG_BINROOT` environment variable is set to `/home/user/bin`, then don't try to install executables into `/usr/local/bin`.
 The user probably set it up that way for a reason.
 * Don't prefix your script commands with "sudo".  If root permissions are required for some reason, then it'll fail with that error, and the user will sudo the npm command in question.
 * Don't use `install`.


### PR DESCRIPTION
## Description

Standardizes all environment variable references in documentation to use uppercase naming convention (NPM_CONFIG_*) instead of lowercase (npm_config_*).

## Changes

- Changed npm_config_binroot to NPM_CONFIG_BINROOT in scripts.md
- Changed npm_config_prefix to NPM_CONFIG_PREFIX in npm.md (2 instances)
- Changed npm_config_ to NPM_CONFIG_ in npm.md
- Changed npm_config_key to NPM_CONFIG_KEY in npm.md

## Fixes

Closes #4891

## Rationale

The documentation had inconsistent casing for environment variables - some references used uppercase (NPM_CONFIG_USERCONFIG) while others used lowercase (npm_config_prefix). Following the standard convention, environment variables should always be referenced in uppercase. While npm internally converts both to lowercase, using uppercase in documentation follows the de-facto standard and avoids confusion.

## Type of Change

Documentation update