### PR TITLE
fix: eagerly require promise-retry to survive self-upgrade

### DIFF
--- a/workspaces/arborist/lib/arborist/rebuild.js
+++ b/workspaces/arborist/lib/arborist/rebuild.js
@@ -8,6 +8,7 @@ const rpj = require('read-package-json-fast')
 const binLinks = require('bin-links')
 const runScript = require('@npmcli/run-script')
 const { callLimit: promiseCallLimit } = require('promise-call-limit')
+const promiseRetry = require('promise-retry')
 const { resolve } = require('node:path')
 const { isNodeGypPackage, defaultGypInstallScript } = require('@npmcli/node-gyp')
 const { log, time } = require('proc-log')
@@ -384,7 +385,6 @@ module.exports = cls => class Builder extends cls {
     const timeEnd = time.start(`build:link:${node.location}`)
 
     // On Windows, antivirus/indexer can transiently lock files, causing EPERM/EACCES/EBUSY on the rename inside write-file-atomic (used by bin-links/fix-bin.js), so, retry with backoff.
-    const promiseRetry = require('promise-retry')
     const p = promiseRetry((retry) => binLinks({
       pkg: node.package,
       path: node.path,


### PR DESCRIPTION
Running `npm install -g npm@latest` on Node 22.22.2 (which bundles npm 10.9.7) fails with `MODULE_NOT_FOUND: promise-retry`.

This happens because npm 11.12.0 removed `promise-retry` from its bundle (in favor of `@gar/promise-retry`). During the self-upgrade, the reify step deletes `promise-retry` from disk, then the still-running 10.x process hits a lazy `require('promise-retry')` in `_linkBins` and blows up.

That lazy require was introduced in #9011 as part of the retry-on-Windows backport, it was just placed inline next to where it's used, no functional reason for it to be lazy.

Moving it to the top of the file with the other imports means it gets loaded at startup while the file still exists. The captured reference survives the upgrade.

Tested on a fresh Node 22.22.2: unpatched fails, patched upgrades to 11.12.0 cleanly.

Fixes https://github.com/npm/cli/issues/9151
Ref https://github.com/nodejs/node/issues/62425