### PR TITLE
fix/clear removed workspace from lockfile

### DIFF
--- a/test/lib/commands/install.js
+++ b/test/lib/commands/install.js
@@ -294,6 +294,7 @@ t.test('completion', async t => {
   })
 })
 
+<<<<<<< HEAD
 t.test('should install in workspace with unhoisted module', async t => {
   const { npm, registry, assert } = await loadMockNpm(t, {
     prefixDir: workspaceMock(t, {

--- a/workspaces/arborist/lib/shrinkwrap.js
+++ b/workspaces/arborist/lib/shrinkwrap.js
@@ -931,9 +931,9 @@ class Shrinkwrap {
         const loc = relpath(this.path, node.path)
 
         // extraneous ws node should not commit
-        if(node.extraneous && root.workspaces && root.workspaces.length) {
+        if (node.extraneous && root.workspaces && root.workspaces.length) {
           const wsIndex = root.workspaces.findIndex(ws => ws === loc)
-          if(wsIndex > -1) {
+          if (wsIndex > -1) {
             root.workspaces.splice(wsIndex, 1)
             continue
           }

--- a/workspaces/arborist/lib/shrinkwrap.js
+++ b/workspaces/arborist/lib/shrinkwrap.js
@@ -931,7 +931,7 @@ class Shrinkwrap {
         const loc = relpath(this.path, node.path)
 
         // extraneous ws node should not commit
-        if(node.extraneous) {
+        if(node.extraneous && root.workspaces && root.workspaces.length) {
           const wsIndex = root.workspaces.findIndex(ws => ws === loc)
           if(wsIndex > -1) {
             root.workspaces.splice(wsIndex, 1)

--- a/workspaces/arborist/lib/shrinkwrap.js
+++ b/workspaces/arborist/lib/shrinkwrap.js
@@ -927,7 +927,18 @@ class Shrinkwrap {
         if (node === this.tree || node.isRoot || node.location === '') {
           continue
         }
+
         const loc = relpath(this.path, node.path)
+
+        // extraneous ws node should not commit
+        if(node.extraneous) {
+          const wsIndex = root.workspaces.findIndex(ws => ws === loc)
+          if(wsIndex > -1) {
+            root.workspaces.splice(wsIndex, 1)
+            continue
+          }
+        }
+
         this.data.packages[loc] = Shrinkwrap.metaFromNode(
           node,
           this.path,


### PR DESCRIPTION
- **fix: clear non-exist workspace part in package-lock.json when npm install (fix #5463)**
- **test: add test case for remove non-exist workspace node**
- **style(shrinkwrap): lint**
