### PR TITLE
Added validation for min-age field to install and publish

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -1,4 +1,6 @@
 const { readdir } = require('node:fs/promises')
+const semver = require('semver')
+const { execSync } = require('child_process')
 const { resolve, join } = require('node:path')
 const { log } = require('proc-log')
 const runScript = require('@npmcli/run-script')
@@ -148,6 +150,16 @@ class Install extends ArboristWorkspaceCmd {
     }
     const arb = new Arborist(opts)
     await arb.reify(opts)
+    if (!isGlobalInstall) {
+      try {
+        const manifest = await pacote.manifest('.', { ...opts })
+        if (manifest['min-age']) {
+          await this.#validateMinAge(manifest, opts)
+        }
+      } catch (err) {
+        // ignore if no package.json
+      }
+    }
 
     if (!args.length && !isGlobalInstall && !ignoreScripts) {
       const scripts = [
@@ -170,6 +182,71 @@ class Install extends ArboristWorkspaceCmd {
       }
     }
     await reifyFinish(this.npm, arb)
+  }
+
+  async #validateMinAge (manifest, opts) {
+    log.warn('', `processing validateMinAge`)
+    const minAgeStr = manifest['min-age'] || '2 days'
+    const match = minAgeStr.match(/^(\d+)\s*days?$/i)
+    if (!match) {
+      throw new Error(`Invalid min-age format: ${minAgeStr}`)
+    }
+    const minAgeDays = parseInt(match[1], 10)
+    const minTime = Date.now() - minAgeDays * 24 * 60 * 60 * 1000
+    const checked = new Map()
+    const depTypes = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies']
+    for (const type of depTypes) {
+      log.warn('', `processing type ${type}`)
+      if (manifest[type]) {
+        log.warn('install', 'Deps for type', type, ':', JSON.stringify(manifest[type], null, 2))
+        await this.#checkDepsMinAge(manifest[type], minTime, checked, opts, minAgeDays, manifest, type)
+      }
+    }
+  }
+  async #checkDepsMinAge (deps, minTime, checked, opts, minAgeDays, manifest = null, type = null) {
+    for (const [name, range] of Object.entries(deps || {})) {
+      try {
+        let version
+        let mani
+        // log.warn('', \`Checking for \${name} \${version}\`)
+        const isExact = semver.valid(range) && !range.includes(' ')
+        if (isExact) {
+          version = range
+          mani = await pacote.manifest(`${name}@${version}`, { ...opts })
+        } else {
+          log.warn('', `Checking for ${name} ${range}`)
+          await new Promise(resolve => setTimeout(resolve, 10)); // 10 msec
+          const pack = await pacote.packument(name, { ...opts })
+          // log.warn('install', 'Deps for type', type, ':', JSON.stringify(pack, null, 2), ':', range)
+          const candidates = Object.keys(pack.versions).filter(v => semver.satisfies(v, range))
+          const timeOutput = execSync(`npm view ${name} time --json`, { encoding: 'utf8' })
+          const times = JSON.parse(timeOutput.trim())
+          const validCandidates = candidates.filter(v => {
+            const timeStr = times[v]
+            if (!timeStr) return false
+            const time = new Date(timeStr).getTime()
+            return time <= minTime
+          })
+          if (validCandidates.length > 0) {
+            version = semver.maxSatisfying(validCandidates, '*')
+          } else {
+            version = candidates.sort(semver.compare)[0]
+          }
+          log.warn('', `Results for ${name} ${version}`)
+          await new Promise(resolve => setTimeout(resolve, 10)); // 10 msec
+          mani = await pacote.manifest(`${name}@${version}`, { ...opts })
+        }
+        // recurse on sub-deps
+        const subDeps = { ...mani.dependencies, ...mani.devDependencies, ...mani.optionalDependencies, ...mani.peerDependencies }
+        await this.#checkDepsMinAge(subDeps, minTime, checked, opts, minAgeDays)
+      } catch (err) {
+        if (err.code === 'E404') {
+          // skip if not found
+          continue
+        }
+        throw err
+      }
+    }
   }
 }
 

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -1,4 +1,5 @@
 const { log, output } = require('proc-log')
+const { execSync } = require('child_process')
 const semver = require('semver')
 const pack = require('libnpmpack')
 const libpub = require('libnpmpublish').publish
