### PR TITLE
fix!: align CycloneDX SBOM component names with SPDX

### DIFF
--- a/lib/utils/sbom-cyclonedx.js
+++ b/lib/utils/sbom-cyclonedx.js
@@ -106,7 +106,7 @@ const toCyclonedxItem = (node, { packageType }) => {
   const component = {
     'bom-ref': toCyclonedxID(node),
     type: packageType,
-    name: node.name,
+    name: node.packageName,
     version: node.version,
     scope: (node.optional || node.devOptional) ? 'optional' : 'required',
     author: (typeof node.package?.author === 'object')

--- a/tap-snapshots/test/lib/commands/sbom.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/sbom.js.test.cjs
@@ -255,7 +255,7 @@ exports[`test/lib/commands/sbom.js TAP sbom basic sbom - cyclonedx > must match 
     "component": {
       "bom-ref": "test-npm-sbom@1.0.0",
       "type": "application",
-      "name": "prefix",
+      "name": "test-npm-sbom",
       "version": "1.0.0",
       "scope": "required",
       "purl": "pkg:npm/test-npm-sbom@1.0.0",
@@ -457,7 +457,7 @@ exports[`test/lib/commands/sbom.js TAP sbom duplicate deps - cyclonedx > must ma
     "component": {
       "bom-ref": "test-npm-sbom@1.0.0",
       "type": "library",
-      "name": "prefix",
+      "name": "test-npm-sbom",
       "version": "1.0.0",
       "scope": "required",
       "purl": "pkg:npm/test-npm-sbom@1.0.0",

--- a/test/lib/utils/sbom-cyclonedx.js
+++ b/test/lib/utils/sbom-cyclonedx.js
@@ -83,6 +83,19 @@ t.test('single node - package lock only', t => {
   t.end()
 })
 
+t.test('single node - uses package name for root component name', t => {
+  const node = {
+    ...root,
+    name: '',
+    packageName: '@scope/root-package',
+    pkgid: '@scope/root-package@1.0.0',
+  }
+  const res = cyclonedxOutput({ npm, nodes: [node] })
+  t.equal(res.metadata.component.name, '@scope/root-package')
+  t.equal(res.metadata.component['bom-ref'], '@scope/root-package@1.0.0')
+  t.end()
+})
+
 t.test('single node - optional ', t => {
   const node = { ...root, optional: true }
   const res = cyclonedxOutput({ npm, nodes: [node] })


### PR DESCRIPTION
BREAKING CHANGE: `npm sbom --sbom-format=cyclonedx` now reports the `name` field from each package's `package.json` instead of the on-disk directory name. The `name`, `bom-ref`, and `purl` of the root component and of aliased dependencies may change.

fixes: #9178 