### PR TITLE
feat: support jsr and github aliases

### DIFF
--- a/test/lib/utils/alias-auth-routing.js
+++ b/test/lib/utils/alias-auth-routing.js
@@ -1,0 +1,69 @@
+const t = require('tap')
+const fetch = require('npm-registry-fetch')
+const npa = require('npm-package-arg')
+
+// Locks in the contract that alias fetches route through the *target*
+// registry's auth, not the default registry's. The contract spans two
+// vendored packages — pacote unwraps spec.subSpec before fetching, and
+// npm-registry-fetch picks registry + auth from that subSpec's scope — so
+// a regression in either dep bump would break alias auth silently. These
+// tests call the same public npm-registry-fetch exports pacote uses, with
+// the inputs pacote produces for each alias type.
+
+t.test('pickRegistry: jsr: alias routes via subSpec.scope (@jsr)', async t => {
+  const { subSpec } = npa('foo@jsr:@scope/name@1.0.0')
+  const registry = fetch.pickRegistry(subSpec, {
+    '@jsr:registry': 'https://npm.jsr.io/',
+    registry: 'https://registry.npmjs.org/',
+  })
+  t.equal(registry, 'https://npm.jsr.io/')
+})
+
+t.test('pickRegistry: github: alias routes via subSpec.scope (@<owner>)', async t => {
+  const { subSpec } = npa('foo@github:@owner/name@1.0.0')
+  const registry = fetch.pickRegistry(subSpec, {
+    '@owner:registry': 'https://npm.pkg.github.com/',
+    registry: 'https://registry.npmjs.org/',
+  })
+  t.equal(registry, 'https://npm.pkg.github.com/')
+})
+
+t.test('getAuth: jsr: alias returns the JSR registry token', async t => {
+  // pickRegistry + getAuth together are the full pacote → registry-fetch
+  // handoff for deciding which credentials accompany an alias fetch.
+  const opts = {
+    '@jsr:registry': 'https://npm.jsr.io/',
+    '//npm.jsr.io/:_authToken': 'jsr-secret',
+    registry: 'https://registry.npmjs.org/',
+    '//registry.npmjs.org/:_authToken': 'npm-secret',
+  }
+  const { subSpec } = npa('foo@jsr:@scope/name@1.0.0')
+  const registry = fetch.pickRegistry(subSpec, opts)
+  const auth = fetch.getAuth(registry, opts)
+  t.equal(auth.token, 'jsr-secret',
+    'alias auth comes from the JSR token, not the default-registry token')
+})
+
+t.test('getAuth: github: alias returns the GitHub Packages token', async t => {
+  const opts = {
+    '@owner:registry': 'https://npm.pkg.github.com/',
+    '//npm.pkg.github.com/:_authToken': 'gh-secret',
+    registry: 'https://registry.npmjs.org/',
+    '//registry.npmjs.org/:_authToken': 'npm-secret',
+  }
+  const { subSpec } = npa('foo@github:@owner/name@1.0.0')
+  const registry = fetch.pickRegistry(subSpec, opts)
+  const auth = fetch.getAuth(registry, opts)
+  t.equal(auth.token, 'gh-secret')
+})
+
+t.test('pickRegistry: npm: alias with unscoped target falls through to opts.registry', async t => {
+  // npm: aliases with an unscoped target have no scope on the subSpec, so
+  // registry selection drops through to opts.registry. Fences the generic
+  // alias-unwrap path from accidentally diverging for the oldest prefix.
+  const { subSpec } = npa('foo@npm:lodash@^4')
+  const registry = fetch.pickRegistry(subSpec, {
+    registry: 'https://registry.npmjs.org/',
+  })
+  t.equal(registry, 'https://registry.npmjs.org/')
+})

--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -1432,7 +1432,21 @@ module.exports = cls => class Reifier extends cls {
 
           const pname = child.packageName
           const alias = name !== pname
-          newSpec = alias ? `npm:${pname}@${range}` : range
+          if (alias) {
+            // Preserve the original alias prefix (npm:, jsr:, github:) so
+            // round-tripping a package.json keeps the author's intent.
+            // For jsr:, save the scoped source name (e.g. @scope/pkg) rather
+            // than the internal @jsr/scope__pkg form.
+            if (req.aliasType === 'jsr' && req.jsrName) {
+              newSpec = `jsr:${req.jsrName}@${range}`
+            } else if (req.aliasType === 'github') {
+              newSpec = `github:${pname}@${range}`
+            } else {
+              newSpec = `npm:${pname}@${range}`
+            }
+          } else {
+            newSpec = range
+          }
         } else if (req.hosted) {
           // save the git+https url if it has auth; otherwise, shortcut
           const h = req.hosted

--- a/workspaces/arborist/test/arborist/reify.js
+++ b/workspaces/arborist/test/arborist/reify.js
@@ -1281,6 +1281,77 @@ t.test('saving the ideal tree', t => {
     })
   })
 
