### PR TITLE
docs: add example to optionalDependencies section

### DIFF
--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -842,6 +842,16 @@ This is a map of package name to version or URL, just like the `dependencies` ob
 The difference is that build failures do not cause installation to fail.
 Running `npm install --omit=optional` will prevent these dependencies from being installed.
 
+For example:
+
+```json
+{
+  "optionalDependencies": {
+    "@npm/foo": "^1.0.0"
+  }
+}
+```
+
 It is still your program's responsibility to handle the lack of the dependency.
 For example, something like this:
 


### PR DESCRIPTION
## Summary

Adds a small `package.json` example to the `optionalDependencies` section of the package.json docs, so readers can see the expected shape at a glance without parsing the surrounding prose.

Closes #9325.

## Test plan

- [x] `npm run build --workspace=docs` succeeds.
- [x] `npm test --workspace=docs` passes (100% coverage, lint, template-oss-check).
- [x] Rendered HTML in `docs/output/configuring-npm/package-json.html` shows the example as a `language-json` code block between the intro paragraph and the "It is still your program's responsibility..." paragraph; surrounding sections and TOC unchanged.