### PR TITLE
fix: sync json output of pack and publish

### DIFF
--- a/lib/commands/pack.js
+++ b/lib/commands/pack.js
@@ -62,10 +62,8 @@ class Pack extends BaseCommand {
       tarballs.push(await getContents(manifest, tarballData))
     }
 
-    for (const [index, tar] of Object.entries(tarballs)) {
-      // XXX(BREAKING_CHANGE): publish outputs a json object with package names as keys.
-      // Pack should do the same here instead of an array
-      logTar(tar, { unicode, json, key: index })
+    for (const tar of tarballs) {
+      logTar(tar, { unicode, json, key: tar.name })
       if (!json) {
         output.standard(tar.filename.replace(/^@/, '').replace(/\//, '-'))
       }

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -106,7 +106,7 @@ class Publish extends BaseCommand {
       workspaces: this.workspacePaths,
     })
     const pkgContents = await getContents(manifest, tarballData)
-    const logPkg = () => logTar(pkgContents, { unicode, json, key: workspace })
+    const logPkg = () => logTar(pkgContents, { unicode, json, key: pkgContents.name })
 
     // The purpose of re-reading the manifest is in case it changed, so that we send the latest and greatest thing to the registry note that publishConfig might have changed as well!
     manifest = await this.#getManifest(spec, opts, true)

--- a/lib/utils/display.js
+++ b/lib/utils/display.js
@@ -90,6 +90,8 @@ const getArrayOrObject = (items) => {
       return foundNonObject
     }
     // We use objects with 0,1,2,etc keys to merge array
+    // We don't currently use this but want to allow for it again
+    // istanbul ignore next
     if (items.every((o, i) => Object.hasOwn(o, i))) {
       return Object.assign([], ...items)
     }

--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -9,7 +9,7 @@ const localeCompare = require('@isaacs/string-locale-compare')('en', {
 
 const logTar = (tarball, { unicode = false, json, key } = {}) => {
   if (json) {
-    output.buffer(key == null ? tarball : { [key]: tarball })
+    output.buffer({ [key]: tarball })
     return
   }
   log.notice('')

--- a/tap-snapshots/test/lib/commands/pack.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/pack.js.test.cjs
@@ -62,8 +62,8 @@ Array []
 
 exports[`test/lib/commands/pack.js TAP should log output as valid json > outputs as json 1`] = `
 Array [
-  Array [
-    Object {
+  Object {
+    "test-package": Object {
       "bundled": Array [],
       "entryCount": 1,
       "filename": "test-package-1.0.0.tgz",
@@ -82,7 +82,7 @@ Array [
       "unpackedSize": 41,
       "version": "1.0.0",
     },
-  ],
+  },
 ]
 `
 
@@ -92,8 +92,8 @@ Array []
 
 exports[`test/lib/commands/pack.js TAP should log scoped package output as valid json > outputs as json 1`] = `
 Array [
-  Array [
-    Object {
+  Object {
+    "@myscope/test-package": Object {
       "bundled": Array [],
       "entryCount": 1,
       "filename": "myscope-test-package-1.0.0.tgz",
@@ -112,7 +112,7 @@ Array [
       "unpackedSize": 88,
       "version": "1.0.0",
     },
-  ],
+  },
 ]
 `
 

--- a/tap-snapshots/test/lib/commands/publish.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/publish.js.test.cjs
@@ -87,23 +87,25 @@ Array [
 
 exports[`test/lib/commands/publish.js TAP json > new package json 1`] = `
 {
-  "id": "@npmcli/test-package@1.0.0",
-  "name": "@npmcli/test-package",
-  "version": "1.0.0",
-  "size": "{size}",
-  "unpackedSize": 95,
-  "shasum": "{sha}",
-  "integrity": "{integrity}",
-  "filename": "npmcli-test-package-1.0.0.tgz",
-  "files": [
-    {
-      "path": "package.json",
-      "size": "{size}",
-      "mode": 420
-    }
-  ],
-  "entryCount": 1,
-  "bundled": []
+  "@npmcli/test-package": {
+    "id": "@npmcli/test-package@1.0.0",
+    "name": "@npmcli/test-package",
+    "version": "1.0.0",
+    "size": "{size}",
+    "unpackedSize": 95,
+    "shasum": "{sha}",
+    "integrity": "{integrity}",
+    "filename": "npmcli-test-package-1.0.0.tgz",
+    "files": [
+      {
+        "path": "package.json",
+        "size": "{size}",
+        "mode": 420
+      }
+    ],
+    "entryCount": 1,
+    "bundled": []
+  }
 }
 `
 


### PR DESCRIPTION
BREAKING CHANGE: the --json output of `npm pack` and `npm publish` have changed.  They are now always consistent, and in the same format.

Previously, `npm pack` would output an array of entries and `npm publish` an object.  The `npm publish` object also changed forms depending on if workspaces were being published.

Now, the output is always an object with the package name as the top level index.

fixes https://github.com/npm/statusboard/issues/1073
