### PR TITLE
fix(arborist): add missing top property to isolated reifier proxy nodes

### DIFF
--- a/workspaces/arborist/lib/arborist/isolated-reifier.js
+++ b/workspaces/arborist/lib/arborist/isolated-reifier.js
@@ -318,6 +318,7 @@ module.exports = cls => class IsolatedReifier extends cls {
     }
     root.inventory.set('', root)
     root.root = root
+    root.top = root
     root.target = root
     // TODO inventory.query is a stub; audit-report needs 'packageName' support
     root.inventory.query = () => {
@@ -335,6 +336,7 @@ module.exports = cls => class IsolatedReifier extends cls {
         hasInstallScript: c.hasInstallScript,
         isLink: false,
         isRoot: false,
+        isWorkspace: true,
         linksIn: new Set(),
         location: c.localLocation,
         name: wsName,
@@ -344,6 +346,7 @@ module.exports = cls => class IsolatedReifier extends cls {
         resolved: c.resolved,
       }
       workspace.target = workspace
+      workspace.top = workspace
       root.fsChildren.add(workspace)
       root.inventory.set(workspace.location, workspace)
 
@@ -369,6 +372,7 @@ module.exports = cls => class IsolatedReifier extends cls {
         realpath: workspace.path,
         root,
         target: workspace,
+        top: root,
       }
       root.children.set(wsLink.name, wsLink)
       root.inventory.set(wsLink.location, wsLink)

--- a/workspaces/arborist/test/arborist/reify.js
+++ b/workspaces/arborist/test/arborist/reify.js
@@ -3250,4 +3250,51 @@ t.test('install stategy linked', async (t) => {
     t.ok(store.isDirectory(), 'abbrev got installed')
     t.ok(abbrev.isSymbolicLink(), 'abbrev got installed')
   })
+
+  t.test('should not crash with --omit=dev in workspaces', async (t) => {
+    const testdir = t.testdir({
+      project: {
+        'package.json': JSON.stringify({
+          name: 'my-monorepo',
+          version: '1.0.0',
+          workspaces: ['packages/*'],
+          dependencies: {
+            abbrev: '1.1.1',
+          },
+          devDependencies: {
+            abbrev: '1.1.1',
+          },
+        }),
+        packages: {
+          'my-lib': {
+            'package.json': JSON.stringify({
+              name: 'my-lib',
+              version: '1.0.0',
+              dependencies: {
+                abbrev: '1.1.1',
+              },
+            }),
+          },
+        },
+      },
+    })
+
+    tnock(t, 'https://registry.npmjs.org')
+      .get('/abbrev')
+      .reply(200, abbrevPackument)
+
+    tnock(t, 'https://registry.npmjs.org')
+      .get('/abbrev/-/abbrev-1.1.1.tgz')
+      .reply(200, abbrevTGZ)
+
+    const path = resolve(testdir, 'project')
+    const arb = new Arborist({
+      path,
+      registry: 'https://registry.npmjs.org',
+      cache: resolve(testdir, 'cache'),
+      installStrategy: 'linked',
+    })
+    await arb.reify({ installStrategy: 'linked', omit: ['dev'] })
+    t.pass('reify with --omit=dev did not crash')
+  })
 })


### PR DESCRIPTION
In continuation of our exploration of using `install-strategy=linked` in the [Gutenberg monorepo](https://github.com/WordPress/gutenberg/pull/75814), which powers the WordPress Block Editor.

##Summary

Fixes `npm install --omit=dev` crashing with `install-strategy=linked` in workspace monorepos.

`addOmitsToTrashList` iterates inventory nodes and accesses `node.top.isProjectRoot`, but the isolated reifier's proxy nodes for the root, workspace, and workspace link were missing the `top` property, causing a `TypeError`.

- Add `top` (self-reference) to root and workspace proxy nodes
- Add `top: root` to workspace link proxy nodes
- Add `isWorkspace: true` to workspace proxy nodes so their dev deps can be omitted


## References

Fixes #9063