### PR TITLE
feat!: remove default license for npm init

### DIFF
--- a/smoke-tests/tap-snapshots/test/index.js.test.cjs
+++ b/smoke-tests/tap-snapshots/test/index.js.test.cjs
@@ -190,7 +190,6 @@ Wrote to {NPM}/{TESTDIR}/project/package.json:
     "test": "echo /"Error: no test specified/" && exit 1"
   },
   "keywords": [],
-  "license": "ISC",
   "type": "commonjs"
 }
 `
@@ -207,7 +206,6 @@ Object {
       "devDependencies": Object {
         "promise-all-reject-late": "^5.0.0",
       },
-      "license": "ISC",
       "name": "project",
       "version": "1.0.0",
     },
@@ -239,7 +237,6 @@ Object {
     "promise-all-reject-late": "^5.0.0",
   },
   "keywords": Array [],
-  "license": "ISC",
   "main": "index.js",
   "name": "project",
   "scripts": Object {
@@ -270,7 +267,6 @@ Object {
       "dependencies": Object {
         "abbrev": "^1.0.4",
       },
-      "license": "ISC",
       "name": "project",
       "version": "1.0.0",
     },
@@ -291,7 +287,6 @@ Object {
   },
   "description": "",
   "keywords": Array [],
-  "license": "ISC",
   "main": "index.js",
   "name": "project",
   "scripts": Object {
@@ -320,7 +315,6 @@ Object {
   },
   "description": "",
   "keywords": Array [],
-  "license": "ISC",
   "main": "index.js",
   "name": "project",
   "scripts": Object {
@@ -339,7 +333,6 @@ Object {
   },
   "description": "",
   "keywords": Array [],
-  "license": "ISC",
   "main": "index.js",
   "name": "project",
   "scripts": Object {
@@ -361,7 +354,7 @@ exports[`test/index.js TAP basic npm pkg > should have expected pkg delete outpu
 `
 
 exports[`test/index.js TAP basic npm pkg > should have expected pkg get output 1`] = `
-ISC
+
 `
 
 exports[`test/index.js TAP basic npm pkg > should have expected pkg set output 1`] = `
@@ -378,7 +371,6 @@ scripts = {
   hello: 'echo Hello'
 }
 keywords = []
-license = 'ISC'
 type = 'commonjs'
 dependencies = { abbrev: '^1.0.4' }
 tap = { 'test-env': [ 'LC_ALL=sk' ] }
@@ -394,7 +386,6 @@ Object {
     "promise-all-reject-late": "^5.0.0",
   },
   "keywords": Array [],