+  t.test('save-spec round-trip preserves alias prefix per aliasType', async t => {
+    // For each of the three alias prefixes npm-package-arg recognizes,
+    // reify must write the dep back to package.json in a form that re-parses
+    // to the same intent. jsr: specifically must NOT leak the internal
+    // @jsr/<scope>__<name> form into package.json — that name is an
+    // on-registry detail and would break round-tripping through pnpm/yarn.
+    createRegistry(t, false)
+    const pkg = {
+      dependencies: {
+        // npm: existing behavior — saves with the target package's name.
+        legacy: 'npm:lodash@^4',
+        // jsr: must save the source scoped name, not @jsr/<scope>__<name>.
+        jsrdep: 'jsr:@scope/name@^1',
+        // github: keeps the scoped name as-is (GitHub Packages doesn't remap).
+        ghdep: 'github:@owner/name@^1',
+      },
+    }
+
+    const npa = require('npm-package-arg')
+    const kResolvedAdd = Symbol.for('resolvedAdd')
+    const path = t.testdir({
+      'package.json': JSON.stringify(pkg),
+    })
+    const a = newArb({ path })
+    const tree = await a.loadActual()
+    const meta = await Shrinkwrap.load({ path })
+    tree.meta = meta
+    meta.add(tree)
+    a.idealTree = tree
+
+    // Simulated installed nodes. packageName on each reflects what the
+    // target registry actually serves — that's the value reify reads to
+    // decide the saved spec's form.
+    new Node({
+      name: 'legacy',
+      resolved: 'https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz',
+      pkg: { name: 'lodash', version: '4.17.21' },
+      parent: tree,
+    })
+    new Node({
+      name: 'jsrdep',
+      resolved: 'https://npm.jsr.io/@jsr/scope__name/-/scope__name-1.2.3.tgz',
+      pkg: { name: '@jsr/scope__name', version: '1.2.3' },
+      parent: tree,
+    })
+    new Node({
+      name: 'ghdep',
+      resolved: 'https://npm.pkg.github.com/@owner/name/-/name-1.2.3.tgz',
+      pkg: { name: '@owner/name', version: '1.2.3' },
+      parent: tree,
+    })
+
+    a[kResolvedAdd] = [
+      npa('legacy@npm:lodash@^4'),
+      npa('jsrdep@jsr:@scope/name@^1'),
+      npa('ghdep@github:@owner/name@^1'),
+    ].map(spec => Object.assign(spec, { tree }))
+
+    await a[kSaveIdealTree]({})
+    const saved = JSON.parse(fs.readFileSync(path + '/package.json', 'utf8'))
+
+    t.equal(saved.dependencies.legacy, 'npm:lodash@^4.17.21',
+      'npm: alias saves with target package name')
+    t.equal(saved.dependencies.jsrdep, 'jsr:@scope/name@^1.2.3',
+      'jsr: alias saves the user-written scoped name, not @jsr/scope__name')
+    t.notMatch(saved.dependencies.jsrdep, '@jsr/scope__name',
+      'jsr: saved form must not leak the internal @jsr/<scope>__<name>')
+    t.equal(saved.dependencies.ghdep, 'github:@owner/name@^1.2.3',
+      'github: alias keeps the scoped name as-is')
+  })
+
   t.end()
 })
 


### PR DESCRIPTION
See https://github.com/pnpm/pnpm/pull/11324 for explanation of the problem it solves.

This PR teaches arborist to save jsr: / github: alias prefixes back to package.json so an install/reinstall cycle preserves the user's original spec. The `npm-package-arg` PR handles parsing; this PR handles the save side. Fetch + auth routing already work unchanged - pacote and npm-registry-fetch unwrap alias specs to their subSpec, which carries the target scope (@jsr / @<owner>) used for both pickRegistry and auth lookup.

## References
Depends on https://github.com/npm/npm-package-arg/pull/221
