### PR TITLE
fix: respect allowScripts policy in prune, dedupe, uninstall, audit, and link

### DIFF
--- a/lib/commands/audit.js
+++ b/lib/commands/audit.js
@@ -3,6 +3,7 @@ const ArboristWorkspaceCmd = require('../arborist-cmd.js')
 const auditError = require('../utils/audit-error.js')
 const { log, output } = require('proc-log')
 const reifyFinish = require('../utils/reify-finish.js')
+const resolveAllowScripts = require('../utils/resolve-allow-scripts.js')
 const VerifySignatures = require('../utils/verify-signatures.js')
 
 class Audit extends ArboristWorkspaceCmd {
@@ -58,12 +59,14 @@ class Audit extends ArboristWorkspaceCmd {
     }
     const reporter = this.npm.config.get('json') ? 'json' : 'detail'
     const Arborist = require('@npmcli/arborist')
+    const { policy: allowScriptsPolicy } = await resolveAllowScripts(this.npm)
     const opts = {
       ...this.npm.flatOptions,
       audit: true,
       path: this.npm.prefix,
       reporter,
       workspaces: this.workspaceNames,
+      allowScripts: allowScriptsPolicy,
     }
 
     const arb = new Arborist(opts)

--- a/lib/commands/dedupe.js
+++ b/lib/commands/dedupe.js
@@ -1,4 +1,5 @@
 const reifyFinish = require('../utils/reify-finish.js')
+const resolveAllowScripts = require('../utils/resolve-allow-scripts.js')
 const ArboristWorkspaceCmd = require('../arborist-cmd.js')
 
 // dedupe duplicated packages, or find them in the tree
@@ -35,6 +36,7 @@ class Dedupe extends ArboristWorkspaceCmd {
     const dryRun = this.npm.config.get('dry-run')
     const where = this.npm.prefix
     const Arborist = require('@npmcli/arborist')
+    const { policy: allowScriptsPolicy } = await resolveAllowScripts(this.npm)
     const opts = {
       ...this.npm.flatOptions,
       path: where,
@@ -44,6 +46,7 @@ class Dedupe extends ArboristWorkspaceCmd {
       // In order to reduce potential confusion we set this to false.
       save: false,
       workspaces: this.workspaceNames,
+      allowScripts: allowScriptsPolicy,
     }
     const arb = new Arborist(opts)
     await arb.dedupe(opts)

--- a/lib/commands/link.js
+++ b/lib/commands/link.js
@@ -4,6 +4,7 @@ const npa = require('npm-package-arg')
 const pkgJson = require('@npmcli/package-json')
 const semver = require('semver')
 const reifyFinish = require('../utils/reify-finish.js')
+const resolveAllowScripts = require('../utils/resolve-allow-scripts.js')
 const ArboristWorkspaceCmd = require('../arborist-cmd.js')
 
 class Link extends ArboristWorkspaceCmd {
@@ -115,11 +116,13 @@ class Link extends ArboristWorkspaceCmd {
       )
     // create a new arborist instance for the local prefix and
     // reify all the pending names as symlinks there
+    const { policy: allowScriptsPolicy } = await resolveAllowScripts(this.npm)
     const localArb = new Arborist({
       ...this.npm.flatOptions,
       prune: false,
       path: this.npm.prefix,
       save,
+      allowScripts: allowScriptsPolicy,
     })
     await localArb.reify({
       ...this.npm.flatOptions,
@@ -128,6 +131,7 @@ class Link extends ArboristWorkspaceCmd {
       add: names.map(l => `file:${resolve(globalTop, 'node_modules', l)}`),
       save,
       workspaces: this.workspaceNames,
+      allowScripts: allowScriptsPolicy,
     })
 
     await reifyFinish(this.npm, localArb)

--- a/lib/commands/prune.js
+++ b/lib/commands/prune.js
@@ -1,4 +1,5 @@
 const reifyFinish = require('../utils/reify-finish.js')
+const resolveAllowScripts = require('../utils/resolve-allow-scripts.js')
 const ArboristWorkspaceCmd = require('../arborist-cmd.js')
 
 class Prune extends ArboristWorkspaceCmd {
@@ -19,10 +20,12 @@ class Prune extends ArboristWorkspaceCmd {
   async exec () {
     const where = this.npm.prefix
     const Arborist = require('@npmcli/arborist')
+    const { policy: allowScriptsPolicy } = await resolveAllowScripts(this.npm)
     const opts = {
       ...this.npm.flatOptions,
       path: where,
       workspaces: this.workspaceNames,
+      allowScripts: allowScriptsPolicy,
     }
     const arb = new Arborist(opts)
     await arb.prune(opts)

--- a/lib/commands/uninstall.js
+++ b/lib/commands/uninstall.js
@@ -1,6 +1,7 @@
 const { resolve } = require('node:path')
 const pkgJson = require('@npmcli/package-json')
 const reifyFinish = require('../utils/reify-finish.js')
+const resolveAllowScripts = require('../utils/resolve-allow-scripts.js')
 const completion = require('../utils/installed-shallow.js')
 const ArboristWorkspaceCmd = require('../arborist-cmd.js')
 
@@ -39,11 +40,13 @@ class Uninstall extends ArboristWorkspaceCmd {
       : this.npm.localPrefix
 
     const Arborist = require('@npmcli/arborist')
+    const { policy: allowScriptsPolicy } = await resolveAllowScripts(this.npm)
     const opts = {
       ...this.npm.flatOptions,
       path,
       rm: args,
       workspaces: this.workspaceNames,
+      allowScripts: allowScriptsPolicy,
     }
     const arb = new Arborist(opts)
     await arb.reify(opts)

--- a/test/lib/commands/audit.js
+++ b/test/lib/commands/audit.js
@@ -2258,3 +2258,31 @@ t.test('audit signatures', async t => {
     })
   })
 })
+
+t.test('audit fix threads allowScripts policy through to arborist', async t => {
+  let capturedOpts
+  const FakeArborist = function (opts) {
+    capturedOpts = opts
+    this.options = opts
+    this.actualTree = { inventory: new Map() }
+    this.auditReport = {}
+  }
+  FakeArborist.prototype.audit = async () => {}
+
+  const { npm } = await loadMockNpm(t, {
+    prefixDir: {
+      'package.json': JSON.stringify({
+        name: 'host',
+        version: '1.0.0',
+        allowScripts: { canvas: true },
+      }),
+    },
+    mocks: {
+      '@npmcli/arborist': FakeArborist,
+      '{LIB}/utils/reify-finish.js': async () => {},
+    },
+  })
+  await npm.exec('audit', ['fix'])
+  t.strictSame(capturedOpts.allowScripts, { canvas: true },
+    'opts.allowScripts populated from package.json')
+})

--- a/test/lib/commands/dedupe.js
+++ b/test/lib/commands/dedupe.js
@@ -94,3 +94,30 @@ t.test('dedupe', async (t) => {
     fs.existsSync(path.join(npm.prefix, 'node_modules', 'test-dep-b', 'node_modules', 'test-sub')),
     'test-dep-b/test-sub was removed')
 })
+
+t.test('dedupe threads allowScripts policy through to arborist', async t => {
+  let capturedOpts
+  const FakeArborist = function (opts) {
+    capturedOpts = opts
+    this.options = opts
+    this.actualTree = { inventory: new Map() }
+  }
+  FakeArborist.prototype.dedupe = async () => {}
+
+  const { npm } = await loadMockNpm(t, {
+    prefixDir: {
+      'package.json': JSON.stringify({
+        name: 'host',
+        version: '1.0.0',
+        allowScripts: { canvas: true },
+      }),
+    },
+    mocks: {
+      '@npmcli/arborist': FakeArborist,
+      '{LIB}/utils/reify-finish.js': async () => {},
+    },
+  })
+  await npm.exec('dedupe', [])
+  t.strictSame(capturedOpts.allowScripts, { canvas: true },
+    'opts.allowScripts populated from package.json')
+})

--- a/test/lib/commands/link.js
+++ b/test/lib/commands/link.js
@@ -523,3 +523,34 @@ t.test('test linked installed as symlinks', async t => {
 
   t.matchSnapshot(await printLinks(), 'linked package should not be installed')
 })
+
+t.test('link threads allowScripts policy through to arborist', async t => {
+  const capturedOpts = []
+  const FakeArborist = function (opts) {
+    capturedOpts.push(opts)
+    this.options = opts
+    this.actualTree = { inventory: new Map() }
+  }
+  FakeArborist.prototype.loadActual = async () => ({ isLink: false, children: new Map() })
+  FakeArborist.prototype.reify = async () => {}
+
+  const mock = await mockNpm(t, {
+    command: 'link',
+    prefixDir: {
+      'package.json': JSON.stringify({
+        name: 'host',
+        version: '1.0.0',
+        allowScripts: { canvas: true },
+      }),
+    },
+    mocks: {
+      '@npmcli/arborist': FakeArborist,
+      '{LIB}/utils/reify-finish.js': async () => {},
+    },
+  })
+  await mock.npm.exec('link', ['canvas'])
+  // the local Arborist is the last one constructed in linkInstall
+  const localOpts = capturedOpts[capturedOpts.length - 1]
+  t.strictSame(localOpts.allowScripts, { canvas: true },
+    'local arborist opts.allowScripts populated from package.json')
+})

--- a/test/lib/commands/prune.js
+++ b/test/lib/commands/prune.js
@@ -19,3 +19,30 @@ t.test('should prune using Arborist', async (t) => {
   })
   await npm.exec('prune', [])
 })
+
+t.test('prune threads allowScripts policy through to arborist', async t => {
+  let capturedOpts
+  const FakeArborist = function (opts) {
+    capturedOpts = opts
+    this.options = opts
+    this.actualTree = { inventory: new Map() }
+  }
+  FakeArborist.prototype.prune = async () => {}
+
+  const { npm } = await loadMockNpm(t, {
+    prefixDir: {
+      'package.json': JSON.stringify({
+        name: 'host',
+        version: '1.0.0',
+        allowScripts: { canvas: true },
+      }),
+    },
+    mocks: {
+      '@npmcli/arborist': FakeArborist,
+      '{LIB}/utils/reify-finish.js': async () => {},
+    },
+  })
+  await npm.exec('prune', [])
+  t.strictSame(capturedOpts.allowScripts, { canvas: true },
+    'opts.allowScripts populated from package.json')
+})

--- a/test/lib/commands/uninstall.js
+++ b/test/lib/commands/uninstall.js
@@ -214,3 +214,30 @@ t.test('completion', async t => {
   const res = await uninstall.completion({ conf: { argv: { remain: ['npm', 'uninstall'] } } })
   t.match(res, ['bar', 'foo'])
 })
+
+t.test('uninstall threads allowScripts policy through to arborist', async t => {
+  let capturedOpts
+  const FakeArborist = function (opts) {
+    capturedOpts = opts
+    this.options = opts
+    this.actualTree = { inventory: new Map() }
+  }
+  FakeArborist.prototype.reify = async () => {}
+
+  const { npm } = await _mockNpm(t, {
+    prefixDir: {
+      'package.json': JSON.stringify({
+        name: 'host',
+        version: '1.0.0',
+        allowScripts: { canvas: true },
+      }),
+    },
+    mocks: {
+      '@npmcli/arborist': FakeArborist,
+      '{LIB}/utils/reify-finish.js': async () => {},
+    },
+  })
+  await npm.exec('uninstall', ['canvas'])
+  t.strictSame(capturedOpts.allowScripts, { canvas: true },
+    'opts.allowScripts populated from package.json')
+})


### PR DESCRIPTION
These commands built Arborist options without resolving the `package.json` `allowScripts` policy, so they warned about install scripts that were already approved. They now resolve the policy the same way `install`, `ci`, and `update` do.

## References

Fixes #9435
Superseded #9438