@@ -113,6 +114,7 @@ class Publish extends BaseCommand {
 
     // The purpose of re-reading the manifest is in case it changed,
     // so that we send the latest and greatest thing to the registry
+    await this.#validateMinAge(manifest, opts)
     // note that publishConfig might have changed as well!
     manifest = await this.#getManifest(spec, opts, true)
     const force = this.npm.config.get('force')
@@ -279,6 +281,70 @@ class Publish extends BaseCommand {
     }
     return manifest
   }
+  async #validateMinAge (manifest, opts) {
+    const minAgeStr = manifest['min-age'] || '2 days'
+    const match = minAgeStr.match(/^(\d+)\s*days?$/i)
+    if (!match) {
+      throw new Error(`Invalid min-age format: ${minAgeStr}`)
+    }
+    const minAgeDays = parseInt(match[1], 10)
+    const minTime = Date.now() - minAgeDays * 24 * 60 * 60 * 1000
+    const checked = new Map()
+    const depTypes = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies']
+    for (const type of depTypes) {
+      log.warn('', `processing type ${type}`)
+      if (manifest[type]) {
+        log.warn('publish', 'Deps for type', type, ':', JSON.stringify(manifest[type], null, 2))
+        await this.#checkDepsMinAge(manifest[type], minTime, checked, opts, minAgeDays, manifest, type)
+      }
+    }
+  }
+  async #checkDepsMinAge (deps, minTime, checked, opts, minAgeDays, manifest = null, type = null) {
+    for (const [name, range] of Object.entries(deps || {})) {
+      try {
+        let version
+        let mani
+        // log.warn('', `Checking for ${name} ${version}`)
+        const isExact = semver.valid(range) && !range.includes(' ')
+        if (isExact) {
+          version = range
+          mani = await pacote.manifest(`${name}@${version}`, { ...opts })
+        } else {
+          log.warn('', `Checking for ${name} ${range}`)
+          await new Promise(resolve => setTimeout(resolve, 10)); // 10 msec
+          const pack = await pacote.packument(name, { ...opts })
+          // log.warn('publish', 'Deps for type', type, ':', JSON.stringify(pack, null, 2), ':', range)
+          const candidates = Object.keys(pack.versions).filter(v => semver.satisfies(v, range))
+          const timeOutput = execSync(`npm view ${name} time --json`, { encoding: 'utf8' })
+          const times = JSON.parse(timeOutput.trim())
+          const validCandidates = candidates.filter(v => {
+            const timeStr = times[v]
+            if (!timeStr) return false
+            const time = new Date(timeStr).getTime()
+            return time <= minTime
+          })
+          if (validCandidates.length > 0) {
+            version = semver.maxSatisfying(validCandidates, '*')
+          } else {
+            version = candidates.sort(semver.compare)[0]
+          }
+          log.warn('', `Results for ${name} ${version}`)
+          await new Promise(resolve => setTimeout(resolve, 10)); // 10 msec
+          mani = await pacote.manifest(`${name}@${version}`, { ...opts })
+        }
+        // recurse on sub-deps
+        const subDeps = { ...mani.dependencies, ...mani.devDependencies, ...mani.optionalDependencies, ...mani.peerDependencies }
+        await this.#checkDepsMinAge(subDeps, minTime, checked, opts, minAgeDays)
+      } catch (err) {
+        if (err.code === 'E404') {
+          // skip if not found
+          continue
+        }
+        throw err
+      }
+    }
+  }
+
 }
 
 module.exports = Publish


### PR DESCRIPTION
<!-- What / Why -->
Added validation for `"min-age"` field to install and publish

<!-- Describe the request in detail. What it does and why it's being changed. -->
In most `package.json` files, dependencies specify minimum versions like `"lodash": "^4.17.0"`. This setting automatically installs the latest compatible version, including packages published just hours ago. Security tools need time to analyze new packages. A package older than 30 days has typically been well reviewed; a package published midnight has not.

Adding a `"min-age"` field to package.json blocks packages younger than a set threshold, say, 30 days, from installation. This gives the security processes time to work, it especially mitigates nightly attacks after a package maintainer's account take over.

The `"min-age"` field accepts values like "n days" (for example, `"7 days"`), and it has a default value of `"2 days"`, if the field is missing in the package.json

An example of a package.json with "min-age" field:
```
{
 "name": "test-package",
 "version": "1.0.0",
 "min-age": "7 days",
 "dependencies": {
   "lodash": "^4.17.0"
 }
}
```

The validation has been added to install and publish commands. For other applicable commands, such as update, it will be added soon.

https://www.linkedin.com/pulse/npms-zero-day-blind-spot-why-package-age-real-fix-reza-b5ale/

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
