### PR TITLE
feat: add color legend to npm outdated output

### DIFF
--- a/lib/commands/outdated.js
+++ b/lib/commands/outdated.js
@@ -222,7 +222,7 @@ class Outdated extends ArboristWorkspaceCmd {
     const long = this.npm.config.get('long')
     const { bold, yellow, red, cyan, blue } = this.npm.chalk
 
-    return table([
+    const tableOutput = table([
       [
         'Package',
         'Current',
@@ -245,6 +245,13 @@ class Outdated extends ArboristWorkspaceCmd {
       align: ['l', 'r', 'r', 'r', 'l'],
       stringLength: s => stripVTControlCharacters(s).length,
     })
+
+    if (this.npm.chalk.level !== 0) {
+      const legend = `\n${red('Red')} = Updateable within your version range\n${yellow('Yellow')} = Update available but requires semver-major bump`
+      return tableOutput + legend
+    }
+
+    return tableOutput
   }
 
   // --parseable creates output like this:

--- a/tap-snapshots/test/lib/commands/outdated.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/outdated.js.test.cjs
@@ -137,6 +137,8 @@ exports[`test/lib/commands/outdated.js TAP should display outdated deps outdated
 [31mcat[39m        1.0.0   [36m1.0.1[39m   [34m1.0.1[39m  node_modules/cat  prefix
 [33mdog[39m        1.0.1   [36m1.0.1[39m   [34m2.0.0[39m  node_modules/dog  prefix
 [31mtheta[39m    MISSING   [36m1.0.1[39m   [34m1.0.1[39m  -                 prefix
+[31mRed[39m = Updateable within your version range
+[33mYellow[39m = Update available but requires semver-major bump
 `
 
 exports[`test/lib/commands/outdated.js TAP should display outdated deps outdated --omit=dev > must match snapshot 1`] = `
@@ -145,6 +147,8 @@ exports[`test/lib/commands/outdated.js TAP should display outdated deps outdated
 [31mchai[39m       1.0.0   [36m1.0.1[39m   [34m1.0.1[39m  node_modules/chai  prefix
 [33mdog[39m        1.0.1   [36m1.0.1[39m   [34m2.0.0[39m  node_modules/dog   prefix
 [31mtheta[39m    MISSING   [36m1.0.1[39m   [34m1.0.1[39m  -                  prefix
+[31mRed[39m = Updateable within your version range
+[33mYellow[39m = Update available but requires semver-major bump
 `
 
 exports[`test/lib/commands/outdated.js TAP should display outdated deps outdated --omit=prod > must match snapshot 1`] = `
@@ -152,6 +156,8 @@ exports[`test/lib/commands/outdated.js TAP should display outdated deps outdated
 [31mcat[39m        1.0.0   [36m1.0.1[39m   [34m1.0.1[39m  node_modules/cat   prefix
 [31mchai[39m       1.0.0   [36m1.0.1[39m   [34m1.0.1[39m  node_modules/chai  prefix
 [33mdog[39m        1.0.1   [36m1.0.1[39m   [34m2.0.0[39m  node_modules/dog   prefix
+[31mRed[39m = Updateable within your version range
+[33mYellow[39m = Update available but requires semver-major bump
 `
 
 exports[`test/lib/commands/outdated.js TAP should display outdated deps outdated --parseable --long > must match snapshot 1`] = `
@@ -174,6 +180,8 @@ exports[`test/lib/commands/outdated.js TAP should display outdated deps outdated
 [31mchai[39m       1.0.0   [36m1.0.1[39m   [34m1.0.1[39m  node_modules/chai  prefix
 [33mdog[39m        1.0.1   [36m1.0.1[39m   [34m2.0.0[39m  node_modules/dog   prefix
 [31mtheta[39m    MISSING   [36m1.0.1[39m   [34m1.0.1[39m  -                  prefix
+[31mRed[39m = Updateable within your version range
+[33mYellow[39m = Update available but requires semver-major bump
 `
 
 exports[`test/lib/commands/outdated.js TAP should display outdated deps outdated global > must match snapshot 1`] = `
@@ -296,4 +304,6 @@ exports[`test/lib/commands/outdated.js TAP workspaces should highlight ws in dep
 [31mtheta[39m    MISSING   [36m1.0.1[39m   [34m1.0.1[39m  -                 [34mc@1.0.0[39m
 [31mtheta[39m    MISSING   [36m1.0.1[39m   [34m1.0.1[39m  -                 [34md@1.0.0[39m
 [31mtheta[39m    MISSING   [36m1.0.1[39m   [34m1.0.1[39m  -                 [34me@1.0.0[39m
+[31mRed[39m = Updateable within your version range
+[33mYellow[39m = Update available but requires semver-major bump
 `


### PR DESCRIPTION
Fixes #8850

### Summary
Added a color legend to the \
pm outdated\ command output to help users understand the meaning of the color-coded package names.

### Changes
- Modified \lib/commands/outdated.js\ to add a legend explaining color meanings
- Updated test snapshots to include the new legend in expected output

### Legend Details
The legend appears at the bottom of the \
pm outdated\ output when terminal colors are enabled:
- **Red** = Updateable within your version range
- **Yellow** = Update available but requires semver-major bump

The legend only displays when colors are enabled (\chalk.level !== 0\), ensuring it doesn't appear in CI environments or when \--no-color\ is used.

### Testing
-  58 out of 59 tests pass (1 pre-existing local environment test failure unrelated to changes)
-  All snapshots updated correctly
-  Legend correctly shows/hides based on color support