### PR TITLE
feat: suggest relevant packages on 404 error

### DIFF
--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -66,7 +66,12 @@ class RunScript extends BaseCommand {
       try {
         await this.#run(args, { path, pkg, workspace })
       } catch (e) {
-        const err = getError(e, { npm: this.npm, command: null })
+        let suggestions = []
+        if (e.code === 'E404' && e.pkgid && e.pkgid !== '-') {
+          const packageSuggestions = require('../utils/package-suggestions.js')
+          suggestions = await packageSuggestions(e.pkgid, this.npm)
+        }
+        const err = getError(e, { npm: this.npm, command: null, suggestions })
         outputError({
           ...err,
           error: [

--- a/lib/commands/view.js
+++ b/lib/commands/view.js
@@ -86,7 +86,12 @@ class View extends BaseCommand {
       try {
         await this.#viewPackage(`${name}${pkg.slice(1)}`, rest, { workspace: true })
       } catch (e) {
-        const err = getError(e, { npm: this.npm, command: this })
+        let suggestions = []
+        if (e.code === 'E404' && e.pkgid && e.pkgid !== '-') {
+          const packageSuggestions = require('../utils/package-suggestions.js')
+          suggestions = await packageSuggestions(e.pkgid, this.npm)
+        }
+        const err = getError(e, { npm: this.npm, command: this, suggestions })
         if (err.code !== 'E404') {
           throw e
         }

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -306,7 +306,14 @@ class Npm {
         .normalize(this.localPrefix)
         .then(p => p.content)
         .catch(() => null)
-      Object.assign(err, this.#getError(err, { pkg: localPkg }))
+
+      let suggestions = []
+      if (err.code === 'E404' && err.pkgid && err.pkgid !== '-') {
+        const packageSuggestions = require('./utils/package-suggestions.js')
+        suggestions = await packageSuggestions(err.pkgid, this)
+      }
+
+      Object.assign(err, this.#getError(err, { pkg: localPkg, suggestions }))
     }
 
     this.finish(err)

--- a/lib/utils/error-message.js
+++ b/lib/utils/error-message.js
@@ -3,7 +3,7 @@ const { resolve } = require('node:path')
 const { redactLog: replaceInfo } = require('@npmcli/redact')
 const { log } = require('proc-log')
 
-const errorMessage = (er, npm) => {
+const errorMessage = (er, npm, { suggestions = [] } = {}) => {
   const summary = []
   const detail = []
   const files = []
@@ -202,6 +202,14 @@ const errorMessage = (er, npm) => {
         detail.push(['404', ''])
         detail.push(['404', 'Note that you can also install from a'])
         detail.push(['404', 'tarball, folder, http url, or git url.'])
+
+        if (suggestions.length > 0) {
+          detail.push(['404', ''])
+          detail.push(['404', `Did you mean ${suggestions.length === 1 ? 'this' : 'one of these'}?`])
+          suggestions.slice(0, 5).forEach(suggestion => {
+            detail.push(['404', `    ${suggestion}`])
+          })
+        }
       }
       break
 
@@ -394,7 +402,7 @@ const getExitCodeFromError = (err) => {
   }
 }
 
-const getError = (err, { npm, command, pkg }) => {
+const getError = (err, { npm, command, pkg, ...opts }) => {
   // if we got a command that just shells out to something else, then it
   // will presumably print its own errors and exit with a proper status
   // code if there's a problem.  If we got an error with a code=0, then...
@@ -444,7 +452,7 @@ const getError = (err, { npm, command, pkg }) => {
   // so they have redacted information
   err.code ??= err.message.match(/^(?:Error: )?(E[A-Z]+)/)?.[1]
   // this mutates the error and redacts stack/message
-  const { summary, detail, files, json } = errorMessage(err, npm)
+  const { summary, detail, files, json } = errorMessage(err, npm, opts)
 
   return {
     err,

--- a/lib/utils/package-suggestions.js
+++ b/lib/utils/package-suggestions.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const libSearch = require('libnpmsearch')
+
+const packageSuggestions = async (name, npm) => {
+  // If we don't have a package name, we can't suggest anything
+  if (!name || name === '-') {
+    return []
+  }
+
+  // Strip version if present (e.g. pkg@1.0.0 -> pkg)
+  const pkgName = name.replace(/(?!^)@.*$/, '')
+
+  try {
+    const results = await libSearch(pkgName, {
+      ...npm.flatOptions,
+      limit: 5,
+    })
+
+    return results
+      .map(r => r.name)
+      .filter(n => n !== pkgName) // Don't suggest the same name
+  } catch (err) {
+    // If search fails for any reason (e.g. network), just return no suggestions
+    // instead of failing the error handling itself.
+    return []
+  }
+}
+
+module.exports = packageSuggestions

--- a/lib/utils/package-suggestions.js
+++ b/lib/utils/package-suggestions.js
@@ -15,6 +15,7 @@ const packageSuggestions = async (name, npm) => {
     const results = await libSearch(pkgName, {
       ...npm.flatOptions,
       limit: 5,
+      timeout: 3000, // 3 seconds timeout
     })
 
     return results

--- a/test/lib/utils/package-suggestions.js
+++ b/test/lib/utils/package-suggestions.js
@@ -1,0 +1,51 @@
+'use strict'
+
+const t = require('tap')
+const tmock = require('../../fixtures/tmock')
+
+t.test('package-suggestions', async t => {
+  const suggestions = tmock(t, '{LIB}/utils/package-suggestions.js', {
+    libnpmsearch: async (query) => {
+      if (query === 'pg-hstor') {
+        return [{ name: 'pg-hstore' }, { name: 'pg' }]
+      }
+      if (query === 'fail') {
+        throw new Error('search failed')
+      }
+      return []
+    },
+  })
+
+  t.test('basic suggestions', async t => {
+    const res = await suggestions('pg-hstor', { flatOptions: {} })
+    t.strictSame(res, ['pg-hstore', 'pg'])
+  })
+
+  t.test('no name', async t => {
+    const res = await suggestions('', { flatOptions: {} })
+    t.strictSame(res, [])
+  })
+
+  t.test('dash name', async t => {
+    const res = await suggestions('-', { flatOptions: {} })
+    t.strictSame(res, [])
+  })
+
+  t.test('search failure', async t => {
+    const res = await suggestions('fail', { flatOptions: {} })
+    t.strictSame(res, [])
+  })
+
+  t.test('same name filter', async t => {
+    const suggestionsSame = tmock(t, '{LIB}/utils/package-suggestions.js', {
+      libnpmsearch: async () => [{ name: 'exact' }, { name: 'other' }],
+    })
+    const res = await suggestionsSame('exact', { flatOptions: {} })
+    t.strictSame(res, ['other'])
+  })
+
+  t.test('strips version from name', async t => {
+    const res = await suggestions('pg-hstor@1.2.3', { flatOptions: {} })
+    t.strictSame(res, ['pg-hstore', 'pg'])
+  })
+})


### PR DESCRIPTION
This PR introduces a feature to suggest relevant packages when a user encounters a 404 error during installation or other commands. It uses `libnpmsearch` for semantic suggestions and includes a 3-second timeout for robustness.