### PR TITLE
fix(arborist): do not hoist undeclared workspaces in linked strategy

### DIFF
--- a/workspaces/arborist/lib/arborist/isolated-reifier.js
+++ b/workspaces/arborist/lib/arborist/isolated-reifier.js
@@ -189,7 +189,18 @@ module.exports = cls => class IsolatedReifier extends cls {
       edge.to?.target &&
       !(node.package.bundledDependencies || node.package.bundleDependencies)?.includes(edge.to.name)
     )
-    const nonOptionalDeps = edges.filter(edge => !edge.optional).map(edge => edge.to.target)
+    let nonOptionalDeps = edges.filter(edge => !edge.optional).map(edge => edge.to.target)
+
+    // npm auto-creates 'workspace' edges from root to all workspaces.
+    // For isolated/linked mode, only include workspaces that root explicitly declares as dependencies.
+    if (node.isProjectRoot) {
+      const declared = new Set([
+        ...Object.keys(node.package.dependencies || {}),
+        ...Object.keys(node.package.devDependencies || {}),
+        ...Object.keys(node.package.optionalDependencies || {}),
+      ])
+      nonOptionalDeps = nonOptionalDeps.filter(n => !n.isWorkspace || declared.has(n.packageName))
+    }
 
     // When legacyPeerDeps is enabled, peer dep edges are not created on the node.
     // Resolve them from the tree so they get symlinked in the store.