-  "license": "ISC",
   "main": "index.js",
   "name": "project",
   "scripts": Object {
@@ -427,7 +418,6 @@ Object {
       "dependencies": Object {
         "abbrev": "^1.0.4",
       },
-      "license": "ISC",
       "name": "project",
       "version": "1.0.0",
     },
@@ -448,7 +438,6 @@ Object {
   },
   "description": "",
   "keywords": Array [],
-  "license": "ISC",
   "main": "index.js",
   "name": "project",
   "scripts": Object {
@@ -476,7 +465,6 @@ Object {
       "devDependencies": Object {
         "promise-all-reject-late": "^5.0.0",
       },
-      "license": "ISC",
       "name": "project",
       "version": "1.0.0",
     },
@@ -508,7 +496,6 @@ Object {
     "promise-all-reject-late": "^5.0.0",
   },
   "keywords": Array [],
-  "license": "ISC",
   "main": "index.js",
   "name": "project",
   "scripts": Object {

--- a/tap-snapshots/test/lib/commands/config.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/config.js.test.cjs
@@ -90,7 +90,7 @@ exports[`test/lib/commands/config.js TAP config list --json > output matches sna
   "init.author.email": "",
   "init.author.name": "",
   "init.author.url": "",
-  "init.license": "ISC",
+  "init.license": "",
   "init.module": "{CWD}/home/.npm-init.js",
   "init.version": "1.0.0",
   "install-links": false,
@@ -271,7 +271,7 @@ include-workspace-root = false
 init-author-email = ""
 ; init-author-name = "" ; overridden by user
 init-author-url = ""
-; init-license = "ISC" ; overridden by global
+; init-license = "" ; overridden by global
 init-module = "{CWD}/home/.npm-init.js"
 init-private = false
 init-type = "commonjs"
@@ -279,7 +279,7 @@ init-version = "1.0.0"
 init.author.email = ""
 init.author.name = ""
 init.author.url = ""
-init.license = "ISC"
+init.license = ""
 init.module = "{CWD}/home/.npm-init.js"
 init.version = "1.0.0"
 install-links = false

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -1044,10 +1044,11 @@ homepage.
 
 #### \`init-license\`
 
-* Default: "ISC"
+* Default: ""
 * Type: String
 
-The value \`npm init\` should use by default for the package license.
+The value \`npm init\` should use by default for the package license. If not
+set, the license field will be omitted from new packages.
 
 
 
@@ -2356,7 +2357,7 @@ Alias for \`--init-author-url\`
 
 #### \`init.license\`
 
-* Default: "ISC"
+* Default: ""
 * Type: String
 * DEPRECATED: Use \`--init-license\` instead.
 

--- a/test/lib/commands/init.js
+++ b/test/lib/commands/init.js
@@ -43,7 +43,7 @@ t.test('classic npm init -y', async t => {
 
   const pkg = require(resolve(prefix, 'package.json'))
   t.equal(pkg.version, '1.0.0')
-  t.equal(pkg.license, 'ISC')
+  t.equal(pkg.license, undefined, 'license is omitted by default')
 })
 
 t.test('classic interactive npm init', async t => {
@@ -273,7 +273,7 @@ t.test('workspaces', async t => {
     const pkg = require(resolve(prefix, 'a/package.json'))
     t.equal(pkg.name, 'a')
     t.equal(pkg.version, '1.0.0')
-    t.equal(pkg.license, 'ISC')
+    t.equal(pkg.license, undefined, 'license is omitted by default')
 
     t.matchSnapshot(joinedOutput(), 'should print helper info')
 
@@ -306,7 +306,7 @@ t.test('workspaces', async t => {
     const pkg = require(resolve(prefix, 'packages/a/package.json'))
     t.equal(pkg.name, 'a')
     t.equal(pkg.version, '2.0.0')
-    t.equal(pkg.license, 'ISC')
+    t.equal(pkg.license, undefined, 'license is omitted by default')
   })
 
   await t.test('fail parsing top-level package.json to set workspace', async t => {
@@ -422,12 +422,12 @@ t.test('workspaces', async t => {
 
     const pkg = require(resolve(npm.localPrefix, 'package.json'))
     t.equal(pkg.version, '1.0.0')
-    t.equal(pkg.license, 'ISC')
+    t.equal(pkg.license, undefined, 'license is omitted by default')
     t.strictSame(pkg.workspaces, ['packages/a'])
 
     const ws = require(resolve(npm.localPrefix, 'packages/a/package.json'))
     t.equal(ws.version, '1.0.0')
-    t.equal(ws.license, 'ISC')
+    t.equal(ws.license, undefined, 'license is omitted by default')
   })
   t.test('init pkg - installed workspace package', async t => {
     const { npm } = await mockNpm(t, {

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -1121,11 +1121,12 @@ const definitions = {
     `,
   }),
   'init-license': new Definition('init-license', {
-    default: 'ISC',
+    default: '',
     hint: '<license>',
     type: String,
     description: `
       The value \`npm init\` should use by default for the package license.
+      If not set, the license field will be omitted from new packages.
     `,
   }),
   'init-module': new Definition('init-module', {
@@ -1196,7 +1197,7 @@ const definitions = {
     `,
   }),
   'init.license': new Definition('init.license', {
-    default: 'ISC',
+    default: '',
     type: String,
     deprecated: `
       Use \`--init-license\` instead.


### PR DESCRIPTION
BREAKING CHANGE: The default license for `npm init` has been changed from "ISC" to an empty string. If not set, the license field will be omitted from new packages.

This will need https://github.com/npm/init-package-json/pull/351
Closes https://github.com/npm/statusboard/issues/970