### PR TITLE
fix(arborist): respect --omit flag in linked install strategy

### DIFF
--- a/workspaces/arborist/lib/arborist/isolated-reifier.js
+++ b/workspaces/arborist/lib/arborist/isolated-reifier.js
@@ -90,6 +90,7 @@ module.exports = cls => class IsolatedReifier extends cls {
    **/
   async makeIdealGraph () {
     const idealTree = this.idealTree
+    const omit = new Set(this.options.omit)
 
     this.idealGraph = {
       external: [],
@@ -110,7 +111,9 @@ module.exports = cls => class IsolatedReifier extends cls {
       processed.add(next.location)
       next.edgesOut.forEach(edge => {
         if (edge.to && !(next.package.bundleDependencies || next.package.bundledDependencies || []).includes(edge.to.name)) {
-          queue.push(edge.to)
+          if (!edge.to.shouldOmit?.(omit)) {
+            queue.push(edge.to)
+          }
         }
       })
       // local `file:` deps are in fsChildren but are not workspaces.

--- a/workspaces/arborist/test/isolated-mode.js
+++ b/workspaces/arborist/test/isolated-mode.js
@@ -2055,6 +2055,48 @@ function parseGraphRecursive (key, deps) {
   return { name, version, workspace, peer, dependencies }
 }
 
+tap.test('omit dev dependencies with linked strategy', async t => {
+  const graph = {
+    registry: [
+      { name: 'which', version: '1.0.0', dependencies: { isexe: '^1.0.0' } },
+      { name: 'isexe', version: '1.0.0' },
+      { name: 'eslint', version: '1.0.0' },
+    ],
+    root: {
+      name: 'myapp',
+      version: '1.0.0',
+      dependencies: { which: '1.0.0' },
+      devDependencies: { eslint: '1.0.0' },
+    },
+    workspaces: [
+      {
+        name: 'mylib',
+        version: '1.0.0',
+        dependencies: { isexe: '1.0.0' },
+        devDependencies: { eslint: '1.0.0' },
+      },
+    ],
+  }
+
+  const { dir, registry } = await getRepo(graph)
+  const cache = fs.mkdtempSync(`${getTempDir()}/test-`)
+  const arborist = new Arborist({
+    path: dir,
+    registry,
+    packumentCache: new Map(),
+    cache,
+    omit: ['dev'],
+  })
+  await arborist.reify({ installStrategy: 'linked' })
+
+  const storeDir = path.join(dir, 'node_modules', '.store')
+  const storeEntries = fs.readdirSync(storeDir)
+
+  t.ok(storeEntries.some(e => e.startsWith('which@')), 'prod dep which is in store')
+  t.ok(storeEntries.some(e => e.startsWith('isexe@')), 'prod dep isexe is in store')
+  t.notOk(storeEntries.some(e => e.startsWith('eslint@')), 'dev dep eslint is not in store')
+})
+
 /*
  * TO TEST:
  *   --------------------------------------


### PR DESCRIPTION
In continuation of our exploration of using `install-strategy=linked` in the [Gutenberg monorepo](https://github.com/WordPress/gutenberg/pull/75814), which powers the WordPress Block Editor.

## Summary

`npm install --omit=dev` with `install-strategy=linked` silently installs all dependencies including devDependencies. The `--omit` flag has no effect because the isolated reifier's `makeIdealGraph` unconditionally traverses all edges without consulting the omit option.

The ideal tree nodes already have `dev`/`optional`/`peer` flags set by `calcDepFlags`, so the fix is to call `shouldOmit()` when traversing edges in `makeIdealGraph` to skip nodes that match the omit set.

## References

Fixes #9065