### PR TITLE
docs: add loglevel to install and update command documentation

### DIFF
--- a/lib/commands/ci.js
+++ b/lib/commands/ci.js
@@ -25,6 +25,7 @@ class CI extends ArboristWorkspaceCmd {
     'bin-links',
     'fund',
     'dry-run',
+    'loglevel',
     ...super.params,
   ]
 

--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -36,6 +36,7 @@ class Install extends ArboristWorkspaceCmd {
     'cpu',
     'os',
     'libc',
+    'loglevel',
     ...super.params,
   ]
 

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -24,6 +24,7 @@ class Update extends ArboristWorkspaceCmd {
     'bin-links',
     'fund',
     'dry-run',
+    'loglevel',
     ...super.params,
   ]
 


### PR DESCRIPTION
## Description

This PR adds the loglevel configuration option to the documentation for 
pm install and 
pm update commands.

## Changes

- Added loglevel to the params array in lib/commands/install.js
- Added loglevel to the params array in lib/commands/update.js

This makes the loglevel option visible in the generated documentation for both commands, allowing users to easily discover that they can use --loglevel=verbose or --loglevel=silly to see more detailed output during package installation and updates.

## Fixes

Closes #4690

## Context

As discussed in #4690, users often don't realize that --loglevel can be used with 
pm install and 
pm update to get more verbose output. While loglevel is a global option available for all commands, it's particularly useful for these two frequently-used commands where users want to see detailed progress information.

The maintainer @lukekarrys suggested this could be added to make it more discoverable, even though it's a global option, since these are very commonly used commands where verbose output is frequently desired.