### PR TITLE
feat!: Remove Twitter and Freenode profile fields

### DIFF
--- a/docs/lib/content/commands/npm-profile.md
+++ b/docs/lib/content/commands/npm-profile.md
@@ -22,15 +22,13 @@ email: e@example.com (verified)
 two-factor auth: auth-and-writes
 fullname: Example User
 homepage:
-freenode:
-twitter:
 github:
 created: 2015-02-26T01:38:35.892Z
 updated: 2017-10-02T21:29:45.922Z
 ```
 
 * `npm profile set <property> <value>`: Set the value of a profile property.
-You can set the following properties this way: email, fullname, homepage, freenode, twitter, github
+You can set the following properties this way: email, fullname, homepage, github
 
 * `npm profile set password`: Change your password.
 This is interactive, you'll be prompted for your current password and a new password.

--- a/lib/commands/profile.js
+++ b/lib/commands/profile.js
@@ -16,8 +16,6 @@ const knownProfileKeys = [
   'two-factor auth',
   'fullname',
   'homepage',
-  'freenode',
-  'twitter',
   'github',
   'created',
   'updated',
@@ -28,8 +26,6 @@ const writableProfileKeys = [
   'password',
   'fullname',
   'homepage',
-  'freenode',
-  'twitter',
   'github',
 ]
 

--- a/tap-snapshots/test/lib/commands/profile.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/profile.js.test.cjs
@@ -40,8 +40,6 @@ created	2015-02-26T01:26:37.384Z
 updated	2020-08-12T16:19:35.326Z
 fullname	Foo Bar
 homepage	https://github.com
-freenode	foobar
-twitter	https://twitter.com/npmjs
 github	https://github.com/npm
 `
 
@@ -51,8 +49,6 @@ email: foo@github.com (verified)
 two-factor auth: auth-and-writes
 fullname: Foo Bar
 homepage: https://github.com
-freenode: foobar
-twitter: https://twitter.com/npmjs
 github: https://github.com/npm
 created: 2015-02-26T01:26:37.384Z
 updated: 2020-08-12T16:19:35.326Z
@@ -64,8 +60,6 @@ email: foo@github.com (verified)
 two-factor auth: disabled
 fullname: Foo Bar
 homepage: https://github.com
-freenode: foobar
-twitter: https://twitter.com/npmjs
 github: https://github.com/npm
 created: 2015-02-26T01:26:37.384Z
 updated: 2020-08-12T16:19:35.326Z
@@ -77,8 +71,6 @@ email: foo@github.com (verified)
 two-factor auth: auth-and-writes
 fullname: Foo Bar
 homepage: https://github.com
-freenode: foobar
-twitter: https://twitter.com/npmjs
 github: https://github.com/npm
 created: 2015-02-26T01:26:37.384Z
 updated: 2020-08-12T16:19:35.326Z
@@ -91,8 +83,6 @@ email: foo@github.com(unverified)
 two-factor auth: auth-and-writes
 fullname: Foo Bar
 homepage: https://github.com
-freenode: foobar
-twitter: https://twitter.com/npmjs
 github: https://github.com/npm
 created: 2015-02-26T01:26:37.384Z
 updated: 2020-08-12T16:19:35.326Z

--- a/test/lib/commands/profile.js
+++ b/test/lib/commands/profile.js
@@ -55,8 +55,6 @@ const userProfile = {
   cidr_whitelist: null,
   fullname: 'Foo Bar',
   homepage: 'https://github.com',
-  freenode: 'foobar',
-  twitter: 'https://twitter.com/npmjs',
   github: 'https://github.com/npm',
 }
 


### PR DESCRIPTION
BREAKING CHANGE: The Twitter and Freenode profile fields have been removed from the npm registry. This means that users will no longer be able to set or view these fields in their npm profiles.
