### PR TITLE
feat: adds circleci to oidc

### DIFF
--- a/lib/utils/oidc.js
+++ b/lib/utils/oidc.js
@@ -162,6 +162,11 @@ async function oidc ({ packageName, registry, opts, config }) {
               opts.provenance = true
               config.set('provenance', true, 'user')
             }
+          } else if (ciInfo.CIRCLE) {
+            // not supported yet for CircleCI
+            log.verbose('oidc', `Disabling provenance for CircleCI (not supported)`)
+            opts.provenance = false
+            config.set('provenance', false, 'user')
           }
         }
       }

--- a/lib/utils/oidc.js
+++ b/lib/utils/oidc.js
@@ -8,8 +8,8 @@ const libaccess = require('libnpmaccess')
 /**
  * Handles OpenID Connect (OIDC) token retrieval and exchange for CI environments.
  *
- * This function is designed to work in Continuous Integration (CI) environments such as GitHub Actions
- * and GitLab. It retrieves an OIDC token from the CI environment, exchanges it for an npm token, and
+ * This function is designed to work in Continuous Integration (CI) environments such as GitHub Actions,
+ * GitLab, and CircleCI. It retrieves an OIDC token from the CI environment, exchanges it for an npm token, and
  * sets the token in the provided configuration for authentication with the npm registry.
  *
  * This function is intended to never throw, as it mutates the state of the `opts` and `config` objects on success.
@@ -17,6 +17,7 @@ const libaccess = require('libnpmaccess')
  *
  * @see https://github.com/watson/ci-info for CI environment detection.
  * @see https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect for GitHub Actions OIDC.
+ * @see https://circleci.com/docs/openid-connect-tokens/ for CircleCI OIDC.
  */
 async function oidc ({ packageName, registry, opts, config }) {
   /*
@@ -29,7 +30,9 @@ async function oidc ({ packageName, registry, opts, config }) {
       /** @see https://github.com/watson/ci-info/blob/v4.2.0/vendors.json#L152 */
       ciInfo.GITHUB_ACTIONS ||
       /** @see https://github.com/watson/ci-info/blob/v4.2.0/vendors.json#L161C13-L161C22 */
-      ciInfo.GITLAB
+      ciInfo.GITLAB ||
+      /** @see https://github.com/watson/ci-info/blob/v4.2.0/vendors.json#L78 */
+      ciInfo.CIRCLE
     )) {
       return undefined
     }

--- a/lib/utils/oidc.js
+++ b/lib/utils/oidc.js
@@ -146,7 +146,8 @@ async function oidc ({ packageName, registry, opts, config }) {
 
     try {
       const isDefaultProvenance = config.isDefault('provenance')
-      if (isDefaultProvenance) {
+      // CircleCI doesn't support provenance yet, so skip the auto-enable logic
+      if (isDefaultProvenance && !ciInfo.CIRCLE) {
         const [headerB64, payloadB64] = idToken.split('.')
         if (headerB64 && payloadB64) {
           const payloadJson = Buffer.from(payloadB64, 'base64').toString('utf8')
@@ -162,11 +163,6 @@ async function oidc ({ packageName, registry, opts, config }) {
               opts.provenance = true
               config.set('provenance', true, 'user')
             }
-          } else if (ciInfo.CIRCLE) {
-            // not supported yet for CircleCI
-            log.verbose('oidc', `Disabling provenance for CircleCI (not supported)`)
-            opts.provenance = false
-            config.set('provenance', false, 'user')
           }
         }
       }

--- a/test/lib/commands/publish.js
+++ b/test/lib/commands/publish.js
@@ -5,7 +5,7 @@ const pacote = require('pacote')
 const Arborist = require('@npmcli/arborist')
 const path = require('node:path')
 const fs = require('node:fs')
-const { githubIdToken, gitlabIdToken, oidcPublishTest, mockOidc } = require('../../fixtures/mock-oidc')
+const { circleciIdToken, githubIdToken, gitlabIdToken, oidcPublishTest, mockOidc } = require('../../fixtures/mock-oidc')
 const { sigstoreIdToken } = require('@npmcli/mock-registry/lib/provenance')
 const mockGlobals = require('@npmcli/mock-globals')
 
@@ -1213,6 +1213,35 @@ t.test('oidc token exchange - no provenance', t => {
     },
     mockOidcTokenExchangeOptions: {
       idToken: gitlabPrivateIdToken,
+      body: {
+        token: 'exchange-token',
+      },
+    },
+    publishOptions: {
+      token: 'exchange-token',
+    },
+  }))
+
+  t.test('circleci missing NPM_ID_TOKEN', oidcPublishTest({
+    oidcOptions: { circleci: true, NPM_ID_TOKEN: '' },
+    config: {
+      '//registry.npmjs.org/:_authToken': 'existing-fallback-token',
+    },
+    publishOptions: {
+      token: 'existing-fallback-token',
+    },
+    logsContain: [
+      'silly oidc Skipped because no id_token available',
+    ],
+  }))
+
+  t.test('default registry success circleci', oidcPublishTest({
+    oidcOptions: { circleci: true, NPM_ID_TOKEN: circleciIdToken() },
+    config: {
+      '//registry.npmjs.org/:_authToken': 'existing-fallback-token',
+    },
+    mockOidcTokenExchangeOptions: {
+      idToken: circleciIdToken(),
       body: {
         token: 'exchange-token',
       },

--- a/test/lib/commands/publish.js
+++ b/test/lib/commands/publish.js
@@ -1248,7 +1248,11 @@ t.test('oidc token exchange - no provenance', t => {
     },
     publishOptions: {
       token: 'exchange-token',
+      provenance: false,
     },
+    logsContain: [
+      'verbose oidc Disabling provenance for CircleCI (not supported)',
+    ],
   }))
 
   // custom registry success

--- a/test/lib/commands/publish.js
+++ b/test/lib/commands/publish.js
@@ -1248,11 +1248,7 @@ t.test('oidc token exchange - no provenance', t => {
     },
     publishOptions: {
       token: 'exchange-token',
-      provenance: false,
     },
-    logsContain: [
-      'verbose oidc Disabling provenance for CircleCI (not supported)',
-    ],
   }))
 
   // custom registry success


### PR DESCRIPTION
This pull request adds support for CircleCI as a provider of OpenID Connect (OIDC) tokens in CI environments, alongside existing support for GitHub Actions and GitLab. The implementation includes both code changes to detect and handle CircleCI OIDC tokens and new tests to ensure correct behavior.

## Usage

In your `.circleci/config.yml`:

```yaml
version: 2.1

jobs:
  publish:
    docker:
      - image: cimg/node:lts
    steps:
      - checkout
      - run:
          name: Publish to npm
          command: |
            NPM_AUDIENCE="npm:$(npm config get registry | sed 's|https\?://||;s|/$||')"
            NPM_ID_TOKEN=$(circleci run oidc get --claims "{\"aud\": \"$NPM_AUDIENCE\"}")
            npm publish

workflows:
  publish:
    jobs:
      - publish
```

Note: Unlike GitHub Actions and GitLab, CircleCI requires manually fetching the OIDC token with the correct audience claim using the `circleci` CLI.