### PR TITLE
Add 'c' key shortcut to copy URL in prompts

### DIFF
--- a/lib/utils/clipboard.js
+++ b/lib/utils/clipboard.js
@@ -1,0 +1,59 @@
+const { spawn } = require('node:child_process')
+const proc = require('node:process')
+
+const spawnCopy = (cmd, args, text) => new Promise((resolve, reject) => {
+  const child = spawn(cmd, args, { stdio: ['pipe', 'ignore', 'ignore'] })
+  child.on('error', reject)
+  child.on('close', (code) => {
+    if (code === 0) {
+      resolve()
+    } else {
+      reject(new Error(`${cmd} exited with code ${code}`))
+    }
+  })
+  child.stdin.write(text)
+  child.stdin.end()
+})
+
+const tryLinuxClipboard = async (text) => {
+  const tools = []
+
+  if (proc.env.WAYLAND_DISPLAY) {
+    tools.push(['wl-copy', []])
+  }
+
+  if (proc.env.DISPLAY) {
+    tools.push(['xclip', ['-selection', 'clipboard']])
+    tools.push(['xsel', ['--clipboard', '--input']])
+  }
+
+  // Fallback: try all known tools regardless of env vars
+  if (tools.length === 0) {
+    tools.push(['wl-copy', []], ['xclip', ['-selection', 'clipboard']], ['xsel', ['--clipboard', '--input']])
+  }
+
+  for (const [cmd, args] of tools) {
+    try {
+      await spawnCopy(cmd, args, text)
+      return
+    } catch {
+      // try next tool
+    }
+  }
+
+  throw new Error('No clipboard tool available. Install xclip, xsel, or wl-copy.')
+}
+
+const copyToClipboard = (text) => {
+  if (proc.platform === 'darwin') {
+    return spawnCopy('pbcopy', [], text)
+  }
+
+  if (proc.platform === 'win32') {
+    return spawnCopy('clip', [], text)
+  }
+
+  return tryLinuxClipboard(text)
+}
+
+module.exports = { copyToClipboard }

--- a/lib/utils/open-url.js
+++ b/lib/utils/open-url.js
@@ -1,8 +1,8 @@
 const { open } = require('@npmcli/promise-spawn')
 const { output, input, META } = require('proc-log')
 const { URL } = require('node:url')
-const readline = require('node:readline/promises')
-const { once } = require('node:events')
+const readline = require('node:readline')
+const { copyToClipboard } = require('./clipboard.js')
 
 const assertValidUrl = (url) => {
   try {
@@ -51,7 +51,7 @@ const openUrl = async (npm, url, title, isFile) => {
   }
 }
 
-// Prompt to open URL in browser if possible
+// Prompt to open URL in browser if possible, or copy it to clipboard with 'c'
 const openUrlPrompt = async (npm, url, title, prompt, { signal }) => {
   const browser = npm.config.get('browser')
   const json = npm.config.get('json')
@@ -63,23 +63,58 @@ const openUrlPrompt = async (npm, url, title, prompt, { signal }) => {
     return
   }
 
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  })
-
   try {
-    await input.read(() => Promise.race([
-      rl.question(prompt, { signal }),
-      once(rl, 'error'),
-      once(rl, 'SIGINT').then(() => {
-        throw new Error('canceled')
-      }),
-    ]))
-    rl.close()
-    await openUrl(npm, url, 'Browser unavailable. Please open the URL manually')
+    await input.read(() => new Promise((resolve, reject) => {
+      readline.emitKeypressEvents(process.stdin)
+
+      const wasRaw = process.stdin.isRaw
+      process.stdin.setRawMode(true)
+
+      process.stdout.write(`${prompt}, or c to copy URL: `)
+
+      const cleanup = () => {
+        process.stdin.setRawMode(wasRaw)
+        process.stdin.removeListener('keypress', onKeypress)
+        if (signal) {
+          signal.removeEventListener('abort', onAbort)
+        }
+        process.stdout.write('\n')
+      }
+
+      const onKeypress = (str, key) => {
+        if (!key) {
+          return
+        }
+
+        if (key.ctrl && key.name === 'c') {
+          cleanup()
+          reject(new Error('canceled'))
+        } else if (key.name === 'c') {
+          cleanup()
+          copyToClipboard(url)
+            .then(() => output.standard('Copied URL to clipboard!'))
+            .catch(() => output.standard('Unable to copy URL to clipboard'))
+            .then(resolve, reject)
+        } else if (key.name === 'return' || key.name === 'enter') {
+          cleanup()
+          openUrl(npm, url, 'Browser unavailable. Please open the URL manually')
+            .then(resolve, reject)
+        }
+      }
+
+      const onAbort = () => {
+        cleanup()
+        const err = new Error('abort')
+        err.name = 'AbortError'
+        reject(err)
+      }
+
+      process.stdin.on('keypress', onKeypress)
+      if (signal) {
+        signal.addEventListener('abort', onAbort)
+      }
+    }))
   } catch (err) {
-    rl.close()
     if (err.name !== 'AbortError') {
       throw err
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5798,6 +5798,18 @@
         }
       }
     },
