### PR TITLE
fix(arborist): unwrap Link nodes in legacyPeerDeps for linked strategy

### DIFF
--- a/workspaces/arborist/lib/arborist/isolated-reifier.js
+++ b/workspaces/arborist/lib/arborist/isolated-reifier.js
@@ -154,7 +154,7 @@ module.exports = cls => class IsolatedReifier extends cls {
         if (!edgeNames.has(peerName)) {
           const resolved = node.resolve(peerName)
           if (resolved && resolved !== node && !resolved.inert) {
-            nonOptionalDeps.push(resolved)
+            nonOptionalDeps.push(resolved.target)
           }
         }
       }

--- a/workspaces/arborist/test/isolated-mode.js
+++ b/workspaces/arborist/test/isolated-mode.js
@@ -369,15 +369,8 @@ tap.test('peer dependencies with legacyPeerDeps', async t => {
 })
 
 tap.test('idempotent install with legacyPeerDeps and workspace peer deps', async t => {
-  // Regression: when legacyPeerDeps is enabled and a workspace has a peer
-  // dependency on another workspace, node.resolve() returns the Link node
-  // (not its target). This caused workspaceProxy to be called with the Link,
-  // producing store links under node_modules/<ws>/node_modules/ that race
-  // with the workspace symlink at node_modules/<ws>, hitting EEXIST on the
-  // second install.
-  //
-  // Use many workspaces with cross-peer-deps to increase concurrency and
-  // make the race window large enough to trigger reliably.
+  // Regression: when legacyPeerDeps is enabled and a workspace has a peer dependency on another workspace, node.resolve() returns the Link node (not its target). This caused workspaceProxy to be called with the Link, producing store links under node_modules/<ws>/node_modules/ that race with the workspace symlink at node_modules/<ws>, hitting EEXIST on the second install.
+  // Use many workspaces with cross-peer-deps to increase concurrency and make the race window large enough to trigger reliably.
   const workspaces = []
   for (let i = 0; i < 20; i++) {
     workspaces.push({

--- a/workspaces/arborist/test/isolated-mode.js
+++ b/workspaces/arborist/test/isolated-mode.js
@@ -368,6 +368,56 @@ tap.test('peer dependencies with legacyPeerDeps', async t => {
   rule7.apply(t, dir, resolved, asserted)
 })
 
+tap.test('idempotent install with legacyPeerDeps and workspace peer deps', async t => {
+  // Regression: when legacyPeerDeps is enabled and a workspace has a peer
+  // dependency on another workspace, node.resolve() returns the Link node
+  // (not its target). This caused workspaceProxy to be called with the Link,
+  // producing store links under node_modules/<ws>/node_modules/ that race
+  // with the workspace symlink at node_modules/<ws>, hitting EEXIST on the
+  // second install.
+  //
+  // Use many workspaces with cross-peer-deps to increase concurrency and
+  // make the race window large enough to trigger reliably.
+  const workspaces = []
+  for (let i = 0; i < 20; i++) {
+    workspaces.push({
+      name: `ws-${i}`,
+      version: '1.0.0',
+      dependencies: { abbrev: '1.0.0' },
+      peerDependencies: { [`ws-${(i + 1) % 20}`]: '*' },
+    })
+  }
+
+  const graph = {
+    registry: [
+      { name: 'abbrev', version: '1.0.0' },
+    ],
+    root: {
+      name: 'myroot', version: '1.0.0',
+    },
+    workspaces,
+  }
+
+  const { dir, registry } = await getRepo(graph)
+
+  const cache = fs.mkdtempSync(`${getTempDir()}/test-`)
+  const opts = { path: dir, registry, packumentCache: new Map(), cache, legacyPeerDeps: true }
+
+  // First install
+  const arb1 = new Arborist(opts)
+  await arb1.reify({ installStrategy: 'linked' })
+
+  // Second install must not throw EEXIST
+  const arb2 = new Arborist({ ...opts, packumentCache: new Map() })
+  await arb2.reify({ installStrategy: 'linked' })
+
+  // Workspace symlinks should still be symlinks (not directories)
+  for (let i = 0; i < 20; i++) {
+    t.ok(fs.lstatSync(path.join(dir, 'node_modules', `ws-${i}`)).isSymbolicLink(),
+      `ws-${i} is still a symlink after second install`)
+  }
+})
+
 tap.test('Lock file is same in hoisted and in isolated mode', async t => {
   const graph = {
     registry: [


### PR DESCRIPTION
When `legacyPeerDeps` is enabled and a workspace has a peer dependency on another workspace, `node.resolve()` in `assignCommonProperties` returns the Link node (at `node_modules/<ws>`) rather than its target (at `packages/<ws>`). The normal edge-based path correctly unwraps via `e.to.target`, but the legacyPeerDeps fallback pushed the raw resolved node directly.

This caused `workspaceProxy` to be called with the Link (a different object from the fsChild), creating a second workspace proxy with `localLocation="node_modules/<ws>"`. Store links for that workspace's deps were then placed at `node_modules/<ws>/node_modules/<dep>` instead of `packages/<ws>/node_modules/<dep>`, racing with the workspace symlink at `node_modules/<ws>` and hitting EEXIST on subsequent installs.

Fix: use `resolved.target` to unwrap Link nodes, consistent with the edge-based path.

## References

Fixes #9050
