### PR TITLE
fix: isolated mode code cleanup

### DIFF
--- a/workspaces/arborist/lib/arborist/isolated-reifier.js
+++ b/workspaces/arborist/lib/arborist/isolated-reifier.js
@@ -1,71 +1,105 @@
-const _makeIdealGraph = Symbol('makeIdealGraph')
-const _createIsolatedTree = Symbol.for('createIsolatedTree')
 const { mkdirSync } = require('node:fs')
 const pacote = require('pacote')
 const { join } = require('node:path')
 const { depth } = require('treeverse')
 const crypto = require('node:crypto')
 
-// cache complicated function results
-const memoize = (fn) => {
-  const memo = new Map()
-  return async function (arg) {
-    const key = arg
-    if (memo.has(key)) {
-      return memo.get(key)
-    }
-    const result = {}
-    memo.set(key, result)
-    await fn(result, arg)
-    return result
-  }
+// generate short hash key based on the dependency tree starting at this node
+const getKey = (startNode) => {
+  const deps = []
+  const branch = []
+  depth({
+    tree: startNode,
+    getChildren: node => node.dependencies,
+    visit: node => {
+      branch.push(`${node.packageName}@${node.version}`)
+      deps.push(`${branch.join('->')}::${node.resolved}`)
+    },
+    leave: () => {
+      branch.pop()
+    },
+  })
+  deps.sort()
+  // TODO these replaces were originally to deal with node 14 not supporting base64url and likely don't need to happen anymore
+  // Changing this is a pretty significant breaking change, but removing parts of the hash increases collision possibilities (even if slight).
+  const hash = crypto.createHash('shake256', { outputLength: 16 })
+    .update(deps.join(','))
+    .digest('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/m, '')
+  return `${startNode.packageName}@${startNode.version}-${hash}`
 }
 
 module.exports = cls => class IsolatedReifier extends cls {
+  #externalProxies = new Map()
+  #processedEdges = new Set()
+  #workspaceProxies = new Map()
+
+  #generateChild (node, location, pkg, inStore, root) {
+    const newChild = {
+      binPaths: [],
+      children: new Map(),
+      edgesIn: new Set(),
+      edgesOut: new Map(),
+      fsChildren: new Set(),
+      /* istanbul ignore next -- emulate Node */
+      getBundler () {
+        return null
+      },
+      global: false,
+      globalTop: false,
+      hasShrinkwrap: false,
+      inDepBundle: false,
+      integrity: null,
+      isInStore: inStore,
+      isLink: false,
+      isProjectRoot: false,
+      isRoot: false,
+      isTop: false,
+      location,
+      name: node.packageName || node.name,
+      optional: node.optional,
+      package: pkg,
+      parent: root,
+      path: join(this.idealGraph.root.localPath, location),
+      realpath: join(this.idealGraph.root.localPath, location),
+      resolved: node.resolved,
+      root,
+      top: { path: this.idealGraph.root.localPath },
+      version: pkg.version,
+    }
+    newChild.target = newChild
+    root.children.set(newChild.location, newChild)
+    root.inventory.set(newChild.location, newChild)
+  }
+
   /**
    * Create an ideal graph.
    *
    * An implementation of npm RFC-0042
    * https://github.com/npm/rfcs/blob/main/accepted/0042-isolated-mode.md
    *
-   * This entire file should be considered technical debt that will be resolved
-   * with an Arborist refactor or rewrite. Embedded logic in Nodes and Links,
-   * and the incremental state of building trees and reifying contains too many
-   * assumptions to do a linked mode properly.
+   * This entire file should be considered technical debt that will be resolved with an Arborist refactor or rewrite.
+   * Embedded logic in Nodes and Links, and the incremental state of building trees and reifying contains too many assumptions to do a linked mode properly.
    *
-   * Instead, this approach takes a tree built from build-ideal-tree, and
-   * returns a new tree-like structure without the embedded logic of Node and
-   * Link classes.
+   * Instead, this approach takes a tree built from build-ideal-tree, and returns a new tree-like structure without the embedded logic of Node and Link classes.
    *
-   * Since the RFC requires leaving the package-lock in place, this approach
-   * temporarily replaces the tree state for a couple of steps of reifying.
+   * Since the RFC requires leaving the package-lock in place, this approach temporarily replaces the tree state for a couple of steps of reifying.
    *
    **/
-  async [_makeIdealGraph] (options) {
-    /* Make sure that the ideal tree is build as the rest of
-     * the algorithm depends on it.
-     */
-    const bitOpt = {
-      ...options,
-      complete: false,
-    }
-    await this.buildIdealTree(bitOpt)
+  async makeIdealGraph () {
     const idealTree = this.idealTree
 
-    this.rootNode = {}
-    const root = this.rootNode
+    this.idealGraph = {
+      external: [],
+      isProjectRoot: true,
+      localLocation: idealTree.location,
+      localPath: idealTree.path,
+    }
     this.counter = 0
 
-    // memoize to cache generating proxy Nodes
-    this.externalProxyMemo = memoize(this.externalProxy.bind(this))
-    this.workspaceProxyMemo = memoize(this.workspaceProxy.bind(this))
-
-    root.external = []
-    root.isProjectRoot = true
-    root.localLocation = idealTree.location
-    root.localPath = idealTree.path
-    root.workspaces = await Promise.all(
-      Array.from(idealTree.fsChildren.values(), this.workspaceProxyMemo))
+    this.idealGraph.workspaces = await Promise.all(Array.from(idealTree.fsChildren.values(), w => this.workspaceProxy(w)))
     const processed = new Set()
     const queue = [idealTree, ...idealTree.fsChildren]
     while (queue.length !== 0) {
@@ -74,32 +108,42 @@ module.exports = cls => class IsolatedReifier extends cls {
         continue
       }
       processed.add(next.location)
-      next.edgesOut.forEach(e => {
-        if (!e.to || (next.package.bundleDependencies || next.package.bundledDependencies || []).includes(e.to.name)) {
-          return
+      next.edgesOut.forEach(edge => {
+        if (edge.to && !(next.package.bundleDependencies || next.package.bundledDependencies || []).includes(edge.to.name)) {
+          queue.push(edge.to)
         }
-        queue.push(e.to)
       })
       if (!next.isProjectRoot && !next.isWorkspace && !next.inert) {
-        root.external.push(await this.externalProxyMemo(next))
+        this.idealGraph.external.push(await this.externalProxy(next))
       }
     }
 
-    await this.assignCommonProperties(idealTree, root)
-
-    this.idealGraph = root
+    await this.assignCommonProperties(idealTree, this.idealGraph)
   }
 
-  async workspaceProxy (result, node) {
+  async workspaceProxy (node) {
+    if (this.#workspaceProxies.has(node)) {
+      return this.#workspaceProxies.get(node)
+    }
+    const result = {}
+    // XXX this goes recursive if we don't set here because assignCommonProperties also calls this.workspaceProxy
+    this.#workspaceProxies.set(node, result)
     result.localLocation = node.location
     result.localPath = node.path
     result.isWorkspace = true
     result.resolved = node.resolved
     await this.assignCommonProperties(node, result)
+    return result
   }
 
-  async externalProxy (result, node) {
-    await this.assignCommonProperties(node, result)
+  async externalProxy (node) {
+    if (this.#externalProxies.has(node)) {
+      return this.#externalProxies.get(node)
+    }
+    const result = {}
+    // XXX this goes recursive if we don't set here because assignCommonProperties also calls this.externalProxy
+    this.#externalProxies.set(node, result)
+    await this.assignCommonProperties(node, result, !node.hasShrinkwrap)
     if (node.hasShrinkwrap) {
       const dir = join(
         node.root.path,
@@ -108,8 +152,7 @@ module.exports = cls => class IsolatedReifier extends cls {
         `${node.packageName}@${node.version}`
       )
       mkdirSync(dir, { recursive: true })
-      // TODO this approach feels wrong
-      // and shouldn't be necessary for shrinkwraps
+      // TODO this approach feels wrong and shouldn't be necessary for shrinkwraps
       await pacote.extract(node.resolved, dir, {
         ...this.options,
         resolved: node.resolved,
@@ -117,40 +160,57 @@ module.exports = cls => class IsolatedReifier extends cls {
       })
       const Arborist = this.constructor
       const arb = new Arborist({ ...this.options, path: dir })
-      await arb[_makeIdealGraph]({ dev: false })
-      this.rootNode.external.push(...arb.idealGraph.external)
-      arb.idealGraph.external.forEach(e => {
-        e.root = this.rootNode
-        e.id = `${node.id}=>${e.id}`
+      // Make sure that the ideal tree is build as the rest of the algorithm depends on it.
+      await arb.buildIdealTree({
+        complete: false,
+        dev: false,
       })
+      await arb.makeIdealGraph()
+      this.idealGraph.external.push(...arb.idealGraph.external)
+      for (const edge of arb.idealGraph.external) {
+        edge.root = this.idealGraph
+        edge.id = `${node.id}=>${edge.id}`
+      }
       result.localDependencies = []
       result.externalDependencies = arb.idealGraph.externalDependencies
       result.externalOptionalDependencies = arb.idealGraph.externalOptionalDependencies
       result.dependencies = [
         ...result.externalDependencies,
-        ...result.localDependencies,
         ...result.externalOptionalDependencies,
       ]
     }
     result.optional = node.optional
     result.resolved = node.resolved
     result.version = node.version
+    return result
   }
 
-  async assignCommonProperties (node, result) {
-    function validEdgesOut (node) {
-      return [...node.edgesOut.values()].filter(e => e.to && e.to.target && !(node.package.bundledDependencies || node.package.bundleDependencies || []).includes(e.to.name))
-    }
-    const edges = validEdgesOut(node)
-    const optionalDeps = edges.filter(e => e.optional).map(e => e.to.target)
-    const nonOptionalDeps = edges.filter(e => !e.optional).map(e => e.to.target)
+  async assignCommonProperties (node, result, populateDeps = true) {
+    result.root = this.idealGraph
+    result.id = this.counter++
+    /* istanbul ignore next - packageName is always set for real packages */
+    result.name = result.isWorkspace ? (node.packageName || node.name) : node.name
+    result.packageName = node.packageName || node.name
+    result.package = { ...node.package }
+    result.package.bundleDependencies = undefined
+    result.hasInstallScript = node.hasInstallScript
 
-    // When legacyPeerDeps is enabled, peer dep edges are not created on the
-    // node. Resolve them from the tree so they get symlinked in the store.
+    if (!populateDeps) {
+      return
+    }
+
+    const edges = [...node.edgesOut.values()].filter(edge =>
+      edge.to?.target &&
+      !(node.package.bundledDependencies || node.package.bundleDependencies)?.includes(edge.to.name)
+    )
+    const nonOptionalDeps = edges.filter(edge => !edge.optional).map(edge => edge.to.target)
+
+    // When legacyPeerDeps is enabled, peer dep edges are not created on the node.
+    // Resolve them from the tree so they get symlinked in the store.
     const peerDeps = node.package.peerDependencies
     if (peerDeps && node.legacyPeerDeps) {
-      const edgeNames = new Set(edges.map(e => e.name))
-      for (const peerName of Object.keys(peerDeps)) {
+      const edgeNames = new Set(edges.map(edge => edge.name))
+      for (const peerName in peerDeps) {
         if (!edgeNames.has(peerName)) {
           const resolved = node.resolve(peerName)
           if (resolved && resolved !== node && !resolved.inert) {
@@ -160,22 +220,15 @@ module.exports = cls => class IsolatedReifier extends cls {
       }
     }
 
-    result.localDependencies = await Promise.all(nonOptionalDeps.filter(n => n.isWorkspace).map(this.workspaceProxyMemo))
-    result.externalDependencies = await Promise.all(nonOptionalDeps.filter(n => !n.isWorkspace && !n.inert).map(this.externalProxyMemo))
-    result.externalOptionalDependencies = await Promise.all(optionalDeps.filter(n => !n.inert).map(this.externalProxyMemo))
+    const optionalDeps = edges.filter(edge => edge.optional).map(edge => edge.to.target)
+    result.localDependencies = await Promise.all(nonOptionalDeps.filter(n => n.isWorkspace).map(n => this.workspaceProxy(n)))
+    result.externalDependencies = await Promise.all(nonOptionalDeps.filter(n => !n.isWorkspace && !n.inert).map(n => this.externalProxy(n)))
+    result.externalOptionalDependencies = await Promise.all(optionalDeps.filter(n => !n.inert).map(n => this.externalProxy(n)))
     result.dependencies = [
       ...result.externalDependencies,
       ...result.localDependencies,
       ...result.externalOptionalDependencies,
     ]
-    result.root = this.rootNode
-    result.id = this.counter++
-    /* istanbul ignore next - packageName is always set for real packages */
-    result.name = result.isWorkspace ? (node.packageName || node.name) : node.name
-    result.packageName = node.packageName || node.name
-    result.package = { ...node.package }
-    result.package.bundleDependencies = undefined
-    result.hasInstallScript = node.hasInstallScript
   }
 
   async #createBundledTree () {
@@ -217,104 +270,73 @@ module.exports = cls => class IsolatedReifier extends cls {
       nodes.set(to.location, { location: to.location, resolved: to.resolved, name: to.name, optional: to.optional, pkg: { ...to.package, bundleDependencies: undefined } })
       edges.push({ from: from.isRoot ? 'root' : from.location, to: to.location })
 
-      to.edgesOut.forEach(e => {
+      to.edgesOut.forEach(edge => {
         // an edge out should always have a to
         /* istanbul ignore else */
-        if (e.to) {
-          queue.push({ from: e.from, to: e.to })
+        if (edge.to) {
+          queue.push({ from: edge.from, to: edge.to })
         }
       })
     }
     return { edges, nodes }
   }
 
-  async [_createIsolatedTree] () {
-    await this[_makeIdealGraph](this.options)
-
-    const proxiedIdealTree = this.idealGraph
+  async createIsolatedTree () {
+    await this.makeIdealGraph()
 
     const bundledTree = await this.#createBundledTree()
 
-    const treeHash = (startNode) => {
-      // generate short hash based on the dependency tree
-      // starting at this node
-      const deps = []
-      const branch = []
-      depth({
-        tree: startNode,
-        getChildren: node => node.dependencies,
-        filter: node => node,
-        visit: node => {
-          branch.push(`${node.packageName}@${node.version}`)
-          deps.push(`${branch.join('->')}::${node.resolved}`)
-        },
-        leave: () => {
-          branch.pop()
-        },
-      })
-      deps.sort()
-      return crypto.createHash('shake256', { outputLength: 16 })
-        .update(deps.join(','))
-        .digest('base64')
-        // Node v14 doesn't support base64url
-        .replace(/\+/g, '-')
-        .replace(/\//g, '_')
-        .replace(/=+$/m, '')
-    }
-
-    const getKey = (idealTreeNode) => {
-      return `${idealTreeNode.packageName}@${idealTreeNode.version}-${treeHash(idealTreeNode)}`
-    }
-
     const root = {
+      binPaths: [],
+      children: new Map(),
+      edgesIn: new Set(),
+      edgesOut: new Map(),
       fsChildren: new Set(),
+      global: false,
+      hasShrinkwrap: false,
       integrity: null,
       inventory: new Map(),
       isLink: false,
+      isProjectRoot: true,
       isRoot: true,
-      binPaths: [],
-      edgesIn: new Set(),
-      edgesOut: new Map(),
-      hasShrinkwrap: false,
+      isTop: true,
+      linksIn: new Set(),
+      meta: { loadedFromDisk: false },
+      package: this.idealGraph.root.package,
       parent: null,
+      path: this.idealGraph.root.localPath,
+      realpath: this.idealGraph.root.localPath,
       // TODO: we should probably not reference this.idealTree
       resolved: this.idealTree.resolved,
-      isTop: true,
-      path: proxiedIdealTree.root.localPath,
-      realpath: proxiedIdealTree.root.localPath,
-      package: proxiedIdealTree.root.package,
-      meta: { loadedFromDisk: false },
-      global: false,
-      isProjectRoot: true,
-      children: new Map(),
-      workspaces: new Map(),
       tops: new Set(),
-      linksIn: new Set(),
+      workspaces: new Map(),
     }
     root.inventory.set('', root)
+    root.root = root
+    root.target = root
     // TODO inventory.query is a stub; audit-report needs 'packageName' support
     root.inventory.query = () => {
       return []
     }
     const processed = new Set()
-    proxiedIdealTree.workspaces.forEach(c => {
+    for (const c of this.idealGraph.workspaces) {
       const wsName = c.packageName
       const workspace = {
+        binPaths: [],
+        children: new Map(),
         edgesIn: new Set(),
         edgesOut: new Map(),
-        children: new Map(),
         fsChildren: new Set(),
         hasInstallScript: c.hasInstallScript,
-        binPaths: [],
-        package: c.package,
+        isLink: false,
+        isRoot: false,
+        linksIn: new Set(),
         location: c.localLocation,
+        name: wsName,
+        package: c.package,
         path: c.localPath,
         realpath: c.localPath,
         resolved: c.resolved,
-        isLink: false,
-        isRoot: false,
-        name: wsName,
-        linksIn: new Set(),
       }
       workspace.target = workspace
       root.fsChildren.add(workspace)
@@ -322,193 +344,155 @@ module.exports = cls => class IsolatedReifier extends cls {
 
       // Create workspace Link entry in children for _diffTrees lookup
       const wsLink = {
-        name: wsName,
-        location: join('node_modules', wsName),
-        path: join(root.path, 'node_modules', wsName),
-        realpath: workspace.path,
-        isLink: true,
-        target: workspace,
+        binPaths: [],
         children: new Map(),
-        fsChildren: new Set(),
         edgesIn: new Set(),
         edgesOut: new Map(),
-        binPaths: [],
-        root,
-        parent: root,
-        isRoot: false,
-        isProjectRoot: false,
-        isTop: false,
+        fsChildren: new Set(),
         global: false,
         globalTop: false,
-        package: workspace.package,
+        isLink: true,
+        isProjectRoot: false,
+        isRoot: false,
+        isTop: false,
         linksIn: new Set(),
+        location: join('node_modules', wsName),
+        name: wsName,
+        package: workspace.package,
+        parent: root,
+        path: join(root.path, 'node_modules', wsName),
+        realpath: workspace.path,
+        root,
+        target: workspace,
       }
       root.children.set(wsLink.name, wsLink)
       root.inventory.set(wsLink.location, wsLink)
       root.workspaces.set(wsName, workspace.path)
       workspace.linksIn.add(wsLink)
-    })
-    const generateChild = (node, location, pkg, inStore) => {
-      const newChild = {
-        global: false,
-        globalTop: false,
-        isProjectRoot: false,
-        isTop: false,
-        location,
-        name: node.packageName || node.name,
-        optional: node.optional,
-        top: { path: proxiedIdealTree.root.localPath },
-        children: new Map(),
-        edgesIn: new Set(),
-        edgesOut: new Map(),
-        binPaths: [],
-        fsChildren: new Set(),
-        /* istanbul ignore next -- emulate Node */
-        getBundler () {
-          return null
-        },
-        hasShrinkwrap: false,
-        inDepBundle: false,
-        integrity: null,
-        isLink: false,
-        isRoot: false,
-        isInStore: inStore,
-        path: join(proxiedIdealTree.root.localPath, location),
-        realpath: join(proxiedIdealTree.root.localPath, location),
-        resolved: node.resolved,
-        version: pkg.version,
-        package: pkg,
-      }
-      newChild.target = newChild
-      root.children.set(newChild.location, newChild)
-      root.inventory.set(newChild.location, newChild)
     }
-    proxiedIdealTree.external.forEach(c => {
+
+    this.idealGraph.external.forEach(c => {
       const key = getKey(c)
       if (processed.has(key)) {
         return
       }
       processed.add(key)
       const location = join('node_modules', '.store', key, 'node_modules', c.packageName)
-      generateChild(c, location, c.package, true)
+      this.#generateChild(c, location, c.package, true, root)
     })
+
     bundledTree.nodes.forEach(node => {
-      generateChild(node, node.location, node.pkg, false)
+      this.#generateChild(node, node.location, node.pkg, false, root)
     })
-    bundledTree.edges.forEach(e => {
-      const from = e.from === 'root' ? root : root.inventory.get(e.from)
-      const to = root.inventory.get(e.to)
+
+    bundledTree.edges.forEach(edge => {
+      const from = edge.from === 'root' ? root : root.inventory.get(edge.from)
+      const to = root.inventory.get(edge.to)
       // Maybe optional should be propagated from the original edge
-      const edge = { optional: false, from, to }
-      from.edgesOut.set(to.name, edge)
-      to.edgesIn.add(edge)
+      const newEdge = { optional: false, from, to }
+      from.edgesOut.set(to.name, newEdge)
+      to.edgesIn.add(newEdge)
     })
-    const memo = new Set()
 
-    function processEdges (node, externalEdge) {
-      externalEdge = !!externalEdge
-      const key = getKey(node)
-      if (memo.has(key)) {
-        return
-      }
-      memo.add(key)
-
-      let from, nmFolder
-      if (externalEdge) {
-        const fromLocation = join('node_modules', '.store', key, 'node_modules', node.packageName)
-        from = root.children.get(fromLocation)
-        nmFolder = join('node_modules', '.store', key, 'node_modules')
-      } else {
-        from = node.isProjectRoot ? root : root.inventory.get(node.localLocation)
-        nmFolder = join(node.localLocation, 'node_modules')
-      }
-      /* istanbul ignore next - strict-peer-deps can exclude nodes from the tree */
-      if (!from) {
-        return
-      }
-
-      const processDeps = (dep, optional, external) => {
-        optional = !!optional
-        external = !!external
-
-        const location = join(nmFolder, dep.name)
-        const binNames = dep.package.bin && Object.keys(dep.package.bin) || []
-        const toKey = getKey(dep)
-
-        let target
-        if (external) {
-          const toLocation = join('node_modules', '.store', toKey, 'node_modules', dep.packageName)
-          target = root.children.get(toLocation)
-        } else {
-          target = root.inventory.get(dep.localLocation)
-        }
-        // TODO: we should no-op is an edge has already been created with the same fromKey and toKey
-        /* istanbul ignore next - strict-peer-deps can exclude nodes from the tree */
-        if (!target) {
-          return
-        }
-
-        binNames.forEach(bn => {
-          target.binPaths.push(join(from.realpath, 'node_modules', '.bin', bn))
-        })
-
-        const link = {
-          global: false,
-          globalTop: false,
-          isProjectRoot: false,
-          edgesIn: new Set(),
-          edgesOut: new Map(),
-          binPaths: [],
-          isTop: false,
-          optional,
-          location: location,
-          path: join(dep.root.localPath, nmFolder, dep.name),
-          realpath: target.path,
-          name: toKey,
-          resolved: dep.resolved,
-          top: { path: dep.root.localPath },
-          children: new Map(),
-          fsChildren: new Set(),
-          isLink: true,
-          isStoreLink: true,
-          isRoot: false,
-          package: { _id: 'abc', bundleDependencies: undefined, deprecated: undefined, bin: target.package.bin, scripts: dep.package.scripts },
-          target,
-        }
-        const newEdge1 = { optional, from, to: link }
-        from.edgesOut.set(dep.name, newEdge1)
-        link.edgesIn.add(newEdge1)
-        const newEdge2 = { optional: false, from: link, to: target }
-        link.edgesOut.set(dep.name, newEdge2)
-        target.edgesIn.add(newEdge2)
-        root.children.set(link.location, link)
-      }
-
-      for (const dep of node.localDependencies) {
-        processEdges(dep, false)
-        // nonOptional, local
-        processDeps(dep, false, false)
-      }
-      for (const dep of node.externalDependencies) {
-        processEdges(dep, true)
-        // nonOptional, external
-        processDeps(dep, false, true)
-      }
-      for (const dep of node.externalOptionalDependencies) {
-        processEdges(dep, true)
-        // optional, external
-        processDeps(dep, true, true)
-      }
+    this.#processEdges(this.idealGraph, false, root)
+    for (const node of this.idealGraph.workspaces) {
+      this.#processEdges(node, false, root)
     }
-
-    processEdges(proxiedIdealTree, false)
-    for (const node of proxiedIdealTree.workspaces) {
-      processEdges(node, false)
-    }
-    root.children.forEach(c => c.parent = root)
-    root.children.forEach(c => c.root = root)
-    root.root = root
-    root.target = root
     return root
+  }
+
+  #processEdges (node, externalEdge, root) {
+    const key = getKey(node)
+    if (this.#processedEdges.has(key)) {
+      return
+    }
+    this.#processedEdges.add(key)
+
+    let from, nmFolder
+    if (externalEdge) {
+      const fromLocation = join('node_modules', '.store', key, 'node_modules', node.packageName)
+      from = root.children.get(fromLocation)
+      nmFolder = join('node_modules', '.store', key, 'node_modules')
+    } else {
+      from = node.isProjectRoot ? root : root.inventory.get(node.localLocation)
+      nmFolder = join(node.localLocation, 'node_modules')
+    }
+    /* istanbul ignore next - strict-peer-deps can exclude nodes from the tree */
+    if (!from) {
+      return
+    }
+
+    for (const dep of node.localDependencies) {
+      this.#processEdges(dep, false, root)
+      // nonOptional, local
+      this.#processDeps(dep, false, false, root, from, nmFolder)
+    }
+    for (const dep of node.externalDependencies) {
+      this.#processEdges(dep, true, root)
+      // nonOptional, external
+      this.#processDeps(dep, false, true, root, from, nmFolder)
+    }
+    for (const dep of node.externalOptionalDependencies) {
+      this.#processEdges(dep, true, root)
+      // optional, external
+      this.#processDeps(dep, true, true, root, from, nmFolder)
+    }
+  }
+
+  #processDeps (dep, optional, external, root, from, nmFolder) {
+    const toKey = getKey(dep)
+
+    let target
+    if (external) {
+      const toLocation = join('node_modules', '.store', toKey, 'node_modules', dep.packageName)
+      target = root.children.get(toLocation)
+    } else {
+      target = root.inventory.get(dep.localLocation)
+    }
+    // TODO: we should no-op is an edge has already been created with the same fromKey and toKey
+    /* istanbul ignore next - strict-peer-deps can exclude nodes from the tree */
+    if (!target) {
+      return
+    }
+
+    if (dep.package.bin) {
+      for (const bn in dep.package.bin) {
+        target.binPaths.push(join(from.realpath, 'node_modules', '.bin', bn))
+      }
+    }
+
+    const link = {
+      binPaths: [],
+      children: new Map(),
+      edgesIn: new Set(),
+      edgesOut: new Map(),
+      fsChildren: new Set(),
+      global: false,
+      globalTop: false,
+      isLink: true,
+      isProjectRoot: false,
+      isRoot: false,
+      isStoreLink: true,
+      isTop: false,
+      location: join(nmFolder, dep.name),
+      name: toKey,
+      optional,
+      // TODO _id: 'abc' ?
+      package: { _id: 'abc', bundleDependencies: undefined, deprecated: undefined, bin: target.package.bin, scripts: dep.package.scripts },
+      parent: root,
+      path: join(dep.root.localPath, nmFolder, dep.name),
+      realpath: target.path,
+      resolved: dep.resolved,
+      root,
+      target,
+      top: { path: dep.root.localPath },
+    }
+    const newEdge1 = { optional, from, to: link }
+    from.edgesOut.set(dep.name, newEdge1)
+    link.edgesIn.add(newEdge1)
+    const newEdge2 = { optional: false, from: link, to: target }
+    link.edgesOut.set(dep.name, newEdge2)
+    target.edgesIn.add(newEdge2)
+    root.children.set(link.location, link)
   }
 }

--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -63,8 +63,6 @@ const _resolvedAdd = Symbol.for('resolvedAdd')
 // used by build-ideal-tree mixin
 const _addNodeToTrashList = Symbol.for('addNodeToTrashList')
 
-const _createIsolatedTree = Symbol.for('createIsolatedTree')
-
 module.exports = cls => class Reifier extends cls {
   #bundleMissing = new Set() // child nodes we'd EXPECT to be included in a bundle, but aren't
   #bundleUnpacked = new Set() // the nodes we unpack to read their bundles
@@ -115,7 +113,7 @@ module.exports = cls => class Reifier extends cls {
       // this is currently technical debt which will be resolved in a refactor
       // of Node/Link trees
       log.warn('reify', 'The "linked" install strategy is EXPERIMENTAL and may contain bugs.')
-      this.idealTree = await this[_createIsolatedTree]()
+      this.idealTree = await this.createIsolatedTree()
     }
     await this[_diffTrees]()
     await this.#reifyPackages()


### PR DESCRIPTION
This started as a removal of the Symbols left in isolated reifier and ended as a bit of a cleanup/refactor.

Inline functions were moved to either static ones or class functions, forEach was changes to for loops where possible, comments were unwrapped, and more.