### PR TITLE
chore: sanitize newlines in flags table default and type values

### DIFF
--- a/docs/lib/index.js
+++ b/docs/lib/index.js
@@ -151,10 +151,12 @@ const generateFlagsTable = (definitionPool) => {
     if (!defaultVal) {
       defaultVal = String(def.default)
     }
+    defaultVal = defaultVal.replace(/\n/g, ' ').trim()
     let typeVal = def.typeDescription || String(def.type)
     if (def.required) {
       typeVal = `${typeVal} (required)`
     }
+    typeVal = typeVal.replace(/\n/g, ' ').trim()
     const desc = (def.description || '').replace(/\n/g, ' ').trim()
     return `| ${flagsStr} | ${defaultVal} | ${typeVal} | ${desc} |`
   })


### PR DESCRIPTION
## Problem

The `generateFlagsTable` function in `docs/lib/index.js` sanitizes `description` for newlines but does not do the same for `defaultVal` or `typeVal`. Some config definitions (like `--access`) have multi-line `defaultDescription` values, which breaks the markdown table — all subsequent columns/rows get collapsed into a single garbled line.

This is visible on the live docs: https://docs.npmjs.com/cli/v11/commands/npm-stage

## Fix

Added `.replace(/\n/g, ' ').trim()` to both `defaultVal` and `typeVal` in `generateFlagsTable`, matching the existing sanitization already applied to `desc`.