### PR TITLE
fix(ls): fix descriptions in --long human output

### DIFF
--- a/lib/commands/ls.js
+++ b/lib/commands/ls.js
@@ -69,6 +69,7 @@ class LS extends ArboristWorkspaceCmd {
       ...this.npm.flatOptions,
       legacyPeerDeps: false,
       path,
+      forceActual: long && !json && !parseable && !packageLockOnly,
     })
     const tree = await this.initTree({ arb, args, packageLockOnly })
 

--- a/lib/commands/ls.js
+++ b/lib/commands/ls.js
@@ -340,7 +340,7 @@ const getHumanOutputItem = (node, { args, chalk, global, long }) => {
     ) +
     (isGitNode(node) ? ` (${node.resolved})` : '') +
     (node.isLink ? ` -> ${relativePrefix}${targetLocation}` : '') +
-    (long ? `\n${node.package.description || ''}` : '')
+    (long && !node[_missing] ? `\n${node.package.description || ''}` : '')
 
   return augmentItemWithIncludeMetadata(node, { label, nodes: [] })
 }

--- a/tap-snapshots/test/lib/commands/ls.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/ls.js.test.cjs
@@ -18,6 +18,32 @@ Array [
 ]
 `
 
+exports[`test/lib/commands/ls.js TAP ignore missing optional deps --long human output > ls --long result 1`] = `
+test-npm-ls-ignore-missing-optional@1.2.3
+| {CWD}/prefix
+| 
++-- UNMET OPTIONAL DEPENDENCY optional-missing@1
++-- optional-ok@1.2.3
+|   
++-- optional-wrong@3.2.1 invalid: "1" from the root project
+|   
++-- UNMET DEPENDENCY peer-missing@1
++-- peer-ok@1.2.3
+|   
++-- UNMET OPTIONAL DEPENDENCY peer-optional-missing@1
++-- peer-optional-ok@1.2.3 extraneous
+|   
++-- peer-optional-wrong@3.2.1 invalid: "1" from the root project extraneous
+|   
++-- peer-wrong@3.2.1 invalid: "1" from the root project
+|   
++-- UNMET DEPENDENCY prod-missing@1
++-- prod-ok@1.2.3
+|   
+\`-- prod-wrong@3.2.1 invalid: "1" from the root project
+    
+`
+
 exports[`test/lib/commands/ls.js TAP ignore missing optional deps --parseable > ls --parseable result 1`] = `
 {CWD}/prefix
 {CWD}/prefix/node_modules/optional-ok

--- a/test/lib/commands/ls.js
+++ b/test/lib/commands/ls.js
@@ -2663,6 +2663,11 @@ t.test('ignore missing optional deps', async t => {
     const result = await mock(t)
     t.matchSnapshot(result, 'ls result')
   })
+
+  t.test('--long human output', async t => {
+    const result = await mock(t, { long: true })
+    t.matchSnapshot(result, 'ls --long result')
+  })
 })
 
 t.test('ls --json', async t => {


### PR DESCRIPTION
[Having arborist's `loadActual` use a hidden lockfile][1] caused a lot of the information in actual `package.json` files to not be available in the tree, some of which is relied upon by cli commands like `ls --long` to output descriptions. This was fixed for `npm query` in #5263 by adding an option to avoid the hidden lockfile, `forceActual`. So, use this option for `ls --long` as well.

Additionally, `ls --long`'s unconditional access of `node.package.description` errors when `node.package` is undefined (#5961). This happens when `node` is not an arborist node but rather an object created by `mapEdgesToNodes` representing a missing linked node. Address this by making description output conditional on `node[_missing]`, as was similarly done for `ls --json --long` in 2aecec591df6866e27d0b17dc49cef8f7d738d77.

[1]: https://github.com/npm/arborist/commit/ab55e0feb788b39fd9c43f63c9e901f07cecee4a
