### PR TITLE
fix: update minimatch to ^10.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "libnpmteam": "^8.0.2",
     "libnpmversion": "^8.0.3",
     "make-fetch-happen": "^15.0.4",
-    "minimatch": "^10.2.2",
+    "minimatch": "^10.2.4",
     "minipass": "^7.1.3",
     "minipass-pipeline": "^1.2.4",
     "ms": "^2.1.2",

--- a/workspaces/arborist/package.json
+++ b/workspaces/arborist/package.json
@@ -20,7 +20,7 @@
     "hosted-git-info": "^9.0.0",
     "json-stringify-nice": "^1.1.4",
     "lru-cache": "^11.2.1",
-    "minimatch": "^10.0.3",
+    "minimatch": "^10.2.4",
     "nopt": "^9.0.0",
     "npm-install-checks": "^8.0.0",
     "npm-package-arg": "^13.0.0",


### PR DESCRIPTION
## References
Related to https://github.com/npm/cli/issues/9037.

I rode https://github.com/npm/cli/blob/latest/CONTRIBUTING.md#dependencies, but nothing is in https://github.com/npm/cli/pull/9047 yet.
