### PR TITLE
fix: add --before param to command ci help output

### DIFF
--- a/lib/commands/ci.js
+++ b/lib/commands/ci.js
@@ -22,6 +22,7 @@ class CI extends ArboristWorkspaceCmd {
     'foreground-scripts',
     'ignore-scripts',
     'audit',
+    'before',
     'bin-links',
     'fund',
     'dry-run',

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -2909,7 +2909,7 @@ Options:
 [--global-style] [--omit <dev|optional|peer> [--omit <dev|optional|peer> ...]]
 [--include <prod|dev|optional|peer> [--include <prod|dev|optional|peer> ...]]
 [--strict-peer-deps] [--foreground-scripts] [--ignore-scripts] [--no-audit]
-[--no-bin-links] [--no-fund] [--dry-run]
+[--before <date>] [--no-bin-links] [--no-fund] [--dry-run]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [--workspaces] [--include-workspace-root] [--install-links]
 
@@ -2932,6 +2932,7 @@ aliases: clean-install, ic, install-clean, isntall-clean
 #### \`foreground-scripts\`
 #### \`ignore-scripts\`
 #### \`audit\`
+#### \`before\`
 #### \`bin-links\`
 #### \`fund\`
 #### \`dry-run\`
@@ -3506,7 +3507,7 @@ Options:
 [--global-style] [--omit <dev|optional|peer> [--omit <dev|optional|peer> ...]]
 [--include <prod|dev|optional|peer> [--include <prod|dev|optional|peer> ...]]
 [--strict-peer-deps] [--foreground-scripts] [--ignore-scripts] [--no-audit]
-[--no-bin-links] [--no-fund] [--dry-run]
+[--before <date>] [--no-bin-links] [--no-fund] [--dry-run]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [--workspaces] [--include-workspace-root] [--install-links]
 
@@ -3529,6 +3530,7 @@ aliases: cit, clean-install-test, sit
 #### \`foreground-scripts\`
 #### \`ignore-scripts\`
 #### \`audit\`
+#### \`before\`
 #### \`bin-links\`
 #### \`fund\`
 #### \`dry-run\`


### PR DESCRIPTION
<!-- What / Why -->
npm ci --before arg isn't documented, but is supported, add to the --help output
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
Related to https://github.com/npm/cli/pull/8447
