### PR TITLE
docs(package-json): add examples for replacing dependencies with forks

### DIFF
--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -926,6 +926,53 @@ To make this limitation easier to deal with, overrides may also be defined as a 
 }
 ```
 
+#### Replacing a dependency with a fork
+
+You can replace a package with a different package or fork using several methods:
+
+**Using the `npm:` prefix to replace with a different package name:**
+
+```json
+{
+  "overrides": {
+    "package-name": "npm:@scope/forked-package@1.0.0"
+  }
+}
+```
+
+**Using a GitHub repository (supports branches, tags, or commit hashes):**
+
+```json
+{
+  "overrides": {
+    "package-name": "github:username/repo#branch-name"
+  }
+}
+```
+
+**Using a local file path:**
+
+```json
+{
+  "overrides": {
+    "package-name": "file:../local-fork"
+  }
+}
+```
+
+These replacement methods work for both top-level overrides and nested overrides.
+For example, to replace a transitive dependency with a fork:
+
+```json
+{
+  "overrides": {
+    "parent-package": {
+      "vulnerable-dep": "github:username/patched-fork#v2.0.1"
+    }
+  }
+}
+```
+
 ### engines
 
 You can specify the version of node that your stuff works on:


### PR DESCRIPTION
## Description

This PR adds documentation for how to replace a dependency with a fork using the `overrides` field in `package.json`. While the existing documentation mentioned this capability, it didn't provide any examples of how to actually do it.

## Changes

- Added a new subsection "Replacing a dependency with a fork" under the `overrides` section
- Documented three methods for replacing dependencies:
  - Using `npm:` prefix to replace with a different package name
  - Using GitHub repositories (with branches, tags, or commits)
  - Using local file paths
- Included practical examples for each method
- Added example showing how to replace a transitive dependency with a fork

## Context

Users were confused by the documentation stating you can replace "an existing dependency with a fork" but not explaining how. The issue thread shows multiple users asking for clarification and sharing their own discovered solutions. This PR consolidates those working examples into the official documentation.

Closes #4909
