### PR TITLE
docs: Document `npm_old_version` and `npm_new_version` environment variables

### DIFF
--- a/docs/lib/content/commands/npm-version.md
+++ b/docs/lib/content/commands/npm-version.md
@@ -69,6 +69,8 @@ The exact order of execution is as follows:
 6. Run the `postversion` script.
    Use it to clean up the file system or automatically push the commit and/or tag.
 
+For the `preversion`, `version` and `postversion` scripts, npm also sets the [environment variables](/using-npm/scripts#environment) `npm_old_version` and `npm_new_version`.
+
 Take the following example:
 
 ```json

--- a/docs/lib/content/using-npm/scripts.md
+++ b/docs/lib/content/using-npm/scripts.md
@@ -290,6 +290,13 @@ For example, if you had `{"name":"foo", "version":"1.2.5"}` in your package.json
 
 See [`package.json`](/configuring-npm/package-json) for more on package configs.
 
+#### versioning variables
+
+For versioning scripts (`preversion`, `version`, `postversion`), npm sets these environment variables:
+
+* `npm_old_version` - The version before being bumped
+* `npm_new_version` – The version after being bumped
+
 #### current lifecycle event
 
 Lastly, the `npm_lifecycle_event` environment variable is set to whichever stage of the cycle is being executed.

--- a/workspaces/libnpmversion/README.md
+++ b/workspaces/libnpmversion/README.md
@@ -85,6 +85,9 @@ The exact order of execution is as follows:
 6. Run the `postversion` script. Use it to clean up the file system or
    automatically push the commit and/or tag.
 
+For the `preversion`, `version` and `postversion` scripts, npm also sets the
+environment variables `npm_old_version` and `npm_new_version`.
+
 Take the following example:
 
 ```json


### PR DESCRIPTION
npm sets two additional environment variables `npm_old_version` and `npm_new_version` when running the `preversion`, `version`, `postversion` scripts, but these aren’t documented anywhere.

Document the variables in the ‘Scripts’ docs, and cross-reference them from the documentation for the version command (and the libnpmversion readme).

I've tried to match the existing formatting conventions for each document. Please let me know if anything needs to change.