### PR TITLE
docs(package-lock-json): clarify version field may be omitted

### DIFF
--- a/docs/lib/content/configuring-npm/package-lock-json.md
+++ b/docs/lib/content/configuring-npm/package-lock-json.md
@@ -149,6 +149,8 @@ Dependency objects have the following fields:
     * local link sources: This is the file URL of the link.
       (eg `file:libs/our-module`)
 
+    **Note:** The `version` field may be omitted for certain types of dependencies, such as optional peer dependencies that are not installed. In these cases, only metadata fields like `dev`, `optional`, and `peer` will be present.
+
 * integrity: A `sha512` or `sha1` [Standard Subresource Integrity](https://w3c.github.io/webappsec/specs/subresourceintegrity/) string for the artifact that was unpacked in this location.
   For git dependencies, this is the commit sha.
 


### PR DESCRIPTION
## Description

This PR clarifies that the `version` field in `package-lock.json` dependency objects may be omitted in certain cases.

## Changes

- Added a note explaining that the `version` field is not always present
- Specified that optional peer dependencies that are not installed may only have metadata fields (`dev`, `optional`, `peer`) without a `version` field
- Updated documentation to match actual package-lock.json behavior

## Context

Users discovered that some dependency objects in `package-lock.json` don't include a `version` field (e.g., optional peer dependencies), but the documentation stated that `version` is always present. This caused confusion when tools tried to parse these lockfiles. The example from the issue showed entries with only `"dev": true, "optional": true, "peer": true` fields.

Closes #4796
