### PR TITLE
docs: clarify version field can be omitted in package-lock

### DIFF
--- a/docs/lib/content/configuring-npm/package-lock-json.md
+++ b/docs/lib/content/configuring-npm/package-lock-json.md
@@ -130,6 +130,7 @@ npm v7 ignores this section entirely if a `packages` section is present, but doe
 Dependency objects have the following fields:
 
 * version: a specifier that varies depending on the nature of the package, and is usable in fetching a new copy of it.
+  Note that for peer dependencies that are not installed, or optional dependencies that are not installed, this field may be omitted.
 
     * bundled dependencies: Regardless of source, this is a version number that is purely for informational purposes.
     * registry sources: This is a version number.


### PR DESCRIPTION
## Description

This PR clarifies that the version field in package-lock.json dependency objects can be omitted in certain cases, specifically for peer dependencies and optional dependencies that are not installed.

## Changes

- Added a note to the version field documentation explaining when it may be omitted
- Clarifies that peer dependencies and optional dependencies that are not installed may not have a version field

## Fixes

Closes #4796

## Context

The current documentation states that dependency objects have a version field but doesn't mention that this field can be absent in some cases. Users encountering package-lock.json files with entries without a version field were confused because the documentation implied the field is always present. This change makes it clear that the version field may be omitted for peer/optional dependencies that are not installed.

## Type of Change

- [x] Documentation update