### PR TITLE
ci: fix expression injection in pull-request workflow


### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -44,7 +44,10 @@ jobs:
       - name: Run Commitlint on Commits
         id: commit
         continue-on-error: true
-        run: npx --offline commitlint -V --from 'origin/${{ github.base_ref }}' --to ${{ github.event.pull_request.head.sha }}
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: npx --offline commitlint -V --from "origin/$BASE_REF" --to "$HEAD_SHA"
       - name: Run Commitlint on PR Title
         if: steps.commit.outcome == 'failure'
         env:


### PR DESCRIPTION
The commitlint step in `pull-request.yml` injects `github.base_ref` and `github.event.pull_request.head.sha` directly into shell. While typically safe values, this pattern is flagged by zizmor/actionlint and violates GitHub's security hardening guidelines.\n\nFix: use env vars instead of inline expressions.\n\nRef: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections
