### PR TITLE
feat: add skip-publish-checks

### DIFF
--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -28,6 +28,7 @@ class Publish extends BaseCommand {
     'workspaces',
     'include-workspace-root',
     'provenance',
+    'skip-publish-checks',
   ]
 
   static usage = ['<package-spec>']
@@ -156,7 +157,8 @@ class Publish extends BaseCommand {
       }
     }
 
-    if (!force) {
+    const skipPublishChecks = this.npm.config.get('skip-publish-checks')
+    if (!force && !skipPublishChecks) {
       const { highestVersion, versions } = await this.#registryVersions(resolved, registry)
       /* eslint-disable-next-line max-len */
       const highestVersionIsGreater = !!highestVersion && semver.gte(highestVersion, manifest.version)

--- a/tap-snapshots/test/lib/commands/config.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/config.js.test.cjs
@@ -163,6 +163,7 @@ exports[`test/lib/commands/config.js TAP config list --json > output matches sna
   "shrinkwrap": true,
   "sign-git-commit": false,
   "sign-git-tag": false,
+  "skip-publish-checks": false,
   "strict-peer-deps": false,
   "strict-ssl": true,
   "tag": "latest",
@@ -342,6 +343,7 @@ shell = "{SHELL}"
 shrinkwrap = true
 sign-git-commit = false
 sign-git-tag = false
+skip-publish-checks = false
 strict-peer-deps = false
 strict-ssl = true
 tag = "latest"

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -1757,6 +1757,18 @@ this to work properly.
 
 
 
+#### \`skip-publish-checks\`
+
+* Default: false
+* Type: Boolean
+
+When set to true, npm publish will skip the check that prevents publishing
+versions that already exist in the registry and the check that requires a
+\`--tag\` when the existing highest version is greater than the version being
+published.
+
+
+
 #### \`strict-peer-deps\`
 
 * Default: false
@@ -2407,6 +2419,7 @@ Array [
   "shrinkwrap",
   "sign-git-commit",
   "sign-git-tag",
+  "skip-publish-checks",
   "strict-peer-deps",
   "strict-ssl",
   "tag",
@@ -2563,6 +2576,7 @@ Array [
   "shrinkwrap",
   "sign-git-commit",
   "sign-git-tag",
+  "skip-publish-checks",
   "strict-peer-deps",
   "strict-ssl",
   "tag",
@@ -2738,6 +2752,7 @@ Object {
   "signGitCommit": false,
   "signGitTag": false,
   "silent": false,
+  "skipPublishChecks": false,
   "strictPeerDeps": false,
   "strictSSL": true,
   "tagVersionPrefix": "v",
@@ -5078,6 +5093,7 @@ Options:
 [--tag <tag>] [--access <restricted|public>] [--dry-run] [--otp <otp>]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [--workspaces] [--include-workspace-root] [--provenance|--provenance-file <file>]
+[--skip-publish-checks]
 
   --tag
     If you ask npm to install a package and don't tell it a specific version,
@@ -5103,6 +5119,9 @@ Options:
   --provenance
     When publishing from a supported cloud CI/CD system, the package will be
 
+  --skip-publish-checks
+    When set to true, npm publish will skip the check that prevents
+
 
 Run "npm help publish" for more info
 
@@ -5119,6 +5138,7 @@ npm publish <package-spec>
 #### \`include-workspace-root\`
 #### \`provenance\`
 #### \`provenance-file\`
+#### \`skip-publish-checks\`
 `
 
 exports[`test/lib/docs.js TAP usage query > must match snapshot 1`] = `

--- a/test/lib/commands/publish.js
+++ b/test/lib/commands/publish.js
@@ -990,6 +990,26 @@ t.test('semver highest dist tag', async t => {
     registry.publish(pkg, { noGet: true, packuments })
     await npm.exec('publish', [])
   })
+
+  await t.test('ALLOWS publish when highest is HIGHER with --skip-publish-checks', async t => {
+    const version = '99.0.0'
+    const { npm, registry } = await loadNpmWithRegistry(t, {
+      ...init({ version }),
+      argv: ['--skip-publish-checks'],
+    })
+    registry.publish(pkg, { noGet: true, packuments })
+    await npm.exec('publish', [])
+  })
+
+  await t.test('ALLOWS publish when version EXISTS with --skip-publish-checks', async t => {
+    const version = '100.0.0'
+    const { npm, registry } = await loadNpmWithRegistry(t, {
+      ...init({ version }),
+      argv: ['--skip-publish-checks'],
+    })
+    registry.publish(pkg, { noGet: true, packuments })
+    await npm.exec('publish', [])
+  })
 })
 
 t.test('oidc token exchange - no provenance', t => {

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -2163,6 +2163,17 @@ const definitions = {
     `,
     flatten,
   }),
+  'skip-publish-checks': new Definition('skip-publish-checks', {
+    default: false,
+    type: Boolean,
+    description: `
+      When set to true, npm publish will skip the check that prevents
+      publishing versions that already exist in the registry and the check
+      that requires a \`--tag\` when the existing highest version is greater
+      than the version being published.
+    `,
+    flatten,
+  }),
   'strict-peer-deps': new Definition('strict-peer-deps', {
     default: false,
     type: Boolean,

--- a/workspaces/config/tap-snapshots/test/type-description.js.test.cjs
+++ b/workspaces/config/tap-snapshots/test/type-description.js.test.cjs
@@ -553,6 +553,9 @@ Object {
   "sign-git-tag": Array [
     "boolean value (true or false)",
   ],
+  "skip-publish-checks": Array [
+    "boolean value (true or false)",
+  ],
   "strict-peer-deps": Array [
     "boolean value (true or false)",
   ],


### PR DESCRIPTION


<!-- What / Why -->
Add an explicit option to skip the existing versions checks. These could already be skipped with --force, but that prints a warning and skips all checks.

I work with a 'virtual' npm repository that supports publishing over package versions.


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
