### PR TITLE
docs(package-json): clarify repository field normalization

### DIFF
--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -502,6 +502,19 @@ For GitHub, GitHub gist, Bitbucket, or GitLab repositories you can use the same 
 }
 ```
 
+**Note on normalization:** When you publish a package, npm normalizes the `repository` field to the full object format with a `url` property. If you use a shorthand format (like `"npm/example"`), you'll see a warning during `npm publish` indicating that the field was auto-corrected. While the shorthand format currently works, it's recommended to use the full object format in your `package.json` to avoid warnings and ensure future compatibility:
+
+```json
+{
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/npm/example.git"
+  }
+}
+```
+
+You can run `npm pkg fix` to automatically convert shorthand formats to the normalized object format.
+
 If the `package.json` for your package is not in the root directory (for example if it is part of a monorepo), you can specify the directory in which it lives:
 
 ```json


### PR DESCRIPTION
## Description

This PR documents npm's normalization behavior for the `repository` field in `package.json` during publishing.

## Changes

- Added a "Note on normalization" section explaining that npm converts shorthand repository formats to the full object format during `npm publish`
- Documented the warning message users see when publishing with shorthand formats
- Recommended using the full object format to avoid warnings
- Mentioned `npm pkg fix` as a tool to automatically convert to normalized format

## Context

Users were confused when `npm publish` showed warnings about auto-correcting the `repository` field, even though the documentation stated shorthand formats were allowed. The maintainer (@wraithgar) explained that npm has historically normalized this field during publishing, creating a discrepancy between local `package.json` and the published manifest. The warning is preparing users for future changes where this discrepancy may no longer be allowed.

Closes #7299
