### PR TITLE
fix: key stage download --json output by package name (v11)

### DIFF
--- a/lib/commands/stage/download.js
+++ b/lib/commands/stage/download.js
@@ -31,7 +31,7 @@ class StageDownload extends BaseCommand {
 
     const manifest = await this.#readManifestFromTarball(data)
     const pkgContents = await getContents(manifest, data)
-    logTar(pkgContents, { unicode, json })
+    logTar(pkgContents, { unicode, json, key: pkgContents.name })
 
     const safeName = pkgContents.name.replace('@', '').replace('/', '-')
     const filename = `${safeName}-${pkgContents.version}-${stageId}.tgz`

--- a/test/lib/utils/tar.js
+++ b/test/lib/utils/tar.js
@@ -109,6 +109,20 @@ t.test('should log tarball contents with unicode', async (t) => {
   t.end()
 })
 
+t.test('logTar with json and no key emits bare tarball object', async (t) => {
+  const buffered = []
+  const logTar = tmock(t, '{LIB}/utils/tar.js', {
+    'proc-log': {
+      log: { notice: () => {} },
+      output: { buffer: (data) => buffered.push(data) },
+    },
+  }).logTar
+
+  const tarball = { name: 'my-pkg', version: '1.0.0' }
+  logTar(tarball, { json: true })
+  t.strictSame(buffered, [tarball], 'buffers the bare tarball when key is omitted')
+})
+
 t.test('should getContents of a tarball with only a package.json', async (t) => {
   const testDir = t.testdir({
     'package.json': JSON.stringify({


### PR DESCRIPTION
Backports #9380 to `release/v11` to keep `npm stage download --json` output consistent across branches.

On `release/v11`, the `key == null` guard in `lib/utils/tar.js` was emitting the bare object (no wrapper key). This change adds a key so the output matches `latest` and aligns with `npm publish --json` / `npm pack --json`.

### Before (on release/v11)

```json
{
  "name": "polo-meow-meow-meow",
  "version": "1.0.3",
  ...
}
```

### After

```json
{
  "polo-meow-meow-meow": {
    "name": "polo-meow-meow-meow",
    "version": "1.0.3",
    ...
  }
}
```

### Background

The `key == null` fallback in `lib/utils/tar.js` (still present on `release/v11`) was removed from `latest` in #9247 ("fix: sync json output of pack and publish") as a `BREAKING CHANGE`. Per that PR:

> BREAKING CHANGE: the --json output of `npm pack` and `npm publish` have changed. They are now always consistent, and in the same format.
>
> Previously, `npm pack` would output an array of entries and `npm publish` an object. The `npm publish` object also changed forms depending on if workspaces were being published.
>
> Now, the output is always an object with the package name as the top level index.

That breaking change was intentionally not backported to v11 (maintenance branch), so the fallback still exists here. This backport keeps the call-site contract aligned across branches so consumers get the same `{ "<pkg>": {...} }` shape on both.

Clean cherry-pick of 9f7834d from #9380.
