### PR TITLE
fix(arborist): only forward Link overrides when a rule names a target dep

### DIFF
--- a/workspaces/arborist/lib/link.js
+++ b/workspaces/arborist/lib/link.js
@@ -109,12 +109,24 @@ class Link extends Node {
   // so this is a no-op
   [_loadDeps] () {}
 
-  // When a Link receives overrides (via edgesIn), forward them to the target node which holds the actual edgesOut.
-  // Without this, overrides stop at the Link and never reach the target's dependency edges.
+  // When a Link receives overrides (via edgesIn), forward them to the target node which holds the actual edgesOut — but only when the OverrideSet has at least one rule that names a dep the target actually depends on.
+  // Without this scope, the link forwards a generic ancestor OverrideSet that has no real effect on the target's edges, but still flips the target to "has overrides", which changes downstream `canReplaceWith` / placement decisions and causes `npm ci` to re-resolve lockfile-pinned edges from the registry.
+  // See npm/cli#9357.
   recalculateOutEdgesOverrides () {
-    if (this.target) {
-      this.target.updateOverridesEdgeInAdded(this.overrides)
+    if (!this.target || !this.overrides) {
+      return
     }
+    let hasMatchingRule = false
+    for (const rule of this.overrides.ruleset.values()) {
+      if (this.target.edgesOut.has(rule.name)) {
+        hasMatchingRule = true
+        break
+      }
+    }
+    if (!hasMatchingRule) {
+      return
+    }
+    this.target.updateOverridesEdgeInAdded(this.overrides)
   }
 
   // links can't have children, only their targets can

--- a/workspaces/arborist/test/link.js
+++ b/workspaces/arborist/test/link.js
@@ -256,6 +256,51 @@ t.test('recalculateOutEdgesOverrides forwards overrides to target', t => {
   t.end()
 })
 
+t.test('recalculateOutEdgesOverrides does not forward when no rule matches a target dep — npm/cli#9357', t => {
+  // Regression: prior to the fix, Link.recalculateOutEdgesOverrides forwarded the link's full OverrideSet to the target unconditionally.
+  // For a target whose edges are NOT named in any override rule, that flipped target.overrides from undefined to the root's OverrideSet.
+  // Downstream, that "has overrides" state changed canPlaceDep's KEEP-vs-REPLACE decision and made `npm ci` re-resolve lockfile-pinned edges from the registry.
+  // After the fix, propagation is gated on at least one rule whose name matches an edge in target.edgesOut.
+  const root = new Node({
+    path: '/path/to/root',
+    pkg: {
+      name: 'root',
+      dependencies: { foo: '1.0.0' },
+      // override is for "bar", but the linked target only depends on "baz"
+      overrides: { bar: '2.0.0' },
+    },
+    loadOverrides: true,
+  })
+
+  const target = new Node({
+    path: '/path/to/store/foo',
+    pkg: {
+      name: 'foo',
+      version: '1.0.0',
+      dependencies: { baz: '1.0.0' },
+    },
+    root,
+  })
+
+  // eslint-disable-next-line no-new
+  new Link({
+    pkg: { name: 'foo', version: '1.0.0' },
+    path: '/path/to/root/node_modules/foo',
+    realpath: '/path/to/store/foo',
+    target,
+    parent: root,
+  })
+
+  t.ok(root.overrides, 'root has overrides')
+  t.notOk(target.overrides,
+    'target.overrides stays undefined when no rule matches a target dep')
+  const bazEdge = target.edgesOut.get('baz')
+  t.notOk(bazEdge.overrides,
+    'unrelated edge keeps edge.overrides undefined')
+  t.equal(bazEdge.spec, '1.0.0', 'unrelated edge spec is unchanged')
+  t.end()
+})
+
 t.test('link to root path gets root as target', t => {
   const root = new Node({
     path: '/project/root',


### PR DESCRIPTION
In continuation of our exploration of using `install-strategy=linked` in the [Gutenberg monorepo](https://github.com/WordPress/gutenberg/pull/75814), which powers the WordPress Block Editor.

`npm ci` in v11.14.x rejects lockfiles that v11.13.x accepts, with `EUSAGE: Invalid: lock file's <pkg>@<old> does not satisfy <pkg>@<new>` for any workspace `^` range that has had a newer matching patch published since the lockfile was generated.

Bisected to commit e7805c3a4 (#9198). The new `Link.recalculateOutEdgesOverrides` was forwarding the link's `OverrideSet` to the target unconditionally — even when the OverrideSet had no rule naming any of the target's deps. That set `target.overrides` from `undefined` to the root's generic OverrideSet, and the cascade caused `canReplaceWith`'s "overrides equal" branch to flip `placeDep`'s decision from `KEEP` to `REPLACE` for an edge the lockfile already satisfied. `validateLockfile` then rejected the resulting ideal tree.

Fixed by gating the forward on the OverrideSet actually containing a rule that names a dep the target depends on. If no rule matches, don't forward — `target.overrides` stays `undefined` and downstream placement matches v11.13.0.

#9198's intent is preserved: when the override DOES name a dep of the target, propagation still fires. #9198's existing test still passes (including `bar edge spec is overridden to 2.0.0`). Added a regression test for the no-matching-rule case; verified failing before this fix and passing after.

## References

Fixes #9357
Refines #9198
