### PR TITLE
fix(arborist): skip linked actual tree diff in package-lock-only mode

### DIFF
--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -117,9 +117,11 @@ module.exports = cls => class Reifier extends cls {
       // of Node/Link trees
       log.warn('reify', 'The "linked" install strategy is EXPERIMENTAL and may contain bugs.')
       this.idealTree = await this.createIsolatedTree()
-      this.#linkedActualForDiff = this.#buildLinkedActualForDiff(
-        this.idealTree, this.actualTree
-      )
+      if (this.actualTree) {
+        this.#linkedActualForDiff = this.#buildLinkedActualForDiff(
+          this.idealTree, this.actualTree
+        )
+      }
     }
     await this[_diffTrees]()
     await this.#reifyPackages()

--- a/workspaces/arborist/test/arborist/reify.js
+++ b/workspaces/arborist/test/arborist/reify.js
@@ -199,6 +199,28 @@ t.test('packageLockOnly can add deps', async t => {
   t.throws(() => fs.statSync(path + '/node_modules'), { code: 'ENOENT' })
 })
 
+t.test('packageLockOnly with linked strategy in workspaces', async t => {
+  const path = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'repro',
+      private: true,
+      workspaces: ['packages/*'],
+    }),
+    packages: {
+      a: {
+        'package.json': JSON.stringify({
+          name: 'a',
+          version: '1.0.0',
+        }),
+      },
+    },
+  })
+  createRegistry(t, false)
+  await reify(path, { packageLockOnly: true, installStrategy: 'linked' })
+  t.ok(fs.existsSync(path + '/package-lock.json'), 'lock file created')
+  t.throws(() => fs.statSync(path + '/node_modules'), { code: 'ENOENT' })
+})
+
 t.test('malformed package.json should not be overwritten', async t => {
   t.plan(2)
 


### PR DESCRIPTION
`npm install --package-lock-only` crashes with `Cannot read properties of undefined (reading 'children')` when `install-strategy=linked` is set in a workspace monorepo.

In `packageLockOnly` mode, `_loadTrees` skips `loadActual()` since nothing needs to be written to disk. But `#buildLinkedActualForDiff` is called unconditionally and tries to access `this.actualTree.children` which is undefined.

Fixed by guarding the `#buildLinkedActualForDiff` call so it's skipped when there is no actual tree.

Regression introduced in #9031.

## References

Fixes #9105
