### PR TITLE
fix(arborist): prune removed-workspace entries from package-lock.json

### DIFF
--- a/workspaces/arborist/lib/shrinkwrap.js
+++ b/workspaces/arborist/lib/shrinkwrap.js
@@ -905,6 +905,10 @@ class Shrinkwrap {
           continue
         }
         const loc = relpath(this.path, node.path)
+        // Drop lockfile entries for extraneous nodes outside node_modules. These are stale workspace entries: the workspace was removed from package.json or its directory was deleted, so it should not be tracked in package-lock.json.
+        if (node.extraneous && !/(^|\/)node_modules\//.test(loc) && loc !== 'node_modules') {
+          continue
+        }
         this.data.packages[loc] = Shrinkwrap.metaFromNode(
           node,
           this.path,

--- a/workspaces/arborist/tap-snapshots/test/arborist/reify.js.test.cjs
+++ b/workspaces/arborist/tap-snapshots/test/arborist/reify.js.test.cjs
@@ -3183,10 +3183,6 @@ exports[`test/arborist/reify.js TAP filtered reification in workspaces > hidden 
     "apps/x": {
       "version": "1.2.3"
     },
-    "foo/x": {
-      "version": "1.2.3",
-      "extraneous": true
-    },
     "node_modules/c": {
       "resolved": "packages/c",
       "link": true
@@ -32369,9 +32365,6 @@ Object {
       "workspaces": Array [
         "e",
       ],
-    },
-    "e": Object {
-      "extraneous": true,
     },
     "node_modules/a": Object {
       "extraneous": true,

--- a/workspaces/arborist/tap-snapshots/test/shrinkwrap.js.test.cjs
+++ b/workspaces/arborist/tap-snapshots/test/shrinkwrap.js.test.cjs
@@ -2734,14 +2734,6 @@ Object {
       "name": "example",
       "version": "1.0.0",
     },
-    "../bar": Object {
-      "extraneous": true,
-      "version": "1.0.0",
-    },
-    "../linked-node-modules/foo": Object {
-      "extraneous": true,
-      "version": "1.0.0",
-    },
     "node_modules/bar": Object {
       "link": true,
       "resolved": "../bar",
@@ -9755,16 +9747,6 @@ Object {
     "": Object {
       "name": "workspace3",
     },
-    "app": Object {
-      "dependencies": Object {
-        "a": "",
-        "b": "",
-        "c": "",
-        "i": "",
-      },
-      "extraneous": true,
-      "version": "1.2.3",
-    },
     "app/node_modules/i": Object {
       "extraneous": true,
       "version": "1.2.3",
@@ -9785,38 +9767,11 @@ Object {
       "link": true,
       "resolved": "packages/c",
     },
-    "packages/a": Object {
-      "dependencies": Object {
-        "b": "",
-        "c": "",
-        "x": "",
-      },
-      "extraneous": true,
-      "version": "1.2.3",
-    },
     "packages/a/node_modules/x": Object {
       "extraneous": true,
       "version": "1.2.3",
     },
-    "packages/b": Object {
-      "dependencies": Object {
-        "a": "",
-        "c": "",
-        "y": "",
-      },
-      "extraneous": true,
-      "version": "1.2.3",
-    },
     "packages/b/node_modules/y": Object {
-      "extraneous": true,
-      "version": "1.2.3",
-    },
-    "packages/c": Object {
-      "dependencies": Object {
-        "a": "",
-        "b": "",
-        "z": "",
-      },
       "extraneous": true,
       "version": "1.2.3",
     },

--- a/workspaces/arborist/test/arborist/reify.js
+++ b/workspaces/arborist/test/arborist/reify.js
@@ -1960,6 +1960,65 @@ t.test('filtered reification in workspaces', async t => {
     'hidden lockfile - foo/x linked, c, old x, removed a')
 })
 
+// Regression for https://github.com/npm/cli/issues/5463: a workspace whose directory has been deleted should not leave behind an extraneous entry (or a lingering reference in the root's workspaces array) in package-lock.json after `npm install`.
+t.test('removed workspace is pruned from package-lock.json', async t => {
+  const setup = () => {
+    const path = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'remove-ws',
+        version: '1.0.0',
+        workspaces: ['packages/a', 'packages/b'],
+      }),
+      packages: {
+        a: {
+          'package.json': JSON.stringify({ name: 'a', version: '1.0.0' }),
+        },
+        b: {
+          'package.json': JSON.stringify({ name: 'b', version: '1.0.0' }),
+        },
+      },
+    })
+    return path
+  }
+
+  // The lockfile's root.workspaces array mirrors package.json verbatim and is intentionally not mutated here, so we only assert that orphan package/link entries are dropped.
+  const assertClean = (t, path, label) => {
+    const lock = JSON.parse(fs.readFileSync(`${path}/package-lock.json`, 'utf8'))
+    t.notOk(lock.packages['packages/b'],
+      `${label}: packages/b entry removed from lockfile`)
+    t.notOk(lock.packages['node_modules/b'],
+      `${label}: node_modules/b link removed from lockfile`)
+    t.notOk(lock.dependencies && lock.dependencies.b,
+      `${label}: dependencies.b removed from legacy lockfile`)
+  }
+
+  for (const strategy of ['hoisted', 'linked']) {
+    t.test(`${strategy} strategy, package.json kept stale`, async t => {
+      const path = setup()
+      createRegistry(t, false)
+      await reify(path, { installStrategy: strategy })
+      // Remove only the directory, leave package.json's workspaces array alone.
+      fs.rmSync(`${path}/packages/b`, { recursive: true, force: true })
+      await reify(path, { installStrategy: strategy })
+      assertClean(t, path, `${strategy}/keep-pj`)
+    })
+
+    t.test(`${strategy} strategy, package.json updated`, async t => {
+      const path = setup(strategy)
+      createRegistry(t, false)
+      await reify(path, { installStrategy: strategy })
+      fs.rmSync(`${path}/packages/b`, { recursive: true, force: true })
+      fs.writeFileSync(`${path}/package.json`, JSON.stringify({
+        name: 'remove-ws',
+        version: '1.0.0',
+        workspaces: ['packages/a'],
+      }))
+      await reify(path, { installStrategy: strategy })
+      assertClean(t, path, `${strategy}/clean-pj`)
+    })
+  }
+})
+
 t.test('project with bundled deps and a link dep on itself', async t => {
   const pkg = {
     name: '@isaacs/testing-bundle-self-link',


### PR DESCRIPTION
In continuation of our exploration of using `install-strategy=linked` in the [Gutenberg monorepo](https://github.com/WordPress/gutenberg/pull/75814), which powers the WordPress Block Editor.


When a workspace is removed from a project, `package-lock.json` keeps a stale entry for the removed location with `extraneous: true` (and a leftover `node_modules/<name>` link in lockfile v2's `dependencies` block).
This happens regardless of the install strategy and regardless of whether the user also removed the workspace from `package.json`'s `workspaces` array.

The root cause is in `Shrinkwrap#commit()` in `workspaces/arborist/lib/shrinkwrap.js`.
On every save, `commit()` rebuilds `data.packages` by iterating the ideal tree's inventory and writing one entry per node.
A workspace whose directory has been deleted (or whose declaration has been removed) survives in the inventory because it was loaded from the previous lockfile, but it has no incoming workspace edge from the root, so `calcDepFlags` marks it `extraneous`.
The current loop writes that node back to `data.packages` unconditionally, so the lockfile carries forward the entry indefinitely.

Fixed by skipping the write for nodes that are `extraneous` and whose lockfile location is not under `node_modules/`.
That precisely targets the "ghost workspace" shape: workspace-style locations (`packages/b`, `app`, `e`, etc.) that no longer have any reference in the project, while leaving real extraneous registry packages (which always live under `node_modules/`) untouched.
The legacy `dependencies` field in lockfile v2 is rebuilt by walking the tree from the root via `#buildLegacyLockfile`, so the orphan never gets visited and naturally drops out alongside the `packages` entry.

The lockfile's `root.workspaces` array is intentionally left as a verbatim mirror of `package.json`'s `workspaces`.
This keeps the two files consistent: if the user kept the deleted workspace in `package.json`, the lockfile reflects that; if they cleaned it up, the lockfile is also clean.
The earlier proposal in #5478 mutated `root.workspaces` independently of `package.json`, which would have decoupled the two files and broken the existing "save some stuff" test that relies on the array surviving extraneous-flagged synthetic nodes.

An `existsSync(node.realpath)` gate was considered to limit the prune to "directory really gone" cases, but it has two practical bypasses that defeat it:

- Gitignored build artifacts (e.g. `dist/`, `*.tsbuildinfo`) commonly survive a manual `rm -rf packages/<ws>`, so the directory still exists even though the user clearly intended to remove the workspace.
- The linked install strategy re-materialises the workspace directory during reify, so by the time `commit()` runs the directory is back on disk regardless of whether the user removed it.

Pruning purely on `extraneous && not-in-node_modules` handles both of these correctly without an fs call inside the lockfile write path.

## References

Fixes #5463
Supersedes #5478
