### PR TITLE
chore: don't run npm update in CI

### DIFF
--- a/.github/workflows/ci-libnpmaccess.yml
+++ b/.github/workflows/ci-libnpmaccess.yml
@@ -42,10 +42,6 @@ jobs:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps
@@ -109,10 +105,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps

--- a/.github/workflows/ci-libnpmdiff.yml
+++ b/.github/workflows/ci-libnpmdiff.yml
@@ -42,10 +42,6 @@ jobs:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps
@@ -109,10 +105,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps

--- a/.github/workflows/ci-libnpmexec.yml
+++ b/.github/workflows/ci-libnpmexec.yml
@@ -42,10 +42,6 @@ jobs:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps
@@ -109,10 +105,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps

--- a/.github/workflows/ci-libnpmfund.yml
+++ b/.github/workflows/ci-libnpmfund.yml
@@ -42,10 +42,6 @@ jobs:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps
@@ -109,10 +105,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps

--- a/.github/workflows/ci-libnpmhook.yml
+++ b/.github/workflows/ci-libnpmhook.yml
@@ -42,10 +42,6 @@ jobs:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps
@@ -109,10 +105,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps

--- a/.github/workflows/ci-libnpmorg.yml
+++ b/.github/workflows/ci-libnpmorg.yml
@@ -42,10 +42,6 @@ jobs:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps
@@ -109,10 +105,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps

--- a/.github/workflows/ci-libnpmpack.yml
+++ b/.github/workflows/ci-libnpmpack.yml
@@ -42,10 +42,6 @@ jobs:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps
@@ -109,10 +105,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps

--- a/.github/workflows/ci-libnpmpublish.yml
+++ b/.github/workflows/ci-libnpmpublish.yml
@@ -42,10 +42,6 @@ jobs:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps
@@ -109,10 +105,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps

--- a/.github/workflows/ci-libnpmsearch.yml
+++ b/.github/workflows/ci-libnpmsearch.yml
@@ -42,10 +42,6 @@ jobs:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps
@@ -109,10 +105,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps

--- a/.github/workflows/ci-libnpmteam.yml
+++ b/.github/workflows/ci-libnpmteam.yml
@@ -42,10 +42,6 @@ jobs:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps
@@ -109,10 +105,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps

--- a/.github/workflows/ci-libnpmversion.yml
+++ b/.github/workflows/ci-libnpmversion.yml
@@ -42,10 +42,6 @@ jobs:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps
@@ -109,10 +105,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps

--- a/.github/workflows/ci-npmcli-arborist.yml
+++ b/.github/workflows/ci-npmcli-arborist.yml
@@ -42,10 +42,6 @@ jobs:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps
@@ -109,10 +105,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps

--- a/.github/workflows/ci-npmcli-config.yml
+++ b/.github/workflows/ci-npmcli-config.yml
@@ -42,10 +42,6 @@ jobs:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps
@@ -109,10 +105,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps

--- a/.github/workflows/ci-npmcli-docs.yml
+++ b/.github/workflows/ci-npmcli-docs.yml
@@ -42,10 +42,6 @@ jobs:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps
@@ -97,10 +93,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps
@@ -135,10 +127,6 @@ jobs:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps

--- a/.github/workflows/ci-npmcli-mock-globals.yml
+++ b/.github/workflows/ci-npmcli-mock-globals.yml
@@ -42,10 +42,6 @@ jobs:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps
@@ -109,10 +105,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps

--- a/.github/workflows/ci-npmcli-mock-registry.yml
+++ b/.github/workflows/ci-npmcli-mock-registry.yml
@@ -42,10 +42,6 @@ jobs:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps
@@ -109,10 +105,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps

--- a/.github/workflows/ci-npmcli-smoke-tests.yml
+++ b/.github/workflows/ci-npmcli-smoke-tests.yml
@@ -42,10 +42,6 @@ jobs:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps
@@ -109,10 +105,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
           cache: npm
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Check Git Status
         run: node scripts/git-dirty.js
       - name: Reset Deps

--- a/package.json
+++ b/package.json
@@ -255,7 +255,8 @@
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
     "version": "4.29.0",
-    "content": "./scripts/template-oss/root.js"
+    "content": "./scripts/template-oss/root.js",
+    "updateNpm": false
   },
   "license": "Artistic-2.0",
   "engines": {

--- a/scripts/template-oss/index.js
+++ b/scripts/template-oss/index.js
@@ -4,4 +4,5 @@ module.exports = {
   // This is needed while workspaces and npm have different engines.
   // TODO: make npm and its workspaces always use the same engines and delete this.
   npm: 'npm',
+  updateNpm: false,
 }


### PR DESCRIPTION
Backport of ci-no-npm-update to release/v10.

Stop upgrading npm in CI workflows. Node v22 ships with npm@10 but the upgrade path to npm@11 is broken. Use whatever npm ships with Node instead.