### PR TITLE
fix: preserve script output lacking a final newline

### DIFF
--- a/lib/utils/display.js
+++ b/lib/utils/display.js
@@ -543,9 +543,8 @@ class Progress {
     if (!this.#rendered) {
       return
     }
-    // Move to the start of the line and clear the rest of the line
-    this.#stream.cursorTo(0)
-    this.#stream.clearLine(1)
+    // Erase the last printed character
+    this.#stream.write('\b \b')
     this.#rendered = false
   }
 }

--- a/test/lib/utils/display.js
+++ b/test/lib/utils/display.js
@@ -96,7 +96,7 @@ t.test('can do progress', async (t) => {
   log.error('', 'after input')
   output.standard('after input')
 
-  t.strictSame([...new Set(outputErrors)].sort(), ['-', '/', '\\', '|'])
+  t.strictSame([...new Set(outputErrors)].sort(), ['\b \b', '-', '/', '\\', '|'])
   t.strictSame(logs, ['error before input', 'error during input', 'error after input'])
   t.strictSame(outputs, ['before input', 'during input', 'after input'])
 })


### PR DESCRIPTION
## Problem
If the script output did not end with a newline, then the last line that was printed to the console would get deleted,
This was due to the `#clearSpinner` method in `Progress` class deleting an entire line, just to erase the spinner.

## Solution
Used control characters to only erase the single spinner character and not the entire line.


## References
Fixes #8583
