### PR TITLE
docs(package-spec): fix alias syntax in examples

### DIFF
--- a/docs/lib/content/using-npm/package-spec.md
+++ b/docs/lib/content/using-npm/package-spec.md
@@ -38,9 +38,9 @@ The `<alias>` is the name of the package as it is reified in the `node_modules` 
 See `Package name` above for more info on referring to a package by name, and [registry](/using-npm/config#registry) for configuring which registry is used when referring to a package by name.
 
 Examples:
-* `semver:@npm:@npmcli/semver-with-patch`
-* `semver:@npm:semver@7.2.2`
-* `semver:@npm:semver@legacy`
+* `semver@npm:@npmcli/semver-with-patch`
+* `semver@npm:semver@7.2.2`
+* `semver@npm:semver@legacy`
 
 ### Folders
 


### PR DESCRIPTION
## Description

This PR fixes the incorrect alias syntax in the package-spec documentation examples.

## Changes

- Fixed three alias examples that incorrectly used `:` instead of `@` before `npm:`
  - `semver:@npm:...` → `semver@npm:...`

## Details

The documentation format specification states:
```
<alias>@npm:<name>
```

However, the examples were showing:
```
semver:@npm:semver@7.2.2
```

Which fails with error:
```
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "semver:": semver:@npm:semver@7.2.2
```

The correct syntax is:
```
semver@npm:semver@7.2.2
```

## Fixes

Related #8223 (partially - addresses the documentation error identified in the comments)