### PR TITLE
fix(audit): exclude locally linked packages from vulnerability audit 

### DIFF
--- a/workspaces/arborist/lib/audit-report.js
+++ b/workspaces/arborist/lib/audit-report.js
@@ -296,6 +296,8 @@ class AuditReport extends Map {
     if (
       !node.version ||
       node.isRoot ||
+      node.isLink ||
+      node.linksIn?.size > 0 ||
       (this.filterSet && this.filterSet?.size !== 0 && !this.filterSet?.has(node))
     ) {
       return false

--- a/workspaces/arborist/test/audit-report.js
+++ b/workspaces/arborist/test/audit-report.js
@@ -421,6 +421,29 @@ t.test('audit supports alias deps', async t => {
   t.equal(report.get('mkdirp').simpleRange, '0.4.1 - 0.5.1')
 })
 
+t.test('linked local package should not be audited against the registry', async t => {
+  const path = resolve(fixtures, 'audit-linked-package')
+  // No registry.audit() mock needed — no request should be made
+  // because linked packages must be excluded from the bulk payload
+  createRegistry(t)
+  const cache = t.testdir()
+  const arb = newArb(path, { cache })
+
+  const tree = await arb.loadVirtual()
+  const report = await AuditReport.load(tree, arb.options)
+
+  t.equal(
+    report.has('electron-test-app'),
+    false,
+    'linked local package should not appear in audit report'
+  )
+  t.equal(
+    report.size,
+    0,
+    'audit report should be empty when all dependencies are local links'
+  )
+})
+
 t.test('audit with filterSet limiting to only mkdirp and minimist', async t => {
   const path = resolve(fixtures, 'audit-nyc-mkdirp')
   const registry = createRegistry(t)

--- a/workspaces/arborist/test/fixtures/audit-linked-package/package-lock.json
+++ b/workspaces/arborist/test/fixtures/audit-linked-package/package-lock.json
@@ -1,0 +1,20 @@
+{
+  "name": "audit-linked-package",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "audit-linked-package",
+      "dependencies": {
+        "electron-test-app": "1.0.0"
+      }
+    },
+    "node_modules/electron-test-app": {
+      "resolved": "resolved/electron-test-app",
+      "link": true
+    },
+    "resolved/electron-test-app": {
+      "version": "1.0.0"
+    }
+  }
+}

--- a/workspaces/arborist/test/fixtures/audit-linked-package/package.json
+++ b/workspaces/arborist/test/fixtures/audit-linked-package/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "audit-linked-package",
+  "dependencies": {
+    "electron-test-app": "1.0.0"
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #8920 

`npm audit` was reporting false positive critical vulnerabilities for packages that resolve to local folders via symlinks (`"link": true` in `package-lock.json`).

*****

### Root Cause

When a `package-lock.json` declares a locally linked package, Arborist creates two nodes in the dependency tree:

- A `Link` node at `node_modules/<package-name>` (with `isLink = true`)
- A regular `Node` at the resolved local path (the symlink target, with `linksIn.size > 0`)

The `shouldAudit()` method in `audit-report.js` was not excluding either of these nodes, so both were included in the bulk advisory payload sent to the registry. If a package on the registry happened to share the same name and version as the local package, its vulnerabilities would be incorrectly reported against the local one.

This was affecting real-world projects, such as the [Microsoft Authentication Library for JS](https://github.com/AzureAD/microsoft-authentication-library-for-js), which has an internal package named `electron-test-app` that coincidentally shares its name with a known malware package on the registry.

*****

### Fix

In `workspaces/arborist/lib/audit-report.js`, the `shouldAudit()` method now returns `false` for:

- `node.isLink` — the symlink node itself
- `node.linksIn?.size > 0` — the local target folder the symlink points to

This prevents locally resolved packages from ever reaching the registry bulk advisory request.

*****

### Testing

Added a new test case and fixture (`audit-linked-package`) to `workspaces/arborist/test/audit-report.js` that:

- Sets up a project with a locally linked package that shares its name with a vulnerable registry package
- Asserts that no vulnerability is reported
- Asserts that no unexpected request is made to the registry (enforced by `MockRegistry` strict mode)