### PR TITLE
fix(arborist): skip extraneous fsChildren in linked-strategy reify

### DIFF
--- a/workspaces/arborist/lib/arborist/isolated-reifier.js
+++ b/workspaces/arborist/lib/arborist/isolated-reifier.js
@@ -95,7 +95,9 @@ module.exports = cls => class IsolatedReifier extends cls {
     }
     this.counter = 0
 
-    this.idealGraph.workspaces = await Promise.all(Array.from(idealTree.fsChildren.values(), w => this.#workspaceProxy(w)))
+    // Skip extraneous fsChildren: workspaces removed from the root manifest can linger in fsChildren via the lockfile, and re-materializing them here would re-create a directory the user just deleted.
+    const fsChildren = Array.from(idealTree.fsChildren.values()).filter(w => !w.extraneous)
+    this.idealGraph.workspaces = await Promise.all(fsChildren.map(w => this.#workspaceProxy(w)))
     const processed = new Set()
     const queue = [idealTree, ...idealTree.fsChildren]
     while (queue.length !== 0) {

--- a/workspaces/arborist/test/arborist/reify.js
+++ b/workspaces/arborist/test/arborist/reify.js
@@ -3748,6 +3748,39 @@ t.test('install strategy linked', async (t) => {
     t.ok(store.isDirectory(), 'abbrev got installed')
     t.ok(abbrev.isSymbolicLink(), 'abbrev got installed')
   })
+
+  t.test('does not re-create a workspace dir removed from manifest', async t => {
+    // Regression test for https://github.com/npm/cli/issues/9331
+    const path = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'host',
+        version: '1.0.0',
+        workspaces: ['packages/a', 'packages/b'],
+      }),
+      packages: {
+        a: { 'package.json': JSON.stringify({ name: 'a', version: '1.0.0' }) },
+        b: { 'package.json': JSON.stringify({ name: 'b', version: '1.0.0' }) },
+      },
+    })
+
+    createRegistry(t, false)
+    await reify(path, { installStrategy: 'linked' })
+
+    // Drop workspace b: remove its directory and its entry from package.json.
+    fs.rmSync(resolve(path, 'packages/b'), { recursive: true, force: true })
+    fs.writeFileSync(resolve(path, 'package.json'), JSON.stringify({
+      name: 'host',
+      version: '1.0.0',
+      workspaces: ['packages/a'],
+    }))
+
+    await reify(path, { installStrategy: 'linked' })
+
+    t.notOk(
+      fs.existsSync(resolve(path, 'packages/b')),
+      'packages/b should remain absent after reinstall'
+    )
+  })
 })
 
 t.test('workspace installs retain existing versions with newer package specs', async t => {


### PR DESCRIPTION
In continuation of our exploration of using `install-strategy=linked` in the [Gutenberg monorepo](https://github.com/WordPress/gutenberg/pull/75814), which powers the WordPress Block Editor.

When using `install-strategy=linked`, removing a workspace from the project (deleting its directory and dropping its entry from the root `package.json`'s `workspaces` array) does not actually clean it up: the next `npm install` re-creates the deleted directory as `<wsdir>/node_modules/<name> -> ..` — an empty directory shell with a self-loop symlink and no source files.
The hoisted (default) install strategy is unaffected: the directory stays gone.

The root cause is in `IsolatedReifier#makeIdealGraph` in `workspaces/arborist/lib/arborist/isolated-reifier.js`.
On every install, `loadVirtual` reads the previous lockfile and re-creates a node for every entry, including a `link: true` entry for a workspace that has just been removed from the manifest.
That node has no incoming workspace edge from the root, so `calcDepFlags` correctly marks it `extraneous`, but it still ends up in `idealTree.fsChildren` because its path is a descendant of the project root.
`makeIdealGraph` then iterated `fsChildren` blindly to populate `idealGraph.workspaces`, treating the orphan exactly like a real workspace.
`createIsolatedTree` materialised it as an `IsolatedNode` plus an `IsolatedLink` and, because the orphan is not in `#rootDeclaredDeps`, took the self-link branch — writing the workspace directory and the `node_modules/<name> -> ..` symlink back to disk.

Fixed by filtering out `extraneous` `fsChildren` before the sweep that populates `idealGraph.workspaces`.
A real workspace declared in `package.json`'s `workspaces` array is reachable via a `workspace`-type edge from the root, so it is never `extraneous`.
A local `file:` dep target that legitimately lives inside the project tree is reachable via the `Link` in `node_modules`, so it is also never `extraneous`.
The only `fsChildren` entries that show up as `extraneous` are precisely the ghost workspaces left over in the lockfile after the user removed them — which is exactly what we want to skip.

The sibling `queue` walk (which seeds `idealGraph.external` from `edgesOut`) is intentionally left alone: the orphan has no edges out and no incoming references, so it falls through the `isLocalFileDep` / `external` branches harmlessly.
This keeps the change surgical to the one place where `fsChildren` is treated as the source of truth for "this is a workspace."

Companion to #9330 (lockfile prune): with the prune fix in place, the orphan no longer appears in `package-lock.json`'s `packages` map; with this fix in place, the linked strategy no longer re-materialises the orphan on disk.
Either fix on its own is incomplete — the lockfile prune does not stop reify from re-creating the directory, and this fix does not stop the lockfile from carrying forward the entry.

The regression test seeds a project with two workspaces under `install-strategy=linked`, removes one workspace's directory and its entry from `package.json`, runs reify again, and asserts the directory stays gone.
The test fails before the fix (the directory and its self-loop symlink come back) and passes after.

## References

Fixes #9331
Related to #9330, #5463
