### PR TITLE
fix: key stage download --json output by package name

### DIFF
--- a/lib/commands/stage/download.js
+++ b/lib/commands/stage/download.js
@@ -31,7 +31,7 @@ class StageDownload extends BaseCommand {
 
     const manifest = await this.#readManifestFromTarball(data)
     const pkgContents = await getContents(manifest, data)
-    logTar(pkgContents, { unicode, json })
+    logTar(pkgContents, { unicode, json, key: pkgContents.name })
 
     const safeName = pkgContents.name.replace('@', '').replace('/', '-')
     const filename = `${safeName}-${pkgContents.version}-${stageId}.tgz`


### PR DESCRIPTION
`npm stage download <id> --json` currently emits the package contents under a literal `"undefined"` key because `logTar` is called without a `key` option.

### Before

```json
{
  "undefined": {
    "name": "polo-meow-meow-meow",
    "version": "1.0.3",
    ...
  }
}
```

### After

```json
{
  "polo-meow-meow-meow": {
    "name": "polo-meow-meow-meow",
    "version": "1.0.3",
    ...
  }
}
```

This matches the JSON shape of `npm publish --json` and `npm pack --json`.

### Background

The `key == null` fallback in `lib/utils/tar.js` (that would have rendered a bare object when no key was passed) was removed from `latest` in #9247 ("fix: sync json output of pack and publish") as a `BREAKING CHANGE`. Per that PR:

> BREAKING CHANGE: the --json output of `npm pack` and `npm publish` have changed. They are now always consistent, and in the same format.
>
> Previously, `npm pack` would output an array of entries and `npm publish` an object. The `npm publish` object also changed forms depending on if workspaces were being published.
>
> Now, the output is always an object with the package name as the top level index.

When #9201 (npm stage) landed, it added a new `logTar` caller in `lib/commands/stage/download.js` that did not pass a `key`, silently violating the v12 contract established in #9247 and producing the `"undefined"` wrapper. This PR brings the new caller into compliance.

### Repro

```
npm stage download <stage-id> --json
```

A follow-up backports this to `release/v11` for consistent output across branches: #9381.
