### PR TITLE
docs: document forceAuth option for libnpmpublish

### DIFF
--- a/workspaces/libnpmpublish/README.md
+++ b/workspaces/libnpmpublish/README.md
@@ -51,6 +51,11 @@ A couple of options of note:
   token for the registry. For other ways to pass in auth details, see the
   n-r-f docs.
 
+* `opts.forceAuth` - an object containing authentication credentials. Use this
+  when publishing with automation tokens or when `opts.token` alone doesn't work.
+  Example: `forceAuth: { token: 'your-token-here' }`. This is required in some
+  cases where the registry URL is not automatically detected.
+
 * `opts.provenance` - when running in a supported CI environment, will trigger
   the generation of a signed provenance statement to be published alongside
   the package. Mutually exclusive with the `provenanceFile` option.
@@ -98,6 +103,18 @@ await libpub.publish(manifest, tarData, {
   npmVersion: 'my-pub-script@1.0.2',
   token: 'my-auth-token-here'
 }, opts)
+// Package has been published to the npm registry.
+```
+
+**Note:** When using automation tokens or if the `token` option doesn't work, use `forceAuth` instead:
+
+```js
+await libpub.publish(manifest, tarData, {
+  npmVersion: 'my-pub-script@1.0.2',
+  forceAuth: {
+    token: 'my-automation-token-here'
+  }
+})
 // Package has been published to the npm registry.
 ```
 


### PR DESCRIPTION
## Description

This PR documents the \orceAuth\ option for libnpmpublish, which is required when using automation tokens or when the \	oken\ option alone doesn't work.

## Changes

- Added documentation for the \opts.forceAuth\ option in the options section
- Added a note and example showing how to use \orceAuth\ with automation tokens
- Clarified when to use \orceAuth\ instead of just \	oken\

## Fixes

Closes #7091

## Context

Users were experiencing 404 and 429 errors when trying to publish packages using automation tokens with libnpmpublish. The solution is to use \orceAuth: { token }\ instead of just \	oken\, but this wasn't documented. This caused significant confusion as mentioned in issue #4250 and #7091.

The \orceAuth\ option is required in cases where the registry URL is not automatically detected from the token, which commonly happens with automation tokens.

## Type of Change

- [x] Documentation update