### PR TITLE
fix: bypass packument cache to prevent ETARGET errors after publish

### DIFF
--- a/lib/commands/pack.js
+++ b/lib/commands/pack.js
@@ -39,6 +39,7 @@ class Pack extends BaseCommand {
       const manifest = await pacote.manifest(spec, {
         ...this.npm.flatOptions,
         Arborist,
+        preferOnline: true,
         _isRoot: true,
       })
       if (!manifest._id) {
@@ -56,6 +57,7 @@ class Pack extends BaseCommand {
         foregroundScripts: this.npm.config.isDefault('foreground-scripts')
           ? true
           : this.npm.config.get('foreground-scripts'),
+        preferOnline: true,
         prefix: this.npm.localPrefix,
         workspaces: this.workspacePaths,
       })


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
This PR fixes a bug where running `npm pack <package-spec>` immediately following `npm publish` in the same environment (like a GitHub Actions workflow) results in an `ETARGET` error ("No matching version found"). 

When `npm publish` runs, the remote registry updates, but any previous registry requests may cause `pacote` to cache the older packument locally. When `npm pack` runs right after, it reads that stale local cache which lacks the newly published version, skipping the remote fetch entirely.

To fix this, I've added `preferOnline: true` to the fetch configurations in lib/commands/pack.js (specifically to the `pacote.manifest()` and `libpack()` calls). This ensures `npm pack` passes a `cache: 'no-cache'` configuration down to the registry fetcher, forcing an online re-validation that bypasses the local max-age cache and successfully locates the newly published tarball. This aligns pack's cache behavior with `npm view`.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Fixes #9043 
