### PR TITLE
fix: preserve serialNumber UUID in CycloneDX SBOM output #8837

### DIFF
--- a/lib/commands/sbom.js
+++ b/lib/commands/sbom.js
@@ -1,6 +1,6 @@
 const localeCompare = require('@isaacs/string-locale-compare')('en')
 const BaseCommand = require('../base-cmd.js')
-const { log, output } = require('proc-log')
+const { log, output, META } = require('proc-log')
 const { cyclonedxOutput } = require('../utils/sbom-cyclonedx.js')
 const { spdxOutput } = require('../utils/sbom-spdx.js')
 
@@ -65,7 +65,7 @@ class SBOM extends BaseCommand {
     // TODO(BREAKING_CHANGE): all sbom output is in json mode but setting it before
     // any of the errors will cause those to be thrown in json mode.
     this.npm.config.set('json', true)
-    output.buffer(this.#response)
+    output.standard(JSON.stringify(this.#response, null, 2), { [META]: true, redact: false })
   }
 
   async execWorkspaces (args) {

--- a/tap-snapshots/test/lib/commands/sbom.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/sbom.js.test.cjs
@@ -11,7 +11,7 @@ exports[`test/lib/commands/sbom.js TAP sbom --omit dev > must match snapshot 1`]
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "test-npm-sbom@1.0.0",
-  "documentNamespace": "http://spdx.org/spdxdocs/test-npm-sbom-1.0.0-00000000-0000-0000-0000-000000000000",
+  "documentNamespace": "http://spdx.org/spdxdocs/test-npm-sbom-1.0.0-12345678-90ab-cdef-1234-567890abcdef",
   "creationInfo": {
     "created": "2020-01-01T00:00:00.000Z",
     "creators": [
@@ -101,7 +101,7 @@ exports[`test/lib/commands/sbom.js TAP sbom --omit optional > must match snapsho
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "test-npm-sbom@1.0.0",
-  "documentNamespace": "http://spdx.org/spdxdocs/test-npm-sbom-1.0.0-00000000-0000-0000-0000-000000000000",
+  "documentNamespace": "http://spdx.org/spdxdocs/test-npm-sbom-1.0.0-12345678-90ab-cdef-1234-567890abcdef",
   "creationInfo": {
     "created": "2020-01-01T00:00:00.000Z",
     "creators": [
@@ -169,7 +169,7 @@ exports[`test/lib/commands/sbom.js TAP sbom --omit peer > must match snapshot 1`
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "test-npm-sbom@1.0.0",
-  "documentNamespace": "http://spdx.org/spdxdocs/test-npm-sbom-1.0.0-00000000-0000-0000-0000-000000000000",
+  "documentNamespace": "http://spdx.org/spdxdocs/test-npm-sbom-1.0.0-12345678-90ab-cdef-1234-567890abcdef",
   "creationInfo": {
     "created": "2020-01-01T00:00:00.000Z",
     "creators": [
@@ -236,7 +236,7 @@ exports[`test/lib/commands/sbom.js TAP sbom basic sbom - cyclonedx > must match 
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-  "serialNumber": "urn:uuid:00000000-0000-0000-0000-000000000000",
+  "serialNumber": "urn:uuid:12345678-90ab-cdef-1234-567890abcdef",
   "version": 1,
   "metadata": {
     "timestamp": "2020-01-01T00:00:00.000Z",
@@ -327,7 +327,7 @@ exports[`test/lib/commands/sbom.js TAP sbom basic sbom - spdx > must match snaps
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "test-npm-sbom@1.0.0",
-  "documentNamespace": "http://spdx.org/spdxdocs/test-npm-sbom-1.0.0-00000000-0000-0000-0000-000000000000",
+  "documentNamespace": "http://spdx.org/spdxdocs/test-npm-sbom-1.0.0-12345678-90ab-cdef-1234-567890abcdef",
   "creationInfo": {
     "created": "2020-01-01T00:00:00.000Z",
     "creators": [
@@ -438,7 +438,7 @@ exports[`test/lib/commands/sbom.js TAP sbom duplicate deps - cyclonedx > must ma
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-  "serialNumber": "urn:uuid:00000000-0000-0000-0000-000000000000",
+  "serialNumber": "urn:uuid:12345678-90ab-cdef-1234-567890abcdef",
   "version": 1,
   "metadata": {
     "timestamp": "2020-01-01T00:00:00.000Z",
@@ -546,7 +546,7 @@ exports[`test/lib/commands/sbom.js TAP sbom duplicate deps - spdx > must match s
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "test-npm-sbom@1.0.0",
-  "documentNamespace": "http://spdx.org/spdxdocs/test-npm-sbom-1.0.0-00000000-0000-0000-0000-000000000000",
+  "documentNamespace": "http://spdx.org/spdxdocs/test-npm-sbom-1.0.0-12345678-90ab-cdef-1234-567890abcdef",
   "creationInfo": {
     "created": "2020-01-01T00:00:00.000Z",
     "creators": [
@@ -685,7 +685,7 @@ exports[`test/lib/commands/sbom.js TAP sbom extraneous dep > must match snapshot
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "test-npm-ls@1.0.0",
-  "documentNamespace": "http://spdx.org/spdxdocs/test-npm-sbom-1.0.0-00000000-0000-0000-0000-000000000000",
+  "documentNamespace": "http://spdx.org/spdxdocs/test-npm-sbom-1.0.0-12345678-90ab-cdef-1234-567890abcdef",
   "creationInfo": {
     "created": "2020-01-01T00:00:00.000Z",
     "creators": [
@@ -797,7 +797,7 @@ exports[`test/lib/commands/sbom.js TAP sbom loading a tree containing workspaces
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "workspaces-tree@1.0.0",
-  "documentNamespace": "http://spdx.org/spdxdocs/test-npm-sbom-1.0.0-00000000-0000-0000-0000-000000000000",
+  "documentNamespace": "http://spdx.org/spdxdocs/test-npm-sbom-1.0.0-12345678-90ab-cdef-1234-567890abcdef",
   "creationInfo": {
     "created": "2020-01-01T00:00:00.000Z",
     "creators": [
@@ -980,7 +980,7 @@ exports[`test/lib/commands/sbom.js TAP sbom loading a tree containing workspaces
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "workspaces-tree@1.0.0",
-  "documentNamespace": "http://spdx.org/spdxdocs/test-npm-sbom-1.0.0-00000000-0000-0000-0000-000000000000",
+  "documentNamespace": "http://spdx.org/spdxdocs/test-npm-sbom-1.0.0-12345678-90ab-cdef-1234-567890abcdef",
   "creationInfo": {
     "created": "2020-01-01T00:00:00.000Z",
     "creators": [
@@ -1070,7 +1070,7 @@ exports[`test/lib/commands/sbom.js TAP sbom loading a tree containing workspaces
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "workspaces-tree@1.0.0",
-  "documentNamespace": "http://spdx.org/spdxdocs/test-npm-sbom-1.0.0-00000000-0000-0000-0000-000000000000",
+  "documentNamespace": "http://spdx.org/spdxdocs/test-npm-sbom-1.0.0-12345678-90ab-cdef-1234-567890abcdef",
   "creationInfo": {
     "created": "2020-01-01T00:00:00.000Z",
     "creators": [
@@ -1341,7 +1341,7 @@ exports[`test/lib/commands/sbom.js TAP sbom loading a tree containing workspaces
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "workspaces-tree@1.0.0",
-  "documentNamespace": "http://spdx.org/spdxdocs/test-npm-sbom-1.0.0-00000000-0000-0000-0000-000000000000",
+  "documentNamespace": "http://spdx.org/spdxdocs/test-npm-sbom-1.0.0-12345678-90ab-cdef-1234-567890abcdef",
   "creationInfo": {
     "created": "2020-01-01T00:00:00.000Z",
     "creators": [
@@ -1413,7 +1413,7 @@ exports[`test/lib/commands/sbom.js TAP sbom lock file only > must match snapshot
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "test-npm-ls@1.0.0",
-  "documentNamespace": "http://spdx.org/spdxdocs/test-npm-sbom-1.0.0-00000000-0000-0000-0000-000000000000",
+  "documentNamespace": "http://spdx.org/spdxdocs/test-npm-sbom-1.0.0-12345678-90ab-cdef-1234-567890abcdef",
   "creationInfo": {
     "created": "2020-01-01T00:00:00.000Z",
     "creators": [
@@ -1525,7 +1525,7 @@ exports[`test/lib/commands/sbom.js TAP sbom missing (optional) dep > must match 
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "test-npm-ls@1.0.0",
-  "documentNamespace": "http://spdx.org/spdxdocs/test-npm-sbom-1.0.0-00000000-0000-0000-0000-000000000000",
+  "documentNamespace": "http://spdx.org/spdxdocs/test-npm-sbom-1.0.0-12345678-90ab-cdef-1234-567890abcdef",
   "creationInfo": {
     "created": "2020-01-01T00:00:00.000Z",
     "creators": [

--- a/test/lib/commands/sbom.js
+++ b/test/lib/commands/sbom.js
@@ -2,7 +2,7 @@ const t = require('tap')
 const mockNpm = require('../../fixtures/mock-npm.js')
 
 const FAKE_TIMESTAMP = '2020-01-01T00:00:00.000Z'
-const FAKE_UUID = '00000000-0000-0000-0000-000000000000'
+const FAKE_UUID = '12345678-90ab-cdef-1234-567890abcdef'
 
 t.cleanSnapshot = s => {
   let sbom


### PR DESCRIPTION
As mentioned in the issue #8837, BOM files in cyclonedx format created by npm-sbom contain an invalid statically UUID value in the serialNumber field: `"serialNumber": "urn:uuid:***"`, because it was being redacted each time. 

This change uses `output.standard()` with `{ [META]: true, redact: false }` to bypass redaction for SBOM output, following the same pattern used in `lib/commands/token.js` for outputting authentication tokens that should not be redacted.
 
**Before:**
```json
"serialNumber": "urn:uuid:***"
```

**After:**
```json
"serialNumber": "urn:uuid:12345678-1234-1234-1234-123456789abc"
```
<img width="1265" height="518" alt="image" src="https://github.com/user-attachments/assets/fc21aa65-2bef-4336-a55c-e7417ae9eebd" />


## Testing 

- All existing tests pass
- Verified locally that `serialNumber` now displays the complete UUID

## References
Fixes #8837 