### PR TITLE
fix(arborist): retry bin-links on Windows EPERM

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -532,6 +532,7 @@ graph LR;
   npmcli-arborist-->bin-links;
   npmcli-arborist-->cacache;
   npmcli-arborist-->common-ancestor-path;
+  npmcli-arborist-->gar-promise-retry["@gar/promise-retry"];
   npmcli-arborist-->hosted-git-info;
   npmcli-arborist-->isaacs-string-locale-compare["@isaacs/string-locale-compare"];
   npmcli-arborist-->json-stringify-nice;

--- a/package-lock.json
+++ b/package-lock.json
@@ -14440,6 +14440,7 @@
       "version": "9.4.0",
       "license": "ISC",
       "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
         "@isaacs/string-locale-compare": "^1.1.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/installed-package-contents": "^4.0.0",

--- a/workspaces/arborist/lib/arborist/rebuild.js
+++ b/workspaces/arborist/lib/arborist/rebuild.js
@@ -15,6 +15,30 @@ const { resolve } = require('node:path')
 const boolEnv = b => b ? '1' : ''
 const sortNodes = (a, b) => (a.depth - b.depth) || localeCompare(a.path, b.path)
 
+// On Windows, antivirus/indexer can transiently lock files, causing
+// EPERM/EACCES/EBUSY on the rename inside write-file-atomic (used by
+// bin-links/fix-bin.js).  Retry with backoff for up to ~7.5 seconds.
+/* istanbul ignore next */
+const retryBinLinks = async (binLinks, node, opts, retries = 4) => {
+  const delay = (5 - retries) * 500
+  await new Promise(r => setTimeout(r, delay))
+  try {
+    return await binLinks({
+      pkg: node.package,
+      path: node.path,
+      top: !!(node.isTop || node.globalTop),
+      force: opts.force,
+      global: !!node.globalTop,
+    })
+  } catch (err) {
+    if (retries > 0 &&
+        (err.code === 'EPERM' || err.code === 'EACCES' || err.code === 'EBUSY')) {
+      return retryBinLinks(binLinks, node, opts, retries - 1)
+    }
+    throw err
+  }
+}
+
 const _checkBins = Symbol.for('checkBins')
 
 // defined by reify mixin
