### PR TITLE
chore: sanitize newlines in flags table default and type values

### DIFF
--- a/docs/lib/index.js
+++ b/docs/lib/index.js
@@ -151,10 +151,12 @@ const generateFlagsTable = (definitionPool) => {
     if (!defaultVal) {
       defaultVal = String(def.default)
     }
+    defaultVal = defaultVal.replace(/\n/g, ' ').trim()
     let typeVal = def.typeDescription || String(def.type)
     if (def.required) {
       typeVal = `${typeVal} (required)`
     }
+    typeVal = typeVal.replace(/\n/g, ' ').trim()
     const desc = (def.description || '').replace(/\n/g, ' ').trim()
     return `| ${flagsStr} | ${defaultVal} | ${typeVal} | ${desc} |`
   })


### PR DESCRIPTION
Backport of #9393 to release/v11.

The `generateFlagsTable` function in `docs/lib/index.js` sanitizes `description` for newlines but not `defaultVal` or `typeVal`. Multi-line `defaultDescription` values (like `--access`) break the markdown table rendering.

Adds `.replace(/\n/g, ' ').trim()` to both `defaultVal` and `typeVal`, matching the existing sanitization on `desc`.