### PR TITLE
fix(arborist): propagate overrides through Link nodes to targets

### DIFF
--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -13,7 +13,6 @@ const { lstat, readlink } = require('node:fs/promises')
 const { depth } = require('treeverse')
 const { log, time } = require('proc-log')
 const { redact } = require('@npmcli/redact')
-const semver = require('semver')
 
 const {
   OK,
@@ -294,10 +293,6 @@ module.exports = cls => class IdealTreeBuilder extends cls {
           }).then(meta => Object.assign(root, { meta }))
         } else {
           return this.loadVirtual({ root })
-            .then(tree => {
-              this.#applyRootOverridesToWorkspaces(tree)
-              return tree
-            })
         }
       })
 
@@ -1506,32 +1501,6 @@ This is a one-time fix-up, please be patient...
     }
 
     timeEnd()
-  }
-
-  #applyRootOverridesToWorkspaces (tree) {
-    const rootOverrides = tree.root.package.overrides || {}
-
-    for (const node of tree.root.inventory.values()) {
-      if (!node.isWorkspace) {
-        continue
-      }
-
-      for (const depName of Object.keys(rootOverrides)) {
-        const edge = node.edgesOut.get(depName)
-        const rootNode = tree.root.children.get(depName)
-
-        // safely skip if either edge or rootNode doesn't exist yet
-        if (!edge || !rootNode) {
-          continue
-        }
-
-        const resolvedRootVersion = rootNode.package.version
-        if (!semver.satisfies(resolvedRootVersion, edge.spec)) {
-          edge.detach()
-          node.children.delete(depName)
-        }
-      }
-    }
   }
 
   #idealTreePrune () {

--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -406,6 +406,7 @@ module.exports = cls => class IdealTreeBuilder extends cls {
         global: this.options.global,
         installLinks: this.installLinks,
         legacyPeerDeps: this.legacyPeerDeps,
+        loadOverrides: true,
         root,
       })
     }

