### PR TITLE
fix: skip hidden lockfile save on dry run

### DIFF
--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -237,7 +237,7 @@ module.exports = cls => class Reifier extends cls {
     this.actualTree = this.idealTree
     this.idealTree = null
 
-    if (!this.options.global) {
+    if (!this.options.global && !this.options.dryRun) {
       await this.actualTree.meta.save()
       const ignoreScripts = !!this.options.ignoreScripts
       // if we aren't doing a dry run or ignoring scripts and we actually made changes to the dep

--- a/workspaces/arborist/test/arborist/reify.js
+++ b/workspaces/arborist/test/arborist/reify.js
@@ -1613,6 +1613,26 @@ t.test('save complete lockfile on update-all', async t => {
   t.matchSnapshot(lock(), 'should update, but not drop root metadata')
 })
 
+t.test('dry-run update does not save lockfiles', async t => {
+  const path = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'dry-run-update-lockfile-test',
+      version: '1.0.0',
+    }),
+  })
+  createRegistry(t, true)
+  await reify(path, { add: ['abbrev@1.0.4'] })
+
+  const lock = filename => fs.readFileSync(resolve(path, filename), 'utf8')
+  const packageLock = lock('package-lock.json')
+  const hiddenLock = lock('node_modules/.package-lock.json')
+
+  await reify(path, { update: true, dryRun: true, save: false })
+
+  t.equal(lock('package-lock.json'), packageLock, 'package-lock.json unchanged')
+  t.equal(lock('node_modules/.package-lock.json'), hiddenLock, 'hidden lockfile unchanged')
+})
+
 t.test('save proper lockfile with bins when upgrading lockfile', async t => {
   for (const complete of [true, false]) {
     await t.test(`complete=${complete}`, async t => {


### PR DESCRIPTION
## Summary

- stop Arborist from saving `node_modules/.package-lock.json` during dry-run reification
- add a regression that keeps both `package-lock.json` and the hidden lockfile unchanged after `update: true, dryRun: true`

This addresses the dry-run lockfile mutation part of #9187. The JSON output behavior is separate and already has #8567 open.

## Testing

- `../../node_modules/.bin/tap --no-coverage --no-check-coverage test/arborist/reify.js -g 'dry-run update does not save lockfiles'`
- `../../node_modules/.bin/tap --no-coverage --no-check-coverage test/arborist/reify.js -g 'dry run, do not get anything wet|save complete lockfile on update-all'`
- `../../node_modules/.bin/eslint lib/arborist/reify.js test/arborist/reify.js`
- `git diff --check`
