### PR TITLE
docs(scripts): update npm_package_* environment variables documentation

### DIFF
--- a/docs/lib/content/using-npm/scripts.md
+++ b/docs/lib/content/using-npm/scripts.md
@@ -268,8 +268,27 @@ then you could run `npm start` to execute the `bar` script, which is exported in
 
 #### package.json vars
 
-The package.json fields are tacked onto the `npm_package_` prefix.
-So, for instance, if you had `{"name":"foo", "version":"1.2.5"}` in your package.json file, then your package scripts would have the `npm_package_name` environment variable set to "foo", and the `npm_package_version` set to "1.2.5".  You can access these variables in your code with `process.env.npm_package_name` and `process.env.npm_package_version`, and so on for other fields.
+npm sets the following environment variables from the package.json:
+
+* `npm_package_name` - The package name
+* `npm_package_version` - The package version
+* `npm_package_bin_*` - Each executable defined in the bin field
+* `npm_package_engines_*` - Each engine defined in the engines field
+* `npm_package_config_*` - Each config value defined in the config field
+* `npm_package_json` - The full path to the package.json file
+
+Additionally, for install scripts (`preinstall`, `install`, `postinstall`), npm sets these environment variables:
+
+* `npm_package_resolved` - The resolved URL for the package
+* `npm_package_integrity` - The integrity hash for the package
+* `npm_package_optional` - Set to `"true"` if the package is optional
+* `npm_package_dev` - Set to `"true"` if the package is a dev dependency
+* `npm_package_peer` - Set to `"true"` if the package is a peer dependency
+* `npm_package_dev_optional` - Set to `"true"` if the package is both dev and optional
+
+For example, if you had `{"name":"foo", "version":"1.2.5"}` in your package.json file, then your package scripts would have the `npm_package_name` environment variable set to "foo", and the `npm_package_version` set to "1.2.5". You can access these variables in your code with `process.env.npm_package_name` and `process.env.npm_package_version`.
+
+**Note:** In npm 7 and later, most package.json fields are no longer provided as environment variables. Scripts that need access to other package.json fields should read the package.json file directly. The `npm_package_json` environment variable provides the path to the file for this purpose.
 
 See [`package.json`](/configuring-npm/package-json) for more on package configs.
 


### PR DESCRIPTION
## Description

This PR updates the npm_package_* environment variables documentation to reflect the changes made in npm 7.

## Changes

- Listed the specific environment variables that npm still provides in npm 7+
- Added note explaining that most package.json fields are no longer provided as environment variables
- Documented that `npm_package_json` provides the path to package.json for scripts that need to read other fields

## Context

In npm 7, the behavior changed from providing all package.json fields as environment variables to only providing a specific subset. This was documented in RFC 21. The old documentation was misleading as it suggested all fields were still available.

## Fixes

Fixes #2452