### PR TITLE
docs(scripts): clarify prepare script runs with --production

### DIFF
--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -337,32 +337,9 @@ If `main` is not set, it defaults to `index.js` in the package's root folder.
 
 ### type
 
-The `type` field defines the module format that Node.js should use for `.js` files in your package. It can have two values:
+The `type` field is used by Node.js to determine whether `.js` files should be treated as ES modules or CommonJS modules. This field is not used by npm directly.
 
-* `"module"` - Tells Node.js to treat `.js` files as ES modules (ESM), allowing you to use `import` and `export` statements.
-* `"commonjs"` - Tells Node.js to treat `.js` files as CommonJS modules (the default), using `require()` and `module.exports`.
-
-If the `type` field is not set, Node.js defaults to `"commonjs"`.
-
-Example for an ES module package:
-
-```json
-{
-  "type": "module"
-}
-```
-
-Example for a CommonJS package (explicit, though this is the default):
-
-```json
-{
-  "type": "commonjs"
-}
-```
-
-**Note:** Regardless of the `type` field value, `.mjs` files are always treated as ES modules, and `.cjs` files are always treated as CommonJS modules.
-
-For more information, see the [Node.js documentation on package.json type field](https://nodejs.org/api/packages.html#type).
+For detailed information about the `type` field, its possible values (`"module"` or `"commonjs"`), and how it affects module resolution, see the [Node.js documentation on the type field](https://nodejs.org/api/packages.html#type).
 
 ### browser
 

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -335,6 +335,35 @@ For most modules, it makes the most sense to have a main script and often not mu
 
 If `main` is not set, it defaults to `index.js` in the package's root folder.
 
+### type
+
+The `type` field defines the module format that Node.js should use for `.js` files in your package. It can have two values:
+
+* `"module"` - Tells Node.js to treat `.js` files as ES modules (ESM), allowing you to use `import` and `export` statements.
+* `"commonjs"` - Tells Node.js to treat `.js` files as CommonJS modules (the default), using `require()` and `module.exports`.
+
+If the `type` field is not set, Node.js defaults to `"commonjs"`.
+
+Example for an ES module package:
+
+```json
+{
+  "type": "module"
+}
+```
+
+Example for a CommonJS package (explicit, though this is the default):
+
+```json
+{
+  "type": "commonjs"
+}
+```
+
+**Note:** Regardless of the `type` field value, `.mjs` files are always treated as ES modules, and `.cjs` files are always treated as CommonJS modules.
+
+For more information, see the [Node.js documentation on package.json type field](https://nodejs.org/api/packages.html#type).
+
 ### browser
 
 If your module is meant to be used client-side the browser field should be used instead of the main field.

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -337,9 +337,9 @@ If `main` is not set, it defaults to `index.js` in the package's root folder.
 
 ### type
 
-The `type` field is used by Node.js to determine whether `.js` files should be treated as ES modules or CommonJS modules. This field is not used by npm directly.
+The `type` field defines how Node.js should interpret `.js` files in your package. This field is not used by npm.
 
-For detailed information about the `type` field, its possible values (`"module"` or `"commonjs"`), and how it affects module resolution, see the [Node.js documentation on the type field](https://nodejs.org/api/packages.html#type).
+See the [Node.js documentation on the type field](https://nodejs.org/api/packages.html#type) for more information.
 
 ### browser
 

--- a/docs/lib/content/using-npm/scripts.md
+++ b/docs/lib/content/using-npm/scripts.md
@@ -42,7 +42,7 @@ These scripts happen in addition to the `pre<event>`, `post<event>`, and
 **prepare** (since `npm@4.0.0`)
 * Runs BEFORE the package is packed, i.e.
 during `npm publish` and `npm pack`
-* Runs on local `npm install` without any arguments
+* Runs on local `npm install` (including with `--production` or other flags)
 * Runs AFTER `prepublishOnly` and `prepack`, but BEFORE `postpack`
 * Runs for a package if it's being installed as a link through `npm install <folder>`
 

--- a/docs/lib/content/using-npm/scripts.md
+++ b/docs/lib/content/using-npm/scripts.md
@@ -268,8 +268,19 @@ then you could run `npm start` to execute the `bar` script, which is exported in
 
 #### package.json vars
 
-The package.json fields are tacked onto the `npm_package_` prefix.
-So, for instance, if you had `{"name":"foo", "version":"1.2.5"}` in your package.json file, then your package scripts would have the `npm_package_name` environment variable set to "foo", and the `npm_package_version` set to "1.2.5".  You can access these variables in your code with `process.env.npm_package_name` and `process.env.npm_package_version`, and so on for other fields.
+npm sets the following environment variables from the package.json:
+
+* `npm_package_name` - The package name
+* `npm_package_version` - The package version  
+* `npm_package_main` - The package main field
+* `npm_package_bin_*` - Each executable defined in the bin field
+* `npm_package_engines_*` - Each engine defined in the engines field
+* `npm_package_config_*` - Each config value defined in the config field
+* `npm_package_json` - The full path to the package.json file
+
+For example, if you had `{"name":"foo", "version":"1.2.5"}` in your package.json file, then your package scripts would have the `npm_package_name` environment variable set to "foo", and the `npm_package_version` set to "1.2.5". You can access these variables in your code with `process.env.npm_package_name` and `process.env.npm_package_version`.
+
+**Note:** In npm 7 and later, most package.json fields are no longer provided as environment variables. Scripts that need access to other package.json fields should read the package.json file directly. The `npm_package_json` environment variable provides the path to the file for this purpose.
 
 See [`package.json`](/configuring-npm/package-json) for more on package configs.
 


### PR DESCRIPTION
## Description

This PR updates the documentation to clarify that the `prepare` lifecycle script runs on all `npm install` commands, not just those "without any arguments".

## Changes

- Update prepare script documentation to reflect it runs with `--production` and other flags
- Remove misleading "without any arguments" phrasing that suggested it only runs on plain `npm install`

## Fixes

Closes #4027

## Context

Since npm 7, the `prepare` script runs on `npm install --production`, which differs from npm 6 behavior and contradicts the current documentation. This has caused confusion for users migrating from npm 6 who expected devDependencies (often required by prepare scripts) to be skipped during production installs.

The documentation currently states prepare "Runs on local `npm install` without any arguments", which is misleading. It actually runs for all install operations, including:
- `npm install` (no arguments)
- `npm install --production`
- `npm install --omit=dev`
- Other install variations

Users who need to skip the prepare script during production installs should use `npm install --production --ignore-scripts` as a workaround.