### PR TITLE
ABANDON: NOT TO BE MERGED

### DIFF
--- a/docs/lib/content/commands/npm-view.md
+++ b/docs/lib/content/commands/npm-view.md
@@ -174,6 +174,7 @@ If only a single string field for a single version is output, then it will not b
 If the field is an object, it will be output as a JavaScript object literal.
 
 If the `--json` flag is given, the outputted fields will be JSON.
+The output is always an array, even if only a single version matches.
 
 If the version range matches multiple versions then each printed value will be prefixed with the version it applies to.
 

--- a/lib/commands/view.js
+++ b/lib/commands/view.js
@@ -101,6 +101,7 @@ class View extends BaseCommand {
   async #viewPackage (name, args, { workspace } = {}) {
     const wholePackument = !args.length
     const json = this.npm.config.get('json')
+    const spec = npa(name)
 
     // If we are viewing many packages and outputting individual fields then output the name before doing any async activity
     if (!json && !wholePackument && workspace) {
@@ -117,7 +118,9 @@ class View extends BaseCommand {
       return
     }
 
-    const res = this.#packageOutput(cleanData(data, wholePackument), pckmnt._id)
+    const res = this.#packageOutput(cleanData(data, wholePackument), pckmnt._id, {
+      unwrapSingleResult: spec.type !== 'range' || spec.rawSpec === '*',
+    })
     if (res) {
       if (json) {
         output.buffer(workspace ? { [name]: res } : res)
@@ -198,7 +201,7 @@ class View extends BaseCommand {
     return [pckmnt, data]
   }
 
-  #packageOutput (data, name) {
+  #packageOutput (data, name, { unwrapSingleResult = true } = {}) {
     const json = this.npm.config.get('json')
     const versions = Object.keys(data)
     const includeVersions = versions.length > 1
@@ -248,7 +251,7 @@ class View extends BaseCommand {
       if (jsonRes.length === 0) {
         return
       }
-      if (jsonRes.length === 1) {
+      if (unwrapSingleResult && jsonRes.length === 1) {
         return jsonRes[0]
       }
       return jsonRes

--- a/lib/commands/view.js
+++ b/lib/commands/view.js
@@ -242,10 +242,7 @@ class View extends BaseCommand {
     })
 
     if (json) {
-      // TODO(BREAKING_CHANGE): all unwrapping should be removed.
       // Users should know based on their arguments if they can expect an array or an object.
-      // And this unwrapping can break that assumption.
-      // e.g. `npm view abbrev@^2` should always return an array, but currently since there is only one version matching `^2` this will return a single object instead.
       const first = Object.keys(res[0] || {})
       const jsonRes = first.length === 1 ? res.map(m => m[first[0]]) : res
       if (jsonRes.length === 0) {

--- a/lib/commands/view.js
+++ b/lib/commands/view.js
@@ -101,7 +101,6 @@ class View extends BaseCommand {
   async #viewPackage (name, args, { workspace } = {}) {
     const wholePackument = !args.length
     const json = this.npm.config.get('json')
-    const spec = npa(name)
 
     // If we are viewing many packages and outputting individual fields then output the name before doing any async activity
     if (!json && !wholePackument && workspace) {
@@ -118,9 +117,7 @@ class View extends BaseCommand {
       return
     }
 
-    const res = this.#packageOutput(cleanData(data, wholePackument), pckmnt._id, {
-      unwrapSingleResult: spec.type !== 'range' || spec.rawSpec === '*',
-    })
+    const res = this.#packageOutput(cleanData(data, wholePackument), pckmnt._id)
     if (res) {
       if (json) {
         output.buffer(workspace ? { [name]: res } : res)
@@ -201,7 +198,7 @@ class View extends BaseCommand {
     return [pckmnt, data]
   }
 
-  #packageOutput (data, name, { unwrapSingleResult = true } = {}) {
+  #packageOutput (data, name) {
     const json = this.npm.config.get('json')
     const versions = Object.keys(data)
     const includeVersions = versions.length > 1
@@ -247,9 +244,6 @@ class View extends BaseCommand {
       const jsonRes = first.length === 1 ? res.map(m => m[first[0]]) : res
       if (jsonRes.length === 0) {
         return
-      }
-      if (unwrapSingleResult && jsonRes.length === 1) {
-        return jsonRes[0]
       }
       return jsonRes
     }

--- a/lib/commands/view.js
+++ b/lib/commands/view.js
@@ -239,7 +239,7 @@ class View extends BaseCommand {
     })
 
     if (json) {
-      // Users should know based on their arguments if they can expect an array or an object.
+      // Users can expect an array .
       const first = Object.keys(res[0] || {})
       const jsonRes = first.length === 1 ? res.map(m => m[first[0]]) : res
       if (jsonRes.length === 0) {

--- a/tap-snapshots/test/lib/commands/view.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/view.js.test.cjs
@@ -321,22 +321,24 @@ published {TIME} ago[39m
 `
 
 exports[`test/lib/commands/view.js TAP package with single version full json > must match snapshot 1`] = `
-{
-  "_id": "single-version",
-  "name": "single-version",
-  "dist-tags": {
-    "latest": "1.0.0"
-  },
-  "versions": [
-    "1.0.0"
-  ],
-  "version": "1.0.0",
-  "dist": {
-    "shasum": "123",
-    "tarball": "http://hm.single-version.com/1.0.0.tgz",
-    "fileCount": 1
+[
+  {
+    "_id": "single-version",
+    "name": "single-version",
+    "dist-tags": {
+      "latest": "1.0.0"
+    },
+    "versions": [
+      "1.0.0"
+    ],
+    "version": "1.0.0",
+    "dist": {
+      "shasum": "123",
+      "tarball": "http://hm.single-version.com/1.0.0.tgz",
+      "fileCount": 1
+    }
   }
-}
+]
 `
 
 exports[`test/lib/commands/view.js TAP specific field names array field - 1 element > must match snapshot 1`] = `
@@ -415,60 +417,62 @@ error [94m404[39m 404
 
 exports[`test/lib/commands/view.js TAP workspaces 404 workspaces json > must match snapshot 1`] = `
 {
-  "green": {
-    "_id": "green",
-    "name": "green",
-    "dist-tags": {
-      "latest": "1.0.0"
-    },
-    "maintainers": [
-      {
-        "name": "claudia",
-        "email": "c@yellow.com",
-        "twitter": "cyellow"
+  "green": [
+    {
+      "_id": "green",
+      "name": "green",
+      "dist-tags": {
+        "latest": "1.0.0"
       },
-      {
-        "name": "isaacs",
-        "email": "i@yellow.com",
-        "twitter": "iyellow"
+      "maintainers": [
+        {
+          "name": "claudia",
+          "email": "c@yellow.com",
+          "twitter": "cyellow"
+        },
+        {
+          "name": "isaacs",
+          "email": "i@yellow.com",
+          "twitter": "iyellow"
+        }
+      ],
+      "keywords": [
+        "colors",
+        "green",
+        "crayola"
+      ],
+      "versions": [
+        "1.0.0",
+        "1.0.1"
+      ],
+      "version": "1.0.0",
+      "description": "green is a very important color",
+      "bugs": {
+        "url": "http://bugs.green.com"
+      },
+      "deprecated": true,
+      "repository": {
+        "url": "http://repository.green.com"
+      },
+      "license": {
+        "type": "ACME"
+      },
+      "bin": {
+        "green": "bin/green.js"
+      },
+      "dependencies": {
+        "red": "1.0.0",
+        "yellow": "1.0.0"
+      },
+      "dist": {
+        "shasum": "123",
+        "tarball": "http://hm.green.com/1.0.0.tgz",
+        "integrity": "---",
+        "fileCount": 1,
+        "unpackedSize": 1000000000
       }
-    ],
-    "keywords": [
-      "colors",
-      "green",
-      "crayola"
-    ],
-    "versions": [
-      "1.0.0",
-      "1.0.1"
-    ],
-    "version": "1.0.0",
-    "description": "green is a very important color",
-    "bugs": {
-      "url": "http://bugs.green.com"
-    },
-    "deprecated": true,
-    "repository": {
-      "url": "http://repository.green.com"
-    },
-    "license": {
-      "type": "ACME"
-    },
-    "bin": {
-      "green": "bin/green.js"
-    },
-    "dependencies": {
-      "red": "1.0.0",
-      "yellow": "1.0.0"
-    },
-    "dist": {
-      "shasum": "123",
-      "tarball": "http://hm.green.com/1.0.0.tgz",
-      "integrity": "---",
-      "fileCount": 1,
-      "unpackedSize": 1000000000
     }
-  },
+  ],
   "error": {
     "missing-package": {
       "code": "E404",
@@ -530,80 +534,84 @@ error Unknown error
 
 exports[`test/lib/commands/view.js TAP workspaces all workspaces --json > must match snapshot 1`] = `
 {
-  "green": {
-    "_id": "green",
-    "name": "green",
-    "dist-tags": {
-      "latest": "1.0.0"
-    },
-    "maintainers": [
-      {
-        "name": "claudia",
-        "email": "c@yellow.com",
-        "twitter": "cyellow"
+  "green": [
+    {
+      "_id": "green",
+      "name": "green",
+      "dist-tags": {
+        "latest": "1.0.0"
       },
-      {
-        "name": "isaacs",
-        "email": "i@yellow.com",
-        "twitter": "iyellow"
+      "maintainers": [
+        {
+          "name": "claudia",
+          "email": "c@yellow.com",
+          "twitter": "cyellow"
+        },
+        {
+          "name": "isaacs",
+          "email": "i@yellow.com",
+          "twitter": "iyellow"
+        }
+      ],
+      "keywords": [
+        "colors",
+        "green",
+        "crayola"
+      ],
+      "versions": [
+        "1.0.0",
+        "1.0.1"
+      ],
+      "version": "1.0.0",
+      "description": "green is a very important color",
+      "bugs": {
+        "url": "http://bugs.green.com"
+      },
+      "deprecated": true,
+      "repository": {
+        "url": "http://repository.green.com"
+      },
+      "license": {
+        "type": "ACME"
+      },
+      "bin": {
+        "green": "bin/green.js"
+      },
+      "dependencies": {
+        "red": "1.0.0",
+        "yellow": "1.0.0"
+      },
+      "dist": {
+        "shasum": "123",
+        "tarball": "http://hm.green.com/1.0.0.tgz",
+        "integrity": "---",
+        "fileCount": 1,
+        "unpackedSize": 1000000000
       }
-    ],
-    "keywords": [
-      "colors",
-      "green",
-      "crayola"
-    ],
-    "versions": [
-      "1.0.0",
-      "1.0.1"
-    ],
-    "version": "1.0.0",
-    "description": "green is a very important color",
-    "bugs": {
-      "url": "http://bugs.green.com"
-    },
-    "deprecated": true,
-    "repository": {
-      "url": "http://repository.green.com"
-    },
-    "license": {
-      "type": "ACME"
-    },
-    "bin": {
-      "green": "bin/green.js"
-    },
-    "dependencies": {
-      "red": "1.0.0",
-      "yellow": "1.0.0"
-    },
-    "dist": {
-      "shasum": "123",
-      "tarball": "http://hm.green.com/1.0.0.tgz",
-      "integrity": "---",
-      "fileCount": 1,
-      "unpackedSize": 1000000000
     }
-  },
-  "orange": {
-    "name": "orange",
-    "dist-tags": {
-      "latest": "1.0.0"
-    },
-    "versions": [
-      "1.0.0",
-      "1.0.1"
-    ],
-    "version": "1.0.0",
-    "homepage": "http://hm.orange.com",
-    "license": {},
-    "dist": {
-      "shasum": "123",
-      "tarball": "http://hm.orange.com/1.0.0.tgz",
-      "integrity": "---",
-      "fileCount": 1,
-      "unpackedSize": 1
+  ],
+  "orange": [
+    {
+      "name": "orange",
+      "dist-tags": {
+        "latest": "1.0.0"
+      },
+      "versions": [
+        "1.0.0",
+        "1.0.1"
+      ],
+      "version": "1.0.0",
+      "homepage": "http://hm.orange.com",
+      "license": {},
+      "dist": {
+        "shasum": "123",
+        "tarball": "http://hm.orange.com/1.0.0.tgz",
+        "integrity": "---",
+        "fileCount": 1,
+        "unpackedSize": 1
+      }
     }
-  }
+  ]
 }
 `
 
@@ -658,8 +666,12 @@ orange:
 
 exports[`test/lib/commands/view.js TAP workspaces all workspaces single field --json > must match snapshot 1`] = `
 {
-  "green": "green",
-  "orange": "orange"
+  "green": [
+    "green"
+  ],
+  "orange": [
+    "orange"
+  ]
 }
 `
 
@@ -720,59 +732,61 @@ Array [
 
 exports[`test/lib/commands/view.js TAP workspaces single workspace --json > must match snapshot 1`] = `
 {
-  "green": {
-    "_id": "green",
-    "name": "green",
-    "dist-tags": {
-      "latest": "1.0.0"
-    },
-    "maintainers": [
-      {
-        "name": "claudia",
-        "email": "c@yellow.com",
-        "twitter": "cyellow"
+  "green": [
+    {
+      "_id": "green",
+      "name": "green",
+      "dist-tags": {
+        "latest": "1.0.0"
       },
-      {
-        "name": "isaacs",
-        "email": "i@yellow.com",
-        "twitter": "iyellow"
+      "maintainers": [
+        {
+          "name": "claudia",
+          "email": "c@yellow.com",
+          "twitter": "cyellow"
+        },
+        {
+          "name": "isaacs",
+          "email": "i@yellow.com",
+          "twitter": "iyellow"
+        }
+      ],
+      "keywords": [
+        "colors",
+        "green",
+        "crayola"
+      ],
+      "versions": [
+        "1.0.0",
+        "1.0.1"
+      ],
+      "version": "1.0.0",
+      "description": "green is a very important color",
+      "bugs": {
+        "url": "http://bugs.green.com"
+      },
+      "deprecated": true,
+      "repository": {
+        "url": "http://repository.green.com"
+      },
+      "license": {
+        "type": "ACME"
+      },
+      "bin": {
+        "green": "bin/green.js"
+      },
+      "dependencies": {
+        "red": "1.0.0",
+        "yellow": "1.0.0"
+      },
+      "dist": {
+        "shasum": "123",
+        "tarball": "http://hm.green.com/1.0.0.tgz",
+        "integrity": "---",
+        "fileCount": 1,
+        "unpackedSize": 1000000000
       }
-    ],
-    "keywords": [
-      "colors",
-      "green",
-      "crayola"
-    ],
-    "versions": [
-      "1.0.0",
-      "1.0.1"
-    ],
-    "version": "1.0.0",
-    "description": "green is a very important color",
-    "bugs": {
-      "url": "http://bugs.green.com"
-    },
-    "deprecated": true,
-    "repository": {
-      "url": "http://repository.green.com"
-    },
-    "license": {
-      "type": "ACME"
-    },
-    "bin": {
-      "green": "bin/green.js"
-    },
-    "dependencies": {
-      "red": "1.0.0",
-      "yellow": "1.0.0"
-    },
-    "dist": {
-      "shasum": "123",
-      "tarball": "http://hm.green.com/1.0.0.tgz",
-      "integrity": "---",
-      "fileCount": 1,
-      "unpackedSize": 1000000000
     }
-  }
+  ]
 }
 `

--- a/test/lib/commands/view.js
+++ b/test/lib/commands/view.js
@@ -503,7 +503,7 @@ t.test('package with --json and no versions', async t => {
 t.test('package with --json and single string arg', async t => {
   const { view, joinedOutput } = await loadMockNpm(t, { config: { json: true } })
   await view.exec(['blue', 'dist-tags.latest'])
-  t.equal(JSON.parse(joinedOutput()), '1.0.0', 'no info to display')
+  t.strictSame(JSON.parse(joinedOutput()), ['1.0.0'], 'returns single string value as array')
 })
 
 t.test('package with single version', async t => {
@@ -517,7 +517,7 @@ t.test('package with single version', async t => {
     const { view, joinedOutput } = await loadMockNpm(t, { config: { json: true } })
     await view.exec(['single-version', 'versions'])
     const parsed = JSON.parse(joinedOutput())
-    t.strictSame(parsed, ['1.0.0'], 'does not unwrap single item arrays in json')
+    t.strictSame(parsed, [['1.0.0']], 'does not unwrap single item arrays in json')
   })
 
   t.test('no json and versions arg', async t => {

--- a/test/lib/commands/view.js
+++ b/test/lib/commands/view.js
@@ -465,6 +465,29 @@ t.test('package with --json and semver range', async t => {
   t.matchSnapshot(joinedOutput())
 })
 
+t.test('package with --json and single-match semver range preserves array output', async t => {
+  const { view, joinedOutput } = await loadMockNpm(t, { config: { json: true } })
+  await view.exec(['single-version@^1'])
+  const parsed = JSON.parse(joinedOutput())
+  t.ok(Array.isArray(parsed), 'preserves the top-level array for semver ranges')
+  t.equal(parsed.length, 1, 'returns the single matching version in an array')
+  t.match(parsed[0], {
+    name: 'single-version',
+    version: '1.0.0',
+    dist: {
+      shasum: '123',
+      tarball: 'http://hm.single-version.com/1.0.0.tgz',
+      fileCount: 1,
+    },
+  }, 'returns the expected package data')
+})
+
+t.test('package field with --json and single-match semver range preserves array output', async t => {
+  const { view, joinedOutput } = await loadMockNpm(t, { config: { json: true } })
+  await view.exec(['single-version@^1', 'version'])
+  t.strictSame(JSON.parse(joinedOutput()), ['1.0.0'], 'does not unwrap single field matches for semver ranges')
+})
+
 t.test('package with _npmUser.trustedPublisher shows cleaned up property with --json', async t => {
   const { view, joinedOutput } = await loadMockNpm(t, { config: { json: true } })
   await view.exec(['cyan-oidc@^1.0.0'])


### PR DESCRIPTION
The --json flag for npm view now always returns an array, even when only a single version matches. Previously, a single item result would be unwrapped and returned as a plain object/string, which made programmatic parsing fragile - consumers had to handle both array and non-array shapes depending on how many versions matched.

This doc update adds a note to npm-view.md clarifying that the output is always an array when --json is used, reflecting the behavioral fix.


## References