### PR TITLE
fix(ls): suppress false UNMET DEPENDENCYs in linked strategy

### DIFF
--- a/lib/commands/ls.js
+++ b/lib/commands/ls.js
@@ -411,14 +411,12 @@ const getJsonOutputItem = (node, { global, long }) => {
 // 1. Workspace edges for undeclared workspaces: the lockfile records edges from root to ALL workspaces, but only declared workspaces are hoisted to root/node_modules in linked mode.  Undeclared ones are intentionally absent.
 // 2. Dev edges on non-root packages: store package link targets have no parent in the node tree, so they are treated as "top" nodes and their devDependencies are loaded as edges.  Those devDeps are never installed.
 const filterLinkedStrategyEdges = ({ node, currentDepth }) => {
-  const declaredDeps = currentDepth === 0
-    ? new Set(Object.keys(Object.assign({},
-      node.target.package.dependencies,
-      node.target.package.devDependencies,
-      node.target.package.optionalDependencies,
-      node.target.package.peerDependencies
-    )))
-    : null
+  const declaredDeps = new Set(Object.keys(Object.assign({},
+    node.target.package.dependencies,
+    node.target.package.devDependencies,
+    node.target.package.optionalDependencies,
+    node.target.package.peerDependencies
+  )))
 
   return (edge) => {
     // Skip workspace edges for undeclared workspaces at root level

--- a/lib/commands/ls.js
+++ b/lib/commands/ls.js
@@ -57,6 +57,7 @@ class LS extends ArboristWorkspaceCmd {
     const unicode = this.npm.config.get('unicode')
     const packageLockOnly = this.npm.config.get('package-lock-only')
     const workspacesEnabled = this.npm.flatOptions.workspacesEnabled
+    const installStrategy = this.npm.flatOptions.installStrategy
 
     const path = global ? resolve(this.npm.globalDir, '..') : this.npm.prefix
 
@@ -136,6 +137,9 @@ class LS extends ArboristWorkspaceCmd {
               link,
               omit,
             }) : () => true)
+            .filter(installStrategy === 'linked'
+              ? filterLinkedStrategyEdges({ node, currentDepth })
+              : () => true)
             .map(mapEdgesToNodes({ seenPaths }))
             .concat(appendExtraneousChildren({ node, seenPaths }))
             .sort(sortAlphabetically)
@@ -401,6 +405,36 @@ const getJsonOutputItem = (node, { global, long }) => {
   }
 
   return augmentItemWithIncludeMetadata(node, item)
+}
+
+// In linked strategy, two types of edges produce false UNMET DEPENDENCYs:
+// 1. Workspace edges for undeclared workspaces: the lockfile records edges from root to ALL workspaces, but only declared workspaces are hoisted to root/node_modules in linked mode.  Undeclared ones are intentionally absent.
+// 2. Dev edges on non-root packages: store package link targets have no parent in the node tree, so they are treated as "top" nodes and their devDependencies are loaded as edges.  Those devDeps are never installed.
+const filterLinkedStrategyEdges = ({ node, currentDepth }) => {
+  const declaredDeps = currentDepth === 0
+    ? new Set(Object.keys(Object.assign({},
+      node.target.package.dependencies,
+      node.target.package.devDependencies,
+      node.target.package.optionalDependencies,
+      node.target.package.peerDependencies
+    )))
+    : null
+
+  return (edge) => {
+    // Skip workspace edges for undeclared workspaces at root level
+    if (currentDepth === 0 && edge.type === 'workspace' && edge.missing) {
+      if (!declaredDeps.has(edge.name)) {
+        return false
+      }
+    }
+
+    // Skip dev edges for non-root packages (store packages)
+    if (currentDepth > 0 && edge.dev) {
+      return false
+    }
+
+    return true
+  }
 }
 
 const filterByEdgesTypes = ({ link, omit }) => (edge) => {

--- a/test/lib/commands/ls.js
+++ b/test/lib/commands/ls.js
@@ -5301,3 +5301,107 @@ t.test('completion', async t => {
   const res = await ls.completion({ conf: { argv: { remain: ['npm', 'ls'] } } })
   t.type(res, Array)
 })
+
+t.test('ls --install-strategy=linked', async t => {
+  t.test('should not report undeclared workspaces as UNMET DEPENDENCY', async t => {
+    const { result, ls } = await mockLs(t, {
+      config: {
+        'install-strategy': 'linked',
+      },
+      prefixDir: {
+        'package.json': JSON.stringify({
+          name: 'test-linked-ws',
+          version: '1.0.0',
+          workspaces: ['packages/*'],
+          dependencies: { 'workspace-a': '*' },
+        }),
+        packages: {
+          'workspace-a': {
+            'package.json': JSON.stringify({
+              name: 'workspace-a',
+              version: '1.0.0',
+            }),
+          },
+          'workspace-b': {
+            'package.json': JSON.stringify({
+              name: 'workspace-b',
+              version: '1.0.0',
+            }),
+          },
+        },
+        node_modules: {
+          'workspace-a': t.fixture('symlink', '../packages/workspace-a'),
+          // workspace-b intentionally NOT linked (undeclared in dependencies)
+        },
+      },
+    })
+    await ls.exec([])
+    const output = cleanCwd(result())
+    t.notMatch(output, /UNMET DEPENDENCY/, 'should not report undeclared workspace as UNMET DEPENDENCY')
+    t.match(output, /workspace-a/, 'should list declared workspace')
+  })
+
+  t.test('should not report devDeps of store packages as UNMET DEPENDENCY', async t => {
+    const { result, ls } = await mockLs(t, {
+      config: {
+        'install-strategy': 'linked',
+      },
+      prefixDir: {
+        'package.json': JSON.stringify({
+          name: 'test-linked-store',
+          version: '1.0.0',
+          dependencies: { nopt: '^1.0.0' },
+        }),
+        node_modules: {
+          nopt: t.fixture('symlink', '.store/nopt@1.0.0/node_modules/nopt'),
+          '.store': {
+            'nopt@1.0.0': {
+              node_modules: {
+                nopt: {
+                  'package.json': JSON.stringify({
+                    name: 'nopt',
+                    version: '1.0.0',
+                    devDependencies: { tap: '^16.0.0' },
+                  }),
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+    await ls.exec([])
+    const output = cleanCwd(result())
+    t.notMatch(output, /UNMET DEPENDENCY/, 'should not report devDeps of store packages')
+    t.match(output, /nopt/, 'should list the dependency')
+  })
+
+  t.test('should still report declared workspace as UNMET DEPENDENCY when missing', async t => {
+    const { ls } = await mockLs(t, {
+      config: {
+        'install-strategy': 'linked',
+      },
+      prefixDir: {
+        'package.json': JSON.stringify({
+          name: 'test-linked-ws-missing',
+          version: '1.0.0',
+          workspaces: ['packages/*'],
+          dependencies: { 'workspace-a': '*' },
+        }),
+        packages: {
+          'workspace-a': {
+            'package.json': JSON.stringify({
+              name: 'workspace-a',
+              version: '1.0.0',
+            }),
+          },
+        },
+        node_modules: {
+          // workspace-a is declared but its symlink is missing
+        },
+      },
+    })
+    await t.rejects(ls.exec([]), { code: 'ELSPROBLEMS' },
+      'should report declared workspace as UNMET DEPENDENCY')
+  })
+})


### PR DESCRIPTION
In continuation of our exploration of using `install-strategy=linked` in the [Gutenberg monorepo](https://github.com/WordPress/gutenberg/pull/75814), which powers the WordPress Block Editor.

In linked install strategy, `npm ls` reports two types of false UNMET DEPENDENCYs:

1. **Undeclared workspaces**: The root node always creates workspace edges for all workspaces (from the `workspaces` field in package.json), but in linked mode only workspaces explicitly declared in dependencies are hoisted to `root/node_modules/`. Undeclared workspaces are intentionally absent, yet `npm ls` reports them as missing.

2. **devDependencies of store packages**: Store package link targets (at `.store/<key>/node_modules/<name>`) have no parent in the node tree, so they are treated as "top" nodes and their `devDependencies` are loaded as edges. Those devDeps are never installed, but `npm ls --all` reports them as UNMET DEPENDENCY.

This PR adds a `filterLinkedStrategyEdges` filter in `ls.js` that is only active when `installStrategy === 'linked'`. It skips workspace edges for undeclared workspaces at the root level and skips dev edges for non-root packages (store packages).

## References

Fixes #9090
Fixes #9092 
