### PR TITLE
test: cover Windows -- arg forwarding in shims

### DIFF
--- a/test/bin/windows-shims.js
+++ b/test/bin/windows-shims.js
@@ -279,6 +279,7 @@ t.test('run shims', t => {
     { bin: 'npx', params: ['--version'], expected: version },
     { bin: 'npm', params: ['test'], expected: '' },
     { bin: 'npm', params: [`test -- hello -p1 world -p2 "hello world" --q1=hello world --q2="hello world"`], expected: `hello\n-p1\nworld\n-p2\nhello world\n--q1=hello\nworld\n--q2=hello world` },
+    { bin: 'npm', params: ['test -- --foo=bar'], expected: '--foo=bar' },
     { bin: 'npm', params: ['test -- a=1,b=2,c=3'], expected: `a=1,b=2,c=3` },
     { bin: 'npx', params: ['. -- a=1,b=2,c=3'], expected: `a=1,b=2,c=3` },
   ]


### PR DESCRIPTION
## Summary

Adds Windows shim regression coverage for `npm test -- --foo=bar`.

Issue #9353 reproduces on the published `npm@11.14.1` PowerShell `-Command` path, where `--foo=bar` is misclassified as npm CLI config instead of being forwarded to the script after the first `--`.

Current `main` already forwards the argument correctly. This PR locks that behavior in with an explicit windows-shims test so the PowerShell path cannot regress.

## Test plan

- Reproduced the bad behavior on published `npm@11.14.1`
- Verified current `main` forwards `--foo=bar` correctly through `npm.cmd`
- Verified current `main` forwards `--foo=bar` correctly through `npm.ps1`
- Added `test -- --foo=bar` coverage to `test/bin/windows-shims.js`

Refs #9353.
