### PR TITLE
docs(install): clarify prerelease version range behavior

### DIFF
--- a/docs/lib/content/commands/npm-install.md
+++ b/docs/lib/content/commands/npm-install.md
@@ -198,6 +198,15 @@ Even if you never publish your package, you can still get a lot of benefits of u
     npm install @myorg/privatepackage@"16 - 17"
     ```
 
+    **Prerelease versions:** By default, version ranges only match stable versions. To include prerelease versions, they must be explicitly specified in the range. Prerelease versions are tied to a specific version triple (major.minor.patch). For example, `^1.2.3-beta.1` will only match prereleases for `1.2.x`, not `1.3.x`. To match all prereleases for a major version, use a range like `^1.0.0-0`, which will include all `1.x.x` prereleases.
+
+    Example:
+
+    ```bash
+    npm install package@^1.2.3-beta.1  # Matches 1.2.3-beta.1, 1.2.3-beta.2, 1.2.4-beta.1, etc.
+    npm install package@^1.0.0-0       # Matches all 1.x.x prereleases and stable versions
+    ```
+
 * `npm install <git remote url>`:
 
     Installs the package from the hosted git provider, cloning it with `git`.


### PR DESCRIPTION
## Description

This PR adds documentation clarifying how prerelease versions work with semver ranges in npm install commands.

## Changes

- Added a 'Prerelease versions' section under version range documentation
- Explained that prereleases must be explicitly specified in ranges
- Clarified that prerelease versions are tied to specific version triples
- Provided examples showing how to match prereleases for patch vs major versions

## Fixes

Closes #7851

## Context

Users were confused about why version ranges like \^1.2.3-beta.1\ don't match \1.3.0-beta.1\ and why \
pm outdated\ doesn't suggest updating from one prerelease to another with a higher patch version. This is by design in semver - prereleases are scoped to a specific major.minor.patch triple. The documentation previously didn't explain this behavior, leading to confusion about whether it was a bug.

The added documentation clarifies:
1. Prerelease versions must be explicitly included in ranges (they're not matched by default)
2. A range like \^1.2.3-beta.1\ only matches prereleases for \1.2.x\ versions
3. To match all prereleases for a major version, use \^1.0.0-0\

## Type of Change

- [x] Documentation update