### PR TITLE
docs(npx): clarify that arguments are passed to executed command

### DIFF
--- a/docs/lib/content/commands/npx.md
+++ b/docs/lib/content/commands/npx.md
@@ -12,6 +12,8 @@ description: Run a command from a local or remote npm package
 
 This command allows you to run an arbitrary command from an npm package (either one installed locally, or fetched remotely), in a similar context as running it via `npm run`.
 
+Run this command to execute a package's binary. Any options and arguments after the package name are passed directly to the executed command, not to npx itself. For example, `npx create-react-app my-app --template typescript` will pass `my-app` and `--template typescript` to the `create-react-app` command. To see what options a specific package accepts, consult that package's documentation (e.g., at npmjs.com or in its repository).
+
 Whatever packages are specified by the `--package` option will be provided in the `PATH` of the executed command, along with any locally installed package executables.
 The `--package` option may be specified multiple times, to execute the supplied command in an environment where all specified packages are available.
 


### PR DESCRIPTION
## Description

This PR adds clarification to the npx documentation about how arguments and options are handled when executing commands.

## Changes

- Added a clear explanation that arguments after the package name are passed directly to the executed command, not to npx
- Included a practical example (`npx create-react-app my-app --template typescript`)
- Directed users to consult package-specific documentation for available options

## Fixes

Closes #7186

## Context

Users were confused about where options like `--use-npm` and `--example` come from when running commands like `npx create-next-app`. As reported in issue #7186, the documentation didn't clearly explain that these options belong to the executed package (e.g., `create-next-app`), not to npx itself.

This clarification helps users understand:
1. Arguments after the package name go to the executed command
2. npx options must come before the package name
3. Package-specific options should be looked up in that package's documentation

While the existing documentation did cover this concept in the "npx vs npm exec" section with technical details, it wasn't immediately clear for new users in the Description section where they start reading.

## Type of Change

- [x] Documentation update
