### PR TITLE
[New] add `publish-registry` config option

### DIFF
--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -26,6 +26,7 @@ class Publish extends BaseCommand {
     'access',
     'dry-run',
     'otp',
+    'publish-registry',
     'workspace',
     'workspaces',
     'include-workspace-root',
@@ -82,6 +83,10 @@ class Publish extends BaseCommand {
     }
 
     const opts = { ...this.npm.flatOptions, progress: false }
+    const publishRegistry = this.npm.config.get('publish-registry')
+    if (publishRegistry) {
+      opts.registry = publishRegistry
+    }
 
     // you can publish name@version, ./foo.tgz, etc.
     // even though the default is the 'file:.' cwd.

--- a/lib/commands/unpublish.js
+++ b/lib/commands/unpublish.js
@@ -16,7 +16,7 @@ const LAST_REMAINING_VERSION_ERROR = 'Refusing to delete the last version of the
 class Unpublish extends BaseCommand {
   static description = 'Remove a package from the registry'
   static name = 'unpublish'
-  static params = ['dry-run', 'force', 'workspace', 'workspaces']
+  static params = ['dry-run', 'force', 'publish-registry', 'workspace', 'workspaces']
   static usage = ['[<package-spec>]']
   static workspaces = true
   static ignoreImplicitWorkspace = false
@@ -103,6 +103,10 @@ class Unpublish extends BaseCommand {
     }
 
     const opts = { ...this.npm.flatOptions }
+    const publishRegistry = this.npm.config.get('publish-registry')
+    if (publishRegistry) {
+      opts.registry = publishRegistry
+    }
 
     let manifest
     try {

--- a/tap-snapshots/test/lib/commands/config.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/config.js.test.cjs
@@ -135,6 +135,7 @@ exports[`test/lib/commands/config.js TAP config list --json > output matches sna
   "proxy": null,
   "read-only": false,
   "rebuild-bundle": true,
+  "publish-registry": null,
   "registry": "https://registry.npmjs.org/",
   "replace-registry-host": "npmjs",
   "save": true,
@@ -315,6 +316,7 @@ progress = {PROGRESS}
 provenance = false
 provenance-file = null
 proxy = null
+publish-registry = null
 read-only = false
 rebuild-bundle = true
 registry = "https://registry.npmjs.org/"

--- a/tap-snapshots/test/lib/commands/publish.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/publish.js.test.cjs
@@ -288,7 +288,15 @@ exports[`test/lib/commands/publish.js TAP public access > new package version 1`
 + @npm/test-package@1.0.0
 `
 
+exports[`test/lib/commands/publish.js TAP publish-registry config overridden by publishConfig.registry > new package version 1`] = `
++ @npmcli/test-package@1.0.0
+`
+
 exports[`test/lib/commands/publish.js TAP re-loads publishConfig.registry if added during script process > new package version 1`] = `
++ @npmcli/test-package@1.0.0
+`
+
+exports[`test/lib/commands/publish.js TAP respects publish-registry config > new package version 1`] = `
 + @npmcli/test-package@1.0.0
 `
 

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -1459,6 +1459,17 @@ by the underlying \`request\` library.
 
 
 
+#### \`publish-registry\`
+
+* Default: null
+* Type: null or URL
+
+The base URL of the npm registry to use for \`npm publish\` and \`npm
+unpublish\`. When set, overrides \`registry\` for these commands while leaving
+\`registry\` in effect for all other operations like install and view.
+
+
+
 #### \`read-only\`
 
 * Default: false
@@ -2364,6 +2375,7 @@ Array [
   "proxy",
   "read-only",
   "rebuild-bundle",
+  "publish-registry",
   "registry",
   "replace-registry-host",
   "save",
@@ -2519,6 +2531,7 @@ Array [
   "proxy",
   "read-only",
   "rebuild-bundle",
+  "publish-registry",
   "registry",
   "replace-registry-host",
   "save",
@@ -2692,6 +2705,7 @@ Object {
   "provenance": false,
   "provenanceFile": null,
   "proxy": null,
+  "publishRegistry": null,
   "readOnly": false,
   "rebuildBundle": true,
   "registry": "https://registry.npmjs.org/",
@@ -5055,6 +5069,7 @@ npm publish <package-spec>
 
 Options:
 [--tag <tag>] [--access <restricted|public>] [--dry-run] [--otp <otp>]
+[--publish-registry <publish-registry>]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [--workspaces] [--include-workspace-root] [--provenance|--provenance-file <file>]
 
@@ -5069,6 +5084,9 @@ Options:
 
   --otp
     This is a one-time password from a two-factor authenticator.  It's needed
+
+  --publish-registry
+    The base URL of the npm registry to use for \`npm publish\` and
 
   -w|--workspace
     Enable running a command in the context of the configured workspaces of the
@@ -5093,6 +5111,7 @@ npm publish <package-spec>
 #### \`access\`
 #### \`dry-run\`
 #### \`otp\`
+#### \`publish-registry\`
 #### \`workspace\`
 #### \`workspaces\`
 #### \`include-workspace-root\`
@@ -5910,7 +5929,7 @@ Usage:
 npm unpublish [<package-spec>]
 
 Options:
-[--dry-run] [-f|--force]
+[--dry-run] [-f|--force] [--publish-registry <publish-registry>]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [--workspaces]
 
@@ -5919,6 +5938,9 @@ Options:
 
   -f|--force
     Removes various protections against unfortunate side effects, common
+
+  --publish-registry
+    The base URL of the npm registry to use for \`npm publish\` and
 
   -w|--workspace
     Enable running a command in the context of the configured workspaces of the
@@ -5935,6 +5957,7 @@ npm unpublish [<package-spec>]
 
 #### \`dry-run\`
 #### \`force\`
+#### \`publish-registry\`
 #### \`workspace\`
 #### \`workspaces\`
 `

--- a/test/lib/commands/publish.js
+++ b/test/lib/commands/publish.js
@@ -58,6 +58,64 @@ t.test('respects publishConfig.registry, runs appropriate scripts', async t => {
   t.same(logs.warn, ['Unknown publishConfig config "other". This will stop working in the next major version of npm. See `npm help npmrc` for supported config options.'])
 })
 
+t.test('respects publish-registry config', async t => {
+  const publishRegistry = alternateRegistry
+  const { joinedOutput, npm, registry } = await loadNpmWithRegistry(t, {
+    config: {
+      'publish-registry': publishRegistry,
+      [`${publishRegistry.slice(6)}/:_authToken`]: 'test-other-token',
+    },
+    prefixDir: {
+      'package.json': JSON.stringify(pkgJson, null, 2),
+    },
+    registry: publishRegistry,
+    authorization: 'test-other-token',
+  })
+  registry.getPackage(pkg, { times: 2, code: 404 })
+  registry.putPackage(pkg, { packageJson: pkgJson, registry: publishRegistry })
+  await npm.exec('publish', [])
+  t.matchSnapshot(joinedOutput(), 'new package version')
+})
+
+t.test('publish-registry config overridden by publishConfig.registry', async t => {
+  const publishRegistry = alternateRegistry
+  const thirdRegistry = 'https://third.registry.npmjs.org'
+  const packageJson = {
+    ...pkgJson,
+    publishConfig: { registry: thirdRegistry },
+  }
+  const { joinedOutput, npm, registry } = await loadNpmWithRegistry(t, {
+    config: {
+      'publish-registry': publishRegistry,
+      [`${thirdRegistry.slice(6)}/:_authToken`]: 'test-third-token',
+    },
+    prefixDir: {
+      'package.json': JSON.stringify(packageJson, null, 2),
+    },
+    registry: thirdRegistry,
+    authorization: 'test-third-token',
+  })
+  registry.publish(pkg, { packageJson })
+  await npm.exec('publish', [])
+  t.matchSnapshot(joinedOutput(), 'new package version')
+})
+
+t.test('publish-registry config does not affect install registry', async t => {
+  const publishRegistry = alternateRegistry
+  const { npm } = await loadNpmWithRegistry(t, {
+    config: {
+      'publish-registry': publishRegistry,
+      ...auth,
+    },
+    prefixDir: {
+      'package.json': JSON.stringify(pkgJson, null, 2),
+    },
+    authorization: token,
+  })
+  t.equal(npm.config.get('registry'), 'https://registry.npmjs.org/')
+  t.equal(npm.config.get('publish-registry'), alternateRegistry + '/')
+})
+
 t.test('re-loads publishConfig.registry if added during script process', async t => {
   const initPackageJson = {
     ...pkgJson,

--- a/test/lib/commands/unpublish.js
+++ b/test/lib/commands/unpublish.js
@@ -378,6 +378,34 @@ t.test('dryRun with no args', async t => {
   t.equal(joinedOutput(), '- test-package@1.0.0')
 })
 
+t.test('publish-registry config', async t => {
+  const alternateRegistry = 'https://other.registry.npmjs.org'
+  const { joinedOutput, npm } = await loadMockNpm(t, {
+    config: {
+      force: true,
+      'publish-registry': alternateRegistry,
+      '//other.registry.npmjs.org/:_authToken': 'test-other-token',
+    },
+    prefixDir: {
+      'package.json': JSON.stringify({
+        name: pkg,
+        version: '1.0.0',
+      }, null, 2),
+    },
+  })
+
+  const registry = new MockRegistry({
+    tap: t,
+    registry: alternateRegistry,
+    authorization: 'test-other-token',
+  })
+  const manifest = registry.manifest({ name: pkg })
+  await registry.package({ manifest, query: { write: true }, times: 2 })
+  registry.unpublish({ manifest })
+  await npm.exec('unpublish', [])
+  t.equal(joinedOutput(), '- test-package')
+})
+
 t.test('publishConfig no spec', async t => {
   const alternateRegistry = 'https://other.registry.npmjs.org'
   const { logs, joinedOutput, npm } = await loadMockNpm(t, {

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -1726,6 +1726,17 @@ const definitions = {
     `,
     flatten,
   }),
+  'publish-registry': new Definition('publish-registry', {
+    default: null,
+    type: [null, url],
+    description: `
+      The base URL of the npm registry to use for \`npm publish\` and
+      \`npm unpublish\`. When set, overrides \`registry\` for these
+      commands while leaving \`registry\` in effect for all other
+      operations like install and view.
+    `,
+    flatten,
+  }),
   registry: new Definition('registry', {
     default: 'https://registry.npmjs.org/',
     type: url,


### PR DESCRIPTION
## Summary

Adds a new `publish-registry` config option that allows setting a separate registry URL for `npm publish` and `npm unpublish`, while leaving `registry` in effect for all other operations (install, view, etc.).

This enables using a local caching proxy (VSR, Verdaccio, etc.) for reads while publishing directly to the public npm registry:

```ini
# .npmrc
registry=http://localhost:1337/npm
publish-registry=https://registry.npmjs.org/
```

### Motivation

There is no clean way today to split read vs write registries in npm:
- `publishConfig.registry` in `package.json` is per-package, not global
- Scoped registries in `.npmrc` apply to both reads and writes
- `--registry` flag must be passed manually every time

This has been a long-standing pain point across many issues: #1937, #559, #4034, #7043, and [npm/feedback#131](https://github.com/npm/feedback/discussions/131).

### Changes

- **`workspaces/config/lib/definitions/definitions.js`**: New `publish-registry` config definition (type: `null | URL`, default: `null`)
- **`lib/commands/publish.js`**: When `publish-registry` is set, overrides `opts.registry` before registry selection. Added to `static params` for help/docs.
- **`lib/commands/unpublish.js`**: Same treatment for symmetry (addresses #559 where publish and unpublish use different registries)
- **Tests**: 3 new publish tests (basic usage, override by publishConfig, no effect on install registry) + 1 new unpublish test

### Behavior

- `null` default means zero behavior change for existing users
- `publishConfig.registry` in `package.json` still takes precedence (applied later via `flatten`)
- Scoped registries still take precedence in `pickRegistry` (existing behavior)
- CLI `--registry` flag still takes precedence (existing behavior)