@@ -387,6 +411,12 @@ module.exports = cls => class Builder extends cls {
       top: !!(node.isTop || node.globalTop),
       force: this.options.force,
       global: !!node.globalTop,
+    }).catch(/* istanbul ignore next - Windows retry for antivirus locks */ err => {
+      if (process.platform === 'win32' &&
+          (err.code === 'EPERM' || err.code === 'EACCES' || err.code === 'EBUSY')) {
+        return retryBinLinks(binLinks, node, this.options)
+      }
+      throw err
     })
 
     await (this.#doHandleOptionalFailure

--- a/workspaces/arborist/lib/arborist/rebuild.js
+++ b/workspaces/arborist/lib/arborist/rebuild.js
@@ -9,35 +9,12 @@ const runScript = require('@npmcli/run-script')
 const { callLimit: promiseCallLimit } = require('promise-call-limit')
 const { depth: dfwalk } = require('treeverse')
 const { isNodeGypPackage, defaultGypInstallScript } = require('@npmcli/node-gyp')
+const { promiseRetry } = require('@gar/promise-retry')
 const { log, time } = require('proc-log')
 const { resolve } = require('node:path')
 
 const boolEnv = b => b ? '1' : ''
 const sortNodes = (a, b) => (a.depth - b.depth) || localeCompare(a.path, b.path)
-
-// On Windows, antivirus/indexer can transiently lock files, causing
-// EPERM/EACCES/EBUSY on the rename inside write-file-atomic (used by
-// bin-links/fix-bin.js).  Retry with backoff for up to ~7.5 seconds.
-/* istanbul ignore next */
-const retryBinLinks = async (binLinks, node, opts, retries = 4) => {
-  const delay = (5 - retries) * 500
-  await new Promise(r => setTimeout(r, delay))
-  try {
-    return await binLinks({
-      pkg: node.package,
-      path: node.path,
-      top: !!(node.isTop || node.globalTop),
-      force: opts.force,
-      global: !!node.globalTop,
-    })
-  } catch (err) {
-    if (retries > 0 &&
-        (err.code === 'EPERM' || err.code === 'EACCES' || err.code === 'EBUSY')) {
-      return retryBinLinks(binLinks, node, opts, retries - 1)
-    }
-    throw err
-  }
-}
 
 const _checkBins = Symbol.for('checkBins')
 
@@ -405,19 +382,20 @@ module.exports = cls => class Builder extends cls {
 
     const timeEnd = time.start(`build:link:${node.location}`)
 
-    const p = binLinks({
+    // On Windows, antivirus/indexer can transiently lock files, causing EPERM/EACCES/EBUSY on the rename inside write-file-atomic (used by bin-links/fix-bin.js), so, retry with backoff.
+    const p = promiseRetry((retry) => binLinks({
       pkg: node.package,
       path: node.path,
       top: !!(node.isTop || node.globalTop),
       force: this.options.force,
       global: !!node.globalTop,
-    }).catch(/* istanbul ignore next - Windows retry for antivirus locks */ err => {
+    }).catch(/* istanbul ignore next - Windows-only transient antivirus locks */ err => {
       if (process.platform === 'win32' &&
           (err.code === 'EPERM' || err.code === 'EACCES' || err.code === 'EBUSY')) {
-        return retryBinLinks(binLinks, node, this.options)
+        return retry(err)
       }
       throw err
-    })
+    }), { retries: 5, minTimeout: 500 })
 
     await (this.#doHandleOptionalFailure
       ? this[_handleOptionalFailure](node, p)

--- a/workspaces/arborist/package.json
+++ b/workspaces/arborist/package.json
@@ -3,6 +3,7 @@
   "version": "9.4.0",
   "description": "Manage node_modules trees",
   "dependencies": {
+    "@gar/promise-retry": "^1.0.0",
     "@isaacs/string-locale-compare": "^1.1.0",
     "@npmcli/fs": "^5.0.0",
     "@npmcli/installed-package-contents": "^4.0.0",


### PR DESCRIPTION
In continuation of our exploration of using `install-strategy=linked` in the [Gutenberg monorepo](https://github.com/WordPress/gutenberg/pull/75814), which powers the WordPress Block Editor, this is a follow up of the fixes from #8996.

On Windows, `npm install` with `install-strategy=linked` fails with `EPERM: operation not permitted` during the bin-linking phase. This is hitting us on Windows CI for the [Gutenberg monorepo](https://github.com/WordPress/gutenberg/pull/75814) (~200 workspace packages).

## Summary

During rebuild, `bin-links/fix-bin.js` rewrites hashbang lines in bin files using `write-file-atomic`, which does a temp-file write followed by `fs.rename()`. On Windows, antivirus (Windows Defender) and the search indexer can transiently lock files that were just written, causing the rename to fail with EPERM.

The linked strategy amplifies this because it writes all packages into `.store/` in parallel, increasing the window for antivirus lock conflicts compared to the hoisted layout.

## Root cause

npm already patches the global `fs` with `graceful-fs` at startup ([entry.js:8](https://github.com/npm/cli/blob/10d530242c7d893c562456013bb1c5104ca3e3b8/lib/cli/entry.js#L8)), which adds Windows rename retry logic. However, `graceful-fs`'s retry only kicks in when the destination file does **not** exist — it checks `fs.stat(to)` after EPERM, and if the target already exists (stat succeeds), it [gives up immediately](https://github.com/isaacs/node-graceful-fs/blob/master/polyfills.js#L107-L111). In `write-file-atomic`'s case, the destination file always exists (it's being overwritten), so the retry never fires.

## Changes

- ~~Wrapped the `binLinks()` call in `rebuild.js` `#createBinLinks` with a new `#binLinksWithRetry` method that retries up to 5 times with 500ms–2.5s backoff on Windows when the error code is EPERM, EACCES, or EBUSY.~~
- Wrapped the `binLinks()` call in `rebuild.js` `#createBinLinks` with `@gar/promise-retry`. On Windows, EPERM/EACCES/EBUSY errors trigger a retry with exponential backoff (5 retries, 500ms min timeout).
- Added `@gar/promise-retry` to arborist's dependencies.
- The retry only activates on `process.platform === 'win32'` — no behavior change on macOS/Linux.

## Testing

We tested this approach in [our fork](https://github.com/manzoorwanijk/npm-cli/commit/ea7a1774eb00143510fbcf5f97d684c8b8652204) and it resolves the issue on Windows CI for the Gutenberg monorepo.

## References

Fixes #9021