--- a/workspaces/arborist/lib/link.js
+++ b/workspaces/arborist/lib/link.js
@@ -109,6 +109,14 @@ class Link extends Node {
   // so this is a no-op
   [_loadDeps] () {}
 
+  // When a Link receives overrides (via edgesIn), forward them to the target node which holds the actual edgesOut.
+  // Without this, overrides stop at the Link and never reach the target's dependency edges.
+  recalculateOutEdgesOverrides () {
+    if (this.target) {
+      this.target.updateOverridesEdgeInAdded(this.overrides)
+    }
+  }
+
   // links can't have children, only their targets can
   // fix it to an empty list so that we can still call
   // things that iterate over them, just as a no-op

--- a/workspaces/arborist/tap-snapshots/test/arborist/load-virtual.js.test.cjs
+++ b/workspaces/arborist/tap-snapshots/test/arborist/load-virtual.js.test.cjs
@@ -16382,15 +16382,18 @@ ArboristNode {
     "arg" => ArboristNode {
       "edgesIn": Set {
         EdgeIn {
-          "error": "INVALID",
           "from": "ws",
           "name": "arg",
+          "override": "4.1.3",
           "spec": "4.1.2",
           "type": "prod",
         },
       },
       "location": "node_modules/arg",
       "name": "arg",
+      "overrides": Map {
+        "arg" => "4.1.3",
+      },
       "path": "{CWD}/test/fixtures/workspaces-with-overrides/node_modules/arg",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "version": "4.1.3",
@@ -16431,8 +16434,8 @@ ArboristNode {
     ArboristNode {
       "edgesOut": Map {
         "arg" => EdgeOut {
-          "error": "INVALID",
           "name": "arg",
+          "override": "4.1.3",
           "spec": "4.1.2",
           "to": "node_modules/arg",
           "type": "prod",
@@ -16441,6 +16444,9 @@ ArboristNode {
       "isWorkspace": true,
       "location": "ws",
       "name": "ws",
+      "overrides": Map {
+        "arg" => "4.1.3",
+      },
       "path": "{CWD}/test/fixtures/workspaces-with-overrides/ws",
       "version": "1.0.0",
     },

--- a/workspaces/arborist/test/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/test/arborist/build-ideal-tree.js
@@ -4064,10 +4064,10 @@ t.test('overrides', async t => {
       '1.1.1',
       'second install: root "abbrev" is still forced to version 1.1.1')
 
-    // Overrides should NOT persist unnecessarily
-    t.notOk(
-      onepackageNode2.overrides && onepackageNode2.overrides.has('abbrev'),
-      'workspace node should not unnecessarily retain overrides after subsequent install'
+    // Workspace targets inherit the root override set via their parent Link node, which is correct behavior needed for proper override propagation through the dependency tree.
+    t.ok(
+      onepackageNode2.overrides,
+      'workspace target inherits root overrides via link propagation'
     )
   })
 })

--- a/workspaces/arborist/test/link.js
+++ b/workspaces/arborist/test/link.js
@@ -207,6 +207,55 @@ t.test('link gets version from target', t => {
   t.end()
 })
 
+t.test('recalculateOutEdgesOverrides forwards overrides to target', t => {
+  const root = new Node({
+    path: '/path/to/root',
+    pkg: {
+      name: 'root',
+      dependencies: { foo: '1.0.0' },
+      overrides: { bar: '2.0.0' },
+    },
+    loadOverrides: true,
+  })
+
+  const target = new Node({
+    path: '/path/to/store/foo',
+    pkg: {
+      name: 'foo',
+      version: '1.0.0',
+      dependencies: { bar: '1.0.0' },
+    },
+    root,
+  })
+
+  const link = new Link({
+    pkg: { name: 'foo', version: '1.0.0' },
+    path: '/path/to/root/node_modules/foo',
+    realpath: '/path/to/store/foo',
+    target,
+    parent: root,
+  })
+
+  // The root has overrides, and the edge from root -> link should propagate them
+  t.ok(root.overrides, 'root has overrides')
+  t.ok(link.overrides, 'link received overrides from root edge')
+  t.ok(link.target.overrides, 'target received overrides forwarded from link')
+
+  // The target's edge to "bar" should have the override applied
+  const barEdge = link.target.edgesOut.get('bar')
+  t.ok(barEdge, 'target has edge to bar')
+  t.ok(barEdge.overrides, 'bar edge has overrides')
+  t.equal(barEdge.spec, '2.0.0', 'bar edge spec is overridden to 2.0.0')
+  t.equal(barEdge.rawSpec, '1.0.0', 'bar edge rawSpec is original 1.0.0')
+
+  // recalculateOutEdgesOverrides is a no-op when target is null
+  link.target = null
+  t.doesNotThrow(() => link.recalculateOutEdgesOverrides(),
+    'no-op when target is null')
+
+  t.end()
+})
+
 t.test('link to root path gets root as target', t => {
   const root = new Node({
     path: '/project/root',


### PR DESCRIPTION
In continuation of our exploration of using `install-strategy=linked` in the [Gutenberg monorepo](https://github.com/WordPress/gutenberg/pull/75814), which powers the WordPress Block Editor.

When using `install-strategy=linked`, npm overrides for transitive dependencies were ignored.
The overridden version was installed but reported as `invalid` instead of `overridden`, and with `strict-peer-deps` the install failed entirely with `ERESOLVE`.

The root cause is that override propagation stops at Link nodes and never reaches their targets.
Overrides propagate through the tree via `addEdgeIn` -> `updateOverridesEdgeInAdded` -> `recalculateOutEdgesOverrides`.
When a Link node receives overrides, `recalculateOutEdgesOverrides` iterates over `this.edgesOut` — but Links have no `edgesOut` (their targets do).
So overrides never reach the target node's dependency edges, and those edges use `rawSpec` instead of the overridden spec.

In the linked strategy, all packages in `node_modules/` are Links pointing to targets in `.store/`.
This meant no overrides propagated past the first level of the dependency tree.

The fix overrides `recalculateOutEdgesOverrides` in the `Link` class to forward overrides to the target node.
When `buildIdealTree` creates a root Link (e.g. on macOS where `/tmp` -> `/private/tmp`), the target Node is now created with `loadOverrides: true` so it loads override rules from `package.json`.

The `#applyRootOverridesToWorkspaces` workaround method is removed — it was compensating for this exact bug by detaching workspace edges whose specs didn't match. With proper propagation, workspace edges already have the correct overridden spec, making the workaround dead code.


## References

Fixes #9197

