### PR TITLE
fix: clear exclusive param siblings when setting from CLI

### DIFF
--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -1353,6 +1353,7 @@ const definitions = {
     hint: '<days>',
     type: [null, Number],
     exclusive: ['before'],
+    envExport: false,
     description: `
        If set, npm will build the npm tree such that only versions that were
        available more than the given number of days ago will be installed.  If

--- a/workspaces/config/lib/index.js
+++ b/workspaces/config/lib/index.js
@@ -582,7 +582,7 @@ class Config {
       }
     } else {
       conf.raw = obj
-      for (const [key, value] of Object.entries(obj)) {
+      outer: for (const [key, value] of Object.entries(obj)) {
         const k = envReplace(key, this.env)
         const v = this.parseField(value, k)
         if (where !== 'default') {
@@ -590,9 +590,12 @@ class Config {
           if (this.definitions[key]?.exclusive) {
             for (const exclusive of this.definitions[key].exclusive) {
               if (!this.isDefault(exclusive)) {
-                // when loading from env, skip if sibling was set via cli
-                if (where === 'env' && this.list[0][exclusive] !== undefined) {
-                  continue
+                // when loading from env, skip only if sibling was explicitly set via CLI
+                if (where === 'env') {
+                  const cliData = this.data.get('cli').data
+                  if (Object.hasOwn(cliData, exclusive)) {
+                    continue outer
+                  }
                 }
                 throw new TypeError(`--${key} cannot be provided when using --${exclusive}`)
               }

--- a/workspaces/config/lib/index.js
+++ b/workspaces/config/lib/index.js
@@ -590,6 +590,10 @@ class Config {
           if (this.definitions[key]?.exclusive) {
             for (const exclusive of this.definitions[key].exclusive) {
               if (!this.isDefault(exclusive)) {
+                // when loading from env, skip if sibling was set via cli
+                if (where === 'env' && this.list[0][exclusive] !== undefined) {
+                  continue
+                }
                 throw new TypeError(`--${key} cannot be provided when using --${exclusive}`)
               }
             }

--- a/workspaces/config/test/index.js
+++ b/workspaces/config/test/index.js
@@ -1437,17 +1437,54 @@ t.test('exclusive options conflict', async t => {
   })
 })
 
-t.test('exclusive options from env do not conflict with cli', async t => {
+t.test('exclusive options both from env still conflict', async t => {
   const path = t.testdir()
   const config = new Config({
     env: {
-      npm_config_lie: 'true',
+      npm_config_aaa: 'true',
+      npm_config_zzz: 'true',
     },
     npmPath: __dirname,
     argv: [
       process.execPath,
       __filename,
-      '--truth=true',
+    ],
+    cwd: join(`${path}/project`),
+    shorthands,
+    definitions: {
+      ...definitions,
+      ...createDef('aaa', {
+        default: false,
+        type: Boolean,
+        description: 'aaa',
+        exclusive: ['zzz'],
+      }),
+      ...createDef('zzz', {
+        default: false,
+        type: Boolean,
+        description: 'zzz',
+        exclusive: ['aaa'],
+      }),
+    },
+    flatten,
+  })
+  await t.rejects(config.load(), {
+    name: 'TypeError',
+    message: '--zzz cannot be provided when using --aaa',
+  })
+})
+
+t.test('exclusive env option is skipped when sibling is set via CLI', async t => {
+  const path = t.testdir()
+  const config = new Config({
+    env: {
+      npm_config_truth: 'true',
+    },
+    npmPath: __dirname,
+    argv: [
+      process.execPath,
+      __filename,
+      '--lie=true',
     ],
     cwd: join(`${path}/project`),
     shorthands,
@@ -1468,8 +1505,10 @@ t.test('exclusive options from env do not conflict with cli', async t => {
     },
     flatten,
   })
-  await config.load()
-  t.equal(config.get('truth'), true, 'cli value wins')
+  // should not throw — env `truth` is skipped because `lie` was set via CLI
+  await t.resolves(config.load())
+  t.equal(config.get('lie'), true, 'CLI lie is set')
+  t.equal(config.get('truth'), false, 'env truth is skipped, remains default')
 })
 
 t.test('env-replaced config from files is not clobbered when saving', async (t) => {

--- a/workspaces/config/test/index.js
+++ b/workspaces/config/test/index.js
@@ -1437,6 +1437,41 @@ t.test('exclusive options conflict', async t => {
   })
 })
 
+t.test('exclusive options from env do not conflict with cli', async t => {
+  const path = t.testdir()
+  const config = new Config({
+    env: {
+      npm_config_lie: 'true',
+    },
+    npmPath: __dirname,
+    argv: [
+      process.execPath,
+      __filename,
+      '--truth=true',
+    ],
+    cwd: join(`${path}/project`),
+    shorthands,
+    definitions: {
+      ...definitions,
+      ...createDef('truth', {
+        default: false,
+        type: Boolean,
+        description: 'The Truth',
+        exclusive: ['lie'],
+      }),
+      ...createDef('lie', {
+        default: false,
+        type: Boolean,
+        description: 'A Lie',
+        exclusive: ['truth'],
+      }),
+    },
+    flatten,
+  })
+  await config.load()
+  t.equal(config.get('truth'), true, 'cli value wins')
+})
+
 t.test('env-replaced config from files is not clobbered when saving', async (t) => {
   const path = t.testdir()
   const opts = {


### PR DESCRIPTION
# fix: clear exclusive sibling configs from env when one is set via CLI

## What's the problem?

If you set an exclusive param via CLI (e.g. `--save-prod`) but a sibling
(`npm_config_save_dev=true`) is already in the environment, child processes
inherit both and crash with a conflict. This was also the root cause of the
`--min-release-age` + `--before` issue in #9005.

## What changed

When `setEnvs` exports a non-default exclusive config, it now resets that
param's siblings to their defaults in the env — so child processes never
see a conflict. Works generically for all exclusive pairs, not just this one.

## Tests

Added a test for the case where `save-prod` is set via CLI while `save-dev`
is already in env — verifies `save-dev` gets reset to its default.

## References

Fixes #9005
