### PR TITLE
fix: more intuitive byte formatting boundaries for rounding

### DIFF
--- a/lib/utils/format-bytes.js
+++ b/lib/utils/format-bytes.js
@@ -13,12 +13,12 @@ const formatBytes = (bytes, space = true) => {
     return `${bytes}${spacer}B`
   }
 
-  if (bytes < 1000000) {
+  if (bytes < 999950) {
     // kB
     return `${(bytes / 1000).toFixed(1)}${spacer}kB`
   }
 
-  if (bytes < 1000000000) {
+  if (bytes < 999950000) {
     // MB
     return `${(bytes / 1000000).toFixed(1)}${spacer}MB`
   }

--- a/test/lib/utils/tar.js
+++ b/test/lib/utils/tar.js
@@ -225,3 +225,37 @@ t.test('should getContents of a tarball with a node_modules directory included',
   }, 'contents are correct')
   t.end()
 })
+
+t.test('should log byte sizes correctly', async (t) => {
+  const cases = [
+    [0, '0 B', '0B'],
+    [1, '1 B', '1B'],
+    [10, '10 B', '10B'],
+    [999, '999 B', '999B'],
+    [1000, '1.0 kB', '1.0kB'],
+    [1001, '1.0 kB', '1.0kB'],
+    [1500, '1.5 kB', '1.5kB'],
+    [999999, '1.0 MB', '1.0MB'],
+    [1000000, '1.0 MB', '1.0MB'],
+    [999999999, '1.0 GB', '1.0GB'],
+    [1000000000, '1.0 GB', '1.0GB'],
+  ]
+
+  for (const [size, expected, expectedNoSpace] of cases) {
+    const logs = printLogs({
+      name: 'pkg',
+      version: '1.0.0',
+      files: [
+        { path: 'file.txt', size: size },
+      ],
+      bundled: [],
+      size: size,
+      unpackedSize: size,
+      integrity: 'sha512-xxx',
+    })
+
+    t.match(logs, `package size: ${expected}`, `package size: ${expected}`)
+    t.match(logs, `unpacked size: ${expected}`, `unpacked size: ${expected}`)
+    t.match(logs, `${expectedNoSpace} file.txt`, `file size: ${expectedNoSpace}`)
+  }
+})


### PR DESCRIPTION
## WHY/WHAT
Fixed non-intuitive unit rounding for byte formatting. Previously, values close to a unit boundary (e.g. 999,999 B) displayed incorrectly as the smaller unit. We adjusted the conversion threshold (e.g. to 999,950 B for MB) to leverage standard `toFixed(1)` rounding, ensuring values that are `almost 1.0` of the next unit are correctly displayed as 1.0 MB, prioritizing a better user experience.

