### PR TITLE
docs(scripts): document that prepare scripts run concurrently in workspaces

### DIFF
--- a/docs/lib/content/using-npm/scripts.md
+++ b/docs/lib/content/using-npm/scripts.md
@@ -51,6 +51,8 @@ during `npm publish` and `npm pack`
 * As of `npm@7` these scripts run in the background.
   To see the output, run with: `--foreground-scripts`.
 
+* **In workspaces, prepare scripts run concurrently** across all packages. If you have interdependent packages where one must build before another, consider using `--foreground-scripts` (which can be set in `.npmrc` with `foreground-scripts=true`) to run scripts sequentially, or structure your build differently.
+
 **prepublish** (DEPRECATED)
 * Does not run during `npm publish`, but does run during `npm ci` and `npm install`.
 See below for more info.


### PR DESCRIPTION
## Description

This PR documents that prepare scripts run concurrently across workspace packages, addressing user confusion about execution order.

## Changes

- Add note that prepare scripts run concurrently in workspaces
- Document `--foreground-scripts` workaround for sequential execution
- Provide guidance for users with interdependent workspace packages (e.g., TypeScript builds)

## Fixes

Closes #4100

## Context

Users with workspace setups that have interdependent packages (such as TypeScript projects where one package depends on another's build output) were confused when prepare scripts ran concurrently, causing build failures. The documentation implied sequential execution but didn't explicitly state that lifecycle scripts run concurrently.

Per @lukekarrys's comment in #4100, the action item was to document this behavior. The workaround is to use `--foreground-scripts` (which can be set in `.npmrc` with `foreground-scripts=true`) to force sequential execution, though this comes with performance trade-offs.