### PR TITLE
docs: Add note on relative path prefix for npm publish

### DIFF
--- a/docs/lib/content/commands/npm-publish.md
+++ b/docs/lib/content/commands/npm-publish.md
@@ -52,6 +52,8 @@ A `package` is interpreted the same way as other commands (like `npm install`) a
 * f) a `<name>` that has a "latest" tag satisfying (e)
 * g) a `<git remote url>` that resolves to (a)
 
+If either (a) or (b) is specified as a relative path, it should begin with an explicit `./` prefix.
+
 The publish will fail if the package name and version combination already exists in the specified registry.
 
 Once a package is published with a given name and version, that specific name and version combination can never be used again, even if it is removed with [`npm unpublish`](/commands/npm-unpublish).


### PR DESCRIPTION
Clarify requirements for relative paths in npm publish.

This adds clarification on relative path support directly to the npm publish documentation. Currently, this documentation only alludes to package spec in the "see also" section, leaving it unclear that the unprefixed relative paths that are supported by most other tools will fail here. Enhancing this documentation is important since unprefixed relative paths result in surprising error messages that do not hint at the appropriate solution.

## References
Related to #2796
