### PR TITLE
feat: add `u` as alias for `update` command

### DIFF
--- a/lib/utils/cmd-list.js
+++ b/lib/utils/cmd-list.js
@@ -98,6 +98,7 @@ const aliases = {
   i: 'install',
   it: 'install-test',
   cit: 'install-ci-test',
+  u: 'update',
   up: 'update',
   c: 'config',
   s: 'search',

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -81,6 +81,7 @@ Object {
   "sit": "install-ci-test",
   "t": "test",
   "tst": "test",
+  "u": "update",
   "udpate": "update",
   "un": "uninstall",
   "unlink": "uninstall",
@@ -6071,14 +6072,14 @@ Options:
     When set file: protocol dependencies will be packed and installed as
 
 
-aliases: up, upgrade, udpate
+aliases: u, up, upgrade, udpate
 
 Run "npm help update" for more info
 
 \`\`\`bash
 npm update [<pkg>...]
 
-aliases: up, upgrade, udpate
+aliases: u, up, upgrade, udpate
 \`\`\`
 
 #### \`save\`


### PR DESCRIPTION
## Summary

Adds `u` as a short alias for the `update` command, making it consistent with `i` for `install`.

## Motivation

`npm i` is the canonical short form for `npm install` — the most commonly used npm command. However, `npm update` lacks an equivalent single-character alias. The existing `npm up` alias works, but feels inconsistent compared to `i`.

Adding `u` makes the CLI more ergonomic and intuitive:

```sh
npm i    # install   ✅ already exists
npm u    # update    ✅ this PR
```

## Changes

- Added `u: 'update'` alias in `lib/utils/cmd-list.js`, grouped alongside the existing `up: 'update'` alias

## Notes

- `u` is not currently used by any other alias or command, so there is no conflict
- Follows the same pattern as other single-character aliases (`i`, `r`, `t`, `c`, `s`, `v`, `x`)