### PR TITLE
docs(version): add note about git version requirements

### DIFF
--- a/docs/lib/content/commands/npm-version.md
+++ b/docs/lib/content/commands/npm-version.md
@@ -25,6 +25,8 @@ If run in a git repo, it will also create a version commit and tag.
 This behavior is controlled by `git-tag-version` (see below), and can be disabled on the command line by running `npm --no-git-tag-version version`.
 It will fail if the working directory is not clean, unless the `-f` or `--force` flag is set.
 
+**Note:** Git integration requires a reasonably recent version of git (2.0.0 or later is recommended). If you encounter issues with git commands, ensure your git installation is up to date.
+
 If supplied with `-m` or [`--message` config](/using-npm/config#message) option, npm will use it as a commit message when creating a version commit.
 If the `message` config contains `%s` then that will be replaced with the resulting version number.
 For example:


### PR DESCRIPTION
## Description

This PR adds documentation about git version requirements for the npm version command.

## Changes

- Added a note to the npm-version.md documentation stating that git 2.0.0 or later is recommended
- Advises users to check their git installation if they encounter issues

## Fixes

Closes #2871

## Context

Users with older versions of git (such as git 1.9.1) encountered cryptic errors when using npm version because npm uses git command options that were not available in older versions (specifically --porcelain=v1).

The maintainer noted that the resolution should be to provide more clear docs/messaging for unsupported versions of dependencies.

While npm implicitly requires a modern version of git for its version command to work properly, this was not documented anywhere. This PR adds a simple note to help users understand this requirement and troubleshoot issues more easily.