### PR TITLE
docs: add examples for command line flags including --prefix

### DIFF
--- a/docs/lib/content/using-npm/config.md
+++ b/docs/lib/content/using-npm/config.md
@@ -20,6 +20,14 @@ Using `--flag` without specifying any value will set the value to `true`.
 Example: `--flag1 --flag2` will set both configuration parameters to `true`, while `--flag1 --flag2 bar` will set `flag1` to `true`, and `flag2` to `bar`.
 Finally, `--flag1 --flag2 -- bar` will set both configuration parameters to `true`, and the `bar` is taken as a command argument.
 
+**Common examples:**
+
+* `npm install --prefix /path/to/dir` - Runs npm commands in a different directory without changing the current working directory
+* `npm install --global` - Installs packages globally (shorthand: `-g`)
+* `npm install --save-dev` - Saves to devDependencies (shorthand: `-D`)
+
+Any configuration option documented in the [Config Settings](#config-settings) section below can be set via command line flags using `--option-name value` syntax.
+
 #### Environment Variables
 
 Any environment variables that start with `npm_config_` will be interpreted as a configuration parameter.


### PR DESCRIPTION
## Description

This PR adds concrete examples for command line flags, specifically documenting the \--prefix\ flag that many users were unable to find in the documentation.

## Changes

- Added a 'Common examples' section under Command Line Flags
- Documented \--prefix\ flag with a clear use case example
- Included other common flag examples (\--global\, \--save-dev\)
- Added a note explicitly stating that any config option can be used as a command line flag

## Fixes

Closes #8197

## Context

Users were unable to find documentation for the \--prefix\ flag, which is a commonly used option for running npm commands in different directories. While the general mechanism (any config option can be a flag) was explained, there were no concrete examples making it hard to discover. The \--prefix\ flag is particularly useful in monorepos and CI/CD scripts where you want to run npm commands in subdirectories without changing the current working directory.

## Type of Change

- [x] Documentation update