### PR TITLE
fix: increase coverage for error-message and output-error

### DIFF
--- a/tap-snapshots/test/lib/utils/error-message.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/error-message.js.test.cjs
@@ -180,6 +180,31 @@ Object {
 }
 `
 
+exports[`test/lib/utils/error-message.js TAP EEXIST with dest > must match snapshot 1`] = `
+Object {
+  "detail": Array [
+    Array [
+      "",
+      "Remove the existing file and try again, or run npm",
+    ],
+    Array [
+      "",
+      "with --force to overwrite files recklessly.",
+    ],
+  ],
+  "summary": Array [
+    Array [
+      "",
+      "exists",
+    ],
+    Array [
+      "",
+      "File exists: /dest",
+    ],
+  ],
+}
+`
+
 exports[`test/lib/utils/error-message.js TAP args are cleaned > must match snapshot 1`] = `
 Object {
   "detail": Array [

--- a/test/lib/utils/error-message.js
+++ b/test/lib/utils/error-message.js
@@ -41,8 +41,118 @@ const loadMockNpm = async (t, { errorMocks, ...opts } = {}) => {
   return {
     ...res,
     errorMessage: (er) => mockError.errorMessage(er, res.npm),
+    getError: (er, args) => mockError.getError(er, { npm: res.npm, ...args }),
   }
 }
+
+t.test('getError', async t => {
+  const { getError } = await loadMockNpm(t)
+
+  t.test('shellout command error', t => {
+    const err = Object.assign(new Error('foo'), { code: 127 })
+    const command = { constructor: { isShellout: true } }
+    const res = getError(err, { command })
+    t.match(res, {
+      exitCode: 127,
+      suppressError: true,
+    })
+    t.end()
+  })
+
+  t.test('string error', t => {
+    const res = getError('string error')
+    t.match(res, {
+      exitCode: 1,
+      suppressError: true,
+      summary: [['', 'string error']],
+    })
+    t.end()
+  })
+
+  t.test('non-error object', t => {
+    const res = getError({ foo: 'bar' })
+    t.match(res, {
+      exitCode: 1,
+      suppressError: true,
+      summary: [['weird error', { foo: 'bar' }]],
+    })
+    t.end()
+  })
+
+  t.test('unknown command', t => {
+    const err = Object.assign(new Error('unknown'), {
+      code: 'EUNKNOWNCOMMAND',
+      command: 'florb',
+    })
+    const res = getError(err, { pkg: { bin: { npm: 'npm' } } })
+    t.match(res, {
+      exitCode: 1,
+      suppressError: true,
+      standard: [
+        'Unknown command: "florb"',
+        String,
+        'To see a list of supported npm commands, run:',
+        '  npm help',
+      ],
+    })
+    t.end()
+  })
+
+  t.test('standard error', t => {
+    const err = new Error('standard')
+    const res = getError(err)
+    t.match(res, {
+      exitCode: 1,
+      suppressError: false,
+      summary: [['', 'standard']],
+    })
+    t.end()
+  })
+
+  t.test('error with details', t => {
+    const err = Object.assign(new Error('detailed'), {
+      code: 'EFOO',
+      syscall: 'open',
+      file: 'file.txt',
+      path: '/path',
+      dest: '/dest',
+      errno: -1,
+      type: 'foo',
+      stack: 'stack',
+      statusCode: 500,
+      pkgid: 'pkg',
+    })
+    const res = getError(err)
+    t.match(res, {
+      code: 'EFOO',
+      error: [
+        ['code', 'EFOO'],
+        ['syscall', 'open'],
+        ['file', 'file.txt'],
+        ['path', '/path'],
+        ['dest', '/dest'],
+        ['errno', -1],
+      ],
+      verbose: [
+        ['type', 'foo'],
+        ['stack', 'stack'],
+        ['statusCode', 500],
+        ['pkgid', 'pkg'],
+      ],
+    })
+    t.end()
+  })
+})
+
+t.test('EEXIST with dest', async t => {
+  const { errorMessage } = await loadMockNpm(t)
+  const er = Object.assign(new Error('exists'), {
+    code: 'EEXIST',
+    path: '/path',
+    dest: '/dest',
+  })
+  t.matchSnapshot(errorMessage(er))
+})
 
 t.test('just simple messages', async t => {
   const { errorMessage } = await loadMockNpm(t, {

--- a/test/lib/utils/output-error.js
+++ b/test/lib/utils/output-error.js
@@ -1,0 +1,97 @@
+const t = require('tap')
+
+t.test('outputError', t => {
+  const output = {
+    standard: [],
+  }
+  const log = {
+    verbose: [],
+    error: [],
+  }
+
+  const mockProcLog = {
+    output: {
+      standard: (msg) => output.standard.push(msg),
+    },
+    log: {
+      verbose: (...args) => log.verbose.push(args),
+      error: (...args) => log.error.push(args),
+    },
+  }
+
+  const { outputError } = t.mock('../../../lib/utils/output-error.js', {
+    'proc-log': mockProcLog,
+  })
+
+  outputError({
+    standard: ['std'],
+    verbose: [['verb', 'ose']],
+    error: [['err', 'or']],
+    summary: [['sum', 'mary']],
+    detail: [['det', 'ail']],
+  })
+
+  t.strictSame(output.standard, ['std'])
+  t.strictSame(log.verbose, [['verb', 'ose']])
+  t.strictSame(log.error, [
+    ['err', 'or'],
+    ['sum', 'mary'],
+    ['det', 'ail'],
+  ])
+  t.end()
+})
+
+t.test('jsonError', t => {
+  const { jsonError } = require('../../../lib/utils/output-error.js')
+
+  const npm = {
+    loaded: true,
+    config: {
+      get: (key) => key === 'json',
+    },
+  }
+
+  const error = {
+    code: 'ECODE',
+    summary: [['code', 'summary']],
+    detail: [['code', 'detail']],
+  }
+
+  const res = jsonError(error, npm)
+  t.match(res, {
+    code: 'ECODE',
+    summary: 'summary',
+    detail: 'detail',
+  })
+
+  t.equal(jsonError(null, npm), undefined, 'returns undefined if no error')
+  t.equal(jsonError(error, { ...npm, loaded: false }), undefined, 'returns undefined if not loaded')
+  t.equal(jsonError(error, { ...npm, config: { get: () => false } }), undefined, 'returns undefined if not json')
+
+  t.end()
+})
+
+t.test('outputError defaults', t => {
+  const output = { standard: [] }
+  const log = { verbose: [], error: [] }
+  const mockProcLog = {
+    output: { standard: (msg) => output.standard.push(msg) },
+    log: { verbose: (...args) => log.verbose.push(args), error: (...args) => log.error.push(args) },
+  }
+  const { outputError } = t.mock('../../../lib/utils/output-error.js', { 'proc-log': mockProcLog })
+
+  outputError({})
+  t.strictSame(output.standard, [])
+  t.strictSame(log.verbose, [])
+  t.strictSame(log.error, [])
+  t.end()
+})
+
+t.test('jsonError missing props', t => {
+  const { jsonError } = require('../../../lib/utils/output-error.js')
+  const npm = { loaded: true, config: { get: () => true } }
+  const error = { code: 'ECODE' }
+  const res = jsonError(error, npm)
+  t.match(res, { code: 'ECODE', summary: '', detail: '' })
+  t.end()
+})


### PR DESCRIPTION
## What / Why
Improve test coverage for `output-error` and `error-message`.