### PR TITLE
fix: surface failed package delete during unpublish

### DIFF
--- a/test/lib/commands/unpublish.js
+++ b/test/lib/commands/unpublish.js
@@ -228,6 +228,30 @@ t.test('unpublish <pkg> --force no version set', async t => {
   t.equal(joinedOutput(), '- test-package')
 })
 
+t.test('unpublish <pkg> surfaces a failed whole-package delete', async t => {
+  const { joinedOutput, npm } = await loadMockNpm(t, {
+    config: {
+      force: true,
+      ...auth,
+    },
+  })
+  const registry = new MockRegistry({
+    tap: t,
+    registry: npm.config.get('registry'),
+    authorization: 'test-auth-token',
+  })
+  const manifest = registry.manifest({ name: pkg })
+  await registry.package({ manifest, query: { write: true }, times: 2 })
+  registry.nock.delete(`/${pkg}/-rev/${manifest._rev}`).reply(404)
+
+  await t.rejects(
+    npm.exec('unpublish', ['test-package']),
+    { code: 'E404' },
+    'should reject when the registry delete fails'
+  )
+  t.equal(joinedOutput(), '')
+})
+
 t.test('silent', async t => {
   const { joinedOutput, npm } = await loadMockNpm(t, {
     config: {

--- a/workspaces/libnpmpublish/lib/unpublish.js
+++ b/workspaces/libnpmpublish/lib/unpublish.js
@@ -31,87 +31,88 @@ const unpublish = async (spec, opts) => {
     spec,
   }
 
+  const pkgUri = spec.escapedName
+  let pkg
   try {
-    const pkgUri = spec.escapedName
-    const pkg = await npmFetch.json(pkgUri, {
+    pkg = await npmFetch.json(pkgUri, {
       ...opts,
       query: { write: true },
     })
-
-    const version = spec.rawSpec
-    const allVersions = pkg.versions || {}
-    const versionData = allVersions[version]
-
-    const rawSpecs = (!spec.rawSpec || spec.rawSpec === '*')
-    const onlyVersion = Object.keys(allVersions).length === 1
-    const noVersions = !Object.keys(allVersions).length
-
-    // if missing specific version,
-    // assumed unpublished
-    if (!versionData && !rawSpecs && !noVersions) {
-      return true
-    }
-
-    // unpublish all versions of a package:
-    // - no specs supplied "npm unpublish foo"
-    // - all specs ("*") "npm unpublish foo@*"
-    // - there was only one version
-    // - has no versions field on packument
-    if (rawSpecs || onlyVersion || noVersions) {
-      await npmFetch(`${pkgUri}/-rev/${pkg._rev}`, {
-        ...opts,
-        method: 'DELETE',
-        ignoreBody: true,
-      })
-      return true
-    } else {
-      const dist = allVersions[version].dist
-      delete allVersions[version]
-
-      const latestVer = pkg['dist-tags'].latest
-
-      // deleting dist tags associated to version
-      Object.keys(pkg['dist-tags']).forEach(tag => {
-        if (pkg['dist-tags'][tag] === version) {
-          delete pkg['dist-tags'][tag]
-        }
-      })
-
-      if (latestVer === version) {
-        pkg['dist-tags'].latest = Object.keys(
-          allVersions
-        ).sort(semver.compareLoose).pop()
-      }
-
-      delete pkg._revisions
-      delete pkg._attachments
-
-      // Update packument with removed versions
-      await npmFetch(`${pkgUri}/-rev/${pkg._rev}`, {
-        ...opts,
-        method: 'PUT',
-        body: pkg,
-        ignoreBody: true,
-      })
-
-      // Remove the tarball itself
-      const { _rev } = await npmFetch.json(pkgUri, {
-        ...opts,
-        query: { write: true },
-      })
-      const tarballUrl = getPathname(dist.tarball, opts.registry)
-      await npmFetch(`${tarballUrl}/-rev/${_rev}`, {
-        ...opts,
-        method: 'DELETE',
-        ignoreBody: true,
-      })
-      return true
-    }
   } catch (err) {
     if (err.code !== 'E404') {
       throw err
     }
 
+    return true
+  }
+
+  const version = spec.rawSpec
+  const allVersions = pkg.versions || {}
+  const versionData = allVersions[version]
+
+  const rawSpecs = (!spec.rawSpec || spec.rawSpec === '*')
+  const onlyVersion = Object.keys(allVersions).length === 1
+  const noVersions = !Object.keys(allVersions).length
+
+  // if missing specific version,
+  // assumed unpublished
+  if (!versionData && !rawSpecs && !noVersions) {
+    return true
+  }
+
+  // unpublish all versions of a package:
+  // - no specs supplied "npm unpublish foo"
+  // - all specs ("*") "npm unpublish foo@*"
+  // - there was only one version
+  // - has no versions field on packument
+  if (rawSpecs || onlyVersion || noVersions) {
+    await npmFetch(`${pkgUri}/-rev/${pkg._rev}`, {
+      ...opts,
+      method: 'DELETE',
+      ignoreBody: true,
+    })
+    return true
+  } else {
+    const dist = allVersions[version].dist
+    delete allVersions[version]
+
+    const latestVer = pkg['dist-tags'].latest
+
+    // deleting dist tags associated to version
+    Object.keys(pkg['dist-tags']).forEach(tag => {
+      if (pkg['dist-tags'][tag] === version) {
+        delete pkg['dist-tags'][tag]
+      }
+    })
+
+    if (latestVer === version) {
+      pkg['dist-tags'].latest = Object.keys(
+        allVersions
+      ).sort(semver.compareLoose).pop()
+    }
+
+    delete pkg._revisions
+    delete pkg._attachments
+
+    // Update packument with removed versions
+    await npmFetch(`${pkgUri}/-rev/${pkg._rev}`, {
+      ...opts,
+      method: 'PUT',
+      body: pkg,
+      ignoreBody: true,
+    })
+
+    // Remove the tarball itself
+    const { _rev } = await npmFetch.json(pkgUri, {
+      ...opts,
+      query: { write: true },
+    })
+    const tarballUrl = getPathname(dist.tarball, opts.registry)
+    await npmFetch(`${tarballUrl}/-rev/${_rev}`, {
+      ...opts,
+      method: 'DELETE',
+      ignoreBody: true,
+    })
     return true
   }
 }

--- a/workspaces/libnpmpublish/test/unpublish.js
+++ b/workspaces/libnpmpublish/test/unpublish.js
@@ -107,6 +107,22 @@ t.test('404 considered a success', async t => {
   t.ok(ret, '@npmcli/npm-unpublish-test was unpublished')
 })
 
+t.test('404 from whole-package delete is not considered a success', async t => {
+  const registry = new MockRegistry({
+    tap: t,
+    registry: opts.registry,
+  })
+  const manifest = registry.manifest({ name: '@npmcli/npm-unpublish-test' })
+  const spec = npa(manifest.name)
+  registry.package({ manifest, query: { write: true } })
+  registry.nock.delete(`/${spec.escapedName}/-rev/${manifest._rev}`).reply(404)
+  await t.rejects(
+    unpublish('@npmcli/npm-unpublish-test', opts),
+    { code: 'E404' },
+    'surfaces a failed full-package delete'
+  )
+})
+
 t.test('non-404 errors', async t => {
   const registry = new MockRegistry({
     tap: t,


### PR DESCRIPTION
## Summary
- Treat `E404` as success only when the initial packument fetch reports the package is already gone.
- Surface `404` failures from the full-package delete path instead of returning success.
- Add regressions at both the libnpmpublish and CLI layers for a failed full-package delete.

## Verification
- `source ~/.nvm/nvm.sh && nvm use 22.22.0 >/dev/null && cd /Users/buley/Documents/Code/cli-fix-unpublish-clean && npx tap --no-coverage workspaces/libnpmpublish/test/unpublish.js`
- `source ~/.nvm/nvm.sh && nvm use 22.22.0 >/dev/null && cd /Users/buley/Documents/Code/cli-fix-unpublish-clean && npx tap --no-coverage test/lib/commands/unpublish.js`

## Repro
Before this change, `npm unpublish <pkg> --force` could receive a `DELETE .../-rev/... 404` from the registry, still exit `0`, and print success because libnpmpublish swallowed any `E404` raised anywhere in the unpublish flow.