### PR TITLE
Add environment-specific config support for CLI commands

### DIFF
--- a/doc/misc/npm-config.md
+++ b/doc/misc/npm-config.md
@@ -63,6 +63,7 @@ The following shorthands are parsed on the command-line:
 * `-d`: `--loglevel info`
 * `-dd`, `--verbose`: `--loglevel verbose`
 * `-ddd`: `--loglevel silly`
+* `-e`: `--env`
 * `-g`: `--global`
 * `-C`: `--prefix`
 * `-l`: `--long`
@@ -365,6 +366,31 @@ commands, eg `dist-tags`, `owner`, etc.
 * Type: path
 
 The command to run for `npm edit` or `npm config edit`.
+
+### env
+
+* Default: null
+* Type: String
+
+Specifies the target environment for npm commands. When set, npm will load
+environment-specific configuration from `.npmrc.{env}` files.
+
+See npm-environments(7) for more details.
+
+Common values: `development`, `staging`, `production`, `test`
+
+Aliases: `dev` -> `development`, `prod` -> `production`, `stg` -> `staging`
+
+### env-config-dir
+
+* Default: null
+* Type: path
+
+Specifies a custom directory to look for environment-specific configuration
+files. When set, npm will look for `.npmrc.{env}` files in this directory
+before checking the project and user directories.
+
+See npm-environments(7) for more details.
 
 ### engine-strict
 

--- a/doc/misc/npm-environments.md
+++ b/doc/misc/npm-environments.md
@@ -1,0 +1,146 @@
+npm-environments(7) -- Running npm commands in different environments
+======================================================================
+
+## DESCRIPTION
+
+npm supports running commands in different environments (e.g., development,
+staging, production) using environment-specific configuration files. This
+allows you to maintain separate configurations for different deployment
+targets without modifying your main `.npmrc` file.
+
+## USAGE
+
+To run a command in a specific environment, use the `--env` flag:
+
+    npm install --env staging
+    npm publish --env production
+    npm run build -e dev
+
+The `-e` shorthand can be used in place of `--env`.
+
+## ENVIRONMENT CONFIGURATION FILES
+
+npm looks for environment-specific configuration in the following locations,
+in order of priority:
+
+1. Custom config directory (if `--env-config-dir` is specified):
+   `{env-config-dir}/.npmrc.{environment}`
+
+2. Project directory:
+   `{project}/.npmrc.{environment}`
+
+3. User home directory:
+   `~/.npmrc.{environment}`
+
+For example, if you run `npm install --env staging`, npm will look for:
+- `./.npmrc.staging` (project directory)
+- `~/.npmrc.staging` (user home directory)
+
+The first file found will be used.
+
+## CREATING ENVIRONMENT CONFIG FILES
+
+Create environment-specific config files with the `.npmrc.{env}` naming pattern:
+
+### Example: .npmrc.staging
+
+    registry=https://staging-registry.example.com/
+    //staging-registry.example.com/:_authToken=${STAGING_NPM_TOKEN}
+    cache=/tmp/npm-staging-cache
+
+### Example: .npmrc.production
+
+    registry=https://registry.example.com/
+    //registry.example.com/:_authToken=${PRODUCTION_NPM_TOKEN}
+    strict-ssl=true
+
+## ENVIRONMENT ALIASES
+
+npm recognizes the following environment name aliases:
+
+* `dev` -> `development`
+* `prod` -> `production`
+* `stg` or `stage` -> `staging`
+* `local` -> `local`
+* `test` -> `test`
+
+For example, `npm install --env dev` is equivalent to
+`npm install --env development`.
+
+## ENVIRONMENT-SPECIFIC ENVIRONMENT VARIABLES
+
+You can also set environment-specific configuration using environment
+variables with the pattern `npm_config_{env}_{key}`:
+
+    export npm_config_staging_registry=https://staging-registry.example.com/
+    export npm_config_production_strict_ssl=true
+
+When running with `--env staging`, npm will automatically include these
+environment-specific variables in its configuration.
+
+## CONFIGURATION PRIORITY
+
+When using `--env`, the configuration priority is (highest to lowest):
+
+1. Command line flags
+2. Standard environment variables (`npm_config_*`)
+3. Project `.npmrc`
+4. **Environment-specific config (`.npmrc.{env}`)** <-- NEW
+5. Environment-specific environment variables (`npm_config_{env}_*`)
+6. User `.npmrc`
+7. Global `.npmrc`
+8. Built-in defaults
+
+## CUSTOM CONFIG DIRECTORY
+
+You can specify a custom directory for environment config files using
+`--env-config-dir`:
+
+    npm install --env staging --env-config-dir /etc/npm-envs
+
+This will look for `/etc/npm-envs/.npmrc.staging`.
+
+## EXAMPLES
+
+### Setting up a staging environment
+
+1. Create `.npmrc.staging` in your project:
+
+       registry=https://staging.npmjs.example.com/
+       //staging.npmjs.example.com/:_authToken=${STAGING_TOKEN}
+
+2. Run commands targeting staging:
+
+       npm install --env staging
+       npm publish --env staging
+
+### Using environment variables only
+
+If you prefer not to create config files, you can use environment variables:
+
+    # Set staging-specific config
+    export npm_config_staging_registry=https://staging.example.com/
+    export npm_config_staging_strict_ssl=false
+
+    # Run with staging environment
+    npm install --env staging
+
+### CI/CD Pipeline Example
+
+    # .github/workflows/deploy.yml
+    jobs:
+      deploy-staging:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v2
+          - run: npm ci --env staging
+          - run: npm run build --env staging
+          - run: npm publish --env staging
+        env:
+          STAGING_TOKEN: ${{ secrets.STAGING_NPM_TOKEN }}
+
+## SEE ALSO
+
+* npm-config(7)
+* npmrc(5)
+* npm-config(1)

