### PR TITLE
feat: set default min-release-age to 3 days

### DIFF
--- a/tap-snapshots/test/lib/commands/config.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/config.js.test.cjs
@@ -104,7 +104,7 @@ exports[`test/lib/commands/config.js TAP config list --json > output matches sna
   "name": null,
   "maxsockets": 15,
   "message": "%s",
-  "min-release-age": null,
+  "min-release-age": 3,
   "node-gyp": "{CWD}/node_modules/node-gyp/bin/node-gyp.js",
   "node-options": null,
   "noproxy": [
@@ -283,7 +283,7 @@ logs-max = 10
 ; long = false ; overridden by cli
 maxsockets = 15
 message = "%s"
-min-release-age = null
+min-release-age = 3
 name = null
 node-gyp = "{CWD}/node_modules/node-gyp/bin/node-gyp.js"
 node-options = null

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -1360,7 +1360,7 @@ const definitions = {
     flatten,
   }),
   'min-release-age': new Definition('min-release-age', {
-    default: null,
+    default: 3,
     hint: '<days>',
     type: [null, Number],
     exclusive: ['before'],


### PR DESCRIPTION
## 🛡️ Motivation: Recent Supply Chain Attacks

This change is motivated by a wave of confirmed supply chain attacks in 2025–2026:

| Incident | Date | Impact |
|----------|------|--------|
| [Shai-Hulud npm Worm](https://about.gitlab.com/blog/2025/09/24/shai-hulud-npm-worm/) | Sep 2025 | 200+ npm packages compromised via stolen GitHub tokens; secrets exfiltrated from CI/CD |
| [Trivy GitHub Actions Compromise](https://github.com/aquasecurity/trivy-action/issues/389) | Mar 2026 | Build pipeline of the popular security scanner hijacked; malicious script injection risk |
| [Polyfill.io Domain Hijack](https://www.cisa.gov/news-events/alerts/2024/07/05/cisa-and-partners-release-advisory-polyfillsio-domain-potentially-compromises-100000-websites) | Ongoing | Domain acquisition used to distribute malicious JS to 100,000+ websites |
| [axios npm Compromise](https://socket.dev/blog/axios-npm-package-compromised) | Mar 2026 | Maintainer account takeover; RAT-infected version published |

**Key finding:** According to [Andrew Nesbitt's research](https://nesbitt.io/2026/03/04/package-managers-need-to-cool-down.html), **8 out of 10 recent supply chain attacks were detected and removed within 1 week of publication**. A 3-day cooldown would have blocked most of them automatically.

## 🔧 What This PR Does

Sets the default value of `min-release-age` from `null` (disabled) to `3` (days).

- **Before:** packages are installable immediately after publishing
- **After:** packages must be at least 3 days old before they can be installed by default
- **Opt-out:** users can set `min-release-age=0` in `.npmrc` to restore the previous behavior

## 📋 Compliance Alignment

- **[NIST Cybersecurity Framework (CSF) 2.0](https://www.nist.gov/cyberframework)** — Emphasizes Supply Chain Risk Management (C-SCRM) as a core function
- **[CISA: Securing the Software Supply Chain](https://www.cisa.gov/resources-tools/resources/securing-software-supply-chain-recommended-practices-guide-developers)** — Official US government roadmap recommending proactive dependency vetting

## 🔗 References

- https://nesbitt.io/2026/03/04/package-managers-need-to-cool-down.html
- https://zenn.dev/dely_jp/articles/supply-chain-kowai
