### PR TITLE
fix: invalid issue template YAML indentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -18,6 +18,6 @@ contact_links:
   - name: 📫 Support
     url: https://github.community/
     about: For general support questions please open a topic over at github.community
-   - name: 🚑 Support Policy
+  - name: 🚑 Support Policy
     url: https://github.com/npm/cli/wiki/Support-Policy
     about: Information about what version(s) of the CLI we support


### PR DESCRIPTION
## What changed

Fix the indentation of the final `contact_links` entry in `.github/ISSUE_TEMPLATE/config.yml`.

## Why

That entry was indented one space too far, which made the issue template config invalid YAML instead of a valid list item.

## Impact

GitHub can parse the issue template config as intended again.

## Validation

- Parsed `.github/ISSUE_TEMPLATE/config.yml` successfully with Ruby `YAML.load_file`
