### PR TITLE
fix(prune): respect allowScripts policy from package.json

### DIFF
--- a/lib/commands/prune.js
+++ b/lib/commands/prune.js
@@ -1,4 +1,5 @@
 const reifyFinish = require('../utils/reify-finish.js')
+const resolveAllowScripts = require('../utils/resolve-allow-scripts.js')
 const ArboristWorkspaceCmd = require('../arborist-cmd.js')
 
 class Prune extends ArboristWorkspaceCmd {
@@ -19,10 +20,12 @@ class Prune extends ArboristWorkspaceCmd {
   async exec () {
     const where = this.npm.prefix
     const Arborist = require('@npmcli/arborist')
+    const { policy: allowScriptsPolicy } = await resolveAllowScripts(this.npm)
     const opts = {
       ...this.npm.flatOptions,
       path: where,
       workspaces: this.workspaceNames,
+      allowScripts: allowScriptsPolicy,
     }
     const arb = new Arborist(opts)
     await arb.prune(opts)

--- a/test/lib/commands/prune.js
+++ b/test/lib/commands/prune.js
@@ -19,3 +19,30 @@ t.test('should prune using Arborist', async (t) => {
   })
   await npm.exec('prune', [])
 })
+
+t.test('prune threads allowScripts policy through to arborist (approve)', async t => {
+  let capturedOpts
+  const FakeArborist = function (opts) {
+    capturedOpts = opts
+    this.options = opts
+    this.actualTree = { inventory: new Map() }
+  }
+  FakeArborist.prototype.prune = async function () {}
+
+  const mock = await loadMockNpm(t, {
+    prefixDir: {
+      'package.json': JSON.stringify({
+        name: 'host',
+        version: '1.0.0',
+        allowScripts: { canvas: true },
+      }),
+    },
+    mocks: {
+      '@npmcli/arborist': FakeArborist,
+      '{LIB}/utils/reify-finish.js': async () => {},
+    },
+  })
+  await mock.npm.exec('prune', [])
+  t.strictSame(capturedOpts.allowScripts, { canvas: true },
+    'opts.allowScripts populated from package.json')
+})


### PR DESCRIPTION
`npm prune` was emitting an `allow-scripts` advisory warning even when the package was explicitly approved in `package.json#allowScripts`. This PR mirrors the `allowScript` setup and testing already present in `lib/commands/update.js`.

> [!NOTE]
> The same `allow-scripts` advisory warning issue was also noticed when executing other commands (e.g.; `npm dedupe`, `npm audit fix`, etc.). They are deliberately out of scope for this PR since I didn't notice them until after I filed the associated issue.

Fixes #9435