### PR TITLE
docs: fix typo/logic error in npm-dedupe docs

### DIFF
--- a/docs/lib/content/commands/npm-dedupe.md
+++ b/docs/lib/content/commands/npm-dedupe.md
@@ -44,7 +44,7 @@ a
 ```
 
 During the installation process, the `c@1.0.3` dependency for `b` was placed in the root of the tree.
-Though `d`'s dependency on `c@1.x` could have been satisfied by `c@1.0.3`, the newer `c@1.9.0` dependency was used, because npm favors updates by default, even when doing so causes duplication.
+Though `d`'s dependency on `c@1.x` could have been satisfied by `c@1.0.3`, the newer `c@1.9.9` dependency was used, because npm favors updates by default, even when doing so causes duplication.
 
 Running `npm dedupe` will cause npm to note the duplication and re-evaluate, deleting the nested `c` module, because the one in the root is sufficient.
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
while reading https://docs.npmjs.com/cli/v11/commands/npm-dedupe

<img width="1582" height="502" alt="image" src="https://github.com/user-attachments/assets/cc8109a3-6d56-40bb-8cc7-09f6c59e0dd8" />

I realized there's probably a typo/logic error/imprecision: the `c@1.9.0` is mentioned nowhere else.

I assume `c@1.9.9` was meant, because it's listed in the dependency graph above. but I have no clue about the inner workings of `npm-dedupe`, so I might be wrong here.

---

alternative solution: noting `c@1.9.x`, but not using a range and explicitly matching the listed version above inherits more clarity, at least in my mind

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

- https://docs.npmjs.com/cli/v11/commands/npm-dedupe