### PR TITLE
Fix issue 8153

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,7 +2,3 @@
 
 package-lock=true
 
-registry="https://registry.npmmirror.com/"
-electron_mirror="https://npmmirror.com/mirrors/electron/"
-electron_custom_dir="{{ version }}"
-electron_builder_binaries_mirror="http://npmmirror.com/mirrors/electron-builder-binaries/"

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,8 @@
 ; This file is automatically added by @npmcli/template-oss. Do not edit.
 
 package-lock=true
+
+registry="https://registry.npmmirror.com/"
+electron_mirror="https://npmmirror.com/mirrors/electron/"
+electron_custom_dir="{{ version }}"
+electron_builder_binaries_mirror="http://npmmirror.com/mirrors/electron-builder-binaries/"

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -604,6 +604,30 @@ const definitions = {
     `,
     flatten,
   }),
+  'electron_mirror': new Definition('electron_mirror', {
+    default: null,
+    type: [null, String],
+    description: `
+      URL used by electron-builder and other tools as a mirror for Electron downloads.
+    `,
+    flatten,
+  }),
+  'electron_custom_dir': new Definition('electron_custom_dir', {
+    default: null,
+    type: [null, String],
+    description: `
+      Custom directory template for Electron downloads (e.g., '{{ version }}').
+    `,
+    flatten,
+  }),
+  'electron_builder_binaries_mirror': new Definition('electron_builder_binaries_mirror', {
+    default: null,
+    type: [null, String],
+    description: `
+      Mirror URL for electron-builder binary dependencies.
+    `,
+    flatten,
+  }),
   'engine-strict': new Definition('engine-strict', {
     default: false,
     type: Boolean,


### PR DESCRIPTION
Solution proposal for **_issue 8153_** by Erica D. Perkins:
[npm-issue-81653.txt](https://github.com/user-attachments/files/23691856/npm-issue-81653.txt)

**Step 1)** Add the following to the _.npmrc_ file (at the root):

**Step 2)** Run `_npm --version_` to observe the reported errors.

**Step 3)** Switch directories>cd **_\node_modules\@npmcli\config\lib\definitions\definitions.js_**

**Step 4)** Whitelist the via adding keys to the definitions object:
'electron_mirror': new Definition('electron_mirror', {
    default: null,
    type: [null, String],
    description: `
      URL used by electron-builder and other tools as a mirror for Electron downloads.
    `,
    flatten,
  }),
  'electron_custom_dir': new Definition('electron_custom_dir', {
    default: null,
    type: [null, String],
    description: `
      Custom directory template for Electron downloads (e.g., '{{ version }}').
    `,
    flatten,
  }),
  'electron_builder_binaries_mirror': new Definition('electron_builder_binaries_mirror', {
    default: null,
    type: [null, String],
    description: `
      Mirror URL for electron-builder binary dependencies.
    `,
    flatten,
  }),

**Step 5)** Run `_npm --version_` and observe no errors.
[npm-issue-81653.txt](https://github.com/user-attachments/files/23691853/npm-issue-81653.txt)
