### PR TITLE
docs(scripts): clarify prepare script runs with --production

### DIFF
--- a/docs/lib/content/using-npm/scripts.md
+++ b/docs/lib/content/using-npm/scripts.md
@@ -42,7 +42,7 @@ These scripts happen in addition to the `pre<event>`, `post<event>`, and
 **prepare** (since `npm@4.0.0`)
 * Runs BEFORE the package is packed, i.e.
 during `npm publish` and `npm pack`
-* Runs on local `npm install` without any arguments
+* Runs on local `npm install` without package arguments (runs with flags like `--production` or `--omit=dev`, but does not run when installing specific packages like `npm install express`)
 * Runs AFTER `prepublishOnly` and `prepack`, but BEFORE `postpack`
 * Runs for a package if it's being installed as a link through `npm install <folder>`
 


### PR DESCRIPTION
## Description

This PR updates the documentation to clarify that the `prepare` lifecycle script runs on all `npm install` commands, not just those "without any arguments".

## Changes

- Update prepare script documentation to reflect it runs with `--production` and other flags
- Remove misleading "without any arguments" phrasing that suggested it only runs on plain `npm install`

## Fixes

Closes #4027

## Context

Since npm 7, the `prepare` script runs on `npm install --production`, which differs from npm 6 behavior and contradicts the current documentation. This has caused confusion for users migrating from npm 6 who expected devDependencies (often required by prepare scripts) to be skipped during production installs.

The documentation currently states prepare "Runs on local `npm install` without any arguments", which is misleading. It actually runs for all install operations, including:
- `npm install` (no arguments)
- `npm install --production`
- `npm install --omit=dev`
- Other install variations

Users who need to skip the prepare script during production installs should use `npm install --production --ignore-scripts` as a workaround.