### PR TITLE
docs(npm-view): clarify object property access syntax

### DIFF
--- a/docs/lib/content/commands/npm-view.md
+++ b/docs/lib/content/commands/npm-view.md
@@ -70,6 +70,22 @@ If the field value you are querying for is a property of an object, you should r
 npm view express time'[4.8.0]'
 ```
 
+Note: When accessing object properties that contain special characters or numeric keys, you need to use quotes around the key name.
+For example, to get the publish time of a specific version:
+
+```bash
+npm view express "time[4.17.1]"
+```
+
+Without quotes, the shell may interpret the square brackets as glob patterns, causing the command to fail.
+You can also access the time field for a specific version by specifying the version in the package descriptor:
+
+```bash
+npm view express@4.17.1 time
+```
+
+This will return all version-time pairs, but the context will be for that specific version.
+
 Multiple fields may be specified, and will be printed one after another.
 For example, to get all the contributor names and email addresses, you can do this:
 


### PR DESCRIPTION
## Description

This PR improves the documentation for `npm view` to clarify how to access object properties, particularly when dealing with special characters or numeric keys.

## Changes

- Added a note explaining that quotes are needed around object property keys with special characters
- Provided clear examples for accessing version-specific time data: `npm view express "time[4.17.1]"`
- Explained alternative syntax using version specifier: `npm view express@4.17.1 time`
- Clarified why quotes are necessary (shell glob pattern interpretation)

## Context

Users were confused about the correct syntax for accessing object properties in `npm view` output, especially for the `time` field which maps version numbers to publish dates. The existing example used single quotes in an unclear way (`time'[4.8.0]'`), and the documentation didn't explain the quoting requirements or provide working examples for common use cases.

Closes #5526
