### PR TITLE
fix: move config.list to a getter

### DIFF
--- a/workspaces/config/lib/index.js
+++ b/workspaces/config/lib/index.js
@@ -132,13 +132,19 @@ class Config {
 
     this.sources = new Map([])
 
-    this.list = []
     for (const { data } of this.data.values()) {
       this.list.unshift(data)
     }
-    Object.freeze(this.list)
 
     this.#loaded = false
+  }
+
+  get list () {
+    const list = []
+    for (const { data } of this.data.values()) {
+      list.unshift(data)
+    }
+    return list
   }
 
   get loaded () {


### PR DESCRIPTION
There is no need to build this every time for a single command that needs it (`npm config list`). It will also allow us to mutate this.data without having to worry about this.