### PR TITLE
fix(arborist): link meta-only optional peers in linked strategy

### DIFF
--- a/workspaces/arborist/lib/arborist/isolated-reifier.js
+++ b/workspaces/arborist/lib/arborist/isolated-reifier.js
@@ -213,6 +213,22 @@ module.exports = cls => class IsolatedReifier extends cls {
     // local `file:` deps (non-workspace fsChildren) should be treated as local dependencies, not external, so they get symlinked directly instead of being extracted into the store.
     const isLocal = (n) => n.isWorkspace || node.fsChildren?.has(n)
     const optionalDeps = edges.filter(edge => edge.optional).map(edge => edge.to.target)
+
+    // Optional peers declared only in peerDependenciesMeta (e.g. `@types/react`) have no edge, so the materialization above misses them.
+    // Resolve each from the tree and link it; if nobody provides it, node.resolve finds nothing and it stays omitted.
+    const peerMeta = node.package.peerDependenciesMeta
+    if (peerMeta) {
+      const resolvedNames = new Set([...nonOptionalDeps, ...optionalDeps].map(n => n.name))
+      for (const peerName in peerMeta) {
+        if (!peerMeta[peerName]?.optional || resolvedNames.has(peerName)) {
+          continue
+        }
+        const resolved = node.resolve(peerName)?.target
+        if (resolved && resolved !== node && !resolved.inert && !isLocal(resolved)) {
+          optionalDeps.push(resolved)
+        }
+      }
+    }
     result.localDependencies = await Promise.all(nonOptionalDeps.filter(isLocal).map(n => this.#workspaceProxy(n)))
     result.externalDependencies = await Promise.all(nonOptionalDeps.filter(n => !isLocal(n) && !n.inert).map(n => this.#externalProxy(n)))
     result.externalOptionalDependencies = await Promise.all(optionalDeps.filter(n => !n.inert).map(n => this.#externalProxy(n)))

--- a/workspaces/arborist/test/isolated-mode.js
+++ b/workspaces/arborist/test/isolated-mode.js
@@ -1310,6 +1310,56 @@ tap.test('failing optional peer deps are not installed', async t => {
   t.notOk(setupRequire(dir)('bar', 'which'), 'Failing optional peer deps should not be installed')
 })
 
+tap.test('optional peer declared only in peerDependenciesMeta is materialized when provided', async t => {
+  // Regression for npm/cli#9460.
+  // `bar` declares `which` as an optional peer via peerDependenciesMeta only, with no peerDependencies entry, so no edge is created for it.
+  // The workspace provides `which`, so under the linked strategy `which` should be linked into `bar`'s store node_modules (matching pnpm).
+  // `which` is not a root dependency, so it is not hoisted to the top-level node_modules where parent-dir lookup would mask the result.
+  const graph = {
+    registry: [
+      { name: 'which', version: '1.0.0' },
+      { name: 'bar', version: '1.0.0', peerDependenciesMeta: { which: { optional: true } } },
+    ],
+    root: { name: 'foo', version: '1.2.3' },
+    workspaces: [
+      { name: 'app', version: '1.0.0', dependencies: { bar: '*', which: '1.0.0' } },
+    ],
+  }
+
+  const { dir, registry } = await getRepo(graph)
+
+  // Note that we override this cache to prevent interference from other tests
+  const cache = fs.mkdtempSync(`${getTempDir()}/test-`)
+  const arborist = new Arborist({ path: dir, registry, packumentCache: new Map(), cache })
+  await arborist.reify({ installStrategy: 'linked' })
+
+  t.ok(setupRequire(path.join(dir, 'packages', 'app'))('bar', 'which'),
+    'optional peer provided by the workspace is materialized into bar store node_modules')
+})
+
+tap.test('optional peer declared only in peerDependenciesMeta is omitted when not provided', async t => {
+  // Counterpart to the regression above: when nobody provides the optional peer it must stay omitted, preserving "optional" semantics.
+  const graph = {
+    registry: [
+      { name: 'bar', version: '1.0.0', peerDependenciesMeta: { which: { optional: true } } },
+    ],
+    root: { name: 'foo', version: '1.2.3' },
+    workspaces: [
+      { name: 'app', version: '1.0.0', dependencies: { bar: '*' } },
+    ],
+  }
+
+  const { dir, registry } = await getRepo(graph)
+
+  // Note that we override this cache to prevent interference from other tests
+  const cache = fs.mkdtempSync(`${getTempDir()}/test-`)
+  const arborist = new Arborist({ path: dir, registry, packumentCache: new Map(), cache })
+  await arborist.reify({ installStrategy: 'linked' })
+
+  t.notOk(setupRequire(path.join(dir, 'packages', 'app'))('bar', 'which'),
+    'optional peer that nobody provides is not materialized')
+})
+
 // Virtual packages are 2 packages that have the same version but are
 // duplicated on disk to solve peer-dependency conflict.
 tap.test('virtual packages', async t => {


### PR DESCRIPTION
In continuation of our exploration of using `install-strategy=linked` in the [Gutenberg monorepo](https://github.com/WordPress/gutenberg/pull/75814), which powers the WordPress Block Editor.

Under `install-strategy=linked`, an optional peer dependency declared only in `peerDependenciesMeta` (with no matching entry in `peerDependencies`) was not linked into the dependent's isolated `node_modules`, even when an ancestor in the graph provided it.
For example `@emotion/react` declares `react` in `peerDependencies` and `@types/react` only in `peerDependenciesMeta`; after a linked install its store `node_modules` contained `react` but not `@types/react`, so its shipped `.d.ts` could not resolve the React typings under strict isolation and the breakage cascaded into consumers as TypeScript errors.

The root cause is that npm only creates dependency edges from `peerDependencies`.
A peer named only in `peerDependenciesMeta` gets no edge at all.
The isolated reifier materializes a dependency into a package's store `node_modules` only when the package has a resolved edge for it (`edge.to.target`), so the meta-only optional peer was silently dropped.
Required peers (and optional peers that also appear in `peerDependencies`) have edges and were materialized correctly; meta-only optional peers were the gap.

This PR resolves the gap in `#assignCommonProperties` in `isolated-reifier.js`.
After the edge-derived dependency lists are built, it iterates `peerDependenciesMeta`, and for each optional entry that is not already a dependency it resolves the name against the tree via `node.resolve()` and, when found, materializes it as an optional store dependency.
Because the peer is added to the package's store dependency set, the store instance's hash is keyed by it, and it resolves to the same instance the consumer uses rather than a duplicate copy.
If no ancestor provides the peer, `node.resolve()` returns nothing and it stays omitted, preserving optional semantics.

## References

Fixes #9460