### PR TITLE
fix(config): correct `--all` help for approve-scripts and deny-scripts

### DIFF
--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -210,9 +210,10 @@ The value \`private\` is an alias for \`restricted\`.
 * Default: false
 * Type: Boolean
 
-When running \`npm outdated\` and \`npm ls\`, setting \`--all\` will show all
-outdated or installed packages, rather than only those directly depended
-upon by the current project.
+Show or act on all packages, not just the ones your project directly depends
+on. For \`npm outdated\` and \`npm ls\` this lists every outdated or installed
+package. For \`npm approve-scripts\` and \`npm deny-scripts\` it selects every
+package with pending install scripts.
 
 
 
@@ -3019,7 +3020,7 @@ Options:
 [-a|--all] [--allow-scripts-pending] [--no-allow-scripts-pin] [--json]
 
   -a|--all
-    When running \`npm outdated\` and \`npm ls\`, setting \`--all\` will show
+    Show or act on all packages, not just the ones your project directly
 
   --allow-scripts-pending
     List packages with install scripts that are not yet covered by the
@@ -3532,7 +3533,7 @@ Options:
 [-a|--all] [--allow-scripts-pending] [--no-allow-scripts-pin] [--json]
 
   -a|--all
-    When running \`npm outdated\` and \`npm ls\`, setting \`--all\` will show
+    Show or act on all packages, not just the ones your project directly
 
   --allow-scripts-pending
     List packages with install scripts that are not yet covered by the
@@ -4807,7 +4808,7 @@ Options:
 [--workspaces] [--include-workspace-root] [--install-links]
 
   -a|--all
-    When running \`npm outdated\` and \`npm ls\`, setting \`--all\` will show
+    Show or act on all packages, not just the ones your project directly
 
   --json
     Whether or not to output JSON data, rather than the normal output.
@@ -4954,7 +4955,7 @@ Options:
 [--workspaces] [--include-workspace-root] [--install-links]
 
   -a|--all
-    When running \`npm outdated\` and \`npm ls\`, setting \`--all\` will show
+    Show or act on all packages, not just the ones your project directly
 
   --json
     Whether or not to output JSON data, rather than the normal output.
@@ -5103,7 +5104,7 @@ Options:
 [--before <date>] [--min-release-age <days>]
 
   -a|--all
-    When running \`npm outdated\` and \`npm ls\`, setting \`--all\` will show
+    Show or act on all packages, not just the ones your project directly
 
   --json
     Whether or not to output JSON data, rather than the normal output.

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -178,9 +178,10 @@ const definitions = {
     type: Boolean,
     short: 'a',
     description: `
-    When running \`npm outdated\` and \`npm ls\`, setting \`--all\` will show
-    all outdated or installed packages, rather than only those directly
-    depended upon by the current project.
+    Show or act on all packages, not just the ones your project directly
+    depends on. For \`npm outdated\` and \`npm ls\` this lists every outdated
+    or installed package. For \`npm approve-scripts\` and \`npm deny-scripts\`
+    it selects every package with pending install scripts.
   `,
     flatten,
   }),
@@ -2347,13 +2348,13 @@ const definitions = {
       If you ask npm to install a package and don't tell it a specific version,
       then it will install the specified tag.
 
-      It is the tag added to the package@version specified in the 
+      It is the tag added to the package@version specified in the
       \`npm dist-tag add\` command, if no explicit tag is given.
 
       When used by the \`npm diff\` command, this is the tag used to fetch the
       tarball that will be compared with the local files by default.
-      
-      If used in the \`npm publish\` command, this is the tag that will be 
+
+      If used in the \`npm publish\` command, this is the tag that will be
       added to the package submitted to the registry.
     `,
     flatten (key, obj, flatOptions) {


### PR DESCRIPTION
The `--all` help text was written for `npm ls`/`npm outdated`, so it made no sense on `approve-scripts` and `deny-scripts`. Reworded it to cover all four commands.

## References

Fixes #9448