### PR TITLE
fix: show full parent command path in subcommand usage errors

### DIFF
--- a/lib/base-cmd.js
+++ b/lib/base-cmd.js
@@ -129,7 +129,8 @@ class BaseCommand {
     }
 
     fullUsage.push('')
-    fullUsage.push(`Run "npm help ${name}" for more info`)
+    const helpName = parentName ? parentName.split(' ')[0] : name
+    fullUsage.push(`Run "npm help ${helpName}" for more info`)
 
     return fullUsage.join('\n')
   }
@@ -137,6 +138,7 @@ class BaseCommand {
   constructor (npm) {
     this.npm = npm
     this.commandArgs = null
+    this.parentName = null
 
     const { config } = this
 
@@ -167,7 +169,7 @@ class BaseCommand {
   }
 
   get usage () {
-    return this.constructor.describeUsage
+    return this.constructor.getUsage(this.parentName)
   }
 
   usageError (prefix = '') {

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -241,12 +241,13 @@ class Npm {
 
       // Check if help is requested for the subcommand
       if (this.config.get('usage')) {
-        const parentName = commandPath[0]
+        const parentName = commandPath.join(' ')
         return output.standard(SubCommand.getUsage(parentName))
       }
 
       // Create subcommand instance and recurse
       const subcommandInstance = new SubCommand(this)
+      subcommandInstance.parentName = commandPath.join(' ')
       const subcommandArgs = args.slice(1) // Remove subcommand name from args
       const subcommandPath = [...commandPath, subcommandName]
 

--- a/tap-snapshots/test/lib/commands/install.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/install.js.test.cjs
@@ -134,8 +134,8 @@ silly logfile done cleaning log files
 verbose stack Error: The developer of this package has specified the following through devEngines
 verbose stack Invalid devEngines.runtime
 verbose stack Invalid name "nondescript" does not match "node" for "runtime"
-verbose stack     at Install.checkDevEngines ({CWD}/lib/base-cmd.js:247:27)
-verbose stack     at MockNpm.execCommandClass ({CWD}/lib/npm.js:281:7)
+verbose stack     at Install.checkDevEngines ({CWD}/lib/base-cmd.js:249:27)
+verbose stack     at MockNpm.execCommandClass ({CWD}/lib/npm.js:282:7)
 verbose stack     at MockNpm.exec ({CWD}/lib/npm.js:182:9)
 error code EBADDEVENGINES
 error EBADDEVENGINES The developer of this package has specified the following through devEngines
@@ -199,8 +199,8 @@ warn EBADDEVENGINES }
 verbose stack Error: The developer of this package has specified the following through devEngines
 verbose stack Invalid devEngines.runtime
 verbose stack Invalid name "nondescript" does not match "node" for "runtime"
-verbose stack     at Install.checkDevEngines ({CWD}/lib/base-cmd.js:247:27)
-verbose stack     at MockNpm.execCommandClass ({CWD}/lib/npm.js:281:7)
+verbose stack     at Install.checkDevEngines ({CWD}/lib/base-cmd.js:249:27)
+verbose stack     at MockNpm.execCommandClass ({CWD}/lib/npm.js:282:7)
 verbose stack     at MockNpm.exec ({CWD}/lib/npm.js:182:9)
 error code EBADDEVENGINES
 error EBADDEVENGINES The developer of this package has specified the following through devEngines
@@ -225,8 +225,8 @@ silly logfile done cleaning log files
 verbose stack Error: The developer of this package has specified the following through devEngines
 verbose stack Invalid devEngines.runtime
 verbose stack Invalid name "nondescript" does not match "node" for "runtime"
-verbose stack     at Install.checkDevEngines ({CWD}/lib/base-cmd.js:247:27)
-verbose stack     at MockNpm.execCommandClass ({CWD}/lib/npm.js:281:7)
+verbose stack     at Install.checkDevEngines ({CWD}/lib/base-cmd.js:249:27)
+verbose stack     at MockNpm.execCommandClass ({CWD}/lib/npm.js:282:7)
 verbose stack     at MockNpm.exec ({CWD}/lib/npm.js:182:9)
 error code EBADDEVENGINES
 error EBADDEVENGINES The developer of this package has specified the following through devEngines

--- a/test/lib/commands/stage/approve.js
+++ b/test/lib/commands/stage/approve.js
@@ -27,6 +27,7 @@ t.test('throws usageError without stage-id', async t => {
   })
   await t.rejects(npm.exec('stage', ['approve']), {
     code: 'EUSAGE',
+    message: /npm stage approve <stage-id>/,
   })
 })
 


### PR DESCRIPTION
## Summary
- Subcommand runtime usage errors (e.g., `npm stage approve` without a `<stage-id>`) rendered the bare subcommand name (e.g., `npm approve <stage-id>`) and `Run "npm help approve" for more info` -- pointing at a command and help page that don't exist.
- The subcommand instance now carries its parent command name, so usage output and `usageError` render the full path (`npm stage approve <stage-id>`) and point to the real help page (`npm help stage`)

This fix applies to `npm stage` and `npm trust`.

## Implementation
- `lib/npm.js`: set `parentName` on the subcommand instance during dispatch (and use the full joined path on the `--help` branch for parity).
- `lib/base-cmd.js`: the instance `usage` getter threads `parentName` into `getUsage`, and the help footer resolves to the top-level documented command.


## References
Fixes #9403 