### PR TITLE
docs(npm-install): document engines field priority

### DIFF
--- a/docs/lib/content/commands/npm-install.md
+++ b/docs/lib/content/commands/npm-install.md
@@ -95,6 +95,8 @@ Even if you never publish your package, you can still get a lot of benefits of u
 
     In most cases, this will install the version of the modules tagged as `latest` on the npm registry.
 
+    **Note:** When installing by name without specifying a version or tag, npm prioritizes versions that match the current Node.js version based on the package's `engines` field. If the `latest` tag points to a version incompatible with your current Node.js version, npm will install the newest compatible version instead. To install a specific version regardless of `engines` compatibility, explicitly specify the version or tag: `npm install <name>@latest`.
+
     Example:
 
     ```bash


### PR DESCRIPTION
## Description

This PR documents npm's behavior of prioritizing package versions based on the `engines` field when installing packages by name without a specific version.

## Changes

- Added a note to `npm install [<@scope>/]<name>` section explaining that npm prioritizes versions compatible with the current Node.js version
- Clarified that if `latest` tag points to an incompatible version, npm installs the newest compatible version instead
- Documented the workaround: explicitly specify `@latest` to install a specific version regardless of `engines` compatibility

## Context

This behavior was introduced in npm 10.8.2 but was not documented, causing confusion for users who expected `npm install <package>` to always install the version tagged as `latest`. Users reported unexpected behavior where older versions were installed when the `latest` version had `engines` requirements that didn't match their Node.js version.

Closes #7704