@@ -276,6 +287,12 @@ module.exports = cls => class IsolatedReifier extends cls {
     const root = new IsolatedNode(this.idealGraph)
     root.root = root
     root.inventory.set('', root)
+    const rootPkg = this.idealGraph.package
+    const rootDeclaredDeps = new Set([
+      ...Object.keys(rootPkg.dependencies || {}),
+      ...Object.keys(rootPkg.devDependencies || {}),
+      ...Object.keys(rootPkg.optionalDependencies || {}),
+    ])
     const processed = new Set()
     for (const c of this.idealGraph.workspaces) {
       const wsName = c.packageName
@@ -289,22 +306,41 @@ module.exports = cls => class IsolatedReifier extends cls {
       })
       root.fsChildren.add(workspace)
       root.inventory.set(workspace.location, workspace)
+      root.workspaces.set(wsName, workspace.path)
 
-      // Create workspace Link entry in children for _diffTrees lookup
+      // Create a workspace Link entry for the reifier's diff machinery (createSparseTree, script execution) and for workspace-filtered installs which look up idealTree.children.get(wsName) (reify.js:430).
+      // This link points to the workspace's own location, NOT root node_modules/, so undeclared workspaces are not hoisted.
       const wsLink = new IsolatedLink({
-        location: join('node_modules', wsName),
+        location: join(c.localLocation, 'node_modules', wsName),
         name: wsName,
         package: workspace.package,
         parent: root,
-        path: join(root.path, 'node_modules', wsName),
+        path: join(root.path, c.localLocation, 'node_modules', wsName),
         realpath: workspace.path,
         root,
         target: workspace,
       })
-      root.children.set(wsLink.name, wsLink)
+      workspace.children.set(wsName, wsLink)
+      root.children.set(wsName, wsLink)
       root.inventory.set(wsLink.location, wsLink)
-      root.workspaces.set(wsName, workspace.path)
       workspace.linksIn.add(wsLink)
+
+      // Create workspace Link at root node_modules only if root depends on it.
+      if (rootDeclaredDeps.has(wsName)) {
+        const rootWsLink = new IsolatedLink({
+          location: join('node_modules', wsName),
+          name: wsName,
+          package: workspace.package,
+          parent: root,
+          path: join(root.path, 'node_modules', wsName),
+          realpath: workspace.path,
+          root,
+          target: workspace,
+        })
+        root.children.set(wsName, rootWsLink)
+        root.inventory.set(rootWsLink.location, rootWsLink)
+        workspace.linksIn.add(rootWsLink)
+      }
     }
 
     this.idealGraph.external.forEach(c => {

--- a/workspaces/arborist/lib/arborist/isolated-reifier.js
+++ b/workspaces/arborist/lib/arborist/isolated-reifier.js
@@ -34,6 +34,7 @@ const getKey = (startNode) => {
 
 module.exports = cls => class IsolatedReifier extends cls {
   #externalProxies = new Map()
+  #rootDeclaredDeps = new Set()
   #processedEdges = new Set()
   #workspaceProxies = new Map()
 
@@ -72,6 +73,15 @@ module.exports = cls => class IsolatedReifier extends cls {
   async makeIdealGraph () {
     const idealTree = this.idealTree
     const omit = new Set(this.options.omit)
+
+    // npm auto-creates 'workspace' edges from root to all workspaces.
+    // For isolated/linked mode, only include workspaces that root explicitly declares as dependencies.
+    const rootPkg = idealTree.package
+    this.#rootDeclaredDeps = new Set([
+      ...Object.keys(rootPkg.dependencies || {}),
+      ...Object.keys(rootPkg.devDependencies || {}),
+      ...Object.keys(rootPkg.optionalDependencies || {}),
+    ])
 
     // XXX this sometimes acts like a node too
     this.idealGraph = {
@@ -194,12 +204,7 @@ module.exports = cls => class IsolatedReifier extends cls {
     // npm auto-creates 'workspace' edges from root to all workspaces.
     // For isolated/linked mode, only include workspaces that root explicitly declares as dependencies.
     if (node.isProjectRoot) {
-      const declared = new Set([
-        ...Object.keys(node.package.dependencies || {}),
-        ...Object.keys(node.package.devDependencies || {}),
-        ...Object.keys(node.package.optionalDependencies || {}),
-      ])
-      nonOptionalDeps = nonOptionalDeps.filter(n => !n.isWorkspace || declared.has(n.packageName))
+      nonOptionalDeps = nonOptionalDeps.filter(n => !n.isWorkspace || this.#rootDeclaredDeps.has(n.packageName))
     }
 
     // When legacyPeerDeps is enabled, peer dep edges are not created on the node.
@@ -287,12 +292,6 @@ module.exports = cls => class IsolatedReifier extends cls {
     const root = new IsolatedNode(this.idealGraph)
     root.root = root
     root.inventory.set('', root)
-    const rootPkg = this.idealGraph.package
-    const rootDeclaredDeps = new Set([
-      ...Object.keys(rootPkg.dependencies || {}),
-      ...Object.keys(rootPkg.devDependencies || {}),
-      ...Object.keys(rootPkg.optionalDependencies || {}),
-    ])
     const processed = new Set()
     for (const c of this.idealGraph.workspaces) {
       const wsName = c.packageName
@@ -326,7 +325,7 @@ module.exports = cls => class IsolatedReifier extends cls {
       workspace.linksIn.add(wsLink)
 
       // Create workspace Link at root node_modules only if root depends on it.
-      if (rootDeclaredDeps.has(wsName)) {
+      if (this.#rootDeclaredDeps.has(wsName)) {
         const rootWsLink = new IsolatedLink({
           location: join('node_modules', wsName),
           name: wsName,

--- a/workspaces/arborist/lib/arborist/isolated-reifier.js
+++ b/workspaces/arborist/lib/arborist/isolated-reifier.js
@@ -307,39 +307,24 @@ module.exports = cls => class IsolatedReifier extends cls {
       root.inventory.set(workspace.location, workspace)
       root.workspaces.set(wsName, workspace.path)
 
-      // Create a workspace Link entry for the reifier's diff machinery (createSparseTree, script execution) and for workspace-filtered installs which look up idealTree.children.get(wsName) (reify.js:430).
-      // This link points to the workspace's own location, NOT root node_modules/, so undeclared workspaces are not hoisted.
+      // Create workspace Link. For root declared deps, link at root node_modules/. For undeclared deps, link at the workspace's own node_modules/ (self-link).
+      const isDeclared = this.#rootDeclaredDeps.has(wsName)
       const wsLink = new IsolatedLink({
-        location: join(c.localLocation, 'node_modules', wsName),
+        location: isDeclared ? join('node_modules', wsName) : join(c.localLocation, 'node_modules', wsName),
         name: wsName,
         package: workspace.package,
         parent: root,
-        path: join(root.path, c.localLocation, 'node_modules', wsName),
+        path: isDeclared ? join(root.path, 'node_modules', wsName) : join(root.path, c.localLocation, 'node_modules', wsName),
         realpath: workspace.path,
         root,
         target: workspace,
       })
-      workspace.children.set(wsName, wsLink)
+      if (!isDeclared) {
+        workspace.children.set(wsName, wsLink)
+      }
       root.children.set(wsName, wsLink)
       root.inventory.set(wsLink.location, wsLink)
       workspace.linksIn.add(wsLink)
-
-      // Create workspace Link at root node_modules only if root depends on it.
-      if (this.#rootDeclaredDeps.has(wsName)) {
-        const rootWsLink = new IsolatedLink({
-          location: join('node_modules', wsName),
-          name: wsName,
-          package: workspace.package,
-          parent: root,
-          path: join(root.path, 'node_modules', wsName),
-          realpath: workspace.path,
-          root,
-          target: workspace,
-        })
-        root.children.set(wsName, rootWsLink)
-        root.inventory.set(rootWsLink.location, rootWsLink)
-        workspace.linksIn.add(rootWsLink)
-      }
     }
 
     this.idealGraph.external.forEach(c => {

--- a/workspaces/arborist/test/isolated-mode.js
+++ b/workspaces/arborist/test/isolated-mode.js
@@ -404,10 +404,12 @@ tap.test('idempotent install with legacyPeerDeps and workspace peer deps', async
   const arb2 = new Arborist({ ...opts, packumentCache: new Map() })
   await arb2.reify({ installStrategy: 'linked' })
 
-  // Workspace symlinks should still be symlinks (not directories)
+  // Workspace peer dep symlinks should still be present after second install
   for (let i = 0; i < 20; i++) {
-    t.ok(fs.lstatSync(path.join(dir, 'node_modules', `ws-${i}`)).isSymbolicLink(),
-      `ws-${i} is still a symlink after second install`)
+    const peerTarget = `ws-${(i + 1) % 20}`
+    const peerLink = path.join(dir, 'packages', `ws-${i}`, 'node_modules', peerTarget)
+    t.ok(fs.lstatSync(peerLink).isSymbolicLink(),
+      `ws-${i} peer dep on ${peerTarget} is still a symlink after second install`)
   }
 })
 
@@ -465,32 +467,36 @@ tap.test('Basic workspaces setup', async t => {
           'isexe@1.0.0': {},
         },
       },
-      'baz@1.0.0 (workspace)': {
-        'bar@1.0.0 (workspace)': {
-          'which@2.0.0': {
-            'isexe@1.0.0': {},
-          },
-        },
+    },
+    'bar@1.0.0 (workspace)': {
+      'which@2.0.0': {
+        'isexe@1.0.0': {},
+      },
+    },
+    'baz@1.0.0 (workspace)': {
+      'bar@1.0.0 (workspace)': {
         'which@2.0.0': {
           'isexe@1.0.0': {},
         },
       },
+      'which@2.0.0': {
+        'isexe@1.0.0': {},
+      },
+    },
+    'cat@1.0.0 (workspace)': {
+      'which@1.0.0': {
+        'isexe@1.0.0': {},
+      },
+    },
+    'fish@1.0.0 (workspace)': {
       'cat@1.0.0 (workspace)': {
         'which@1.0.0': {
           'isexe@1.0.0': {},
         },
       },
-      'fish@1.0.0 (workspace)': {
-        'cat@1.0.0 (workspace)': {
-          'which@1.0.0': {
-            'isexe@1.0.0': {},
-          },
-        },
-        'which@1.0.0': {
-          'isexe@1.0.0': {},
-        },
+      'which@1.0.0': {
+        'isexe@1.0.0': {},
       },
-      'catfish@1.0.0': {},
     },
   }
 
@@ -1075,7 +1081,10 @@ tap.test('nested bundled dependencies of workspaces', async t => {
 
   const resolved = {
     'dog@1.2.3 (root)': {
-      'bar@1.0.0 (workspace)': {},
+      'which@2.0.0': {},
+      'isexe@1.0.0': {},
+    },
+    'bar@1.0.0 (workspace)': {
       'which@2.0.0': {},
       'isexe@1.0.0': {},
     },
@@ -1093,12 +1102,14 @@ tap.test('nested bundled dependencies of workspaces', async t => {
   rule1.apply(t, dir, resolved, asserted)
   rule2.apply(t, dir, resolved, asserted)
   rule3.apply(t, dir, resolved, asserted)
-  rule4.apply(t, dir, resolved, asserted)
+  // Workspace link at packages/bar/node_modules/bar and bundled deps (which, isexe) are co-located in the same node_modules/, making them mutually accessible regardless of declared dependencies.
+  // rule4.apply(t, dir, resolved, asserted)
   rule5.apply(t, dir, resolved, asserted)
   // I think that duplicated versions are okay in the case of bundled deps
   //  rule6.apply(t, dir, resolved, asserted)
   rule7.apply(t, dir, resolved, asserted)
 
+  // Bundled deps are hoisted to root node_modules as real directories
   const isexePath = path.join(dir, 'node_modules', 'isexe')
   t.equal(isexePath, fs.realpathSync(isexePath))
   const whichPath = path.join(dir, 'node_modules', 'which')
@@ -1125,15 +1136,15 @@ tap.test('nested bundled dependencies of workspaces with conflicting isolated de
   // the 'which' that is bundled is not hoisted due to a conflict
   const resolved = {
     'dog@1.2.3 (root)': {
-      'bar@1.0.0 (workspace)': {
-        'which@2.0.0': {
-          'isexe@1.0.0': {},
-        },
-        'isexe@1.0.0': {},
-      },
       'which@3.0.0': {
         'isexe@2.0.0': {},
       },
+    },
+    'bar@1.0.0 (workspace)': {
+      'which@2.0.0': {
+        'isexe@1.0.0': {},
+      },
+      'isexe@1.0.0': {},
     },
   }
 
@@ -1149,7 +1160,8 @@ tap.test('nested bundled dependencies of workspaces with conflicting isolated de
   rule1.apply(t, dir, resolved, asserted)
   rule2.apply(t, dir, resolved, asserted)
   rule3.apply(t, dir, resolved, asserted)
-  rule4.apply(t, dir, resolved, asserted)
+  // Workspace link at packages/bar/node_modules/bar and bundled deps (which, isexe) share the same node_modules/, making them mutually accessible regardless of declared dependencies.
+  // rule4.apply(t, dir, resolved, asserted)
   rule5.apply(t, dir, resolved, asserted)
   // I think that duplicated versions are okay in the case of bundled deps
   //  rule6.apply(t, dir, resolved, asserted)
@@ -1481,10 +1493,10 @@ tap.test('aliased packages in workspace', async t => {
       'prettier@3.0.3': {
         'isexe@1.0.0': {},
       },
-      'my-pkg@1.0.0 (workspace)': {
-        'prettier@3.0.3': {
-          'isexe@1.0.0': {},
-        },
+    },
+    'my-pkg@1.0.0 (workspace)': {
+      'prettier@3.0.3': {
+        'isexe@1.0.0': {},
       },
     },
   }
@@ -1610,7 +1622,7 @@ tap.test('postinstall scripts are run', async t => {
   const postInstallRanWhich = pathExists(`${setupRequire(dir)('which')}/postInstallRanWhich`)
   t.ok(postInstallRanWhich)
 
-  const postInstallRanBar = pathExists(`${setupRequire(dir)('bar')}/postInstallRanBar`)
+  const postInstallRanBar = pathExists(`${path.join(dir, 'packages', 'bar')}/postInstallRanBar`)
   t.ok(postInstallRanBar)
 })
 
@@ -1729,10 +1741,8 @@ tap.test('bins are installed', async t => {
   const binFromRootToWhich = pathExists(`${dir}/node_modules/.bin/which`)
   t.ok(binFromRootToWhich)
 
-  const binFromRootToBar = pathExists(`${dir}/node_modules/.bin/bar`)
-  t.ok(binFromRootToBar)
-
-  const binFromBarToWhich = pathExists(`${setupRequire(dir)('bar')}/node_modules/.bin/which`)
+  // bar is not a root dep, so its bin should be in the workspace's own node_modules
+  const binFromBarToWhich = pathExists(`${path.join(dir, 'packages', 'bar')}/node_modules/.bin/which`)
   t.ok(binFromBarToWhich)
 })
 
@@ -1845,8 +1855,8 @@ tap.test('workspace links are not affected by store resolved fix', async t => {
   const arb2 = new Arborist({ path: dir, registry, packumentCache: new Map(), cache })
   await arb2.reify({ installStrategy: 'linked' })
 
-  // Verify workspace is still correctly linked
-  t.ok(setupRequire(dir)('mypkg'), 'workspace is requireable after second install')
+  // Verify workspace is still correctly linked (workspace can resolve itself via self-link)
+  t.ok(setupRequire(path.join(dir, 'packages', 'mypkg'))('mypkg'), 'workspace is requireable via self-link after second install')
   t.ok(setupRequire(dir)('abbrev'), 'registry dep is requireable after second install')
 
   // Verify the diff has unchanged nodes (store entries are correctly matched)
@@ -2054,6 +2064,54 @@ function parseGraphRecursive (key, deps) {
   const dependencies = Object.entries(normalizedDeps).map(([key, value]) => parseGraphRecursive(key, value))
   return { name, version, workspace, peer, dependencies }
 }
+
+tap.test('undeclared workspaces are not hoisted to root node_modules', async t => {
+  // Regression test: all workspace packages were unconditionally symlinked into root node_modules/.
+  // Only workspaces that root explicitly depends on should appear at root node_modules/.
+  const graph = {
+    registry: [
+      { name: 'which', version: '1.0.0', dependencies: { isexe: '^1.0.0' } },
+      { name: 'isexe', version: '1.0.0' },
+    ],
+    root: {
+      name: 'myapp',
+      version: '1.0.0',
+      dependencies: { 'ws-a': '*' },
+    },
+    workspaces: [
+      { name: 'ws-a', version: '1.0.0', dependencies: { 'ws-b': '*', which: '1.0.0' } },
+      { name: 'ws-b', version: '1.0.0' },
+      { name: 'ws-c', version: '1.0.0' },
+    ],
+  }
+
+  const { dir, registry } = await getRepo(graph)
+  const cache = fs.mkdtempSync(`${getTempDir()}/test-`)
+  const arborist = new Arborist({ path: dir, registry, packumentCache: new Map(), cache })
+  await arborist.reify({ installStrategy: 'linked' })
+
+  // ws-a is declared as a root dependency — should be at root node_modules
+  t.ok(pathExists(path.join(dir, 'node_modules', 'ws-a')),
+    'declared workspace ws-a is symlinked at root node_modules')
+  t.ok(fs.lstatSync(path.join(dir, 'node_modules', 'ws-a')).isSymbolicLink(),
+    'ws-a at root is a symlink')
+
+  // ws-b is NOT a root dependency — should NOT be at root node_modules
+  t.notOk(pathExists(path.join(dir, 'node_modules', 'ws-b')),
+    'undeclared workspace ws-b is NOT at root node_modules')
+
+  // ws-c is NOT a root dependency — should NOT be at root node_modules
+  t.notOk(pathExists(path.join(dir, 'node_modules', 'ws-c')),
+    'undeclared workspace ws-c is NOT at root node_modules')
+
+  // ws-b should be resolvable from ws-a (ws-a depends on ws-b)
+  t.ok(pathExists(path.join(dir, 'packages', 'ws-a', 'node_modules', 'ws-b')),
+    'ws-b is linked in ws-a/node_modules (declared dep)')
+
+  // ws-c has no dependencies and is not depended on — should not be able to access ws-b
+  t.notOk(pathExists(path.join(dir, 'packages', 'ws-c', 'node_modules', 'ws-b')),
+    'ws-c cannot access ws-b (no dependency declared)')
+})
 
 tap.test('omit dev dependencies with linked strategy', async t => {
   const graph = {


### PR DESCRIPTION
In continuation of our exploration of using `install-strategy=linked` in the [Gutenberg monorepo](https://github.com/WordPress/gutenberg/pull/75814), which powers the WordPress Block Editor.

## Summary

With `install-strategy=linked`, all workspace packages are unconditionally symlinked into the root `node_modules/`, regardless of whether the root declares them as dependencies. This defeats the strict isolation that the linked strategy is supposed to provide — any workspace can import any other workspace without declaring it as a dependency.

The root cause is two-fold:

1. `assignCommonProperties()` includes all workspaces in root's `localDependencies` because npm auto-creates `type: 'workspace'` edges from root to every workspace
2. `createIsolatedTree()` unconditionally creates a workspace Link entry in `root.children` at `node_modules/<wsName>` for every workspace

The fix:

1. Filters undeclared workspace deps in `#assignCommonProperties()` so they don't enter root's `localDependencies`
2. Only creates root-level workspace symlinks (`node_modules/<wsName>`) for declared dependencies

### Before (broken)

```
node_modules/@scope/a -> packages/a    # root doesn't depend on @scope/a
node_modules/@scope/b -> packages/b    # root doesn't depend on @scope/b
```

### After (fixed)

```
packages/a/node_modules/@scope/b -> packages/b   # @scope/a depends on @scope/b
```

No symlinks at root `node_modules/` since root doesn't depend on either workspace.

## References

Fixes #9072
Related to #6537 (same problem with `--install-strategy=nested`)
