### PR TITLE
feat: add a tolerate-republish parameter in npm publish

### DIFF
--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -28,6 +28,7 @@ class Publish extends BaseCommand {
     'workspaces',
     'include-workspace-root',
     'provenance',
+    'tolerate-republish',
   ]
 
   static usage = ['<package-spec>']
@@ -73,6 +74,7 @@ class Publish extends BaseCommand {
     const json = this.npm.config.get('json')
     const defaultTag = this.npm.config.get('tag')
     const ignoreScripts = this.npm.config.get('ignore-scripts')
+    const tolerateRepublish = this.npm.config.get('tolerate-republish')
     const { silent } = this.npm
 
     if (semver.validRange(defaultTag)) {
@@ -162,7 +164,12 @@ class Publish extends BaseCommand {
       const highestVersionIsGreater = !!highestVersion && semver.gte(highestVersion, manifest.version)
 
       if (versions.includes(manifest.version)) {
-        throw new Error(`You cannot publish over the previously published versions: ${manifest.version}.`)
+        if (tolerateRepublish) {
+          log.notice(`Registry already knows about version ${manifest.version}; skipping.`)
+          return
+        } else {
+          throw new Error(`You cannot publish over the previously published versions: ${manifest.version}.`)
+        }
       }
 
       if (highestVersionIsGreater && isDefaultTag) {

--- a/tap-snapshots/test/lib/commands/publish.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/publish.js.test.cjs
@@ -99,7 +99,7 @@ exports[`test/lib/commands/publish.js TAP json > new package json 1`] = `
     {
       "path": "package.json",
       "size": "{size}",
-      "mode": 420
+      "mode": 493
     }
   ],
   "entryCount": 1,
@@ -356,6 +356,24 @@ exports[`test/lib/commands/publish.js TAP tarball > new package json 1`] = `
 + test-tar-package@1.0.0
 `
 
+exports[`test/lib/commands/publish.js TAP tolerate-republish > must match snapshot 1`] = `
+Array [
+  "package: @npmcli/test-package@1.0.0",
+  "Tarball Contents",
+  "95B package.json",
+  "Tarball Details",
+  "name: @npmcli/test-package",
+  "version: 1.0.0",
+  "filename: npmcli-test-package-1.0.0.tgz",
+  "package size: {size}",
+  "unpacked size: 95 B",
+  "shasum: {sha}",
+  "integrity: {integrity}
+  "total files: 1",
+  "Publishing to https://other.registry.npmjs.org/ with tag latest and default access",
+]
+`
+
 exports[`test/lib/commands/publish.js TAP workspaces all workspaces - color > all public workspaces 1`] = `
 + workspace-a@1.2.3-a
 + workspace-b@1.2.3-n
@@ -425,7 +443,7 @@ exports[`test/lib/commands/publish.js TAP workspaces json > all workspaces in js
       {
         "path": "package.json",
         "size": "{size}",
-        "mode": 420
+        "mode": 493
       }
     ],
     "entryCount": 1,
@@ -444,7 +462,7 @@ exports[`test/lib/commands/publish.js TAP workspaces json > all workspaces in js
       {
         "path": "package.json",
         "size": "{size}",
-        "mode": 420
+        "mode": 493
       }
     ],
     "entryCount": 1,
@@ -463,7 +481,7 @@ exports[`test/lib/commands/publish.js TAP workspaces json > all workspaces in js
       {
         "path": "package.json",
         "size": "{size}",
-        "mode": 420
+        "mode": 493
       }
     ],
     "entryCount": 1,

--- a/test/lib/commands/publish.js
+++ b/test/lib/commands/publish.js
@@ -151,6 +151,25 @@ t.test('dry-run', async t => {
   t.matchSnapshot(logs.notice)
 })
 
+t.test('tolerate-republish', async t => {
+  const { npm, joinedOutput, registry, logs } = await loadNpmWithRegistry(t, {
+    config: {
+      registry: alternateRegistry,
+      [`${alternateRegistry.slice(6)}/:_authToken`]: 'test-publish-token',
+    },
+    prefixDir: {
+      'package.json': JSON.stringify(pkgJson, null, 2),
+    },
+    registry: alternateRegistry,
+    authorization: 'test-publish-token',
+    argv: ['--tolerate-republish'],
+  })
+  registry.publish(pkg)
+  await npm.exec('publish', [])
+  t.equal(joinedOutput(), `+ ${pkg}@1.0.0`)
+  t.matchSnapshot(logs.notice)
+})
+
 t.test('foreground-scripts defaults to true', async t => {
   const { outputs, npm, logs, registry } = await loadNpmWithRegistry(t, {
     config: {


### PR DESCRIPTION
## Summary
This pr is adding a tolerate-republish parameter in npm publish like bun and yarn.
This parameter skips the publishing process for packages that version is already exist when you publish.

Command Example:
```
npm publish --tolerate-republish
```

## Why
In a monorepo environment, if you wanted to publish only a single package during a CI/CD process, the only options were to specify the package name via workflow_dispatch in GitHub Actions or to use a package manager like Yarn or Bun that has a tolerate-republish parameter implemented.

This PR implements the tolerate-republish feature, which is already available in Yarn and Bun, into npm.

## References
- https://yarnpkg.com/cli/npm/publish#options
- https://bun.com/docs/pm/cli/publish#tolerate-republish

