### PR TITLE
docs: document gypfile field in package.json

### DIFF
--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -511,6 +511,20 @@ The key is the lifecycle event, and the value is the command to run at that poin
 
 See [`scripts`](/using-npm/scripts) to find out more about writing package scripts.
 
+### gypfile
+
+If you have a binding.gyp file in the root of your package and you have not defined your own `install` or `preinstall` scripts, npm will default to building your module using node-gyp.
+
+To prevent npm from automatically building your module with node-gyp, set `gypfile` to `false`:
+
+```json
+{
+  "gypfile": false
+}
+```
+
+This is useful for packages that include native addons but want to handle the build process differently, or packages that have a binding.gyp file but should not be built as a native addon.
+
 ### config
 
 A "config" object can be used to set configuration parameters used in package scripts that persist across upgrades.


### PR DESCRIPTION
## Description

This PR adds documentation for the \gypfile\ field in package.json, which was previously undocumented.

## Changes

- Added a new section documenting the \gypfile\ field
- Explained that npm automatically builds packages with binding.gyp using node-gyp
- Documented that setting \gypfile: false\ prevents automatic building
- Included example showing how to disable the automatic build

## Fixes

Closes #6898

## Context

The \gypfile\ field is currently respected by \
pm rebuild\ (as documented in the rebuild command docs), but the field itself was not documented in the package.json specification. This change ensures users understand how to control node-gyp build behavior for native addons.

## Type of Change

- [x] Documentation update