### PR TITLE
fix: add 'would have' prefix to --dry-run output

### DIFF
--- a/lib/utils/reify-output.js
+++ b/lib/utils/reify-output.js
@@ -165,6 +165,7 @@ const getAuditReport = (npm, report) => {
 }
 
 const packagesChangedMessage = (npm, { added, removed, changed, audited }) => {
+  const dryRun = npm.config.get('dry-run')
   const msg = ['\n']
   if (added === 0 && removed === 0 && changed === 0) {
     msg.push('up to date')
@@ -173,7 +174,7 @@ const packagesChangedMessage = (npm, { added, removed, changed, audited }) => {
     }
   } else {
     if (added) {
-      msg.push(`added ${added} package${added === 1 ? '' : 's'}`)
+      msg.push(`${dryRun ? 'would have ' : ''}added ${added} package${added === 1 ? '' : 's'}`)
     }
 
     if (removed) {
@@ -185,7 +186,7 @@ const packagesChangedMessage = (npm, { added, removed, changed, audited }) => {
         msg.push('and ')
       }
 
-      msg.push(`removed ${removed} package${removed === 1 ? '' : 's'}`)
+      msg.push(`${dryRun ? 'would have ' : ''}removed ${removed} package${removed === 1 ? '' : 's'}`)
     }
     if (changed) {
       if (added || removed) {
@@ -196,14 +197,14 @@ const packagesChangedMessage = (npm, { added, removed, changed, audited }) => {
         msg.push('and ')
       }
 
-      msg.push(`changed ${changed} package${changed === 1 ? '' : 's'}`)
+      msg.push(`${dryRun ? 'would have ' : ''}changed ${changed} package${changed === 1 ? '' : 's'}`)
     }
     if (audited) {
       msg.push(', and ')
     }
   }
   if (audited) {
-    msg.push(`audited ${audited} package${audited === 1 ? '' : 's'}`)
+    msg.push(`${dryRun ? 'would have ' : ''}audited ${audited} package${audited === 1 ? '' : 's'}`)
   }
 
   msg.push(` in ${ms(Date.now() - npm.started)}`)

--- a/tap-snapshots/test/lib/utils/reify-output.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/reify-output.js.test.cjs
@@ -3828,7 +3828,7 @@ change bar 1.0.0 => 2.1.0
 remove bar 1.0.0
 add foo 1.0.0
 
-removed 1 package, and changed 1 package in {TIME}
+would have removed 1 package, and would have changed 1 package in {TIME}
 `
 
 exports[`test/lib/utils/reify-output.js TAP prints dedupe difference on long > diff table 1`] = `
@@ -3837,4 +3837,12 @@ remove bar 1.0.0
 add foo 1.0.0
 
 removed 1 package, and changed 1 package in {TIME}
+`
+
+exports[`test/lib/utils/reify-output.js TAP prints package changes with audit on dry-run > dry-run with audit 1`] = `
+add foo 1.0.0
+
+would have added 1 package, and would have audited 10 packages in {TIME}
+
+found 0 vulnerabilities
 `

--- a/test/lib/utils/reify-output.js
+++ b/test/lib/utils/reify-output.js
@@ -421,6 +421,39 @@ t.test('prints dedupe difference on dry-run', async t => {
   t.matchSnapshot(out, 'diff table')
 })
 
+t.test('prints package changes with audit on dry-run', async t => {
+  const mock = {
+    actualTree: {
+      name: 'foo',
+      inventory: {
+        size: 10,
+        has: () => true,
+      },
+      children: [],
+    },
+    auditReport: {
+      toJSON: () => mock.auditReport,
+      vulnerabilities: {},
+      metadata: {
+        vulnerabilities: {
+          total: 0,
+        },
+      },
+    },
+    diff: {
+      children: [
+        { action: 'ADD', ideal: { path: 'test/foo', name: 'foo', location: 'loc', package: { version: '1.0.0' } } },
+      ],
+    },
+  }
+
+  const out = await mockReify(t, mock, {
+    'dry-run': true,
+  })
+
+  t.matchSnapshot(out, 'dry-run with audit')
+})
+
 t.test('prints dedupe difference on long', async t => {
   const mock = {
     actualTree: {


### PR DESCRIPTION
## Description

Fixes #1999

When running commands with --dry-run flag, the output now clearly indicates that no actual changes were made by prefixing actions with 'would have'.

## Changes

- Modified lib/utils/reify-output.js to check for --dry-run flag
- Added 'would have' prefix to all action messages (added, removed, changed, audited) when in dry-run mode
- Updated test snapshots to match new behavior

## Examples

**Before:**
\\\
$ npm install express --dry-run
added 25 packages, and changed 23 packages in 2s
\\\

**After:**
\\\
$ npm install express --dry-run
would have added 25 packages, and changed 23 packages in 2s
\\\

## Testing

- All 179 tests in 	est/lib/utils/reify-output.js pass
- Verified with 
pm install --dry-run
- Verified with 
pm uninstall --dry-run
- Verified normal mode (without --dry-run) still works correctly