### PR TITLE
fix(query): support package-lock-only in workspaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2794,9 +2794,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.14",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.14.tgz",
-      "integrity": "sha512-GM9c0cWWR8Ga7//Ves/9KRgTS8nLausCkP3CGiFLrnwA2CDUluXgaQqvrULoR2Ujrd/mz/lkX87F5BHFsNr5sQ==",
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.5.tgz",
+      "integrity": "sha512-D5vIoztZOq1XM54LUdttJVc96ggEsIfju2JBvht06pSzpckp3C7HReun67Bghzrtdsq9XdMGbSSB3v3GhMNmAA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/tap-snapshots/test/lib/commands/query.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/query.js.test.cjs
@@ -124,6 +124,10 @@ exports[`test/lib/commands/query.js TAP missing > should return missing node 1`]
 ]
 `
 
+exports[`test/lib/commands/query.js TAP package-lock-only missing workspace in tree > should return empty array for missing workspace 1`] = `
+[]
+`
+
 exports[`test/lib/commands/query.js TAP package-lock-only with package lock > should return valid response with only lock info 1`] = `
 [
   {
@@ -162,6 +166,48 @@ exports[`test/lib/commands/query.js TAP package-lock-only with package lock > sh
     "from": [
       ""
     ],
+    "to": [],
+    "dev": false,
+    "inBundle": false,
+    "deduped": false,
+    "overridden": false,
+    "queryContext": {}
+  }
+]
+`
+
+exports[`test/lib/commands/query.js TAP package-lock-only with package lock and workspace > should return workspace object with package-lock-only 1`] = `
+[
+  {
+    "name": "root",
+    "workspaces": [
+      "packages/*"
+    ],
+    "pkgid": "root@",
+    "location": "",
+    "path": "{CWD}/prefix",
+    "realpath": "{CWD}/prefix",
+    "resolved": null,
+    "from": [],
+    "to": [
+      "node_modules/a"
+    ],
+    "dev": false,
+    "inBundle": false,
+    "deduped": false,
+    "overridden": false,
+    "queryContext": {}
+  },
+  {
+    "name": "a",
+    "version": "1.0.0",
+    "_id": "a@1.0.0",
+    "pkgid": "a@1.0.0",
+    "location": "packages/a",
+    "path": "{CWD}/prefix/packages/a",
+    "realpath": "{CWD}/prefix/packages/a",
+    "resolved": null,
+    "from": [],
     "to": [],
     "dev": false,
     "inBundle": false,


### PR DESCRIPTION
## Why/What
This change fixes a bug in npm query so that `--package-lock-only` now works correctly with workspaces, by properly loading the dependency tree from the lockfile instead of node_modules.

## References
Related to  https://github.com/npm/cli/pull/6732#issuecomment-1708804921
