### PR TITLE
fix(arborist): update store symlinks when hash changes in linked strategy

### DIFF
--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -10,7 +10,7 @@ const { callLimit: promiseCallLimit } = require('promise-call-limit')
 const { depth: dfwalk } = require('treeverse')
 const { dirname, resolve, relative, join, sep } = require('node:path')
 const { log, time } = require('proc-log')
-const { existsSync } = require('node:fs')
+const { existsSync, readlinkSync } = require('node:fs')
 const { lstat, mkdir, readdir, rm, symlink } = require('node:fs/promises')
 const { moveFile } = require('@npmcli/fs')
 const { subset, intersects } = require('semver')
@@ -818,6 +818,17 @@ module.exports = cls => class Reifier extends cls {
       let entry
       if (child.isLink) {
         entry = new IsolatedLink(child)
+        // Read the on-disk symlink target so the diff detects store hash changes.
+        if (child.resolved?.startsWith('file:.store/')) {
+          try {
+            const onDiskTarget = readlinkSync(child.path)
+            if (onDiskTarget.startsWith('.store/')) {
+              entry.resolved = `file:${onDiskTarget}`
+            }
+          } catch {
+            // If we can't read the symlink, fall through to the ideal value
+          }
+        }
       } else {
         entry = new IsolatedNode(child)
       }

--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -10,7 +10,7 @@ const { callLimit: promiseCallLimit } = require('promise-call-limit')
 const { depth: dfwalk } = require('treeverse')
 const { dirname, resolve, relative, join, sep } = require('node:path')
 const { log, time } = require('proc-log')
-const { existsSync, readlinkSync } = require('node:fs')
+const { existsSync } = require('node:fs')
 const { lstat, mkdir, readdir, rm, symlink } = require('node:fs/promises')
 const { moveFile } = require('@npmcli/fs')
 const { subset, intersects } = require('semver')
@@ -815,26 +815,13 @@ module.exports = cls => class Reifier extends cls {
       if (combined.has(child.path) || !existsSync(child.path)) {
         continue
       }
+      // Skip store links whose ideal realpath doesn't exist on disk yet — the store hash changed and the symlink needs recreating via ADD.
+      if (child.isLink && child.resolved?.startsWith('file:.store/') && !existsSync(child.realpath)) {
+        continue
+      }
       let entry
       if (child.isLink) {
         entry = new IsolatedLink(child)
-        // Read the on-disk symlink target so the diff detects store hash changes. Only for root-level store links (path does not contain .store); store-internal links are recreated with their parent directory.
-        if (child.resolved?.startsWith('file:.store/') && !child.path.includes(`${sep}.store${sep}`)) {
-          try {
-            const onDiskTarget = readlinkSync(child.path)
-            // On POSIX, readlink returns ".store/pkg@ver-HASH/node_modules/pkg". On Windows, junctions return absolute paths like "D:\...\node_modules\.store\pkg@ver-HASH\...".
-            const storeMarker = `${sep}.store${sep}`
-            const storeIdx = onDiskTarget.indexOf(storeMarker)
-            if (onDiskTarget.startsWith(`.store${sep}`) || onDiskTarget.startsWith('.store/')) {
-              entry.resolved = `file:${onDiskTarget.split(sep).join('/')}`
-            } else /* istanbul ignore next -- Windows junctions return absolute paths */ if (storeIdx !== -1) {
-              const rel = onDiskTarget.substring(storeIdx + 1).split(sep).join('/')
-              entry.resolved = `file:${rel}`
-            }
-          } catch {
-            // If we can't read the symlink, fall through to the ideal value
-          }
-        }
       } else {
         entry = new IsolatedNode(child)
       }

--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -818,17 +818,16 @@ module.exports = cls => class Reifier extends cls {
       let entry
       if (child.isLink) {
         entry = new IsolatedLink(child)
-        // Read the on-disk symlink target so the diff detects store hash changes.
-        if (child.resolved?.startsWith('file:.store/')) {
+        // Read the on-disk symlink target so the diff detects store hash changes. Only for root-level store links (path does not contain .store); store-internal links are recreated with their parent directory.
+        if (child.resolved?.startsWith('file:.store/') && !child.path.includes(`${sep}.store${sep}`)) {
           try {
             const onDiskTarget = readlinkSync(child.path)
-            // On POSIX, readlink returns a relative path like ".store/pkg@ver-HASH/node_modules/pkg". On Windows, junctions store absolute paths like "D:\...\node_modules\.store\pkg@ver-HASH\...". Extract the ".store/..." portion in both cases.
+            // On POSIX, readlink returns ".store/pkg@ver-HASH/node_modules/pkg". On Windows, junctions return absolute paths like "D:\...\node_modules\.store\pkg@ver-HASH\...".
             const storeMarker = `${sep}.store${sep}`
             const storeIdx = onDiskTarget.indexOf(storeMarker)
-            if (onDiskTarget.startsWith('.store/') || onDiskTarget.startsWith(`.store${sep}`)) {
+            if (onDiskTarget.startsWith(`.store${sep}`) || onDiskTarget.startsWith('.store/')) {
               entry.resolved = `file:${onDiskTarget.split(sep).join('/')}`
-            /* istanbul ignore next -- Windows junctions return absolute paths */
-            } else if (storeIdx !== -1) {
+            } else /* istanbul ignore next -- Windows junctions return absolute paths */ if (storeIdx !== -1) {
               const rel = onDiskTarget.substring(storeIdx + 1).split(sep).join('/')
               entry.resolved = `file:${rel}`
             }

--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -822,8 +822,15 @@ module.exports = cls => class Reifier extends cls {
         if (child.resolved?.startsWith('file:.store/')) {
           try {
             const onDiskTarget = readlinkSync(child.path)
-            if (onDiskTarget.startsWith('.store/')) {
-              entry.resolved = `file:${onDiskTarget}`
+            // On POSIX, readlink returns a relative path like ".store/pkg@ver-HASH/node_modules/pkg". On Windows, junctions store absolute paths like "D:\...\node_modules\.store\pkg@ver-HASH\...". Extract the ".store/..." portion in both cases.
+            const storeMarker = `${sep}.store${sep}`
+            const storeIdx = onDiskTarget.indexOf(storeMarker)
+            if (onDiskTarget.startsWith('.store/') || onDiskTarget.startsWith(`.store${sep}`)) {
+              entry.resolved = `file:${onDiskTarget.split(sep).join('/')}`
+            /* istanbul ignore next -- Windows junctions return absolute paths */
+            } else if (storeIdx !== -1) {
+              const rel = onDiskTarget.substring(storeIdx + 1).split(sep).join('/')
+              entry.resolved = `file:${rel}`
             }
           } catch {
             // If we can't read the symlink, fall through to the ideal value

--- a/workspaces/arborist/test/isolated-mode.js
+++ b/workspaces/arborist/test/isolated-mode.js
@@ -1979,6 +1979,53 @@ tap.test('orphaned store entries are cleaned up on dependency removal', async t 
     'all store entries are removed when dependencies are removed')
 })
 
+tap.test('store symlinks are updated when hash changes after adding a dep', async t => {
+  const graph = {
+    registry: [
+      { name: 'which', version: '1.0.0', dependencies: { isexe: '^1.0.0' } },
+      { name: 'isexe', version: '1.0.0' },
+      { name: 'abbrev', version: '2.0.0' },
+    ],
+    root: {
+      name: 'myproject',
+      version: '1.0.0',
+      dependencies: { which: '1.0.0' },
+    },
+  }
+  const { dir, registry } = await getRepo(graph)
+  const cache = fs.mkdtempSync(`${getTempDir()}/test-`)
+
+  // First install — only which
+  const arb1 = new Arborist({ path: dir, registry, packumentCache: new Map(), cache })
+  await arb1.reify({ installStrategy: 'linked' })
+
+  const whichLink = path.join(dir, 'node_modules', 'which')
+  t.ok(fs.lstatSync(whichLink).isSymbolicLink(), 'which is a symlink after first install')
+  const hashBefore = fs.readlinkSync(whichLink)
+
+  // Add abbrev — changes the dep graph, causing store hash recalculation
+  const pkgPath = path.join(dir, 'package.json')
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'))
+  pkg.dependencies.abbrev = '2.0.0'
+  fs.writeFileSync(pkgPath, JSON.stringify(pkg))
+
+  const arb2 = new Arborist({ path: dir, registry, packumentCache: new Map(), cache })
+  await arb2.reify({ installStrategy: 'linked' })
+
+  // The symlink target should still be valid (not dangling)
+  t.ok(fs.existsSync(whichLink), 'which symlink target exists after adding abbrev')
+  t.ok(setupRequire(dir)('which'), 'which is requireable after adding abbrev')
+
+  // Verify the symlink was updated if the hash changed
+  const hashAfter = fs.readlinkSync(whichLink)
+  if (hashBefore !== hashAfter) {
+    const storeDir = path.join(dir, 'node_modules', '.store')
+    const storeEntries = fs.readdirSync(storeDir)
+    const oldKey = hashBefore.split('/')[0].replace('.store/', '')
+    t.notOk(storeEntries.includes(oldKey), 'old store entry was cleaned up')
+  }
+})
+
 function setupRequire (cwd) {
   return function requireChain (...chain) {
     return chain.reduce((path, name) => {


### PR DESCRIPTION
In continuation of our exploration of using `install-strategy=linked` in the [Gutenberg monorepo](https://github.com/WordPress/gutenberg/pull/75814), which powers the WordPress Block Editor.

When using `install-strategy=linked`, adding a new dependency via `npm install` can change the store hash for existing packages (because `getKey` hashes the entire dependency subtree). The old `.store/` directories are cleaned up by `#cleanOrphanedStoreEntries`, but the symlinks in `node_modules/` still point to the old hash paths, leaving them dangling.

The root cause is in `#buildLinkedActualForDiff`: it builds synthetic actual tree entries by copying from the ideal tree, so the `resolved` values already contain the new hash. The diff engine sees `ideal.resolved === actual.resolved` and skips updating the symlink.

Fixed by reading the actual symlink target from disk with `readlinkSync` for root-level store links, so the diff can detect when the store hash has changed and trigger symlink recreation. The `onDiskTarget.startsWith('.store/')` guard ensures only root `node_modules/` symlinks are affected — workspace-internal and store-internal links use different relative paths and are left unchanged.

## References

Fixes #9106
