### PR TITLE
docs: use the latest version for global update and outdated's `wanted`

### DIFF
--- a/docs/lib/content/commands/npm-outdated.md
+++ b/docs/lib/content/commands/npm-outdated.md
@@ -18,7 +18,7 @@ Use `--all` to find all outdated meta-dependencies as well.
 In the output:
 
 * `wanted` is the maximum version of the package that satisfies the semver range specified in `package.json`.
-  If there's no available semver range (i.e. you're running `npm outdated --global`, or the package isn't included in `package.json`), then `wanted` shows the currently-installed version.
+  If there's no available semver range (i.e. you're running `npm outdated --global`, or the package isn't included in `package.json`), then `wanted` shows the latest version.
 * `latest` is the version of the package tagged as latest in the registry.
   Running `npm publish` with no special configuration will publish the package with a dist-tag of `latest`.
   This may or may not be the maximum version of the package, or the most-recently published version of the package, depending on how the package's developer manages the latest [dist-tag](/commands/npm-dist-tag).

--- a/docs/lib/content/commands/npm-update.md
+++ b/docs/lib/content/commands/npm-update.md
@@ -128,8 +128,7 @@ In this case if you really did need your package to use a newer version you woul
 
 `npm update -g` will apply the `update` action to each globally installed package that is `outdated` -- that is, has a version that is different from `wanted`.
 
-Note: Globally installed packages are treated as if they are installed with a caret semver range specified.
-So if you require to update to `latest` you may need to run `npm install -g [<pkg>...]`
+Note: Globally installed packages do not have a `package.json` semver range available, so their `wanted` version is `latest`.
 
 NOTE: If a package has been upgraded to a version newer than `latest`, it will be _downgraded_.
 


### PR DESCRIPTION
For now, `npm outdated`'s document shows `wanted` field for global `npm outdated` is always the same as `current` field, but the runtime behavior shows `npm outdated` prints `wanted` as latest version. Considering `npm update`'s behavior, it should be a document issue.

This PR fixes it by saying `the latest version` instead of `currently-installed version`. 

## References

Close #3612