### PR TITLE
fix(arborist): simplify rootDeclaredDeps initialization

### DIFF
--- a/workspaces/arborist/lib/arborist/isolated-reifier.js
+++ b/workspaces/arborist/lib/arborist/isolated-reifier.js
@@ -80,12 +80,12 @@ module.exports = cls => class IsolatedReifier extends cls {
     // For isolated/linked mode, only include workspaces that root explicitly declares as dependencies.
     // When omitting dep types, exclude those from the declared set so their workspaces aren't hoisted.
     const rootPkg = idealTree.package
-    this.#rootDeclaredDeps = new Set([
-      ...Object.keys(rootPkg.dependencies || {}),
-      ...(!omit.has('dev') ? Object.keys(rootPkg.devDependencies || {}) : []),
-      ...(!omit.has('optional') ? Object.keys(rootPkg.optionalDependencies || {}) : []),
-      ...(!omit.has('peer') ? Object.keys(rootPkg.peerDependencies || {}) : []),
-    ])
+    this.#rootDeclaredDeps = new Set(Object.keys(Object.assign({},
+      rootPkg.dependencies,
+      (!omit.has('dev') && rootPkg.devDependencies),
+      (!omit.has('optional') && rootPkg.optionalDependencies),
+      (!omit.has('peer') && rootPkg.peerDependencies)
+    )))
 
     // XXX this sometimes acts like a node too
     this.idealGraph = {


### PR DESCRIPTION
## Summary

Simplifies the `#rootDeclaredDeps` initialization in `isolated-reifier.js` by using `Object.assign` instead of multiple `Object.keys` spread calls.

Suggested in https://github.com/npm/cli/pull/9095#discussion_r2912876753.

## Before

```javascript
this.#rootDeclaredDeps = new Set([
  ...Object.keys(rootPkg.dependencies || {}),
  ...(!omit.has('dev') ? Object.keys(rootPkg.devDependencies || {}) : []),
  ...(!omit.has('optional') ? Object.keys(rootPkg.optionalDependencies || {}) : []),
  ...(!omit.has('peer') ? Object.keys(rootPkg.peerDependencies || {}) : []),
])
```

## After

```javascript
this.#rootDeclaredDeps = new Set(Object.keys(Object.assign({},
  rootPkg.dependencies,
  (!omit.has('dev') && rootPkg.devDependencies),
  (!omit.has('optional') && rootPkg.optionalDependencies),
  (!omit.has('peer') && rootPkg.peerDependencies),
)))
```
