### PR TITLE
fix(adduser): improve email prompt

### DIFF
--- a/lib/utils/auth.js
+++ b/lib/utils/auth.js
@@ -51,7 +51,7 @@ const adduser = async (npm, { creds, ...opts }) => {
   if (!res) {
     const username = await read.username('Username:', creds.username)
     const password = await read.password('Password:', creds.password)
-    const email = await read.email('Email: (this IS public) ', creds.email)
+    const email = await read.email('Email (this will be public):', creds.email)
     // npm registry quirk: If you "add" an existing user with their current
     // password, it's effectively a login, and if that account has otp you'll
     // be prompted for it.

--- a/lib/utils/read-user-info.js
+++ b/lib/utils/read-user-info.js
@@ -9,7 +9,7 @@ https://docs.npmjs.com/getting-started/using-two-factor-authentication
 Enter OTP: `
 const passwordPrompt = 'npm password: '
 const usernamePrompt = 'npm username: '
-const emailPrompt = 'email (this IS public): '
+const emailPrompt = 'email (this will be public): '
 
 const read = (...args) => input.read(() => _read(...args))
 


### PR DESCRIPTION
This makes the email prompt in `npm adduser` a bit more friendly (no need to shout) and places the colon at the end like in the other prompts 😃 

Works well with the #8322 spinner fix. 
