### PR TITLE
docs: fix typo and grammar in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ npm <command>
 
 #### Is "npm" an acronym for "Node Package Manager"?
 
-Contrary to popular belief, **`npm`** **is not** an acronym for "Node Package Manager." It is a recursive backronymic abbreviation for **"npm is not an acronym"** (if the project were named "ninaa," then it would be an acronym). The precursor to **`npm`** was actually a bash utility named **"pm"**, which was the shortform name of **"pkgmakeinst"** - a bash function that installed various things on various platforms. If **`npm`** was ever considered an acronym, it would be "node pm" or, potentially, "new pm".
+Contrary to popular belief, **`npm`** **is not** an acronym for "Node Package Manager." It is a recursive backronymic abbreviation for **"npm is not an acronym"** (if the project were named "ninaa," then it would be an acronym). The precursor to **`npm`** was actually a bash utility named **"pm"**, which was the shortform name of **"pkgmakeinst"** - a bash function that installed various things on various platforms. If **`npm`** were ever considered an acronym, it would be as "node pm" or, potentially, "new pm".

--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ npm <command>
 
 #### Is "npm" an acronym for "Node Package Manager"?
 
-Contrary to popular belief, **`npm`** **is not** in fact an acronym for "Node Package Manager"; It is a recursive bacronymic abbreviation for **"npm is not an acronym"** (if the project was named "ninaa", then it would be an acronym). The precursor to **`npm`** was actually a bash utility named **"pm"**, which was the shortform name of **"pkgmakeinst"** - a bash function that installed various things on various platforms. If **`npm`** were to ever have been considered an acronym, it would be as "node pm" or, potentially "new pm".
+Contrary to popular belief, **`npm`** **is not** an acronym for "Node Package Manager." It is a recursive backronymic abbreviation for **"npm is not an acronym"** (if the project were named "ninaa," then it would be an acronym). The precursor to **`npm`** was actually a bash utility named **"pm"**, which was the shortform name of **"pkgmakeinst"** - a bash function that installed various things on various platforms. If **`npm`** was ever considered an acronym, it would be "node pm" or, potentially, "new pm".


### PR DESCRIPTION
- Fixed spelling of "backronymic" (from "bacronymic").
- Improved sentence structure in the branding FAQ to be more concise.
- Corrected "if the project was" to "if the project were" (subjunctive mood).
- Removed redundant "in fact" and "to ever have been."