### PR TITLE
fix: save libc field to package-lock.json

### DIFF
--- a/workspaces/arborist/lib/shrinkwrap.js
+++ b/workspaces/arborist/lib/shrinkwrap.js
@@ -95,6 +95,7 @@ const pkgMetaKeys = [
   'engines',
   'os',
   'cpu',
+  'libc',
   '_integrity',
   'license',
   '_hasShrinkwrap',

--- a/workspaces/arborist/tap-snapshots/test/shrinkwrap.js.test.cjs
+++ b/workspaces/arborist/tap-snapshots/test/shrinkwrap.js.test.cjs
@@ -390,6 +390,9 @@ Object {
       "funding": Object {
         "url": "https://example.com/",
       },
+      "libc": Array [
+        "glibc",
+      ],
       "os": Array [
         "any",
         "!win32",
@@ -547,6 +550,9 @@ Object {
   "funding": Object {
     "url": "https://example.com/",
   },
+  "libc": Array [
+    "glibc",
+  ],
   "os": Array [
     "any",
     "!win32",

--- a/workspaces/arborist/test/shrinkwrap.js
+++ b/workspaces/arborist/test/shrinkwrap.js
@@ -393,6 +393,7 @@ t.test('construct metadata from node and package data', t => {
       },
       os: ['any', '!win32'],
       cpu: ['x64'],
+      libc: ['glibc'],
     },
     resolved: '/home/user/projects/root/archives/tarball.tgz',
     parent: root,


### PR DESCRIPTION
Fixes: https://github.com/npm/cli/issues/8514

The `libc` field was missing from `pkgMetaKeys` in `shrinkwrap.js`, so it was never written to `package-lock.json`. This meant that on reinstall from a lockfile, `checkPlatform` couldn't distinguish between glibc and musl variants of optional dependencies — both would be installed instead of just the one matching the current platform.

The fix adds `libc` to `pkgMetaKeys` alongside `os` and `cpu`. This is purely additive — packages without `libc` are unaffected, and older npm versions will silently ignore the new field in lockfiles.