### PR TITLE
fix(arborist): skip postinstall on store links in linked strategy

### DIFF
--- a/workspaces/arborist/lib/arborist/rebuild.js
+++ b/workspaces/arborist/lib/arborist/rebuild.js
@@ -295,12 +295,12 @@ module.exports = cls => class Builder extends cls {
         devOptional,
         package: pkg,
         location,
-        isStoreLink,
       } = node.target
 
       // skip any that we know we'll be deleting
-      // or storeLinks
-      if (this[_trashList].has(path) || isStoreLink) {
+      // or links to store entries (their scripts run on the store
+      // entry itself, not through the link)
+      if (this[_trashList].has(path) || (node.isLink && node.target?.isInStore)) {
         return
       }
 

--- a/workspaces/arborist/test/isolated-mode.js
+++ b/workspaces/arborist/test/isolated-mode.js
@@ -1571,6 +1571,36 @@ tap.test('postinstall scripts are run', async t => {
   t.ok(postInstallRanBar)
 })
 
+tap.test('postinstall scripts run once for store packages', async t => {
+  // Regression test: store links should not cause scripts to run twice.
+  // The store entry and its symlink both end up in the build queue, but
+  // only the store entry should run scripts.
+  const graph = {
+    registry: [
+      {
+        name: 'which',
+        version: '1.0.0',
+        scripts: {
+          postinstall: 'node -e "var c=0;try{c=+fs.readFileSync(\'postinstall-count\',\'utf8\')}catch(e){};fs.writeFileSync(\'postinstall-count\',String(c+1))"',
+        },
+      },
+    ],
+    root: {
+      name: 'foo', version: '1.2.3', dependencies: { which: '1.0.0' },
+    },
+  }
+
+  const { dir, registry } = await getRepo(graph)
+
+  const cache = fs.mkdtempSync(`${getTempDir()}/test-`)
+  const arborist = new Arborist({ path: dir, registry, packumentCache: new Map(), cache })
+  await arborist.reify({ installStrategy: 'linked' })
+
+  const whichDir = setupRequire(dir)('which')
+  const count = Number(fs.readFileSync(`${whichDir}/postinstall-count`, 'utf8'))
+  t.equal(count, 1, 'postinstall ran exactly once')
+})
+
 tap.test('bins are installed', async t => {
   // Input of arborist
   const graph = {


### PR DESCRIPTION
Continuing the `install-strategy=linked` fixes from #8996. While testing in the [Gutenberg monorepo](https://github.com/WordPress/gutenberg/pull/75814), `esbuild` installs fail because its postinstall script runs twice in parallel against the same store directory.

## Summary

With `install-strategy=linked`, postinstall scripts run twice for every store package — once for the store entry and once for its symlink. For packages like `esbuild` whose postinstall modifies files in-place (`fs.linkSync` to replace the JS wrapper with a native binary), this race condition corrupts the install.

## Root cause

In `rebuild.js`, `#runScripts` destructures `isStoreLink` from `node.target` (the store entry) to decide whether to skip a node. But `isStoreLink` is a property of the link node itself (`node`), not its target. Store entries don't have `isStoreLink`, so it's always `undefined` and the guard never triggers. Both the store entry and the store link run scripts against the same directory in parallel.

## Changes

- Fixed the skip condition in `rebuild.js` `#runScripts` to use `node.isLink && node.target?.isInStore` instead of reading `isStoreLink` from `node.target`. This correctly skips store links (symlinks pointing to store entries) while still allowing workspace links and store entries themselves to run scripts.
- Added a regression test that verifies postinstall scripts run exactly once for store packages.

## References
Fixes #9012