--- a/lib/config/core.js
+++ b/lib/config/core.js
@@ -11,6 +11,8 @@ var Umask = configDefs.Umask
 var mkdirp = require('gentle-fs').mkdir
 var umask = require('../utils/umask')
 var isWindows = require('../utils/is-windows.js')
+var loadEnvConfig = require('./load-env.js')
+var log = require('npmlog')
 
 exports.load = load
 exports.Conf = Conf
@@ -140,6 +142,55 @@ function load_ (builtin, rc, cli, cb) {
   })
 
   function afterPrefix () {
+    // Load environment-specific configuration if --env is specified
+    var targetEnv = conf.get('env')
+    if (targetEnv) {
+      var osenv = require('osenv')
+      var envOptions = {
+        projectDir: conf.localPrefix,
+        userDir: osenv.home(),
+        envConfigDir: conf.get('env-config-dir')
+      }
+
+      loadEnvConfig(targetEnv, envOptions, function (err, envResult) {
+        if (err) {
+          log.warn('env', 'Error loading environment config:', err.message)
+        }
+
+        if (envResult && envResult.config) {
+          // Add environment-specific config file
+          conf.addFile(envResult.config.path, 'env')
+          conf.once('load', function () {
+            // Merge environment-specific env vars
+            if (envResult.envVars && Object.keys(envResult.envVars).length > 0) {
+              Object.keys(envResult.envVars).forEach(function (key) {
+                if (!conf.get(key)) {
+                  conf.set(key, envResult.envVars[key], 'env')
+                }
+              })
+            }
+            log.info('env', 'Running in', envResult.env, 'environment')
+            afterEnvConfig()
+          })
+        } else {
+          // No env config file found, but still process env vars
+          if (envResult && envResult.envVars && Object.keys(envResult.envVars).length > 0) {
+            conf.add(envResult.envVars, 'env')
+            log.info('env', 'Running in', envResult.env, 'environment (using env vars only)')
+          } else {
+            conf.add({}, 'env')
+            log.info('env', 'Running in', targetEnv, 'environment (no specific config found)')
+          }
+          afterEnvConfig()
+        }
+      })
+    } else {
+      conf.add({}, 'env')
+      afterEnvConfig()
+    }
+  }
+
+  function afterEnvConfig () {
     conf.addFile(conf.get('userconfig'), 'user')
     conf.once('error', cb)
     conf.once('load', afterUser)

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -140,6 +140,8 @@ Object.defineProperty(exports, 'defaults', {get: function () {
     'dry-run': false,
     editor: osenv.editor(),
     'engine-strict': false,
+    env: null,
+    'env-config-dir': null,
     force: false,
     'format-package-lock': true,
 
@@ -283,6 +285,8 @@ exports.types = {
   'dry-run': Boolean,
   editor: String,
   'engine-strict': Boolean,
+  env: [null, String],
+  'env-config-dir': [null, path],
   force: Boolean,
   'format-package-lock': Boolean,
   'fetch-retries': Number,
@@ -400,6 +404,7 @@ function getLocalAddresses () {
 
 exports.shorthands = {
   before: ['--enjoy-by'],
+  e: ['--env'],
   s: ['--loglevel', 'silent'],
   d: ['--loglevel', 'info'],
   dd: ['--loglevel', 'verbose'],

--- a/lib/config/load-env.js
+++ b/lib/config/load-env.js
@@ -1,0 +1,200 @@
+'use strict'
+
+/**
+ * Load Environment-Specific Configuration
+ *
+ * This module loads environment-specific configuration files
+ * when the --env flag is used with npm commands.
+ *
+ * Configuration files are loaded from:
+ *   1. {projectDir}/.npmrc.{env}
+ *   2. {userDir}/.npmrc.{env}
+ *   3. {envConfigDir}/.npmrc.{env} (if env-config-dir is set)
+ *
+ * Environment-specific configs are merged into the config chain
+ * after project config but before user config.
+ */
+
+module.exports = loadEnvConfig
+
+var fs = require('fs')
+var path = require('path')
+var log = require('npmlog')
+var environments = require('../utils/environments')
+
+/**
+ * Load environment-specific configuration
+ *
+ * @param {string} env - The environment name (e.g., 'staging', 'production')
+ * @param {object} options - Options object
+ * @param {string} options.projectDir - Project directory path
+ * @param {string} options.userDir - User home directory path
+ * @param {string} [options.envConfigDir] - Optional custom env config directory
+ * @param {function} cb - Callback(err, configData)
+ */
+function loadEnvConfig (env, options, cb) {
+  if (!env) {
+    return process.nextTick(function () {
+      cb(null, null)
+    })
+  }
+
+  var resolvedEnv = environments.resolveEnvName(env)
+  if (!resolvedEnv) {
+    return process.nextTick(function () {
+      cb(null, null)
+    })
+  }
+
+  log.verbose('env', 'Loading configuration for environment:', resolvedEnv)
+
+  var configPaths = []
+
+  // Add custom env config directory if specified
+  if (options.envConfigDir) {
+    configPaths.push(path.join(options.envConfigDir, '.npmrc.' + resolvedEnv))
+  }
+
+  // Add project-level env config
+  if (options.projectDir) {
+    configPaths.push(path.join(options.projectDir, '.npmrc.' + resolvedEnv))
+  }
+
+  // Add user-level env config
+  if (options.userDir) {
+    configPaths.push(path.join(options.userDir, '.npmrc.' + resolvedEnv))
+  }
+
+  // Try to load from each path in order, using first found
+  findFirstConfig(configPaths, function (err, result) {
+    if (err) return cb(err)
+
+    if (result) {
+      log.info('env', 'Using environment config from:', result.path)
+    } else {
+      log.verbose('env', 'No environment config file found for:', resolvedEnv)
+      log.verbose('env', 'Searched paths:', configPaths.join(', '))
+    }
+
+    // Also load environment-specific environment variables
+    var envVars = environments.getEnvSpecificVars(resolvedEnv)
+    var envVarCount = Object.keys(envVars).length
+    if (envVarCount > 0) {
+      log.verbose('env', 'Found', envVarCount, 'environment-specific variables')
+    }
+
+    cb(null, {
+      env: resolvedEnv,
+      config: result,
+      envVars: envVars
+    })
+  })
+}
+
+/**
+ * Find the first existing config file from a list of paths
+ */
+function findFirstConfig (paths, cb) {
+  if (paths.length === 0) {
+    return cb(null, null)
+  }
+
+  var currentPath = paths[0]
+  var remainingPaths = paths.slice(1)
+
+  fs.readFile(currentPath, 'utf8', function (err, data) {
+    if (err) {
+      if (err.code === 'ENOENT') {
+        // File doesn't exist, try next path
+        return findFirstConfig(remainingPaths, cb)
+      }
+      return cb(err)
+    }
+
+    // Found a config file
+    cb(null, {
+      path: currentPath,
+      data: data
+    })
+  })
+}
+
+/**
+ * Parse environment config file content
+ * Returns an object with key-value pairs
+ */
+loadEnvConfig.parse = function parseEnvConfig (data) {
+  if (!data) return {}
+
+  var config = {}
+  var lines = data.split(/\r?\n/)
+
+  lines.forEach(function (line) {
+    // Skip comments and empty lines
+    line = line.trim()
+    if (!line || line.startsWith('#') || line.startsWith(';')) {
+      return
+    }
+
+    // Parse key=value pairs
+    var eqIndex = line.indexOf('=')
+    if (eqIndex > 0) {
+      var key = line.substring(0, eqIndex).trim()
+      var value = line.substring(eqIndex + 1).trim()
+
+      // Remove quotes if present
+      if ((value.startsWith('"') && value.endsWith('"')) ||
+          (value.startsWith("'") && value.endsWith("'"))) {
+        value = value.slice(1, -1)
+      }
+
+      config[key] = value
+    }
+  })
+
+  return config
+}
+
+/**
+ * Get environment information for display
+ */
+loadEnvConfig.getEnvInfo = function getEnvInfo (env, options) {
+  var resolvedEnv = environments.resolveEnvName(env)
+  if (!resolvedEnv) return null
+
+  var info = {
+    name: resolvedEnv,
+    configPaths: []
+  }
+
+  if (options.envConfigDir) {
+    var customPath = path.join(options.envConfigDir, '.npmrc.' + resolvedEnv)
+    info.configPaths.push({
+      path: customPath,
+      exists: environments.envConfigExists(options.envConfigDir, resolvedEnv),
+      type: 'custom'
+    })
+  }
+
+  if (options.projectDir) {
+    var projectPath = path.join(options.projectDir, '.npmrc.' + resolvedEnv)
+    info.configPaths.push({
+      path: projectPath,
+      exists: environments.envConfigExists(options.projectDir, resolvedEnv),
+      type: 'project'
+    })
+  }
+
+  if (options.userDir) {
+    var userPath = path.join(options.userDir, '.npmrc.' + resolvedEnv)
+    info.configPaths.push({
+      path: userPath,
+      exists: environments.envConfigExists(options.userDir, resolvedEnv),
+      type: 'user'
+    })
+  }
+
+  info.envVars = environments.getEnvSpecificVars(resolvedEnv)
+
+  return info
+}

--- a/lib/utils/environments.js
+++ b/lib/utils/environments.js
@@ -1,0 +1,194 @@
+'use strict'
+
+/**
+ * Environment Configuration Utility
+ *
+ * This module provides utilities for running CLI commands in different environments
+ * (e.g., development, staging, production).
+ *
+ * Usage:
+ *   npm <command> --env staging
+ *   npm <command> --env production
+ *   npm <command> -e dev
+ *
+ * Environment configs are loaded from:
+ *   1. .npmrc.{env} files in the project directory
+ *   2. ~/.npmrc.{env} files in the user's home directory
+ *   3. Environment variables prefixed with npm_config_{env}_
+ *
+ * Example .npmrc.staging:
+ *   registry=https://staging-registry.example.com/
+ *   //staging-registry.example.com/:_authToken=${STAGING_NPM_TOKEN}
+ */
+
+var fs = require('fs')
+var path = require('path')
+var log = require('npmlog')
+
+// Common environment names and their aliases
+var ENV_ALIASES = {
+  dev: 'development',
+  prod: 'production',
+  stg: 'staging',
+  stage: 'staging',
+  local: 'local',
+  test: 'test'
+}
+
+// Resolve environment name to its canonical form
+function resolveEnvName (env) {
+  if (!env) return null
+  var normalized = env.toLowerCase().trim()
+  return ENV_ALIASES[normalized] || normalized
+}
+
+// Get the path to an environment-specific config file
+function getEnvConfigPath (baseDir, env) {
+  if (!env) return null
+  var resolved = resolveEnvName(env)
+  return path.join(baseDir, '.npmrc.' + resolved)
+}
+
+// Check if an environment config file exists
+function envConfigExists (baseDir, env) {
+  var configPath = getEnvConfigPath(baseDir, env)
+  if (!configPath) return false
+  try {
+    fs.accessSync(configPath, fs.constants.R_OK)
+    return true
+  } catch (e) {
+    return false
+  }
+}
+
+// Load environment-specific config file content
+function loadEnvConfig (baseDir, env, cb) {
+  var configPath = getEnvConfigPath(baseDir, env)
+  if (!configPath) {
+    return process.nextTick(function () {
+      cb(null, null)
+    })
+  }
+
+  fs.readFile(configPath, 'utf8', function (err, data) {
+    if (err) {
+      if (err.code === 'ENOENT') {
+        return cb(null, null)
+      }
+      return cb(err)
+    }
+    log.verbose('env', 'Loaded environment config from', configPath)
+    cb(null, { path: configPath, data: data })
+  })
+}
+
+// Get environment-specific environment variables
+// Looks for npm_config_{env}_{key} pattern
+function getEnvSpecificVars (env) {
+  if (!env) return {}
+
+  var resolved = resolveEnvName(env)
+  var prefix = 'npm_config_' + resolved + '_'
+  var vars = {}
+
+  Object.keys(process.env)
+    .filter(function (k) {
+      return k.toLowerCase().startsWith(prefix.toLowerCase())
+    })
+    .forEach(function (k) {
+      // Extract the key after the env-specific prefix
+      var key = k.toLowerCase()
+        .replace(prefix.toLowerCase(), '')
+        .replace(/(?!^)_/g, '-')
+      vars[key] = process.env[k]
+    })
+
+  return vars
+}
+
+// Validate that an environment is known/configured
+function validateEnv (env, projectDir, userDir) {
+  if (!env) return { valid: true, env: null }
+
+  var resolved = resolveEnvName(env)
+  var projectConfig = envConfigExists(projectDir, resolved)
+  var userConfig = envConfigExists(userDir, resolved)
+  var hasEnvVars = Object.keys(getEnvSpecificVars(resolved)).length > 0
+
+  if (!projectConfig && !userConfig && !hasEnvVars) {
+    log.warn('env', 'No configuration found for environment: ' + resolved)
+    log.warn('env', 'Expected one of:')
+    log.warn('env', '  - ' + getEnvConfigPath(projectDir, resolved))
+    log.warn('env', '  - ' + getEnvConfigPath(userDir, resolved))
+    log.warn('env', '  - Environment variables prefixed with npm_config_' + resolved + '_')
+  }
+
+  return {
+    valid: true, // We allow running even without config
+    env: resolved,
+    projectConfig: projectConfig,
+    userConfig: userConfig,
+    hasEnvVars: hasEnvVars
+  }
+}
+
+// Get information about available environments
+function listAvailableEnvs (projectDir, userDir) {
+  var envs = {}
+
+  // Check project directory
+  try {
+    fs.readdirSync(projectDir)
+      .filter(function (f) {
+        return f.startsWith('.npmrc.')
+      })
+      .forEach(function (f) {
+        var env = f.replace('.npmrc.', '')
+        envs[env] = envs[env] || {}
+        envs[env].projectConfig = path.join(projectDir, f)
+      })
+  } catch (e) {
+    // Directory might not exist
+  }
+
+  // Check user directory
+  try {
+    fs.readdirSync(userDir)
+      .filter(function (f) {
+        return f.startsWith('.npmrc.')
+      })
+      .forEach(function (f) {
+        var env = f.replace('.npmrc.', '')
+        envs[env] = envs[env] || {}
+        envs[env].userConfig = path.join(userDir, f)
+      })
+  } catch (e) {
+    // Directory might not exist
+  }
+
+  return envs
+}
+
+// Create a wrapper that runs a command with environment-specific config
+function withEnvConfig (env, fn) {
+  return function (args, cb) {
+    var resolved = resolveEnvName(env)
+    if (resolved) {
+      log.info('env', 'Running with environment:', resolved)
+    }
+    return fn(args, cb)
+  }
+}
+
+// Export utilities
+module.exports = {
+  resolveEnvName: resolveEnvName,
+  getEnvConfigPath: getEnvConfigPath,
+  envConfigExists: envConfigExists,
+  loadEnvConfig: loadEnvConfig,
+  getEnvSpecificVars: getEnvSpecificVars,
+  validateEnv: validateEnv,
+  listAvailableEnvs: listAvailableEnvs,
+  withEnvConfig: withEnvConfig,
+  ENV_ALIASES: ENV_ALIASES
+}

--- a/test/tap/config-env-specific.js
+++ b/test/tap/config-env-specific.js
@@ -1,0 +1,182 @@
+var test = require('tap').test
+var path = require('path')
+var fs = require('graceful-fs')
+var rimraf = require('rimraf')
+var mkdirp = require('mkdirp')
+var environments = require('../../lib/utils/environments.js')
+var loadEnvConfig = require('../../lib/config/load-env.js')
+
+var testDir = path.join(__dirname, 'config-env-specific-test')
+
+test('setup', function (t) {
+  mkdirp.sync(testDir)
+  t.end()
+})
+
+test('environments.resolveEnvName - resolves aliases', function (t) {
+  t.equal(environments.resolveEnvName('dev'), 'development')
+  t.equal(environments.resolveEnvName('prod'), 'production')
+  t.equal(environments.resolveEnvName('stg'), 'staging')
+  t.equal(environments.resolveEnvName('stage'), 'staging')
+  t.equal(environments.resolveEnvName('staging'), 'staging')
+  t.equal(environments.resolveEnvName('production'), 'production')
+  t.equal(environments.resolveEnvName('custom'), 'custom')
+  t.equal(environments.resolveEnvName(null), null)
+  t.equal(environments.resolveEnvName(''), null)
+  t.end()
+})
+
+test('environments.getEnvConfigPath - generates correct paths', function (t) {
+  var baseDir = '/test/dir'
+  t.equal(
+    environments.getEnvConfigPath(baseDir, 'staging'),
+    path.join(baseDir, '.npmrc.staging')
+  )
+  t.equal(
+    environments.getEnvConfigPath(baseDir, 'dev'),
+    path.join(baseDir, '.npmrc.development')
+  )
+  t.equal(environments.getEnvConfigPath(baseDir, null), null)
+  t.end()
+})
+
+test('environments.envConfigExists - detects existing configs', function (t) {
+  // Create a test config file
+  var envConfigPath = path.join(testDir, '.npmrc.staging')
+  fs.writeFileSync(envConfigPath, 'registry=https://staging.example.com/')
+
+  t.equal(environments.envConfigExists(testDir, 'staging'), true)
+  t.equal(environments.envConfigExists(testDir, 'production'), false)
+  t.equal(environments.envConfigExists(testDir, null), false)
+  t.end()
+})
+
+test('environments.loadEnvConfig - loads config file', function (t) {
+  var envConfigPath = path.join(testDir, '.npmrc.staging')
+  fs.writeFileSync(envConfigPath, 'registry=https://staging.example.com/\ncache=/tmp/staging-cache')
+
+  environments.loadEnvConfig(testDir, 'staging', function (err, result) {
+    t.equal(err, null)
+    t.ok(result)
+    t.equal(result.path, envConfigPath)
+    t.ok(result.data.includes('registry=https://staging.example.com/'))
+    t.end()
+  })
+})
+
+test('environments.loadEnvConfig - returns null for missing config', function (t) {
+  environments.loadEnvConfig(testDir, 'nonexistent', function (err, result) {
+    t.equal(err, null)
+    t.equal(result, null)
+    t.end()
+  })
+})
+
+test('environments.loadEnvConfig - returns null for null env', function (t) {
+  environments.loadEnvConfig(testDir, null, function (err, result) {
+    t.equal(err, null)
+    t.equal(result, null)
+    t.end()
+  })
+})
+
+test('environments.getEnvSpecificVars - extracts env-specific vars', function (t) {
+  // Set some environment-specific variables
+  process.env.npm_config_staging_registry = 'https://staging.example.com/'
+  process.env.npm_config_staging_cache = '/tmp/staging-cache'
+  process.env.npm_config_production_registry = 'https://prod.example.com/'
+
+  var stagingVars = environments.getEnvSpecificVars('staging')
+  t.equal(stagingVars.registry, 'https://staging.example.com/')
+  t.equal(stagingVars.cache, '/tmp/staging-cache')
+  t.notOk(stagingVars['production-registry'])
+
+  var prodVars = environments.getEnvSpecificVars('production')
+  t.equal(prodVars.registry, 'https://prod.example.com/')
+
+  // Cleanup
+  delete process.env.npm_config_staging_registry
+  delete process.env.npm_config_staging_cache
+  delete process.env.npm_config_production_registry
+
+  t.end()
+})
+
+test('environments.validateEnv - validates environment', function (t) {
+  var result = environments.validateEnv('staging', testDir, testDir)
+  t.equal(result.valid, true)
+  t.equal(result.env, 'staging')
+  t.ok(result.projectConfig || result.userConfig || result.hasEnvVars || true)
+  t.end()
+})
+
+test('environments.listAvailableEnvs - lists available environments', function (t) {
+  // Create additional test config files
+  fs.writeFileSync(path.join(testDir, '.npmrc.production'), 'registry=https://prod.example.com/')
+  fs.writeFileSync(path.join(testDir, '.npmrc.development'), 'registry=https://dev.example.com/')
+
+  var envs = environments.listAvailableEnvs(testDir, testDir)
+  t.ok(envs.staging)
+  t.ok(envs.production)
+  t.ok(envs.development)
+  t.end()
+})
+
+test('loadEnvConfig module - loads environment config', function (t) {
+  var options = {
+    projectDir: testDir,
+    userDir: testDir
+  }
+
+  loadEnvConfig('staging', options, function (err, result) {
+    t.equal(err, null)
+    t.ok(result)
+    t.equal(result.env, 'staging')
+    t.ok(result.config)
+    t.ok(result.config.path.includes('.npmrc.staging'))
+    t.end()
+  })
+})
+
+test('loadEnvConfig module - returns null for no env', function (t) {
+  var options = {
+    projectDir: testDir,
+    userDir: testDir
+  }
+
+  loadEnvConfig(null, options, function (err, result) {
+    t.equal(err, null)
+    t.equal(result, null)
+    t.end()
+  })
+})
+
+test('loadEnvConfig.parse - parses config content', function (t) {
+  var content = 'registry=https://example.com/\n# Comment\ncache=/tmp/cache\nkey="quoted value"'
+  var parsed = loadEnvConfig.parse(content)
+
+  t.equal(parsed.registry, 'https://example.com/')
+  t.equal(parsed.cache, '/tmp/cache')
+  t.equal(parsed.key, 'quoted value')
+  t.notOk(parsed['# Comment'])
+  t.end()
+})
+
+test('loadEnvConfig.getEnvInfo - returns environment info', function (t) {
+  var options = {
+    projectDir: testDir,
+    userDir: testDir
+  }
+
+  var info = loadEnvConfig.getEnvInfo('staging', options)
+  t.ok(info)
+  t.equal(info.name, 'staging')
+  t.ok(Array.isArray(info.configPaths))
+  t.ok(info.configPaths.length > 0)
+  t.end()
+})
+
+test('cleanup', function (t) {
+  rimraf.sync(testDir)
+  t.end()
+})


### PR DESCRIPTION
Introduces a pattern for running npm commands in different environments (development, staging, production, etc.) using the --env flag.

Features:
- New --env (-e) flag to specify target environment
- Loads .npmrc.{env} files for environment-specific configuration
- Supports environment aliases (dev -> development, prod -> production)
- Environment-specific env vars via npm_config_{env}_{key} pattern
- New --env-config-dir option for custom config directory

Config files are loaded from:
1. {env-config-dir}/.npmrc.{env} (if --env-config-dir specified)
2. {project}/.npmrc.{env}
3. ~/.npmrc.{env}

This enables workflows like:
  npm install --env staging
  npm publish --env production

Documentation added in doc/misc/npm-environments.md

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
