### PR TITLE
fix(search): disable output redaction for json mode

### DIFF
--- a/lib/commands/search.js
+++ b/lib/commands/search.js
@@ -1,6 +1,6 @@
 const Pipeline = require('minipass-pipeline')
 const libSearch = require('libnpmsearch')
-const { log, output } = require('proc-log')
+const { log, output, META } = require('proc-log')
 const formatSearchStream = require('../utils/format-search-stream.js')
 const BaseCommand = require('../base-cmd.js')
 
@@ -51,11 +51,16 @@ class Search extends BaseCommand {
       outputStream
     )
 
+    const isJson = this.npm.config.get('json')
     p.on('data', chunk => {
       if (!anyOutput) {
         anyOutput = true
       }
-      output.standard(chunk.toString('utf8'))
+      if (isJson) {
+        output.standard(chunk.toString('utf8'), { [META]: true, redact: false })
+      } else {
+        output.standard(chunk.toString('utf8'))
+      }
     })
 
     await p.promise()

--- a/test/lib/commands/search.js
+++ b/test/lib/commands/search.js
@@ -289,6 +289,36 @@ t.test('search', t => {
     t.matchSnapshot(joinedOutput(), 'results should not have libnpmversion')
   })
 
+  t.test('json output is not corrupted by redaction', async t => {
+    const { npm, joinedOutput } = await loadMockNpm(t, { config: { json: true } })
+    const registry = new MockRegistry({
+      tap: t,
+      registry: npm.config.get('registry'),
+    })
+
+    const results = [{
+      name: '@scope/pkg-name',
+      scope: 'scope',
+      version: '1.0.0',
+      description: 'a]package with id 12345678-1234-1234-1234-123456789abc',
+      keywords: [],
+      date: '2020-01-01T00:00:00.000Z',
+      author: { name: 'Foo', email: 'foo@npmjs.com' },
+      publisher: { username: 'foo', email: 'foo@npmjs.com' },
+      maintainers: [
+        { username: 'foo', email: 'foo@npmjs.com' },
+      ],
+      sanitized_name: 'scope/pkg-name',
+    }]
+    registry.search({ results })
+
+    await npm.exec('search', ['pkg-name'])
+    const output = joinedOutput()
+    const parsed = JSON.parse(output)
+    t.equal(parsed[0].name, '@scope/pkg-name', 'name should not be redacted')
+    t.match(parsed[0].description, /12345678/, 'uuid-like strings in values should not be redacted')
+  })
+
   t.test('exclude forward slash', async t => {
     const { npm, joinedOutput } = await loadMockNpm(t, { config: { searchexclude: '/version' } })
     const registry = new MockRegistry({


### PR DESCRIPTION
## Summary

Disables `@npmcli/redact` processing on `npm search --json` output by passing `{ [META]: true, redact: false }` to `output.standard()`, preventing redaction from corrupting structured JSON.

## Why this matters

When search results contain values matching redaction patterns (UUIDs, token-like strings), `redactLog()` replaces them with `***` inside the JSON string, producing output that fails `JSON.parse`. Reported in [#9112](https://github.com/npm/cli/issues/9112) where the `sanitized_name` field was corrupted to `"sanitized_name":***@automattic/newspack-blocks"`.

The root cause: `output.standard()` runs all output through `formatWithOptions()` in `lib/utils/format.js`, which calls `redactLog()` by default. For structured JSON output this is destructive since the redactor operates on the raw string, not the parsed JSON values.

## Changes

- `lib/commands/search.js`: Import `META` from `proc-log`. When in JSON mode, pass `{ [META]: true, redact: false }` to `output.standard()` to skip redaction. Non-JSON output (text, parseable) continues to be redacted normally.
- `test/lib/commands/search.js`: Added test verifying JSON output containing UUID-like strings is not corrupted by redaction.

This matches the pattern used by `trust-cmd.js` and `sbom.js` for structured output.

## Testing

- All 19 existing search tests pass
- New test verifies JSON output with UUID-like data parses correctly
- `search.js` and `format-search-stream.js` at 100% coverage

Fixes #9112

This contribution was developed with AI assistance (Claude Code).