### PR TITLE
fix(config): preserve min-release-age after flattening

### DIFF
--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -1378,7 +1378,6 @@ const definitions = {
       if (obj['min-release-age'] !== null) {
         flatOptions.before = new Date(Date.now() - (86400000 * obj['min-release-age']))
         obj.before = flatOptions.before
-        delete obj['min-release-age']
       }
     },
   }),

--- a/workspaces/config/test/index.js
+++ b/workspaces/config/test/index.js
@@ -1867,4 +1867,5 @@ t.test('before and min-release-age', async t => {
   await config.load()
   // Simple gut check to make sure we didn't do + instead of -
   t.ok(config.flat.before < Date.now(), 'before date is in the past not the future')
+  t.equal(config.get('min-release-age'), 30, 'min-release-age config remains readable after flattening')
 })


### PR DESCRIPTION
Fixes #9199.

`min-release-age` derives a `before` date while config is flattened, but the flatten hook also deleted the original `min-release-age` value from the loaded config data. After anything read `config.flat`, `npm config get min-release-age` and `npm config ls --long` reported `null` even when the user had configured a value.

This keeps the configured `min-release-age` value readable while still deriving `flat.before` for package resolution.

Before this change:

```bash
node . config get min-release-age --userconfig "$tmp/npmrc"
# null
```

After this change:

```bash
node . config get min-release-age --userconfig "$tmp/npmrc"
# 5
```

Validation:

```bash
npm test --ignore-scripts
npm run lint --ignore-scripts --workspace @npmcli/config
npm run postlint --ignore-scripts --workspace @npmcli/config
git diff --check
```
