### PR TITLE
docs: update npm_package_* environment variables documentation

### DIFF
--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -337,32 +337,9 @@ If `main` is not set, it defaults to `index.js` in the package's root folder.
 
 ### type
 
-The `type` field defines the module format that Node.js should use for `.js` files in your package. It can have two values:
+The `type` field is used by Node.js to determine whether `.js` files should be treated as ES modules or CommonJS modules. This field is not used by npm directly.
 
-* `"module"` - Tells Node.js to treat `.js` files as ES modules (ESM), allowing you to use `import` and `export` statements.
-* `"commonjs"` - Tells Node.js to treat `.js` files as CommonJS modules (the default), using `require()` and `module.exports`.
-
-If the `type` field is not set, Node.js defaults to `"commonjs"`.
-
-Example for an ES module package:
-
-```json
-{
-  "type": "module"
-}
-```
-
-Example for a CommonJS package (explicit, though this is the default):
-
-```json
-{
-  "type": "commonjs"
-}
-```
-
-**Note:** Regardless of the `type` field value, `.mjs` files are always treated as ES modules, and `.cjs` files are always treated as CommonJS modules.
-
-For more information, see the [Node.js documentation on package.json type field](https://nodejs.org/api/packages.html#type).
+For detailed information about the `type` field, its possible values (`"module"` or `"commonjs"`), and how it affects module resolution, see the [Node.js documentation on the type field](https://nodejs.org/api/packages.html#type).
 
 ### browser
 

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -335,6 +335,35 @@ For most modules, it makes the most sense to have a main script and often not mu
 
 If `main` is not set, it defaults to `index.js` in the package's root folder.
 
+### type
+
+The `type` field defines the module format that Node.js should use for `.js` files in your package. It can have two values:
+
+* `"module"` - Tells Node.js to treat `.js` files as ES modules (ESM), allowing you to use `import` and `export` statements.
+* `"commonjs"` - Tells Node.js to treat `.js` files as CommonJS modules (the default), using `require()` and `module.exports`.
+
+If the `type` field is not set, Node.js defaults to `"commonjs"`.
+
+Example for an ES module package:
+
+```json
+{
+  "type": "module"
+}
+```
+
+Example for a CommonJS package (explicit, though this is the default):
+
+```json
+{
+  "type": "commonjs"
+}
+```
+
+**Note:** Regardless of the `type` field value, `.mjs` files are always treated as ES modules, and `.cjs` files are always treated as CommonJS modules.
+
+For more information, see the [Node.js documentation on package.json type field](https://nodejs.org/api/packages.html#type).
+
 ### browser
 
 If your module is meant to be used client-side the browser field should be used instead of the main field.

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -337,9 +337,9 @@ If `main` is not set, it defaults to `index.js` in the package's root folder.
 
 ### type
 
-The `type` field is used by Node.js to determine whether `.js` files should be treated as ES modules or CommonJS modules. This field is not used by npm directly.
+The `type` field defines how Node.js should interpret `.js` files in your package. This field is not used by npm.
 
-For detailed information about the `type` field, its possible values (`"module"` or `"commonjs"`), and how it affects module resolution, see the [Node.js documentation on the type field](https://nodejs.org/api/packages.html#type).
+See the [Node.js documentation on the type field](https://nodejs.org/api/packages.html#type) for more information.
 
 ### browser
 

--- a/docs/lib/content/using-npm/scripts.md
+++ b/docs/lib/content/using-npm/scripts.md
@@ -268,8 +268,19 @@ then you could run `npm start` to execute the `bar` script, which is exported in
 
 #### package.json vars
 
-The package.json fields are tacked onto the `npm_package_` prefix.
-So, for instance, if you had `{"name":"foo", "version":"1.2.5"}` in your package.json file, then your package scripts would have the `npm_package_name` environment variable set to "foo", and the `npm_package_version` set to "1.2.5".  You can access these variables in your code with `process.env.npm_package_name` and `process.env.npm_package_version`, and so on for other fields.
+npm sets the following environment variables from the package.json:
+
+* `npm_package_name` - The package name
+* `npm_package_version` - The package version  
+* `npm_package_main` - The package main field
+* `npm_package_bin_*` - Each executable defined in the bin field
+* `npm_package_engines_*` - Each engine defined in the engines field
+* `npm_package_config_*` - Each config value defined in the config field
+* `npm_package_json` - The full path to the package.json file
+
+For example, if you had `{"name":"foo", "version":"1.2.5"}` in your package.json file, then your package scripts would have the `npm_package_name` environment variable set to "foo", and the `npm_package_version` set to "1.2.5". You can access these variables in your code with `process.env.npm_package_name` and `process.env.npm_package_version`.
+
+**Note:** In npm 7 and later, most package.json fields are no longer provided as environment variables. Scripts that need access to other package.json fields should read the package.json file directly. The `npm_package_json` environment variable provides the path to the file for this purpose.
 
 See [`package.json`](/configuring-npm/package-json) for more on package configs.
 


### PR DESCRIPTION
## Description

This PR updates the documentation for package.json environment variables to reflect the changes made in npm 7.

## Changes

- Document which 
pm_package_* variables are actually available in npm 7+
- Add note that most package.json fields are no longer provided as environment variables
- Reference 
pm_package_json variable for reading package.json directly
- Based on [RFC 21](https://github.com/npm/rfcs/blob/latest/implemented/0021-reduce-lifecycle-script-environment.md)

## Fixes

Closes #2452

## Context

In npm 7, RFC 21 reduced the environment variables provided to lifecycle scripts. The documentation still claimed that all package.json fields were available as 
pm_package_* variables, which has been incorrect since npm 7 was released in 2020.

The documentation now correctly lists only the variables that are actually provided:
- 
pm_package_name
- 
pm_package_version
- 
pm_package_main
- 
pm_package_bin_*
- 
pm_package_engines_*
- 
pm_package_config_*
- 
pm_package_json (new in npm 7 - path to package.json)

Scripts that need access to other fields should read package.json directly using the path provided in 
pm_package_json.