### PR TITLE
feat!: default allow-git and allow-remote to none

### DIFF
--- a/lib/utils/error-message.js
+++ b/lib/utils/error-message.js
@@ -80,6 +80,7 @@ const errorMessage = (er, npm) => {
     }
 
     case 'EALLOWGIT':
+    case 'EALLOWREMOTE':
       summary.push(['', er.message])
       detail.push(['', `Refusing to fetch "${er.package}"`])
       break

--- a/tap-snapshots/test/lib/commands/config.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/config.js.test.cjs
@@ -18,8 +18,8 @@ exports[`test/lib/commands/config.js TAP config list --json > output matches sna
   "allow-same-version": false,
   "allow-directory": "all",
   "allow-file": "all",
-  "allow-git": "all",
-  "allow-remote": "all",
+  "allow-git": "none",
+  "allow-remote": "none",
   "allow-scripts": [
     ""
   ],
@@ -201,8 +201,8 @@ access = null
 all = false
 allow-directory = "all"
 allow-file = "all"
-allow-git = "all"
-allow-remote = "all"
+allow-git = "none"
+allow-remote = "none"
 allow-same-version = false
 allow-scripts = [""]
 allow-scripts-pending = false

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -255,7 +255,7 @@ dependencies to be used for other commands like \`npm view\`
 
 #### \`allow-git\`
 
-* Default: "all"
+* Default: "none"
 * Type: "all", "none", or "root"
 
 Limits the ability for npm to fetch dependencies from git references. That
@@ -263,6 +263,11 @@ is, dependencies that point to a git repo instead of a version or semver
 range. Please note that this could leave your tree incomplete and some
 packages may not function as intended or designed. Changing this setting
 will not remove dependencies that are already installed.
+
+As of npm 12 the default is \`none\`. Git dependencies run \`git\` against a
+remote repo and may install configuration the project does not control. Opt
+in explicitly per project (in \`.npmrc\`) or per command (on the CLI) when you
+need git deps.
 
 \`all\` allows any git dependencies to be fetched and installed. \`none\`
 prevents any git dependencies from being fetched and installed. \`root\` only
@@ -274,7 +279,7 @@ like \`npm view\`
 
 #### \`allow-remote\`
 
-* Default: "all"
+* Default: "none"
 * Type: "all", "none", or "root"
 
 Limits the ability for npm to fetch dependencies from urls. That is,
@@ -282,6 +287,13 @@ dependencies that point to a tarball url instead of a version or semver
 range. Please note that this could leave your tree incomplete and some
 packages may not function as intended or designed. Changing this setting
 will not remove dependencies that are already installed.
+
+As of npm 12 the default is \`none\`. Tarballs that share a hostname with the
+configured registry (the typical case for the npm registry, GitHub Packages,
+and most private registries) are still installed normally. If your registry
+serves tarballs from a different host, set \`replace-registry-host\` or
+override this setting. Opt in explicitly per project (in \`.npmrc\`) or per
+command (on the CLI) when you intentionally install from a URL.
 
 \`all\` allows any url to be installed. \`none\` prevents any url from being
 installed. \`root\` only allows urls defined in your project's package.json to
@@ -2778,8 +2790,8 @@ Object {
   "all": false,
   "allowDirectory": "all",
   "allowFile": "all",
-  "allowGit": "all",
-  "allowRemote": "all",
+  "allowGit": "none",
+  "allowRemote": "none",
   "allowSameVersion": false,
   "allowScripts": Array [],
   "allowScriptsPending": false,

--- a/test/lib/commands/exec.js
+++ b/test/lib/commands/exec.js
@@ -268,6 +268,7 @@ t.test('packs from git spec', async t => {
     config: {
       audit: false,
       yes: true,
+      'allow-git': 'all',
     },
   })
   try {

--- a/test/lib/commands/install.js
+++ b/test/lib/commands/install.js
@@ -367,6 +367,20 @@ t.test('exec commands', async t => {
     )
   })
 
+  t.test('allow-git default rejects git deps', async t => {
+    const { npm } = await loadMockNpm(t, {
+      config: { audit: false },
+    })
+    await t.rejects(
+      npm.exec('install', ['npm/npm']),
+      {
+        code: 'EALLOWGIT',
+        package: 'github:npm/npm',
+      },
+      'no explicit allow-git config still blocks git installs'
+    )
+  })
+
   t.test('allow-git=root refuses non-root git dependency', async t => {
     const { npm } = await loadMockNpm(t, {
       config: {
@@ -505,6 +519,24 @@ t.test('exec commands', async t => {
       npm.exec('install', []),
       { code: 'EALLOWREMOTE' },
       'user-supplied remote URL is still blocked'
+    )
+  })
+
+  t.test('allow-remote default rejects a user-supplied remote URL', async t => {
+    const { npm } = await loadMockNpm(t, {
+      config: { audit: false },
+      prefixDir: {
+        'package.json': JSON.stringify({
+          name: '@npmcli/test-package',
+          version: '1.0.0',
+          dependencies: { abbrev: 'https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz' },
+        }),
+      },
+    })
+    await t.rejects(
+      npm.exec('install', []),
+      { code: 'EALLOWREMOTE' },
+      'no explicit allow-remote config still blocks user-supplied tarball URLs'
     )
   })
 })

--- a/test/lib/commands/view.js
+++ b/test/lib/commands/view.js
@@ -394,7 +394,9 @@ const loadMockNpm = async function (t, opts = {}) {
 }
 
 t.test('package from git', async t => {
-  const { view, joinedOutput } = await loadMockNpm(t, { config: { unicode: false } })
+  const { view, joinedOutput } = await loadMockNpm(t, {
+    config: { unicode: false, 'allow-git': 'all' },
+  })
   await view.exec(['https://github.com/npm/green'])
   t.matchSnapshot(joinedOutput())
 })

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -225,13 +225,18 @@ const definitions = {
     flatten,
   }),
   'allow-git': new Definition('allow-git', {
-    default: 'all',
+    default: 'none',
     type: ['all', 'none', 'root'],
     description: `
       Limits the ability for npm to fetch dependencies from git references.
       That is, dependencies that point to a git repo instead of a version or semver range.
       Please note that this could leave your tree incomplete and some packages may not function as intended or designed.
       Changing this setting will not remove dependencies that are already installed.
+
+      As of npm 12 the default is \`none\`. Git dependencies run \`git\`
+      against a remote repo and may install configuration the project does
+      not control. Opt in explicitly per project (in \`.npmrc\`) or per
+      command (on the CLI) when you need git deps.
 
       \`all\` allows any git dependencies to be fetched and installed.
       \`none\` prevents any git dependencies from being fetched and installed.
@@ -240,13 +245,21 @@ const definitions = {
     flatten,
   }),
   'allow-remote': new Definition('allow-remote', {
-    default: 'all',
+    default: 'none',
     type: ['all', 'none', 'root'],
     description: `
       Limits the ability for npm to fetch dependencies from urls.
       That is, dependencies that point to a tarball url instead of a version or semver range.
       Please note that this could leave your tree incomplete and some packages may not function as intended or designed.
       Changing this setting will not remove dependencies that are already installed.
+
+      As of npm 12 the default is \`none\`. Tarballs that share a hostname
+      with the configured registry (the typical case for the npm registry,
+      GitHub Packages, and most private registries) are still installed
+      normally. If your registry serves tarballs from a different host,
+      set \`replace-registry-host\` or override this setting. Opt in
+      explicitly per project (in \`.npmrc\`) or per command (on the CLI)
+      when you intentionally install from a URL.
 
       \`all\` allows any url to be installed.
       \`none\` prevents any url from being installed.

--- a/workspaces/config/test/definitions/definitions.js
+++ b/workspaces/config/test/definitions/definitions.js
@@ -1068,6 +1068,33 @@ t.test('node-gyp', t => {
   t.end()
 })
 
+t.test('allow-git defaults to none and flattens to allowGit', t => {
+  const defs = mockDefs()
+  t.equal(defs['allow-git'].default, 'none')
+  t.strictSame(defs['allow-git'].type, ['all', 'none', 'root'])
+  const flat = {}
+  defs['allow-git'].flatten('allow-git', { 'allow-git': 'root' }, flat)
+  t.strictSame(flat, { allowGit: 'root' })
+  t.end()
+})
+
+t.test('allow-remote defaults to none and flattens to allowRemote', t => {
+  const defs = mockDefs()
+  t.equal(defs['allow-remote'].default, 'none')
+  t.strictSame(defs['allow-remote'].type, ['all', 'none', 'root'])
+  const flat = {}
+  defs['allow-remote'].flatten('allow-remote', { 'allow-remote': 'all' }, flat)
+  t.strictSame(flat, { allowRemote: 'all' })
+  t.end()
+})
+
+t.test('allow-file and allow-directory still default to all', t => {
+  const defs = mockDefs()
+  t.equal(defs['allow-file'].default, 'all', 'allow-file unchanged')
+  t.equal(defs['allow-directory'].default, 'all', 'allow-directory unchanged')
+  t.end()
+})
+
 t.test('allow-scripts', t => {
   t.test('defaults to empty string and flattens to []', t => {
     const defs = mockDefs()

--- a/workspaces/libnpmdiff/lib/tarball.js
+++ b/workspaces/libnpmdiff/lib/tarball.js
@@ -29,10 +29,21 @@ const tarball = (manifest, opts) => {
     return nodeModulesTarball(manifest, opts)
   }
 
-  return pacote.tarball(manifest._resolved, {
-    ...opts,
-    Arborist,
-  })
+  // pacote re-parses manifest._resolved as type=remote, so allow-remote=none
+  // would mis-fire on the tarball URL the registry just handed us. mirror
+  // arborist reify's carve-out: trust resolved tarballs for registry-typed specs.
+  const tarballOpts = { ...opts, Arborist }
+  let fromSpec
+  try {
+    fromSpec = manifest._from ? npa(manifest._from) : null
+  } catch {
+    fromSpec = null
+  }
+  if (fromSpec?.registry) {
+    tarballOpts.allowRemote = 'all'
+  }
+
+  return pacote.tarball(manifest._resolved, tarballOpts)
 }
 
 module.exports = tarball

--- a/workspaces/libnpmdiff/test/tarball.js
+++ b/workspaces/libnpmdiff/test/tarball.js
@@ -93,3 +93,51 @@ t.test('pkg not in a node_modules folder', async t => {
     'should call regular pacote.tarball method instead'
   )
 })
+
+t.test('allowRemote carve-out for registry-mediated tarballs', async t => {
+  const originalTarball = pacote.tarball
+  let captured
+  pacote.tarball = async (resolved, opts) => {
+    captured = { resolved, opts }
+    return Buffer.alloc(0)
+  }
+  t.teardown(() => {
+    pacote.tarball = originalTarball
+  })
+
+  t.beforeEach(() => {
+    captured = undefined
+  })
+
+  t.test('registry-typed _from sets allowRemote=all', async t => {
+    await tarball({
+      _from: 'abbrev@1.0.0',
+      _resolved: 'https://registry.npmjs.org/abbrev/-/abbrev-1.0.0.tgz',
+    }, {})
+    t.equal(captured.opts.allowRemote, 'all')
+  })
+
+  t.test('non-registry _from leaves allowRemote untouched', async t => {
+    await tarball({
+      _from: 'https://example.com/foo.tgz',
+      _resolved: 'https://example.com/foo.tgz',
+    }, {})
+    t.notOk(captured.opts.allowRemote)
+  })
+
+  t.test('missing _from leaves allowRemote untouched', async t => {
+    await tarball({
+      _resolved: 'https://example.com/foo.tgz',
+    }, {})
+    t.notOk(captured.opts.allowRemote)
+  })
+
+  t.test('unparseable _from leaves allowRemote untouched', async t => {
+    // npa throws on tags with reserved characters, exercising the catch branch
+    await tarball({
+      _from: '@',
+      _resolved: 'https://example.com/foo.tgz',
+    }, {})
+    t.notOk(captured.opts.allowRemote)
+  })
+})

--- a/workspaces/libnpmpack/lib/index.js
+++ b/workspaces/libnpmpack/lib/index.js
@@ -64,11 +64,18 @@ async function pack (spec = 'file:.', opts = {}) {
   }
 
   // packs tarball
-  const tarball = await pacote.tarball(manifest._resolved, {
+  const tarballOpts = {
     ...opts,
     Arborist,
     integrity: manifest._integrity,
-  })
+  }
+  // pacote re-parses manifest._resolved as type=remote, so allow-remote=none
+  // would mis-fire on the tarball URL the registry just handed us. mirror
+  // arborist reify's carve-out: trust resolved tarballs for registry-typed specs.
+  if (spec.registry) {
+    tarballOpts.allowRemote = 'all'
+  }
+  const tarball = await pacote.tarball(manifest._resolved, tarballOpts)
 
   // check for explicit `false` so the default behavior is to skip writing to disk
   if (opts.dryRun === false) {


### PR DESCRIPTION
BREAKING CHANGE:  allow-git and allow-remote now default to "none"; set them to "all" (or "root") to install git or user-supplied tarball-URL dependencies.
