### PR TITLE
docs(npm-install): clarify --tag does not override package.json

### DIFF
--- a/docs/lib/content/commands/npm-install.md
+++ b/docs/lib/content/commands/npm-install.md
@@ -315,6 +315,8 @@ npm install sax@">=0.1.0 <0.2.0" bench supervisor
 The `--tag` argument will apply to all of the specified install targets.
 If a tag with the given name exists, the tagged version is preferred over newer versions.
 
+**Note:** The `--tag` option only affects packages specified on the command line. It does not override version ranges specified in `package.json`. For example, if `package.json` specifies `"foo": "^1.0.0"` and you run `npm install --tag beta`, npm will still install a version matching `^1.0.0` even if the `beta` tag points to a different version. To install a tagged version, specify the package explicitly: `npm install foo@beta`.
+
 The `--dry-run` argument will report in the usual way what the install would have done without actually installing anything.
 
 The `--package-lock-only` argument will only update the `package-lock.json`, instead of checking `node_modules` and downloading dependencies.


### PR DESCRIPTION
## Description

This PR clarifies that the `--tag` option for `npm install` only applies to packages specified on the command line, and does not override version ranges in `package.json`.

## Changes

- Added a note explaining that `--tag` does not affect dependencies listed in `package.json`
- Explained that version ranges in `package.json` take precedence over the `--tag` flag
- Provided an example showing the correct way to install a tagged version: `npm install foo@beta`

## Context

Users were confused when `npm install --tag beta` didn't install beta-tagged versions of dependencies listed in `package.json`. The issue reporter discovered that when `package.json` specifies a version range like `"^0.3.0"`, the `--tag` flag is ignored and npm installs a version matching the range, even if the `beta` tag points to a different version (like `0.4.0-beta.1`). This was marked as needing better documentation/logging to make the behavior less surprising.

Closes #4685
