### PR TITLE
fix(arborist): backport linked strategy hoisting fixes to v10

### DIFF
--- a/workspaces/arborist/lib/arborist/isolated-reifier.js
+++ b/workspaces/arborist/lib/arborist/isolated-reifier.js
@@ -34,6 +34,7 @@ const getKey = (startNode) => {
 
 module.exports = cls => class IsolatedReifier extends cls {
   #externalProxies = new Map()
+  #omit = new Set()
   #rootDeclaredDeps = new Set()
   #processedEdges = new Set()
   #workspaceProxies = new Map()
@@ -72,15 +73,18 @@ module.exports = cls => class IsolatedReifier extends cls {
    **/
   async makeIdealGraph () {
     const idealTree = this.idealTree
-    const omit = new Set(this.options.omit)
+    this.#omit = new Set(this.options.omit)
+    const omit = this.#omit
 
     // npm auto-creates 'workspace' edges from root to all workspaces.
     // For isolated/linked mode, only include workspaces that root explicitly declares as dependencies.
+    // When omitting dep types, exclude those from the declared set so their workspaces aren't hoisted.
     const rootPkg = idealTree.package
     this.#rootDeclaredDeps = new Set([
       ...Object.keys(rootPkg.dependencies || {}),
-      ...Object.keys(rootPkg.devDependencies || {}),
-      ...Object.keys(rootPkg.optionalDependencies || {}),
+      ...(!omit.has('dev') ? Object.keys(rootPkg.devDependencies || {}) : []),
+      ...(!omit.has('optional') ? Object.keys(rootPkg.optionalDependencies || {}) : []),
+      ...(!omit.has('peer') ? Object.keys(rootPkg.peerDependencies || {}) : []),
     ])
 
     // XXX this sometimes acts like a node too
@@ -196,10 +200,27 @@ module.exports = cls => class IsolatedReifier extends cls {
       return
     }
 
-    const edges = [...node.edgesOut.values()].filter(edge =>
+    let edges = [...node.edgesOut.values()].filter(edge =>
       edge.to?.target &&
       !(node.package.bundledDependencies || node.package.bundleDependencies)?.includes(edge.to.name)
     )
+
+    // Only omit edge types for root and workspace nodes (matching shouldOmit scope)
+    if ((node.isProjectRoot || node.isWorkspace) && this.#omit.size) {
+      edges = edges.filter(edge => {
+        if (edge.dev && this.#omit.has('dev')) {
+          return false
+        }
+        if (edge.optional && this.#omit.has('optional')) {
+          return false
+        }
+        if (edge.peer && this.#omit.has('peer')) {
+          return false
+        }
+        return true
+      })
+    }
+
     let nonOptionalDeps = edges.filter(edge => !edge.optional).map(edge => edge.to.target)
 
     // npm auto-creates 'workspace' edges from root to all workspaces.

--- a/workspaces/arborist/lib/arborist/isolated-reifier.js
+++ b/workspaces/arborist/lib/arborist/isolated-reifier.js
@@ -39,23 +39,6 @@ module.exports = cls => class IsolatedReifier extends cls {
   #processedEdges = new Set()
   #workspaceProxies = new Map()
 
-  // Inline version of Node.shouldOmit which doesn't exist on v10's Node class.
-  // The non-root/non-workspace top guard is omitted because the isolated reifier only traverses nodes under the idealTree root where top is always root or workspace.
-  #shouldOmit (node) {
-    const omit = this.#omit
-    if (!omit.size) {
-      return false
-    }
-    return (
-      /* istanbul ignore next - peer-only nodes are rare as they're usually also prod deps of another package */
-      node.peer && omit.has('peer') ||
-      node.dev && omit.has('dev') ||
-      node.optional && omit.has('optional') ||
-      /* istanbul ignore next - devOptional requires both flags to omit */
-      node.devOptional && omit.has('optional') && omit.has('dev')
-    )
-  }
-
   #generateChild (node, location, pkg, isInStore, root) {
     const newChild = new IsolatedNode({
       isInStore,
@@ -124,7 +107,7 @@ module.exports = cls => class IsolatedReifier extends cls {
       }
       processed.add(next.location)
       next.edgesOut.forEach(edge => {
-        if (edge.to && !(next.package.bundleDependencies || next.package.bundledDependencies || []).includes(edge.to.name) && !this.#shouldOmit(edge.to)) {
+        if (edge.to && !(next.package.bundleDependencies || next.package.bundledDependencies || []).includes(edge.to.name) && !edge.to.shouldOmit?.(omit)) {
           queue.push(edge.to)
         }
       })

--- a/workspaces/arborist/lib/arborist/isolated-reifier.js
+++ b/workspaces/arborist/lib/arborist/isolated-reifier.js
@@ -47,9 +47,11 @@ module.exports = cls => class IsolatedReifier extends cls {
       return false
     }
     return (
+      /* istanbul ignore next - peer-only nodes are rare as they're usually also prod deps of another package */
       node.peer && omit.has('peer') ||
       node.dev && omit.has('dev') ||
       node.optional && omit.has('optional') ||
+      /* istanbul ignore next - devOptional requires both flags to omit */
       node.devOptional && omit.has('optional') && omit.has('dev')
     )
   }

--- a/workspaces/arborist/lib/arborist/isolated-reifier.js
+++ b/workspaces/arborist/lib/arborist/isolated-reifier.js
@@ -39,6 +39,21 @@ module.exports = cls => class IsolatedReifier extends cls {
   #processedEdges = new Set()
   #workspaceProxies = new Map()
 
+  // Inline version of Node.shouldOmit which doesn't exist on v10's Node class.
+  // The non-root/non-workspace top guard is omitted because the isolated reifier only traverses nodes under the idealTree root where top is always root or workspace.
+  #shouldOmit (node) {
+    const omit = this.#omit
+    if (!omit.size) {
+      return false
+    }
+    return (
+      node.peer && omit.has('peer') ||
+      node.dev && omit.has('dev') ||
+      node.optional && omit.has('optional') ||
+      node.devOptional && omit.has('optional') && omit.has('dev')
+    )
+  }
+
   #generateChild (node, location, pkg, isInStore, root) {
     const newChild = new IsolatedNode({
       isInStore,
@@ -107,7 +122,7 @@ module.exports = cls => class IsolatedReifier extends cls {
       }
       processed.add(next.location)
       next.edgesOut.forEach(edge => {
-        if (edge.to && !(next.package.bundleDependencies || next.package.bundledDependencies || []).includes(edge.to.name) && !edge.to.shouldOmit?.(omit)) {
+        if (edge.to && !(next.package.bundleDependencies || next.package.bundledDependencies || []).includes(edge.to.name) && !this.#shouldOmit(edge.to)) {
           queue.push(edge.to)
         }
       })

--- a/workspaces/arborist/lib/arborist/isolated-reifier.js
+++ b/workspaces/arborist/lib/arborist/isolated-reifier.js
@@ -34,6 +34,7 @@ const getKey = (startNode) => {
 
 module.exports = cls => class IsolatedReifier extends cls {
   #externalProxies = new Map()
+  #rootDeclaredDeps = new Set()
   #processedEdges = new Set()
   #workspaceProxies = new Map()
 
@@ -72,6 +73,15 @@ module.exports = cls => class IsolatedReifier extends cls {
   async makeIdealGraph () {
     const idealTree = this.idealTree
     const omit = new Set(this.options.omit)
+
+    // npm auto-creates 'workspace' edges from root to all workspaces.
+    // For isolated/linked mode, only include workspaces that root explicitly declares as dependencies.
+    const rootPkg = idealTree.package
+    this.#rootDeclaredDeps = new Set([
+      ...Object.keys(rootPkg.dependencies || {}),
+      ...Object.keys(rootPkg.devDependencies || {}),
+      ...Object.keys(rootPkg.optionalDependencies || {}),
+    ])
 
     // XXX this sometimes acts like a node too
     this.idealGraph = {
@@ -190,7 +200,13 @@ module.exports = cls => class IsolatedReifier extends cls {
       edge.to?.target &&
       !(node.package.bundledDependencies || node.package.bundleDependencies)?.includes(edge.to.name)
     )
-    const nonOptionalDeps = edges.filter(edge => !edge.optional).map(edge => edge.to.target)
+    let nonOptionalDeps = edges.filter(edge => !edge.optional).map(edge => edge.to.target)
+
+    // npm auto-creates 'workspace' edges from root to all workspaces.
+    // For isolated/linked mode, only include workspaces that root explicitly declares as dependencies.
+    if (node.isProjectRoot) {
+      nonOptionalDeps = nonOptionalDeps.filter(n => !n.isWorkspace || this.#rootDeclaredDeps.has(n.packageName))
+    }
 
     // When legacyPeerDeps is enabled, peer dep edges are not created on the node.
     // Resolve them from the tree so they get symlinked in the store.
@@ -293,22 +309,26 @@ module.exports = cls => class IsolatedReifier extends cls {
       workspace.isWorkspace = true
       root.fsChildren.add(workspace)
       root.inventory.set(workspace.location, workspace)
+      root.workspaces.set(wsName, workspace.path)
 
-      // Create workspace Link entry in children for _diffTrees lookup
+      // Create workspace Link. For root declared deps, link at root node_modules/. For undeclared deps, link at the workspace's own node_modules/ (self-link).
+      const isDeclared = this.#rootDeclaredDeps.has(wsName)
       const wsLink = new IsolatedLink({
-        location: join('node_modules', wsName),
+        location: isDeclared ? join('node_modules', wsName) : join(c.localLocation, 'node_modules', wsName),
         name: wsName,
         package: workspace.package,
         parent: root,
-        path: join(root.path, 'node_modules', wsName),
+        path: isDeclared ? join(root.path, 'node_modules', wsName) : join(root.path, c.localLocation, 'node_modules', wsName),
         realpath: workspace.path,
         root,
         target: workspace,
       })
       wsLink.top = root
-      root.children.set(wsLink.name, wsLink)
+      if (!isDeclared) {
+        workspace.children.set(wsName, wsLink)
+      }
+      root.children.set(wsName, wsLink)
       root.inventory.set(wsLink.location, wsLink)
-      root.workspaces.set(wsName, workspace.path)
       workspace.linksIn.add(wsLink)
     }
 

--- a/workspaces/arborist/lib/node.js
+++ b/workspaces/arborist/lib/node.js
@@ -463,6 +463,27 @@ class Node {
     return false
   }
 
+  shouldOmit (omitSet) {
+    if (!omitSet.size) {
+      return false
+    }
+
+    const { top } = this
+
+    // if the top is not the root or workspace then we do not want to omit it
+    if (!top.isProjectRoot && !top.isWorkspace) {
+      return false
+    }
+
+    // omit node if the dep type matches any omit flags that were set
+    return (
+      this.peer && omitSet.has('peer') ||
+      this.dev && omitSet.has('dev') ||
+      this.optional && omitSet.has('optional') ||
+      this.devOptional && omitSet.has('optional') && omitSet.has('dev')
+    )
+  }
+
   getBundler (path = []) {
     // made a cycle, definitely not bundled!
     if (path.includes(this)) {

--- a/workspaces/arborist/test/isolated-mode.js
+++ b/workspaces/arborist/test/isolated-mode.js
@@ -2155,6 +2155,139 @@ tap.test('omit dev dependencies with linked strategy', async t => {
   t.notOk(storeEntries.some(e => e.startsWith('eslint@')), 'dev dep eslint is not in store')
 })
 
+tap.test('omit dev deps from root even when shared with workspace prod deps', async t => {
+  // In a monorepo, a root devDependency may also be a workspace prod dependency.
+  // With --omit=dev, root should NOT link to it, but the workspace still should.
+  // Also covers the case where a workspace itself is a root devDependency.
+  const graph = {
+    registry: [
+      { name: 'typescript', version: '5.0.0' },
+      { name: 'which', version: '1.0.0', dependencies: { isexe: '^1.0.0' } },
+      { name: 'isexe', version: '1.0.0' },
+    ],
+    root: {
+      name: 'myapp',
+      version: '1.0.0',
+      dependencies: { which: '1.0.0', mylib: '1.0.0' },
+      devDependencies: { typescript: '5.0.0', devtool: '1.0.0' },
+    },
+    workspaces: [
+      {
+        name: 'mylib',
+        version: '1.0.0',
+        dependencies: { typescript: '5.0.0' },
+      },
+      {
+        name: 'devtool',
+        version: '1.0.0',
+      },
+    ],
+  }
+
+  const { dir, registry } = await getRepo(graph)
+  const cache = fs.mkdtempSync(`${getTempDir()}/test-`)
+  const arborist = new Arborist({
+    path: dir,
+    registry,
+    packumentCache: new Map(),
+    cache,
+    omit: ['dev'],
+  })
+  await arborist.reify({ installStrategy: 'linked' })
+
+  const storeDir = path.join(dir, 'node_modules', '.store')
+  const storeEntries = fs.readdirSync(storeDir)
+
+  // typescript should still be in the store because mylib needs it as a prod dep
+  t.ok(storeEntries.some(e => e.startsWith('typescript@')), 'typescript is in store (workspace prod dep)')
+  t.ok(storeEntries.some(e => e.startsWith('which@')), 'which is in store')
+
+  // root should NOT have a symlink to typescript (it's a dev dep of root)
+  const rootNmEntries = fs.readdirSync(path.join(dir, 'node_modules'))
+  t.ok(rootNmEntries.includes('which'), 'root has symlink to prod dep which')
+  t.ok(rootNmEntries.includes('mylib'), 'root has symlink to prod workspace mylib')
+  t.notOk(rootNmEntries.includes('typescript'), 'root does not have symlink to dev dep typescript')
+  t.notOk(rootNmEntries.includes('devtool'), 'root does not have symlink to dev workspace devtool')
+
+  // workspace should have a symlink to typescript (it's a prod dep of mylib)
+  const wsNmEntries = fs.readdirSync(path.join(dir, 'packages', 'mylib', 'node_modules'))
+  t.ok(wsNmEntries.includes('typescript'), 'workspace has symlink to prod dep typescript')
+})
+
+tap.test('omit optional dependencies with linked strategy', async t => {
+  const graph = {
+    registry: [
+      { name: 'which', version: '1.0.0' },
+      { name: 'fsevents', version: '1.0.0' },
+    ],
+    root: {
+      name: 'myapp',
+      version: '1.0.0',
+      dependencies: { which: '1.0.0' },
+      optionalDependencies: { fsevents: '1.0.0' },
+    },
+    workspaces: [
+      {
+        name: 'mylib',
+        version: '1.0.0',
+        dependencies: { fsevents: '1.0.0' },
+      },
+    ],
+  }
+
+  const { dir, registry } = await getRepo(graph)
+  const cache = fs.mkdtempSync(`${getTempDir()}/test-`)
+  const arborist = new Arborist({
+    path: dir,
+    registry,
+    packumentCache: new Map(),
+    cache,
+    omit: ['optional'],
+  })
+  await arborist.reify({ installStrategy: 'linked' })
+
+  const rootNmEntries = fs.readdirSync(path.join(dir, 'node_modules'))
+  t.ok(rootNmEntries.includes('which'), 'root has prod dep which')
+  t.notOk(rootNmEntries.includes('fsevents'), 'root does not have optional dep fsevents')
+})
+
+tap.test('omit peer dependencies with linked strategy', async t => {
+  const graph = {
+    registry: [
+      { name: 'which', version: '1.0.0' },
+      { name: 'react', version: '18.0.0' },
+    ],
+    root: {
+      name: 'myapp',
+      version: '1.0.0',
+      dependencies: { which: '1.0.0' },
+      peerDependencies: { react: '18.0.0' },
+    },
+    workspaces: [
+      {
+        name: 'mylib',
+        version: '1.0.0',
+        dependencies: { react: '18.0.0' },
+      },
+    ],
+  }
+
+  const { dir, registry } = await getRepo(graph)
+  const cache = fs.mkdtempSync(`${getTempDir()}/test-`)
+  const arborist = new Arborist({
+    path: dir,
+    registry,
+    packumentCache: new Map(),
+    cache,
+    omit: ['peer'],
+  })
+  await arborist.reify({ installStrategy: 'linked' })
+
+  const rootNmEntries = fs.readdirSync(path.join(dir, 'node_modules'))
+  t.ok(rootNmEntries.includes('which'), 'root has prod dep which')
+  t.notOk(rootNmEntries.includes('react'), 'root does not have peer dep react')
+})
+
 /*
  * TO TEST:
  *   --------------------------------------

--- a/workspaces/arborist/test/isolated-mode.js
+++ b/workspaces/arborist/test/isolated-mode.js
@@ -404,10 +404,12 @@ tap.test('idempotent install with legacyPeerDeps and workspace peer deps', async
   const arb2 = new Arborist({ ...opts, packumentCache: new Map() })
   await arb2.reify({ installStrategy: 'linked' })
 
-  // Workspace symlinks should still be symlinks (not directories)
+  // Workspace peer dep symlinks should still be present after second install
   for (let i = 0; i < 20; i++) {
-    t.ok(fs.lstatSync(path.join(dir, 'node_modules', `ws-${i}`)).isSymbolicLink(),
-      `ws-${i} is still a symlink after second install`)
+    const peerTarget = `ws-${(i + 1) % 20}`
+    const peerLink = path.join(dir, 'packages', `ws-${i}`, 'node_modules', peerTarget)
+    t.ok(fs.lstatSync(peerLink).isSymbolicLink(),
+      `ws-${i} peer dep on ${peerTarget} is still a symlink after second install`)
   }
 })
 
@@ -465,32 +467,36 @@ tap.test('Basic workspaces setup', async t => {
           'isexe@1.0.0': {},
         },
       },
-      'baz@1.0.0 (workspace)': {
-        'bar@1.0.0 (workspace)': {
-          'which@2.0.0': {
-            'isexe@1.0.0': {},
-          },
-        },
+    },
+    'bar@1.0.0 (workspace)': {
+      'which@2.0.0': {
+        'isexe@1.0.0': {},
+      },
+    },
+    'baz@1.0.0 (workspace)': {
+      'bar@1.0.0 (workspace)': {
         'which@2.0.0': {
           'isexe@1.0.0': {},
         },
       },
+      'which@2.0.0': {
+        'isexe@1.0.0': {},
+      },
+    },
+    'cat@1.0.0 (workspace)': {
+      'which@1.0.0': {
+        'isexe@1.0.0': {},
+      },
+    },
+    'fish@1.0.0 (workspace)': {
       'cat@1.0.0 (workspace)': {
         'which@1.0.0': {
           'isexe@1.0.0': {},
         },
       },
-      'fish@1.0.0 (workspace)': {
-        'cat@1.0.0 (workspace)': {
-          'which@1.0.0': {
-            'isexe@1.0.0': {},
-          },
-        },
-        'which@1.0.0': {
-          'isexe@1.0.0': {},
-        },
+      'which@1.0.0': {
+        'isexe@1.0.0': {},
       },
-      'catfish@1.0.0': {},
     },
   }
 
@@ -1075,7 +1081,10 @@ tap.test('nested bundled dependencies of workspaces', async t => {
 
   const resolved = {
     'dog@1.2.3 (root)': {
-      'bar@1.0.0 (workspace)': {},
+      'which@2.0.0': {},
+      'isexe@1.0.0': {},
+    },
+    'bar@1.0.0 (workspace)': {
       'which@2.0.0': {},
       'isexe@1.0.0': {},
     },
@@ -1093,12 +1102,14 @@ tap.test('nested bundled dependencies of workspaces', async t => {
   rule1.apply(t, dir, resolved, asserted)
   rule2.apply(t, dir, resolved, asserted)
   rule3.apply(t, dir, resolved, asserted)
-  rule4.apply(t, dir, resolved, asserted)
+  // Workspace link at packages/bar/node_modules/bar and bundled deps (which, isexe) are co-located in the same node_modules/, making them mutually accessible regardless of declared dependencies.
+  // rule4.apply(t, dir, resolved, asserted)
   rule5.apply(t, dir, resolved, asserted)
   // I think that duplicated versions are okay in the case of bundled deps
   //  rule6.apply(t, dir, resolved, asserted)
   rule7.apply(t, dir, resolved, asserted)
 
+  // Bundled deps are hoisted to root node_modules as real directories
   const isexePath = path.join(dir, 'node_modules', 'isexe')
   t.equal(isexePath, fs.realpathSync(isexePath))
   const whichPath = path.join(dir, 'node_modules', 'which')
@@ -1125,15 +1136,15 @@ tap.test('nested bundled dependencies of workspaces with conflicting isolated de
   // the 'which' that is bundled is not hoisted due to a conflict
   const resolved = {
     'dog@1.2.3 (root)': {
-      'bar@1.0.0 (workspace)': {
-        'which@2.0.0': {
-          'isexe@1.0.0': {},
-        },
-        'isexe@1.0.0': {},
-      },
       'which@3.0.0': {
         'isexe@2.0.0': {},
       },
+    },
+    'bar@1.0.0 (workspace)': {
+      'which@2.0.0': {
+        'isexe@1.0.0': {},
+      },
+      'isexe@1.0.0': {},
     },
   }
 
@@ -1149,7 +1160,8 @@ tap.test('nested bundled dependencies of workspaces with conflicting isolated de
   rule1.apply(t, dir, resolved, asserted)
   rule2.apply(t, dir, resolved, asserted)
   rule3.apply(t, dir, resolved, asserted)
-  rule4.apply(t, dir, resolved, asserted)
+  // Workspace link at packages/bar/node_modules/bar and bundled deps (which, isexe) share the same node_modules/, making them mutually accessible regardless of declared dependencies.
+  // rule4.apply(t, dir, resolved, asserted)
   rule5.apply(t, dir, resolved, asserted)
   // I think that duplicated versions are okay in the case of bundled deps
   //  rule6.apply(t, dir, resolved, asserted)
@@ -1481,10 +1493,10 @@ tap.test('aliased packages in workspace', async t => {
       'prettier@3.0.3': {
         'isexe@1.0.0': {},
       },
-      'my-pkg@1.0.0 (workspace)': {
-        'prettier@3.0.3': {
-          'isexe@1.0.0': {},
-        },
+    },
+    'my-pkg@1.0.0 (workspace)': {
+      'prettier@3.0.3': {
+        'isexe@1.0.0': {},
       },
     },
   }
@@ -1610,7 +1622,7 @@ tap.test('postinstall scripts are run', async t => {
   const postInstallRanWhich = pathExists(`${setupRequire(dir)('which')}/postInstallRanWhich`)
   t.ok(postInstallRanWhich)
 
-  const postInstallRanBar = pathExists(`${setupRequire(dir)('bar')}/postInstallRanBar`)
+  const postInstallRanBar = pathExists(`${path.join(dir, 'packages', 'bar')}/postInstallRanBar`)
   t.ok(postInstallRanBar)
 })
 
@@ -1729,10 +1741,8 @@ tap.test('bins are installed', async t => {
   const binFromRootToWhich = pathExists(`${dir}/node_modules/.bin/which`)
   t.ok(binFromRootToWhich)
 
-  const binFromRootToBar = pathExists(`${dir}/node_modules/.bin/bar`)
-  t.ok(binFromRootToBar)
-
-  const binFromBarToWhich = pathExists(`${setupRequire(dir)('bar')}/node_modules/.bin/which`)
+  // bar is not a root dep, so its bin should be in the workspace's own node_modules
+  const binFromBarToWhich = pathExists(`${path.join(dir, 'packages', 'bar')}/node_modules/.bin/which`)
   t.ok(binFromBarToWhich)
 })
 
@@ -1845,8 +1855,8 @@ tap.test('workspace links are not affected by store resolved fix', async t => {
   const arb2 = new Arborist({ path: dir, registry, packumentCache: new Map(), cache })
   await arb2.reify({ installStrategy: 'linked' })
 
-  // Verify workspace is still correctly linked
-  t.ok(setupRequire(dir)('mypkg'), 'workspace is requireable after second install')
+  // Verify workspace is still correctly linked (workspace can resolve itself via self-link)
+  t.ok(setupRequire(path.join(dir, 'packages', 'mypkg'))('mypkg'), 'workspace is requireable via self-link after second install')
   t.ok(setupRequire(dir)('abbrev'), 'registry dep is requireable after second install')
 
   // Verify the diff has unchanged nodes (store entries are correctly matched)
@@ -2054,6 +2064,96 @@ function parseGraphRecursive (key, deps) {
   const dependencies = Object.entries(normalizedDeps).map(([key, value]) => parseGraphRecursive(key, value))
   return { name, version, workspace, peer, dependencies }
 }
+
+tap.test('undeclared workspaces are not hoisted to root node_modules', async t => {
+  // Regression test: all workspace packages were unconditionally symlinked into root node_modules/.
+  // Only workspaces that root explicitly depends on should appear at root node_modules/.
+  const graph = {
+    registry: [
+      { name: 'which', version: '1.0.0', dependencies: { isexe: '^1.0.0' } },
+      { name: 'isexe', version: '1.0.0' },
+    ],
+    root: {
+      name: 'myapp',
+      version: '1.0.0',
+      dependencies: { 'ws-a': '*' },
+    },
+    workspaces: [
+      { name: 'ws-a', version: '1.0.0', dependencies: { 'ws-b': '*', which: '1.0.0' } },
+      { name: 'ws-b', version: '1.0.0' },
+      { name: 'ws-c', version: '1.0.0' },
+    ],
+  }
+
+  const { dir, registry } = await getRepo(graph)
+  const cache = fs.mkdtempSync(`${getTempDir()}/test-`)
+  const arborist = new Arborist({ path: dir, registry, packumentCache: new Map(), cache })
+  await arborist.reify({ installStrategy: 'linked' })
+
+  // ws-a is declared as a root dependency — should be at root node_modules
+  t.ok(pathExists(path.join(dir, 'node_modules', 'ws-a')),
+    'declared workspace ws-a is symlinked at root node_modules')
+  t.ok(fs.lstatSync(path.join(dir, 'node_modules', 'ws-a')).isSymbolicLink(),
+    'ws-a at root is a symlink')
+
+  // ws-b is NOT a root dependency — should NOT be at root node_modules
+  t.notOk(pathExists(path.join(dir, 'node_modules', 'ws-b')),
+    'undeclared workspace ws-b is NOT at root node_modules')
+
+  // ws-c is NOT a root dependency — should NOT be at root node_modules
+  t.notOk(pathExists(path.join(dir, 'node_modules', 'ws-c')),
+    'undeclared workspace ws-c is NOT at root node_modules')
+
+  // ws-b should be resolvable from ws-a (ws-a depends on ws-b)
+  t.ok(pathExists(path.join(dir, 'packages', 'ws-a', 'node_modules', 'ws-b')),
+    'ws-b is linked in ws-a/node_modules (declared dep)')
+
+  // ws-c has no dependencies and is not depended on — should not be able to access ws-b
+  t.notOk(pathExists(path.join(dir, 'packages', 'ws-c', 'node_modules', 'ws-b')),
+    'ws-c cannot access ws-b (no dependency declared)')
+})
+
+tap.test('omit dev dependencies with linked strategy', async t => {
+  const graph = {
+    registry: [
+      { name: 'which', version: '1.0.0', dependencies: { isexe: '^1.0.0' } },
+      { name: 'isexe', version: '1.0.0' },
+      { name: 'eslint', version: '1.0.0' },
+    ],
+    root: {
+      name: 'myapp',
+      version: '1.0.0',
+      dependencies: { which: '1.0.0' },
+      devDependencies: { eslint: '1.0.0' },
+    },
+    workspaces: [
+      {
+        name: 'mylib',
+        version: '1.0.0',
+        dependencies: { isexe: '1.0.0' },
+        devDependencies: { eslint: '1.0.0' },
+      },
+    ],
+  }
+
+  const { dir, registry } = await getRepo(graph)
+  const cache = fs.mkdtempSync(`${getTempDir()}/test-`)
+  const arborist = new Arborist({
+    path: dir,
+    registry,
+    packumentCache: new Map(),
+    cache,
+    omit: ['dev'],
+  })
+  await arborist.reify({ installStrategy: 'linked' })
+
+  const storeDir = path.join(dir, 'node_modules', '.store')
+  const storeEntries = fs.readdirSync(storeDir)
+
+  t.ok(storeEntries.some(e => e.startsWith('which@')), 'prod dep which is in store')
+  t.ok(storeEntries.some(e => e.startsWith('isexe@')), 'prod dep isexe is in store')
+  t.notOk(storeEntries.some(e => e.startsWith('eslint@')), 'dev dep eslint is not in store')
+})
 
 /*
  * TO TEST:

--- a/workspaces/arborist/test/node.js
+++ b/workspaces/arborist/test/node.js
@@ -2981,3 +2981,30 @@ t.test('node with only registry edges in a registry dep', async t => {
 
   t.equal(node.isRegistryDependency, true)
 })
+
+t.test('shouldOmit', t => {
+  const root = new Node({ path: '/some/path', pkg: { devDependencies: { foo: '' }, peerDependencies: { baz: '' }, optionalDependencies: { qux: '' } } })
+  const foo = new Node({ pkg: { name: 'foo', version: '1.0.0' }, parent: root })
+  const baz = new Node({ pkg: { name: 'baz', version: '1.0.0' }, parent: root })
+  const qux = new Node({ pkg: { name: 'qux', version: '1.0.0' }, parent: root })
+
+  t.equal(foo.shouldOmit(new Set()), false, 'empty omit set returns false')
+  t.equal(foo.shouldOmit(new Set(['dev'])), true, 'dev dep with omit dev returns true')
+  t.equal(baz.shouldOmit(new Set(['peer'])), true, 'peer dep with omit peer returns true')
+  t.equal(qux.shouldOmit(new Set(['optional'])), true, 'optional dep with omit optional returns true')
+
+  const devOpt = new Node({ pkg: { name: 'devopt', version: '1.0.0' }, parent: root })
+  devOpt.dev = false
+  devOpt.optional = false
+  devOpt.devOptional = true
+  t.equal(devOpt.shouldOmit(new Set(['dev', 'optional'])), true, 'devOptional with both omitted returns true')
+  t.equal(devOpt.shouldOmit(new Set(['dev'])), false, 'devOptional with only dev omitted returns false')
+
+  // node whose top is neither root nor workspace should not be omitted
+  const bar = new Node({ pkg: { name: 'bar', version: '1.0.0' }, parent: root })
+  bar.dev = true
+  Object.defineProperty(bar, 'top', { get: () => bar })
+  t.equal(bar.shouldOmit(new Set(['dev'])), false, 'non-root/workspace top returns false')
+
+  t.end()
+})


### PR DESCRIPTION
Cherry pick of:
- 5fd40b6fb272ebca00ed4ef1df919b8a66c2e25e (#9076)
- e2c24436de7216a6ac083addca0fce45c2e5b034 (#9081)

Additional changes:

- Ported `shouldOmit` method to v10's `Node` class (exists on `latest` but was missing on v10) with full test coverage

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
