### PR TITLE
fix(arborist): handle scripts set to null during rebuild

### DIFF
--- a/workspaces/arborist/lib/arborist/rebuild.js
+++ b/workspaces/arborist/lib/arborist/rebuild.js
@@ -196,7 +196,7 @@ module.exports = cls => class Builder extends cls {
 
     for (const node of queue) {
       const { package: { bin, scripts = {} } } = node.target
-      const { preinstall, install, postinstall, prepare } = scripts
+      const { preinstall, install, postinstall, prepare } = scripts || {}
       const tests = { bin, preinstall, install, postinstall, prepare }
       for (const [key, has] of Object.entries(tests)) {
         if (has) {
@@ -234,7 +234,7 @@ module.exports = cls => class Builder extends cls {
     const { package: pkg, hasInstallScript } = node.target
     const { gypfile, bin, scripts = {} } = pkg
 
-    const { preinstall, install, postinstall, prepare } = scripts
+    const { preinstall, install, postinstall, prepare } = scripts || {}
     const anyScript = preinstall || install || postinstall || prepare
     if (!refreshed && !anyScript && (hasInstallScript || this.#oldMeta)) {
       // we either have an old metadata (and thus might have scripts)

--- a/workspaces/arborist/test/arborist/rebuild.js
+++ b/workspaces/arborist/test/arborist/rebuild.js
@@ -847,3 +847,19 @@ t.test('do not run lifecycle scripts of linked deps twice', async t => {
   const arb = new Arborist({ path, ignoreScripts: true })
   await arb.rebuild()
 })
+
+t.test('handle scripts: null gracefully', async t => {
+  const path = t.testdir({
+    node_modules: {
+      dep: {
+        'package.json': JSON.stringify({
+          name: 'dep',
+          version: '1.0.0',
+          scripts: null,
+        }),
+      },
+    },
+  })
+  const arb = newArb({ path })
+  await arb.rebuild()
+})


### PR DESCRIPTION
## Bug

Destructuring `scripts` when set to `null` throws a `TypeError`: 

> Cannot destructure property 'preinstall' of 'scripts' as it is null.

## Problem

Even though there (seemingly) is a fallback in place when destructuring an object with `scripts`, this only works for `undefined`:

```js
// `{ pkg: { scripts: undefined } }` --> `scripts` is `{}` (fallback)
// `{ pkg: { scripts: null } }` --> `scripts` is `null` (fallback does not apply)
const { gypfile, bin, scripts = {} } = pkg
```

When dealing with JSON, of course, `undefined` is not even a valid value in the first place, so `null` becomes the go-to alternative.

## Fix

The solution is to handle `scripts` gracefully:

```js
const scripts = null;

const { preinstall, install, postinstall, prepare } = scripts || {}; // Okay

console.log(preinstall); // undefined
console.log(install); // undefined
console.log(postinstall); // undefined
console.log(prepare); // undefined
```

Compared to:

```js
const scripts = null;

const { preinstall, install, postinstall, prepare } = scripts; // Error
```

`|| {}` for `scripts` already exists [in some](https://github.com/npm/cli/blob/latest/workspaces/arborist/lib/isolated-classes.js#L103) [places](https://github.com/npm/cli/blob/latest/workspaces/arborist/lib/node.js#L330), but was missing from [`workspaces/arborist/lib/arborist/rebuild.js`](https://github.com/npm/cli/blob/latest/workspaces/arborist/lib/arborist/rebuild.js).

Note: At least in the following case, `scripts = {}` is still needed, as confirmed by current tests. 

```js
const { gypfile, bin, scripts = {} } = pkg
```

## Test

A test was added to [`workspaces/arborist/test/arborist/rebuild.js`](https://github.com/npm/cli/blob/latest/workspaces/arborist/test/arborist/rebuild.js).

[✓] Without the fix, the test fails.
[✓] After applying the fix, the test passes.

## References

No existing issue could be found.
