### PR TITLE
fix: don't apply min-release-age in `npm audit signatures`

### DIFF
--- a/lib/utils/verify-signatures.js
+++ b/lib/utils/verify-signatures.js
@@ -303,6 +303,11 @@ class VerifySignatures {
       verifyAttestations: true,
       ...this.buildRegistryConfig(registry),
       ...this.npm.flatOptions,
+      // These versions are already installed, so the before/min-release-age
+      // filter doesn't apply here. It was already applied at install time, and
+      // leaving it set makes pacote throw ETARGET for any version newer than
+      // the cutoff. See npm/cli#9277.
+      before: null,
     })
     const signatures = _signatures || []
     const result = {

--- a/test/lib/commands/audit.js
+++ b/test/lib/commands/audit.js
@@ -906,6 +906,26 @@ t.test('audit signatures', async t => {
     t.matchSnapshot(joinedOutput())
   })
 
+  t.test('with min-release-age set verifies installed versions', async t => {
+    const { npm, joinedOutput } = await loadMockNpm(t, {
+      prefixDir: installWithValidSigs,
+      config: {
+        'min-release-age': 99999,
+      },
+    })
+    const registry = new MockRegistry({ tap: t, registry: npm.config.get('registry') })
+    await manifestWithValidSigs({ registry })
+    mockTUF({ npm, target: TUF_VALID_KEYS_TARGET })
+
+    // min-release-age flattens into a `before` cutoff that previously leaked
+    // into the exact-version manifest lookup, producing a spurious ETARGET on
+    // already-installed versions. See npm/cli#9277.
+    await npm.exec('audit', ['signatures'])
+
+    t.notOk(process.exitCode, 'should exit successfully')
+    t.match(joinedOutput(), /audited 1 package/)
+  })
+
   t.test('with valid signatures using alias', async t => {
     const { npm, joinedOutput } = await loadMockNpm(t, {
       prefixDir: installWithAlias,


### PR DESCRIPTION
`audit signatures` checks the exact versions already installed, but `min-release-age`/`before` was being passed into the manifest lookup and failing with ETARGET on versions `npm ci` had just installed. Setting `before: null` for that lookup fixes it. Fixes #9277.