+    "node_modules/git-raw-commits/node_modules/conventional-commits-filter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/github-slugger": {
       "version": "2.0.0",
       "dev": true,

--- a/tap-snapshots/test/lib/utils/open-url.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/open-url.js.test.cjs
@@ -29,7 +29,7 @@ Browser unavailable. Please open the URL manually:
 https://www.npmjs.com
 `
 
-exports[`test/lib/utils/open-url.js TAP open url prompt opens a url > must match snapshot 1`] = `
+exports[`test/lib/utils/open-url.js TAP open url prompt opens a url when ENTER is pressed > must match snapshot 1`] = `
 npm home:
 https://www.npmjs.com
 `

--- a/test/lib/utils/clipboard.js
+++ b/test/lib/utils/clipboard.js
@@ -1,0 +1,112 @@
+const t = require('tap')
+const tmock = require('../../fixtures/tmock')
+
+const makeSpawn = (results = {}) => {
+  const spawned = []
+  const spawn = (cmd, args) => {
+    const EventEmitter = require('node:events')
+    const child = new EventEmitter()
+    child.stdin = {
+      write: () => {},
+      end: () => {
+        const result = results[cmd]
+        if (result instanceof Error) {
+          child.emit('error', result)
+        } else {
+          child.emit('close', result ?? 0)
+        }
+      },
+    }
+    spawned.push({ cmd, args })
+    return child
+  }
+  return { spawn, spawned }
+}
+
+const mockClipboard = (t, { platform, env, spawnResults } = {}) => {
+  const { spawn, spawned } = makeSpawn(spawnResults)
+  const { copyToClipboard } = tmock(t, '{LIB}/utils/clipboard.js', {
+    'node:child_process': { spawn },
+    'node:process': { platform, env: env ?? {} },
+  })
+  return { copyToClipboard, spawned }
+}
+
+t.test('clipboard', async t => {
+  t.test('macOS uses pbcopy', async t => {
+    const { copyToClipboard, spawned } = mockClipboard(t, { platform: 'darwin' })
+    await copyToClipboard('https://example.com')
+    t.equal(spawned[0].cmd, 'pbcopy')
+    t.same(spawned[0].args, [])
+  })
+
+  t.test('Windows uses clip', async t => {
+    const { copyToClipboard, spawned } = mockClipboard(t, { platform: 'win32' })
+    await copyToClipboard('https://example.com')
+    t.equal(spawned[0].cmd, 'clip')
+    t.same(spawned[0].args, [])
+  })
+
+  t.test('Linux uses wl-copy when WAYLAND_DISPLAY is set', async t => {
+    const { copyToClipboard, spawned } = mockClipboard(t, {
+      platform: 'linux',
+      env: { WAYLAND_DISPLAY: ':0' },
+    })
+    await copyToClipboard('hello')
+    t.equal(spawned[0].cmd, 'wl-copy')
+    t.same(spawned[0].args, [])
+  })
+
+  t.test('Linux uses xclip when DISPLAY is set', async t => {
+    const { copyToClipboard, spawned } = mockClipboard(t, {
+      platform: 'linux',
+      env: { DISPLAY: ':0' },
+    })
+    await copyToClipboard('hello')
+    t.equal(spawned[0].cmd, 'xclip')
+    t.same(spawned[0].args, ['-selection', 'clipboard'])
+  })
+
+  t.test('Linux prefers wl-copy over xclip when both env vars are set', async t => {
+    const { copyToClipboard, spawned } = mockClipboard(t, {
+      platform: 'linux',
+      env: { WAYLAND_DISPLAY: ':0', DISPLAY: ':0' },
+    })
+    await copyToClipboard('hello')
+    t.equal(spawned[0].cmd, 'wl-copy', 'tries wl-copy first')
+  })
+
+  t.test('Linux falls back to xsel if xclip fails', async t => {
+    const { copyToClipboard, spawned } = mockClipboard(t, {
+      platform: 'linux',
+      env: { DISPLAY: ':0' },
+      spawnResults: { xclip: new Error('not found') },
+    })
+    await copyToClipboard('hello')
+    t.equal(spawned[0].cmd, 'xclip', 'tried xclip first')
+    t.equal(spawned[1].cmd, 'xsel', 'fell back to xsel')
+    t.same(spawned[1].args, ['--clipboard', '--input'])
+  })
+
+  t.test('Linux falls back to all tools when no env vars set', async t => {
+    const { copyToClipboard, spawned } = mockClipboard(t, {
+      platform: 'linux',
+      env: {},
+    })
+    await copyToClipboard('hello')
+    t.equal(spawned[0].cmd, 'wl-copy', 'tried wl-copy as first fallback')
+  })
+
+  t.test('throws when no clipboard tool is available', async t => {
+    const { copyToClipboard } = mockClipboard(t, {
+      platform: 'linux',
+      env: {},
+      spawnResults: {
+        'wl-copy': new Error('not found'),
+        xclip: new Error('not found'),
+        xsel: new Error('not found'),
+      },
+    })
+    await t.rejects(copyToClipboard('hello'), /No clipboard tool available/, 'throws appropriate error')
+  })
+})

--- a/test/lib/utils/open-url.js
+++ b/test/lib/utils/open-url.js
@@ -38,9 +38,9 @@ const mockOpenUrl = async (t, args, { openerResult, ...config } = {}) => {
 }
 
 const mockOpenUrlPrompt = async (t, {
-  questionShouldResolve = true,
-  openUrlPromptInterrupted = false,
+  key = { name: 'return' },
   openerResult = null,
+  clipboardResult = null,
   isTTY = true,
   abort = false,
   url: openUrl = 'https://www.npmjs.com',
@@ -50,12 +50,15 @@ const mockOpenUrlPrompt = async (t, {
     globals: {
       'process.stdin.isTTY': isTTY,
       'process.stdout.isTTY': isTTY,
+      'process.stdin.isRaw': false,
+      'process.stdin.setRawMode': () => {},
     },
     config,
   })
 
   let openerUrl = null
   let openerOpts = null
+  let clipboardText = null
 
   const { openUrlPrompt } = tmock(t, '{LIB}/utils/open-url.js', {
     '@npmcli/promise-spawn': {
@@ -67,29 +70,15 @@ const mockOpenUrlPrompt = async (t, {
         }
       },
     },
-    'node:readline/promises': {
-      createInterface: () => {
-        return Object.assign(new EventEmitter(), {
-          question: async (p, { signal } = {}) => {
-            if (questionShouldResolve !== true) {
-              await new Promise((res, rej) => {
-                if (signal) {
-                  signal.addEventListener('abort', () => {
-                    const err = new Error('abort')
-                    err.name = 'AbortError'
-                    rej(err)
-                  })
-                }
-              })
-            }
-          },
-          close: () => {},
-          once: function (event, cb) {
-            if (openUrlPromptInterrupted && event === 'SIGINT') {
-              cb()
-            }
-          },
-        })
+    'node:readline': {
+      emitKeypressEvents: () => {},
+    },
+    '{LIB}/utils/clipboard.js': {
+      copyToClipboard: async (text) => {
+        clipboardText = text
+        if (clipboardResult) {
+          throw clipboardResult
+        }
       },
     },
   })
@@ -97,10 +86,17 @@ const mockOpenUrlPrompt = async (t, {
   let error
   const abortController = new AbortController()
   const args = [mock.npm, openUrl, 'npm home', 'prompt', { signal: abortController.signal }]
+
   if (abort) {
     mock.open = openUrlPrompt(...args)
   } else {
-    await openUrlPrompt(...args).catch((er) => error = er)
+    // The keypress handler is registered synchronously inside the Promise constructor,
+    // so we can emit the keypress right after calling openUrlPrompt and before awaiting.
+    const promptPromise = openUrlPrompt(...args)
+    if (isTTY && key) {
+      process.stdin.emit('keypress', key.str || '', key)
+    }
+    await promptPromise.catch((er) => error = er)
   }
 
   mock.npm.finish()
@@ -109,6 +105,7 @@ const mockOpenUrlPrompt = async (t, {
     ...mock,
     openerUrl,
     openerOpts,
+    clipboardText,
     OUTPUT: mock.joinedOutput(),
     error,
     abortController,
@@ -123,7 +120,7 @@ t.test('open url prompt', async t => {
     t.same(openerOpts, null, 'did not open')
   })
 
-  t.test('opens a url', async t => {
+  t.test('opens a url when ENTER is pressed', async t => {
     const { OUTPUT, openerUrl, openerOpts } = await mockOpenUrlPrompt(t, { browser: true })
 
     t.equal(openerUrl, 'https://www.npmjs.com', 'opened the given url')
@@ -157,14 +154,12 @@ t.test('open url prompt', async t => {
     t.same(OUTPUT, '', 'printed no output')
   })
 
-  t.test('does not open url if canceled', async t => {
+  t.test('does not open url if canceled via abort signal', async t => {
     const { openerUrl, openerOpts, open, abortController } = await mockOpenUrlPrompt(t, {
-      questionShouldResolve: false,
       abort: true,
     })
 
     abortController.abort()
-
     await open
 
     t.equal(openerUrl, null, 'did not open')
@@ -177,7 +172,7 @@ t.test('open url prompt', async t => {
     })
 
     t.match(error, /Opener failed/, 'got the correct error')
-    t.equal(openerUrl, 'https://www.npmjs.com', 'did not open')
+    t.equal(openerUrl, 'https://www.npmjs.com', 'did open')
   })
 
   t.test('does not error when opener cannot find command', async t => {
@@ -186,18 +181,36 @@ t.test('open url prompt', async t => {
     })
 
     t.notOk(error, 'Did not error')
-    t.equal(openerUrl, 'https://www.npmjs.com', 'did not open')
+    t.equal(openerUrl, 'https://www.npmjs.com', 'tried to open')
     t.matchSnapshot(OUTPUT, 'Outputs extra Browser unavailable message and url')
   })
 
-  t.test('throws "canceled" error on SIGINT', async t => {
-    const { open } = await mockOpenUrlPrompt(t, {
-      questionShouldResolve: false,
-      openUrlPromptInterrupted: true,
-      abort: true,
+  t.test('throws "canceled" error on ctrl+c', async t => {
+    const { error } = await mockOpenUrlPrompt(t, {
+      key: { ctrl: true, name: 'c' },
     })
 
-    await t.rejects(open, /canceled/, 'message is canceled')
+    t.match(error, /canceled/, 'message is canceled')
+  })
+
+  t.test('copies url to clipboard when c is pressed', async t => {
+    const { OUTPUT, clipboardText, openerUrl } = await mockOpenUrlPrompt(t, {
+      key: { name: 'c' },
+    })
+
+    t.equal(clipboardText, 'https://www.npmjs.com', 'copied the correct url')
+    t.equal(openerUrl, null, 'did not open browser')
+    t.match(OUTPUT, /Copied URL to clipboard/, 'printed success message')
+  })
+
+  t.test('handles clipboard failure gracefully', async t => {
+    const { OUTPUT, error } = await mockOpenUrlPrompt(t, {
+      key: { name: 'c' },
+      clipboardResult: new Error('clipboard unavailable'),
+    })
+
+    t.notOk(error, 'did not throw')
+    t.match(OUTPUT, /Unable to copy URL to clipboard/, 'printed failure message')
   })
 })
 


### PR DESCRIPTION
This pull request adds cross-platform clipboard support and enhances the user experience when prompting to open URLs.

Users can now press 'c' to copy a URL to the clipboard if they choose not to open it in a browser, with robust support and fallbacks for macOS, Windows, and Linux environments. 

The changes also include comprehensive tests for the new clipboard functionality and update the open URL prompt logic and tests to reflect the new behavior.

These changes provide a more flexible and user-friendly experience for handling URLs, especially in environments where opening a browser may not be possible.