### PR TITLE
docs: npm view with json outputs array docs update

### DIFF
--- a/docs/lib/content/commands/npm-view.md
+++ b/docs/lib/content/commands/npm-view.md
@@ -174,6 +174,7 @@ If only a single string field for a single version is output, then it will not b
 If the field is an object, it will be output as a JavaScript object literal.
 
 If the `--json` flag is given, the outputted fields will be JSON.
+The output is always an array, even if only a single version matches.
 
 If the version range matches multiple versions then each printed value will be prefixed with the version it applies to.
 


### PR DESCRIPTION
<!-- What / Why -->
The --json flag for npm view now always returns an array, even when only a single version matches. Previously, a single item result would be unwrapped and returned as a plain object/string, which made programmatic parsing fragile - consumers had to handle both array and non-array shapes depending on how many versions matched.

This doc update adds a note to npm-view.md clarifying that the output is always an array when --json is used, reflecting the behavioral fix.


## References
Related to https://github.com/npm/statusboard/issues/1074#issuecomment-4372665984
