### PR TITLE
fix: skip isolated tree for workspace-filtered installs with linked strategy

### DIFF
--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -110,16 +110,23 @@ module.exports = cls => class Reifier extends cls {
     await this[_loadTrees](options)
 
     const oldTree = this.idealTree
+    let swappedToIsolated = false
     if (linked) {
       // swap out the tree with the isolated tree
       // this is currently technical debt which will be resolved in a refactor
       // of Node/Link trees
       log.warn('reify', 'The "linked" install strategy is EXPERIMENTAL and may contain bugs.')
-      this.idealTree = await this[_createIsolatedTree]()
+      // Workspace-filtered installs are incompatible with the isolated tree
+      // which uses plain objects with Array children and a stub inventory.
+      // Use the normal reify path for workspace installs.
+      if (!this.options.workspaces.length) {
+        this.idealTree = await this[_createIsolatedTree]()
+        swappedToIsolated = true
+      }
     }
     await this[_diffTrees]()
     await this.#reifyPackages()
-    if (linked) {
+    if (swappedToIsolated) {
       // swap back in the idealTree
       // so that the lockfile is preserved
       this.idealTree = oldTree

--- a/workspaces/arborist/lib/node.js
+++ b/workspaces/arborist/lib/node.js
@@ -593,7 +593,12 @@ class Node {
       return false
     }
     for (const edge of this.edgesIn) {
-      if (!npa(edge.spec).registry) {
+      try {
+        if (!npa(edge.spec).registry) {
+          return false
+        }
+      } catch {
+        // unsupported spec types (e.g. link:) are not registry deps
         return false
       }
     }

--- a/workspaces/arborist/test/isolated-mode.js
+++ b/workspaces/arborist/test/isolated-mode.js
@@ -1637,6 +1637,47 @@ tap.test('bins are installed', async t => {
   t.ok(binFromBarToWhich)
 })
 
+tap.test('workspace-filtered install with linked strategy does not crash', async t => {
+  const graph = {
+    registry: [
+      { name: 'which', version: '1.0.0' },
+      { name: 'isexe', version: '1.0.0' },
+    ],
+    root: {
+      name: 'dog', version: '1.2.3',
+    },
+    workspaces: [
+      { name: 'bar', version: '1.0.0', dependencies: { which: '1.0.0' } },
+      { name: 'baz', version: '1.0.0', dependencies: { isexe: '1.0.0' } },
+    ],
+  }
+
+  const { dir, registry } = await getRepo(graph)
+
+  const cache = fs.mkdtempSync(`${getTempDir()}/test-`)
+
+  // First, do a full linked install
+  const arb1 = new Arborist({ path: dir, registry, packumentCache: new Map(), cache })
+  await arb1.reify({ installStrategy: 'linked' })
+
+  // Now do a workspace-filtered install - this used to crash with
+  // "Cannot read properties of null (reading 'package')" because the
+  // isolated tree's plain objects are incompatible with workspace filtering.
+  const arb2 = new Arborist({
+    path: dir,
+    registry,
+    packumentCache: new Map(),
+    cache,
+    installStrategy: 'linked',
+    workspaces: ['bar'],
+  })
+  await arb2.reify({ installStrategy: 'linked' })
+
+  // The workspace's dependency should still be resolvable
+  const whichPath = resolvePackage('which', path.join(dir, 'packages', 'bar'))
+  t.ok(whichPath, 'bar workspace can still resolve which')
+})
+
 function setupRequire (cwd) {
   return function requireChain (...chain) {
     return chain.reduce((path, name) => {


### PR DESCRIPTION
In continuation of our exploration of using `install-strategy=linked` in the [Gutenberg monorepo](https://github.com/WordPress/gutenberg/pull/75814), which powers the WordPress Block Editor, this is a follow-up of the fixes from #8996.

`npm install --workspace` crashes with a `TypeError` when `install-strategy=linked` is configured.

The isolated tree built by `_createIsolatedTree()` is structurally incompatible with workspace-filtered installs:

1. `root.children` is an Array, not a Map — workspace filtering calls `.get(ws)` which doesn't exist on Array
2. `inventory.query()` is a stub returning `[]` — the `set root` setter can't resolve Link targets during post-reify re-rooting
3. The `filterSet` computed against the isolated tree becomes invalid after the tree is swapped back to the original

**npm 11.x** throws:
```
TypeError: Cannot read properties of null (reading 'package')
    at set root (lib/node.js:797:35)
```

**npm 10.x** throws:
```
TypeError: this.idealTree.children.get is not a function
    at Arborist.[diffTrees] (lib/arborist/reify.js:441:45)
```

This PR:

1. **Skips `_createIsolatedTree()`** when `--workspace` is active, falling back to the normal reify path with real Node/Link instances. A subsequent full `npm install` restructures everything back to linked layout. The isolated tree was designed for full `npm install`, not filtered installs.

2. **Handles unsupported spec types in `isRegistryDependency`** — packages with `link:` specs in their dependencies (e.g. `link:.`) cause `npa` to throw `EUNSUPPORTEDPROTOCOL` when `isRegistryDependency` is accessed during lockfile save. The fix catches the error and treats unsupported spec types as non-registry dependencies.

## References

Fixes #9038
