### PR TITLE
docs: update minimum npm required for npm trust

### DIFF
--- a/docs/lib/content/commands/npm-trust.md
+++ b/docs/lib/content/commands/npm-trust.md
@@ -12,7 +12,7 @@ description: Manage trusted publishing relationships between packages and CI/CD 
 
 Before using npm trust commands, ensure the following requirements are met:
 
-* **npm version**: `npm@11.10.0` or above is required. Use `npm install -g npm@^11.10.0` to update if needed.
+* **npm version**: `npm@11.15.0` or above is required. Use `npm install -g npm@^11.15.0` to update if needed.
 * **Write permissions on the package**: You must have write access to the package you're configuring.
 * **2FA enabled on account**: Two-factor authentication must be enabled at the account level. Even if it's not currently enabled, you must enable it to use trust commands.
 * **Supported authentication methods**: Granular Access Tokens (GAT) with the bypass 2FA option are not supported. Legacy basic auth (username and password) credentials will not work for trust commands or endpoints.


### PR DESCRIPTION
<!-- What / Why -->

with new `--allow-publish/--allow-staged-publish` the minimum version of npm needed for the trust command has changed
