### PR TITLE
fix(arborist): v10 - backport store, lock-only, and override sibling fixes

### DIFF
--- a/lib/utils/explain-dep.js
+++ b/lib/utils/explain-dep.js
@@ -1,9 +1,9 @@
 const { relative } = require('node:path')
 
-const explainNode = (node, depth, chalk) =>
+const explainNode = (node, depth, chalk, seen = new Set()) =>
   printNode(node, chalk) +
-  explainDependents(node, depth, chalk) +
-  explainLinksIn(node, depth, chalk)
+  explainDependents(node, depth, chalk, seen) +
+  explainLinksIn(node, depth, chalk, seen)
 
 const colorType = (type, chalk) => {
   const style = type === 'extraneous' ? chalk.red
@@ -34,24 +34,24 @@ const printNode = (node, chalk) => {
     (node.location ? chalk.dim(`\n${node.location}`) : '')
 }
 
-const explainLinksIn = ({ linksIn }, depth, chalk) => {
+const explainLinksIn = ({ linksIn }, depth, chalk, seen) => {
   if (!linksIn || !linksIn.length || depth <= 0) {
     return ''
   }
 
-  const messages = linksIn.map(link => explainNode(link, depth - 1, chalk))
+  const messages = linksIn.map(link => explainNode(link, depth - 1, chalk, seen))
   const str = '\n' + messages.join('\n')
   return str.split('\n').join('\n  ')
 }
 
-const explainDependents = ({ dependents }, depth, chalk) => {
+const explainDependents = ({ dependents }, depth, chalk, seen) => {
   if (!dependents || !dependents.length || depth <= 0) {
     return ''
   }
 
   const max = Math.ceil(depth / 2)
   const messages = dependents.slice(0, max)
-    .map(edge => explainEdge(edge, depth, chalk))
+    .map(edge => explainEdge(edge, depth, chalk, seen))
 
   // show just the names of the first 5 deps that overflowed the list
   if (dependents.length > max) {
@@ -75,7 +75,10 @@ const explainDependents = ({ dependents }, depth, chalk) => {
   return str.split('\n').join('\n  ')
 }
 
-const explainEdge = ({ name, type, bundled, from, spec, rawSpec, overridden }, depth, chalk) => {
+const explainEdge = (
+  { name, type, bundled, from, spec, rawSpec, overridden },
+  depth, chalk, seen = new Set()
+) => {
   let dep = type === 'workspace'
     ? chalk.bold(relative(from.location, spec.slice('file:'.length)))
     : `${name}@"${spec}"`
@@ -83,21 +86,31 @@ const explainEdge = ({ name, type, bundled, from, spec, rawSpec, overridden }, d
     dep = `${colorType('overridden', chalk)} ${dep} (was "${rawSpec}")`
   }
 
-  const fromMsg = ` from ${explainFrom(from, depth, chalk)}`
+  const fromMsg = ` from ${explainFrom(from, depth, chalk, seen)}`
 
   return (type === 'prod' ? '' : `${colorType(type, chalk)} `) +
     (bundled ? `${colorType('bundled', chalk)} ` : '') +
     `${dep}${fromMsg}`
 }
 
-const explainFrom = (from, depth, chalk) => {
+const explainFrom = (from, depth, chalk, seen) => {
   if (!from.name && !from.version) {
     return 'the root project'
   }
 
-  return printNode(from, chalk) +
-    explainDependents(from, depth - 1, chalk) +
-    explainLinksIn(from, depth - 1, chalk)
+  // Prevent infinite recursion from cycles in the dependency graph (e.g. linked strategy store nodes). Use stack-based tracking so diamond dependencies (same node reached via different paths) are still explained, but recursive cycles are broken.
+  const nodeId = `${from.name}@${from.version}:${from.location}`
+  if (seen.has(nodeId)) {
+    return printNode(from, chalk)
+  }
+  seen.add(nodeId)
+
+  const result = printNode(from, chalk) +
+    explainDependents(from, depth - 1, chalk, seen) +
+    explainLinksIn(from, depth - 1, chalk, seen)
+
+  seen.delete(nodeId)
+  return result
 }
 
 module.exports = { explainNode, printNode, explainEdge }

--- a/tap-snapshots/test/lib/utils/explain-dep.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/explain-dep.js.test.cjs
@@ -5,6 +5,28 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/lib/utils/explain-dep.js TAP basic > circular dependency does not recurse infinitely 1`] = `
+cycle-a@1.0.0
+node_modules/cycle-a
+  cycle-a@"1.x" from cycle-b@2.0.0
+  node_modules/cycle-b
+    cycle-b@"2.x" from cycle-a@1.0.0
+    node_modules/cycle-a
+      cycle-a@"1.x" from cycle-b@2.0.0
+      node_modules/cycle-b
+`
+
+exports[`test/lib/utils/explain-dep.js TAP basic > circular dependency from other side 1`] = `
+cycle-b@2.0.0
+node_modules/cycle-b
+  cycle-b@"2.x" from cycle-a@1.0.0
+  node_modules/cycle-a
+    cycle-a@"1.x" from cycle-b@2.0.0
+    node_modules/cycle-b
+      cycle-b@"2.x" from cycle-a@1.0.0
+      node_modules/cycle-a
+`
+
 exports[`test/lib/utils/explain-dep.js TAP basic > ellipses test one 1`] = `
 manydep@1.0.0
   manydep@"1.0.0" from prod-dep@1.2.3
@@ -19,6 +41,11 @@ manydep@1.0.0
   node_modules/prod-dep
     prod-dep@"1.x" from the root project
   6 more (optdep, extra-neos, deep-dev, peer, the root project, a package with a pretty long name)
+`
+
+exports[`test/lib/utils/explain-dep.js TAP basic > explainEdge without seen parameter 1`] = `
+some-dep@"1.x" from parent-pkg@2.0.0
+node_modules/parent-pkg
 `
 
 exports[`test/lib/utils/explain-dep.js TAP basic bundled > explain color deep 1`] = `

--- a/test/lib/utils/explain-dep.js
+++ b/test/lib/utils/explain-dep.js
@@ -1,6 +1,6 @@
 const { resolve } = require('node:path')
 const t = require('tap')
-const { explainNode, printNode } = require('../../../lib/utils/explain-dep.js')
+const { explainNode, printNode, explainEdge } = require('../../../lib/utils/explain-dep.js')
 const { cleanCwd } = require('../../fixtures/clean-snapshot')
 
 t.cleanSnapshot = (str) => cleanCwd(str)
@@ -267,6 +267,47 @@ t.test('basic', async t => {
       t.end()
     })
   }
+
+  // Regression test for https://github.com/npm/cli/issues/9109
+  // Circular dependency graphs (common in linked strategy store nodes) should not cause infinite recursion in explainNode.
+  const cycleA = {
+    name: 'cycle-a',
+    version: '1.0.0',
+    location: 'node_modules/cycle-a',
+    dependents: [],
+  }
+  const cycleB = {
+    name: 'cycle-b',
+    version: '2.0.0',
+    location: 'node_modules/cycle-b',
+    dependents: [{
+      type: 'prod',
+      name: 'cycle-b',
+      spec: '2.x',
+      from: cycleA,
+    }],
+  }
+  cycleA.dependents = [{
+    type: 'prod',
+    name: 'cycle-a',
+    spec: '1.x',
+    from: cycleB,
+  }]
+  t.matchSnapshot(explainNode(cycleA, Infinity, noColor), 'circular dependency does not recurse infinitely')
+  t.matchSnapshot(explainNode(cycleB, Infinity, noColor), 'circular dependency from other side')
+
+  // explainEdge called without seen parameter (covers default seen = new Set() branch on explainEdge and explainFrom)
+  t.matchSnapshot(explainEdge({
+    type: 'prod',
+    name: 'some-dep',
+    spec: '1.x',
+    from: {
+      name: 'parent-pkg',
+      version: '2.0.0',
+      location: 'node_modules/parent-pkg',
+      dependents: [],
+    },
+  }, 2, noColor), 'explainEdge without seen parameter')
 
   // make sure that we show the last one if it's the only one that would
   // hit the ...

--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -139,9 +139,11 @@ module.exports = cls => class Reifier extends cls {
       // of Node/Link trees
       log.warn('reify', 'The "linked" install strategy is EXPERIMENTAL and may contain bugs.')
       this.idealTree = await this.createIsolatedTree()
-      this.#linkedActualForDiff = this.#buildLinkedActualForDiff(
-        this.idealTree, this.actualTree
-      )
+      if (this.actualTree) {
+        this.#linkedActualForDiff = this.#buildLinkedActualForDiff(
+          this.idealTree, this.actualTree
+        )
+      }
     }
     await this[_diffTrees]()
     await this[_reifyPackages]()

--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -851,6 +851,10 @@ module.exports = cls => class Reifier extends cls {
       if (combined.has(child.path) || !existsSync(child.path)) {
         continue
       }
+      // Skip store links whose ideal realpath doesn't exist on disk yet — the store hash changed and the symlink needs recreating via ADD.
+      if (child.isLink && child.resolved?.startsWith('file:.store/') && !existsSync(child.realpath)) {
+        continue
+      }
       let entry
       if (child.isLink) {
         entry = new IsolatedLink(child)

--- a/workspaces/arborist/lib/override-set.js
+++ b/workspaces/arborist/lib/override-set.js
@@ -1,5 +1,6 @@
 const npa = require('npm-package-arg')
 const semver = require('semver')
+const { log } = require('proc-log')
 
 class OverrideSet {
   constructor ({ overrides, key, parent }) {
@@ -141,6 +142,123 @@ class OverrideSet {
     }
 
     return ruleset
+  }
+
+  static findSpecificOverrideSet (first, second) {
+    for (let overrideSet = second; overrideSet; overrideSet = overrideSet.parent) {
+      if (overrideSet.isEqual(first)) {
+        return second
+      }
+    }
+    for (let overrideSet = first; overrideSet; overrideSet = overrideSet.parent) {
+      if (overrideSet.isEqual(second)) {
+        return first
+      }
+    }
+
+    // The override sets are incomparable (e.g. siblings like the "react" and "react-dom" children of the root override set). Check if they have semantically conflicting rules before treating this as an error.
+    if (this.haveConflictingRules(first, second)) {
+      log.silly('Conflicting override sets', first, second)
+      return undefined
+    }
+
+    // The override sets are structurally incomparable but have compatible rules. Fall back to their nearest common ancestor so the node still has a valid override set.
+    return this.findCommonAncestor(first, second)
+  }
+
+  static findCommonAncestor (first, second) {
+    const firstAncestors = []
+    for (const ancestor of first.ancestry()) {
+      firstAncestors.push(ancestor)
+    }
+    for (const secondAnc of second.ancestry()) {
+      for (const firstAnc of firstAncestors) {
+        if (firstAnc.isEqual(secondAnc)) {
+          return firstAnc
+        }
+      }
+    }
+    return null
+  }
+
+  static doOverrideSetsConflict (first, second) {
+    // If override sets contain one another then we can try to use the more specific one.
+    // If neither one is more specific, check for semantic conflicts.
+    const specificSet = this.findSpecificOverrideSet(first, second)
+    if (specificSet !== undefined) {
+      // One contains the other, so no conflict
+      return false
+    }
+
+    // The override sets are structurally incomparable, but this doesn't necessarily
+    // mean they conflict. We need to check if they have conflicting version requirements
+    // for any package that appears in both rulesets.
+    return this.haveConflictingRules(first, second)
+  }
+
+  static haveConflictingRules (first, second) {
+    // Get all rules from both override sets
+    const firstRules = first.ruleset
+    const secondRules = second.ruleset
+
+    // Check each package that appears in both rulesets
+    for (const [key, firstRule] of firstRules) {
+      const secondRule = secondRules.get(key)
+      if (!secondRule) {
+        // Package only appears in one ruleset, no conflict
+        continue
+      }
+
+      // Same rule object means no conflict
+      if (firstRule === secondRule || firstRule.isEqual(secondRule)) {
+        continue
+      }
+
+      // Both rulesets have rules for this package with different values.
+      // Check if the version requirements are actually incompatible.
+      const firstValue = firstRule.value
+      const secondValue = secondRule.value
+
+      // If either value is a reference (starts with $), we can't determine
+      // compatibility here - the reference might resolve to compatible versions.
+      // We defer to runtime resolution rather than failing early.
+      if (firstValue.startsWith('$') || secondValue.startsWith('$')) {
+        continue
+      }
+
+      // Check if the version ranges are compatible using semver
+      // If both specify version ranges, they conflict only if they have no overlap
+      try {
+        const firstSpec = npa(`${firstRule.name}@${firstValue}`)
+        const secondSpec = npa(`${secondRule.name}@${secondValue}`)
+
+        // For range/version types, check if they intersect
+        if ((firstSpec.type === 'range' || firstSpec.type === 'version') &&
+            (secondSpec.type === 'range' || secondSpec.type === 'version')) {
+          // Check if the ranges intersect
+          const firstRange = firstSpec.fetchSpec
+          const secondRange = secondSpec.fetchSpec
+
+          // If the ranges don't intersect, we have a real conflict
+          if (!semver.intersects(firstRange, secondRange)) {
+            log.silly('Found conflicting override rules', {
+              package: firstRule.name,
+              first: firstValue,
+              second: secondValue,
+            })
+            return true
+          }
+        }
+        // For other types (git, file, directory, tag), we can't easily determine
+        // compatibility, so we conservatively assume no conflict
+      } catch {
+        // If we can't parse the specs, conservatively assume no conflict
+        // Real conflicts will be caught during dependency resolution
+      }
+    }
+
+    // No conflicting rules found
+    return false
   }
 }
 

--- a/workspaces/arborist/lib/override-set.js
+++ b/workspaces/arborist/lib/override-set.js
@@ -45,6 +45,43 @@ class OverrideSet {
     }
   }
 
+  childrenAreEqual (other) {
+    if (this.children.size !== other.children.size) {
+      return false
+    }
+    for (const [key] of this.children) {
+      if (!other.children.has(key)) {
+        return false
+      }
+      if (this.children.get(key).value !== other.children.get(key).value) {
+        return false
+      }
+      if (!this.children.get(key).childrenAreEqual(other.children.get(key))) {
+        return false
+      }
+    }
+    return true
+  }
+
+  isEqual (other) {
+    if (this === other) {
+      return true
+    }
+    if (!other) {
+      return false
+    }
+    if (this.key !== other.key || this.value !== other.value) {
+      return false
+    }
+    if (!this.childrenAreEqual(other)) {
+      return false
+    }
+    if (!this.parent) {
+      return !other.parent
+    }
+    return this.parent.isEqual(other.parent)
+  }
+
   getEdgeRule (edge) {
     for (const rule of this.ruleset.values()) {
       if (rule.name !== edge.name) {

--- a/workspaces/arborist/test/arborist/reify.js
+++ b/workspaces/arborist/test/arborist/reify.js
@@ -186,7 +186,28 @@ t.test('packageLockOnly can add deps', async t => {
   t.throws(() => fs.statSync(path + '/node_modules'), { code: 'ENOENT' })
 })
 
-t.test('malformed package.json should not be overwitten', async t => {
+t.test('packageLockOnly with linked strategy in workspaces', async t => {
+  const path = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'repro',
+      private: true,
+      workspaces: ['packages/*'],
+    }),
+    packages: {
+      a: {
+        'package.json': JSON.stringify({
+          name: 'a',
+          version: '1.0.0',
+        }),
+      },
+    },
+  })
+  await reify(path, { packageLockOnly: true, installStrategy: 'linked', registry })
+  t.ok(fs.existsSync(path + '/package-lock.json'), 'lock file created')
+  t.throws(() => fs.statSync(path + '/node_modules'), { code: 'ENOENT' })
+})
+
+t.test('malformed package.json should not be overwritten', async t => {
   t.plan(2)
 
   const path = fixture(t, 'malformed-json')

--- a/workspaces/arborist/test/isolated-mode.js
+++ b/workspaces/arborist/test/isolated-mode.js
@@ -1979,6 +1979,53 @@ tap.test('orphaned store entries are cleaned up on dependency removal', async t 
     'all store entries are removed when dependencies are removed')
 })
 
+tap.test('store symlinks are updated when hash changes after adding a dep', async t => {
+  const graph = {
+    registry: [
+      { name: 'which', version: '1.0.0', dependencies: { isexe: '^1.0.0' } },
+      { name: 'isexe', version: '1.0.0' },
+      { name: 'abbrev', version: '2.0.0' },
+    ],
+    root: {
+      name: 'myproject',
+      version: '1.0.0',
+      dependencies: { which: '1.0.0' },
+    },
+  }
+  const { dir, registry } = await getRepo(graph)
+  const cache = fs.mkdtempSync(`${getTempDir()}/test-`)
+
+  // First install — only which
+  const arb1 = new Arborist({ path: dir, registry, packumentCache: new Map(), cache })
+  await arb1.reify({ installStrategy: 'linked' })
+
+  const whichLink = path.join(dir, 'node_modules', 'which')
+  t.ok(fs.lstatSync(whichLink).isSymbolicLink(), 'which is a symlink after first install')
+  const hashBefore = fs.readlinkSync(whichLink)
+
+  // Add abbrev — changes the dep graph, causing store hash recalculation
+  const pkgPath = path.join(dir, 'package.json')
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'))
+  pkg.dependencies.abbrev = '2.0.0'
+  fs.writeFileSync(pkgPath, JSON.stringify(pkg))
+
+  const arb2 = new Arborist({ path: dir, registry, packumentCache: new Map(), cache })
+  await arb2.reify({ installStrategy: 'linked' })
+
+  // The symlink target should still be valid (not dangling)
+  t.ok(fs.existsSync(whichLink), 'which symlink target exists after adding abbrev')
+  t.ok(setupRequire(dir)('which'), 'which is requireable after adding abbrev')
+
+  // Verify the symlink was updated if the hash changed
+  const hashAfter = fs.readlinkSync(whichLink)
+  if (hashBefore !== hashAfter) {
+    const storeDir = path.join(dir, 'node_modules', '.store')
+    const storeEntries = fs.readdirSync(storeDir)
+    const oldKey = hashBefore.split('/')[0].replace('.store/', '')
+    t.notOk(storeEntries.includes(oldKey), 'old store entry was cleaned up')
+  }
+})
+
 function setupRequire (cwd) {
   return function requireChain (...chain) {
     return chain.reduce((path, name) => {

--- a/workspaces/arborist/test/override-set.js
+++ b/workspaces/arborist/test/override-set.js
@@ -271,4 +271,364 @@ t.test('constructor', async (t) => {
     const outOfRangeRule = bazEdgeRule.getEdgeRule({ name: 'buzz', spec: 'github:baz/buzz#semver:^2.0.0' })
     t.equal(outOfRangeRule.name, 'baz', 'no match - returned parent')
   })
+
+  t.test('isequal and findspecificoverrideset tests', async (t) => {
+    const overrides1 = new OverrideSet({
+      overrides: {
+        foo: {
+          bar: {
+            '.': '2.0.0',
+            baz: '3.0.0',
+          },
+          baz: '2.0.0',
+        },
+        bar: '1.0.0',
+        baz: '1.0.0',
+      },
+    })
+    const overrides2 = new OverrideSet({
+      overrides: {
+        foo: {
+          bar: {
+            '.': '2.0.0',
+            baz: '3.0.0',
+          },
+          baz: '2.0.0',
+        },
+        bar: '1.0.0',
+        baz: '1.0.0',
+      },
+    })
+    const overrides3 = new OverrideSet({
+      overrides: {
+        foo: {
+          bar: {
+            '.': '2.0.0',
+            baz: '3.1.0',
+          },
+          baz: '2.0.0',
+        },
+        bar: '1.0.0',
+        baz: '1.0.0',
+      },
+    })
+    const overrides4 = new OverrideSet({
+      overrides: {
+        foo: {
+          bar: {
+            '.': '2.0.0',
+          },
+          baz: '2.0.0',
+        },
+        bar: '1.0.0',
+        baz: '1.0.0',
+      },
+    })
+    const overrides5 = new OverrideSet({
+      overrides: {
+        foo: {
+          bar: {
+            '.': '2.0.0',
+          },
+          bat: '2.0.0',
+        },
+        bar: '1.0.0',
+        baz: '1.0.0',
+      },
+    })
+    const overrides6 = new OverrideSet({
+      overrides: {
+        bar: {
+          '.': '2.0.0',
+        },
+        bat: '2.0.0',
+      },
+    })
+    overrides6.parent = overrides5
+    const overrides7 = new OverrideSet({
+      overrides: {
+        bat: '2.0.0',
+      },
+    })
+    const overrides8 = new OverrideSet({
+      overrides: {
+        bat: '1.2.0',
+      },
+    })
+    const overrides9 = new OverrideSet({
+      overrides: {
+        'bat@3.0.0': '1.2.0',
+      },
+    })
+
+    t.ok(overrides1.isEqual(overrides1), 'override set is equal to itself')
+    t.ok(overrides1.isEqual(overrides2), 'two identical override sets are equal')
+    t.ok(!overrides1.isEqual(overrides3), 'two different override sets are not equal')
+    t.ok(!overrides2.isEqual(overrides3), 'two different override sets are not equal')
+    t.ok(!overrides3.isEqual(overrides1), 'two different override sets are not equal')
+    t.ok(!overrides3.isEqual(overrides2), 'two different override sets are not equal')
+    t.ok(!overrides4.isEqual(overrides1), 'two different override sets are not equal')
+    t.ok(!overrides4.isEqual(overrides2), 'two different override sets are not equal')
+    t.ok(!overrides4.isEqual(overrides3), 'two different override sets are not equal')
+    t.ok(!overrides4.isEqual(overrides5), 'two override sets that differ only by package name are not equal')
+    t.ok(!overrides5.isEqual(overrides4), 'two override sets that differ only by package name are not equal')
+    t.equal(OverrideSet.findSpecificOverrideSet(overrides5, overrides5), overrides5, 'find more specific override set when the sets are identical')
+    t.equal(OverrideSet.findSpecificOverrideSet(overrides5, overrides6), overrides6, "find more specific override set when it's the second")
+    t.equal(OverrideSet.findSpecificOverrideSet(overrides6, overrides5), overrides6, "find more specific override set when it's the first")
+    t.ok(!OverrideSet.doOverrideSetsConflict(overrides1, overrides2), 'override sets are equal')
+    t.ok(!OverrideSet.doOverrideSetsConflict(overrides5, overrides5), 'override sets are the same object')
+    t.ok(!OverrideSet.doOverrideSetsConflict(overrides5, overrides6), 'one override set is the specific version of the other')
+    t.ok(!OverrideSet.doOverrideSetsConflict(overrides6, overrides5), 'one override set is the specific version of the other')
+    // With semantic conflict detection, overrides5 and overrides7 don't conflict because
+    // they have the same value for 'bat' (2.0.0). Structurally they're incomparable,
+    // but semantically they're compatible.
+    t.ok(!OverrideSet.doOverrideSetsConflict(overrides5, overrides7), 'structurally incomparable but semantically compatible')
+    t.ok(!OverrideSet.doOverrideSetsConflict(overrides7, overrides5), 'structurally incomparable but semantically compatible')
+    t.ok(!overrides7.isEqual(overrides8), 'two override sets that differ in the version are not equal')
+    t.ok(!overrides8.isEqual(overrides9), 'two override sets that differ in the range are not equal')
+    t.ok(!overrides7.isEqual(overrides9), 'two override sets that differ in both version and range are not equal')
+    // overrides7 (bat: 2.0.0) and overrides8 (bat: 1.2.0) have conflicting versions for the same package
+    t.ok(OverrideSet.doOverrideSetsConflict(overrides7, overrides8), 'override sets have conflicting versions for bat')
+    // overrides7 (bat: 2.0.0) and overrides9 (bat@3.0.0: 1.2.0) don't directly conflict because
+    // overrides9 only applies to bat@3.x, not bat@2.x
+    t.ok(!OverrideSet.doOverrideSetsConflict(overrides7, overrides9), 'override sets apply to different version ranges')
+    // overrides8 (bat: 1.2.0) and overrides9 (bat@3.0.0: 1.2.0) have same target version
+    t.ok(!OverrideSet.doOverrideSetsConflict(overrides8, overrides9), 'override sets have compatible target versions')
+  })
+
+  t.test('semantic conflict detection (haveConflictingRules)', async (t) => {
+    t.test('no conflict when packages are different', async (t) => {
+      const overrides1 = new OverrideSet({
+        overrides: {
+          foo: '1.0.0',
+        },
+      })
+      const overrides2 = new OverrideSet({
+        overrides: {
+          bar: '1.0.0',
+        },
+      })
+      t.ok(!OverrideSet.haveConflictingRules(overrides1, overrides2), 'different packages should not conflict')
+    })
+
+    t.test('no conflict when version ranges intersect', async (t) => {
+      const overrides1 = new OverrideSet({
+        overrides: {
+          lodash: '^4.0.0',
+        },
+      })
+      const overrides2 = new OverrideSet({
+        overrides: {
+          lodash: '4.17.0',
+        },
+      })
+      t.ok(!OverrideSet.haveConflictingRules(overrides1, overrides2), 'intersecting ranges should not conflict')
+    })
+
+    t.test('conflict when version ranges do not intersect', async (t) => {
+      const overrides1 = new OverrideSet({
+        overrides: {
+          lodash: '1.x',
+        },
+      })
+      const overrides2 = new OverrideSet({
+        overrides: {
+          lodash: '4.x',
+        },
+      })
+      t.ok(OverrideSet.haveConflictingRules(overrides1, overrides2), 'non-intersecting ranges should conflict')
+    })
+
+    t.test('no conflict when using reference overrides', async (t) => {
+      const overrides1 = new OverrideSet({
+        overrides: {
+          lodash: '$ref1',
+        },
+      })
+      const overrides2 = new OverrideSet({
+        overrides: {
+          lodash: '$ref2',
+        },
+      })
+      t.ok(!OverrideSet.haveConflictingRules(overrides1, overrides2), 'reference overrides should not conflict')
+    })
+
+    t.test('no conflict when one is a reference override', async (t) => {
+      const overrides1 = new OverrideSet({
+        overrides: {
+          lodash: '$ref1',
+        },
+      })
+      const overrides2 = new OverrideSet({
+        overrides: {
+          lodash: '4.17.21',
+        },
+      })
+      t.ok(!OverrideSet.haveConflictingRules(overrides1, overrides2), 'reference override with version should not conflict')
+    })
+
+    t.test('no conflict when rules are equal', async (t) => {
+      const overrides1 = new OverrideSet({
+        overrides: {
+          lodash: '4.17.21',
+        },
+      })
+      const overrides2 = new OverrideSet({
+        overrides: {
+          lodash: '4.17.21',
+        },
+      })
+      t.ok(!OverrideSet.haveConflictingRules(overrides1, overrides2), 'equal rules should not conflict')
+    })
+
+    t.test('handles non-semver spec types gracefully', async (t) => {
+      const overrides1 = new OverrideSet({
+        overrides: {
+          foo: 'github:user/repo',
+        },
+      })
+      const overrides2 = new OverrideSet({
+        overrides: {
+          foo: 'file:./local',
+        },
+      })
+      // Non-semver types should not be considered conflicting
+      t.ok(!OverrideSet.haveConflictingRules(overrides1, overrides2), 'non-semver specs should not conflict')
+    })
+
+    t.test('regression test for issue #8688 - Vaadin case', async (t) => {
+      const overridesComponents = new OverrideSet({
+        overrides: {
+          '@vaadin/react-components': '24.9.2',
+        },
+      })
+      const overridesComponentsPro = new OverrideSet({
+        overrides: {
+          '@vaadin/react-components-pro': '24.9.2',
+        },
+      })
+      t.ok(!OverrideSet.doOverrideSetsConflict(overridesComponents, overridesComponentsPro), 'Vaadin components should not conflict')
+    })
+  })
+})
+
+t.test('findSpecificOverrideSet returns common ancestor for compatible siblings', async (t) => {
+  // Regression test for https://github.com/npm/cli/issues/9109
+  // When two top-level overrides (e.g. react + react-dom) share a transitive dep (e.g. loose-envify), the dep's node gets override sets from both siblings. findSpecificOverrideSet must return their common ancestor instead of undefined.
+  const root = new OverrideSet({
+    overrides: {
+      react: '18.3.1',
+      'react-dom': '18.3.1',
+    },
+  })
+
+  const reactChild = root.children.get('react')
+  const reactDomChild = root.children.get('react-dom')
+
+  t.ok(reactChild, 'react child exists')
+  t.ok(reactDomChild, 'react-dom child exists')
+
+  // These are siblings - neither is an ancestor of the other
+  const result = OverrideSet.findSpecificOverrideSet(reactChild, reactDomChild)
+  t.ok(result, 'findSpecificOverrideSet should not return undefined for compatible siblings')
+  t.ok(result.isEqual(root), 'should return the common ancestor (root)')
+
+  const reverse = OverrideSet.findSpecificOverrideSet(reactDomChild, reactChild)
+  t.ok(reverse, 'reverse order should also return a result')
+  t.ok(reverse.isEqual(root), 'reverse order should also return the root')
+})
+
+t.test('findCommonAncestor', async (t) => {
+  const root = new OverrideSet({
+    overrides: {
+      foo: '1.0.0',
+      bar: '2.0.0',
+    },
+  })
+
+  const fooChild = root.children.get('foo')
+  const barChild = root.children.get('bar')
+
+  const ancestor = OverrideSet.findCommonAncestor(fooChild, barChild)
+  t.ok(ancestor, 'should find a common ancestor')
+  t.ok(ancestor.isEqual(root), 'common ancestor should be the root')
+
+  // Two unrelated roots have no common ancestor
+  const other = new OverrideSet({ overrides: { baz: '3.0.0' } })
+  const noAncestor = OverrideSet.findCommonAncestor(fooChild, other)
+  t.equal(noAncestor, null, 'unrelated sets have no common ancestor')
+})
+
+t.test('findSpecificOverrideSet returns undefined for truly conflicting siblings', async (t) => {
+  // Siblings with conflicting rules should still return undefined
+  const root = new OverrideSet({
+    overrides: {
+      foo: {
+        '.': '1.0.0',
+        shared: '1.0.0',
+      },
+      bar: {
+        '.': '2.0.0',
+        shared: '99.0.0',
+      },
+    },
+  })
+
+  const fooChild = root.children.get('foo')
+  const barChild = root.children.get('bar')
+
+  t.ok(fooChild, 'foo child exists')
+  t.ok(barChild, 'bar child exists')
+
+  const result = OverrideSet.findSpecificOverrideSet(fooChild, barChild)
+  t.equal(result, undefined, 'truly conflicting siblings should return undefined')
+})
+
+t.test('coverage for isEqual edge cases', async t => {
+  t.test('isEqual with null/undefined other', async t => {
+    const overrides = new OverrideSet({ overrides: { foo: '1.0.0' } })
+    t.ok(!overrides.isEqual(null), 'override set is not equal to null')
+    t.ok(!overrides.isEqual(undefined), 'override set is not equal to undefined')
+  })
+
+  t.test('isEqual when parent != null', async t => {
+    // Both parents have the SAME config -> parent.isEqual(...) will return TRUE
+    const parentA = new OverrideSet({ overrides: { foo: '1.0.0' } })
+    const parentB = new OverrideSet({ overrides: { foo: '1.0.0' } })
+
+    // Child override sets with the same parent config => should be equal
+    const childA = new OverrideSet({
+      overrides: { bar: '2.0.0' },
+      key: 'bar',
+      parent: parentA,
+    })
+    const childB = new OverrideSet({
+      overrides: { bar: '2.0.0' },
+      key: 'bar',
+      parent: parentB,
+    })
+
+    // This specifically covers the code path where parent != null
+    // AND parent.isEqual(...) returns true
+    t.ok(childA.isEqual(childB), 'two children with equivalent parents are equal')
+
+    // Different parent configs -> parent.isEqual(...) will return FALSE
+    const parentC = new OverrideSet({ overrides: { foo: '1.0.0' } })
+    const parentD = new OverrideSet({ overrides: { foo: '1.0.1' } })
+
+    const childC = new OverrideSet({
+      overrides: { bar: '2.0.0' },
+      key: 'bar',
+      parent: parentC,
+    })
+    const childD = new OverrideSet({
+      overrides: { bar: '2.0.0' },
+      key: 'bar',
+      parent: parentD,
+    })
+
+    // This specifically covers the code path where parent != null
+    // AND parent.isEqual(...) returns false
+    t.notOk(childC.isEqual(childD), 'two children with different parents are not equal')
+  })
 })


### PR DESCRIPTION
This is a cherry-pick of 

- 8e0a7315d0719227c83ce9921c2bd56d201ad3ca - #9108 
- 51365b1b8a7924d082f00c27a4aedcb1f81110ec - #9107
- 21ea382a60b3693ff6c44c81447caa5d0294169c - #9110 

and cf34e6fb20334b7f03b86ce7468889e8339bd43a (the changes needed for 21ea382a60b3693ff6c44c81447caa5d0294169c in v10 branch)

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
