### PR TITLE
feat: allowScripts tooling and inBundle hardening

### DIFF
--- a/lib/commands/rebuild.js
+++ b/lib/commands/rebuild.js
@@ -58,7 +58,7 @@ class Rebuild extends ArboristWorkspaceCmd {
 
         return spec
       })
-      const nodes = tree.inventory.filter(node => this.isNode(specs, node))
+      const nodes = [...tree.inventory.filter(node => this.isNode(specs, node))]
 
       await strictAllowScriptsPreflight({ arb, npm: this.npm })
       await arb.rebuild({ nodes })
@@ -93,6 +93,13 @@ class Rebuild extends ArboristWorkspaceCmd {
   }
 
   isNode (specs, node) {
+    // Bundled dependencies are never selected by name. Their identity comes
+    // from the bundling parent's tarball (a bundled folder can call itself
+    // anything), so `npm rebuild bcrypt` must never target a bundled
+    // `node_modules/bcrypt`. Their install scripts never run regardless.
+    if (node.inBundle) {
+      return false
+    }
     return specs.some(spec => {
       if (spec.type === 'directory') {
         return node.path === spec.fetchSpec

--- a/lib/utils/allow-scripts-cmd.js
+++ b/lib/utils/allow-scripts-cmd.js
@@ -110,27 +110,10 @@ class AllowScriptsCmd extends BaseCommand {
       output.standard('No packages with unreviewed install scripts.')
       return
     }
-    // Bundled dependencies cannot be allowlisted in Phase 1 (RFC defers
-    // this to a follow-up because matching by name@version from the
-    // bundled tarball would reintroduce manifest confusion). Exclude
-    // them from `--all` so we don't silently write a policy entry under
-    // attacker-controlled identity.
-    const candidates = unreviewed.filter(({ node }) => !node.inBundle)
-    const skipped = unreviewed.length - candidates.length
-    if (skipped > 0) {
-      /* istanbul ignore next: plural variant covered separately */
-      const noun = skipped === 1 ? 'dependency' : 'dependencies'
-      log.warn(
-        this.logTitle,
-        `Skipping ${skipped} bundled ${noun}; bundled deps with install ` +
-        'scripts cannot be allowlisted in this release.'
-      )
-    }
-    if (candidates.length === 0) {
-      output.standard('No packages eligible for approval.')
-      return
-    }
-    const groups = this.groupByPackage(candidates.map(({ node }) => node))
+    // Bundled dependencies never appear in `unreviewed` (checkAllowScripts
+    // skips them because they never run their install scripts and cannot
+    // be allowlisted), so there is nothing extra to filter here.
+    const groups = this.groupByPackage(unreviewed.map(({ node }) => node))
     await this.writePolicyChanges(groups)
   }
 

--- a/lib/utils/check-allow-scripts.js
+++ b/lib/utils/check-allow-scripts.js
@@ -1,59 +1,27 @@
-const isScriptAllowed = require('@npmcli/arborist/lib/script-allowed.js')
-const getInstallScripts = require('@npmcli/arborist/lib/install-scripts.js')
+const { collectUnreviewedScripts } = require('@npmcli/arborist/lib/unreviewed-scripts.js')
 
-// Walks arb.actualTree.inventory and returns the list of dep nodes that
-// have install-relevant lifecycle scripts and are not yet covered (or
-// explicitly denied) by the allowScripts policy.
+// Walks a tree's inventory and returns the list of dep nodes that have
+// install-relevant lifecycle scripts and are not yet covered (or explicitly
+// denied) by the allowScripts policy.
+//
+// Thin wrapper around arborist's shared `collectUnreviewedScripts`, mapping
+// the CLI's `({ arb, npm, tree })` shape onto the shared walk. Defaults to
+// `arb.actualTree` (post-reify) but accepts an explicit tree so callers can
+// pre-flight against the idealTree before scripts run.
 //
 // Returns an array of `{ node, scripts }` entries. `scripts` is an object
 // describing the relevant lifecycle scripts that would run.
-
-const checkAllowScripts = async ({ arb, npm, tree, includeWhenIgnored = false }) => {
-  const ignoreScripts = !!arb.options?.ignoreScripts
-  const dangerouslyAllowAll = !!npm?.flatOptions?.dangerouslyAllowAllScripts
-
-  // With ignore-scripts set, no scripts run, so execution callers
-  // (install, rebuild, strict preflight) bail out here. approve/deny pass
-  // includeWhenIgnored so they keep listing unreviewed packages, which is
-  // what you need to move from a blanket ignore-scripts to an allowlist.
-  // Listing never runs anything.
-  if ((ignoreScripts && !includeWhenIgnored) || dangerouslyAllowAll) {
-    return []
-  }
-
-  // Defaults to actualTree (post-reify) but accepts an explicit tree so
-  // callers can pre-flight against the idealTree before scripts run.
-  const targetTree = tree || arb.actualTree
-  if (!targetTree?.inventory) {
-    return []
-  }
-
-  const policy = arb.options?.allowScripts || null
-
-  const unreviewed = []
-  for (const node of targetTree.inventory.values()) {
-    if (node.isProjectRoot || node.isWorkspace) {
-      continue
-    }
-    if (node.isLink) {
-      // Linked workspace dependencies are managed by the workspace owner.
-      continue
-    }
-
-    const verdict = isScriptAllowed(node, policy)
-    if (verdict === true || verdict === false) {
-      continue
-    }
-
-    const scripts = await getInstallScripts(node)
-    if (Object.keys(scripts).length === 0) {
-      continue
-    }
-
-    unreviewed.push({ node, scripts })
-  }
-
-  return unreviewed
-}
+//
+// `includeWhenIgnored` keeps listing unreviewed packages even when
+// ignore-scripts is set, so approve/deny can show what you'd move from a
+// blanket ignore-scripts to an allowlist. Execution callers leave it false.
+const checkAllowScripts = async ({ arb, npm, tree, includeWhenIgnored = false }) =>
+  collectUnreviewedScripts({
+    tree: tree || arb.actualTree,
+    policy: arb.options?.allowScripts || null,
+    ignoreScripts: !!arb.options?.ignoreScripts,
+    dangerouslyAllowAllScripts: !!npm?.flatOptions?.dangerouslyAllowAllScripts,
+    includeWhenIgnored,
+  })
 
 module.exports = checkAllowScripts

--- a/test/lib/commands/approve-scripts.js
+++ b/test/lib/commands/approve-scripts.js
@@ -397,10 +397,10 @@ t.test('approve-scripts --pending lists packages that only have binding.gyp', as
   t.match(out, /install: node-gyp rebuild/, 'synthetic node-gyp install is named')
 })
 
-t.test('approve-scripts --all skips bundled deps with a notice', async t => {
-  // Bundled deps cannot be allowlisted in Phase 1 (RFC defers their
-  // allowlisting to a follow-up). --all must not silently write a key
-  // derived from the bundled tarball's self-claimed identity.
+t.test('approve-scripts --all never approves bundled deps', async t => {
+  // Bundled deps never run their install scripts and cannot be
+  // allowlisted. They never reach the unreviewed list, so --all must not
+  // write a key derived from the bundled tarball's self-claimed identity.
   const { npm, logs, prefix } = await _mockNpm(t, {
     prefixDir: {
       'package.json': JSON.stringify({
@@ -457,7 +457,8 @@ t.test('approve-scripts --all skips bundled deps with a notice', async t => {
     'non-bundled parent gets approved')
   t.notOk(Object.keys(pkg.allowScripts).some(k => k.startsWith('inner')),
     'bundled inner is not approved')
-  t.match(logs.warn.byTitle('approve-scripts'), [/Skipping 1 bundled dependency/])
+  t.strictSame(logs.warn.byTitle('approve-scripts'), [],
+    'no warning; bundled deps are excluded upstream')
 })
 
 t.test('approve-scripts <bundled-pkg> positional is ignored', async t => {
@@ -517,7 +518,7 @@ t.test('approve-scripts <bundled-pkg> positional is ignored', async t => {
   )
 })
 
-t.test('approve-scripts --all with only bundled deps prints "no eligible" notice', async t => {
+t.test('approve-scripts --all with only bundled deps has nothing to review', async t => {
   const { npm, logs, joinedOutput, prefix } = await _mockNpm(t, {
     prefixDir: {
       'package.json': JSON.stringify({
@@ -566,8 +567,9 @@ t.test('approve-scripts --all with only bundled deps prints "no eligible" notice
     config: { all: true },
   })
   await npm.exec('approve-scripts', [])
-  t.match(joinedOutput(), /No packages eligible for approval/)
-  t.match(logs.warn.byTitle('approve-scripts'), [/Skipping 1 bundled dependency/])
+  t.match(joinedOutput(), /No packages with unreviewed install scripts/)
+  t.strictSame(logs.warn.byTitle('approve-scripts'), [],
+    'no warning; bundled deps are excluded upstream')
   // Ensure no policy entry was written.
   const pkg = JSON.parse(fs.readFileSync(resolve(prefix, 'package.json'), 'utf8'))
   t.notOk(pkg.allowScripts, 'no allowScripts written')

--- a/test/lib/commands/rebuild.js
+++ b/test/lib/commands/rebuild.js
@@ -306,3 +306,49 @@ t.test('no advisory warning when allowScripts covers the package', async t => {
   await npm.exec('rebuild', [])
   t.strictSame(logs.warn.byTitle('rebuild'), [])
 })
+
+t.test('rebuild <name> never targets a bundled dependency', async t => {
+  const { npm, prefix: path } = await setupMockNpm(t, {
+    prefixDir: {
+      'package.json': JSON.stringify({
+        name: 'host',
+        version: '1.0.0',
+        dependencies: { parent: '1.0.0' },
+      }),
+      node_modules: {
+        parent: {
+          'index.js': '',
+          'package.json': JSON.stringify({
+            name: 'parent',
+            version: '1.0.0',
+            bundleDependencies: ['bcrypt'],
+            dependencies: { bcrypt: '1.0.0' },
+          }),
+          node_modules: {
+            bcrypt: {
+              'index.js': '',
+              'package.json': JSON.stringify({
+                name: 'bcrypt',
+                version: '1.0.0',
+                bin: 'index.js',
+                scripts: {
+                  install: "node -e \"require('fs').writeFileSync('ran', '')\"",
+                },
+              }),
+            },
+          },
+        },
+      },
+    },
+  })
+
+  const ranFile = resolve(path, 'node_modules/parent/node_modules/bcrypt/ran')
+  t.throws(() => fs.statSync(ranFile))
+
+  await npm.exec('rebuild', ['bcrypt'])
+
+  t.throws(
+    () => fs.statSync(ranFile),
+    'bundled bcrypt install script must not run'
+  )
+})

--- a/test/lib/utils/check-allow-scripts.js
+++ b/test/lib/utils/check-allow-scripts.js
@@ -149,46 +149,6 @@ t.test('prepare counts for non-registry sources only', async t => {
   t.equal(result[0].node.name, 'git-pkg')
 })
 
-t.test('detects synthetic node-gyp via binding.gyp runtime check', async t => {
-  const checkAllowScripts = mockCheck(t, {
-    '@npmcli/arborist/lib/install-scripts.js': async (n) => {
-      if (n.path === '/has-bindings') {
-        return { install: 'node-gyp rebuild' }
-      }
-      return {}
-    },
-  })
-
-  const result = await checkAllowScripts({
-    arb: arb({
-      nodes: [
-        node({ name: 'native', path: '/has-bindings' }),
-        node({ name: 'pure-js', path: '/no-bindings' }),
-      ],
-    }),
-    npm: { flatOptions: {} },
-  })
-  t.equal(result.length, 1)
-  t.equal(result[0].node.name, 'native')
-  t.strictSame(result[0].scripts, { install: 'node-gyp rebuild' })
-})
-
-t.test('skips node-gyp detection when gypfile is explicitly false', async t => {
-  // Mock returns no scripts to simulate the gypfile:false short-circuit
-  // inside getInstallScripts.
-  const checkAllowScripts = mockCheck(t, {
-    '@npmcli/arborist/lib/install-scripts.js': async () => ({}),
-  })
-
-  const result = await checkAllowScripts({
-    arb: arb({
-      nodes: [node({ name: 'opt-out', gypfile: false })],
-    }),
-    npm: { flatOptions: {} },
-  })
-  t.strictSame(result, [])
-})
-
 t.test('skips approved nodes', async t => {
   const checkAllowScripts = mockCheck(t)
   const result = await checkAllowScripts({
@@ -252,7 +212,7 @@ t.test('survives missing actualTree', async t => {
   t.strictSame(result, [])
 })
 
-t.test('bundled dep with install scripts is reported as unreviewed regardless of policy', async t => {
+t.test('bundled dep with install scripts is never reported (never runs, never pending)', async t => {
   const checkAllowScripts = mockCheck(t)
   const bundled = node({
     name: 'bundled-pkg',
@@ -265,13 +225,12 @@ t.test('bundled dep with install scripts is reported as unreviewed regardless of
   const result = await checkAllowScripts({
     arb: arb({
       nodes: [bundled],
-      // Policy explicitly allows the bundled name — the matcher should
-      // still return null and the walker should still flag the bundled
-      // dep as unreviewed.
+      // Even with an explicit allow entry, a bundled dep never runs its
+      // install scripts and is never counted as pending, so the walker
+      // must not flag it.
       allowScripts: { 'bundled-pkg': true },
     }),
     npm: { flatOptions: {} },
   })
-  t.equal(result.length, 1, 'bundled dep flagged despite explicit allow entry')
-  t.equal(result[0].node, bundled)
+  t.strictSame(result, [], 'bundled dep never flagged')
 })

--- a/workspaces/arborist/lib/arborist/isolated-reifier.js
+++ b/workspaces/arborist/lib/arborist/isolated-reifier.js
@@ -38,9 +38,10 @@ module.exports = cls => class IsolatedReifier extends cls {
   #processedEdges = new Set()
   #workspaceProxies = new Map()
 
-  #generateChild (node, location, pkg, isInStore, root) {
+  #generateChild (node, location, pkg, isInStore, root, inBundle = false) {
     const newChild = new IsolatedNode({
       isInStore,
+      inBundle,
       location,
       name: node.packageName || node.name,
       optional: node.optional,
@@ -327,7 +328,7 @@ module.exports = cls => class IsolatedReifier extends cls {
     })
 
     bundledTree.nodes.forEach(node => {
-      this.#generateChild(node, node.location, node.pkg, false, root)
+      this.#generateChild(node, node.location, node.pkg, false, root, true)
     })
 
     bundledTree.edges.forEach(edge => {

--- a/workspaces/arborist/lib/isolated-classes.js
+++ b/workspaces/arborist/lib/isolated-classes.js
@@ -19,6 +19,7 @@ class IsolatedNode {
   integrity = null
   inventory = new IsolatedInventory()
   isInStore = false
+  inBundle = false
   linksIn = new Set()
   meta = { loadedFromDisk: false }
   optional = false
@@ -45,6 +46,9 @@ class IsolatedNode {
     }
     if (options.isInStore) {
       this.isInStore = true
+    }
+    if (options.inBundle) {
+      this.inBundle = true
     }
     if (options.optional) {
       this.optional = true

--- a/workspaces/arborist/lib/script-allowed.js
+++ b/workspaces/arborist/lib/script-allowed.js
@@ -24,13 +24,13 @@ const versionFromTgz = require('./version-from-tgz.js')
 //     resolved committish
 
 const isScriptAllowed = (node, policy) => {
-  // Bundled dependencies cannot be allowlisted in Phase 1. The RFC defers
-  // allowlisting them to a follow-up RFC because matching by name@version
-  // from the bundled tarball would reintroduce manifest confusion (a
-  // bundled tarball can claim any name and version). Returning null here
-  // marks bundled deps as unreviewed regardless of any policy entries, so
-  // their install scripts surface in the Phase 1 advisory warning and
-  // (eventually) get blocked at the install-time gate.
+  // Bundled dependencies never run their install scripts and cannot be
+  // allowlisted. Matching by name@version from the bundled tarball would
+  // reintroduce manifest confusion (a bundled tarball can claim any name
+  // and version). Returning null marks them as not-allowed regardless of
+  // any policy entry, so their install scripts are blocked by the
+  // install-time gate. A package that needs a bundled dep's script must
+  // forward it as one of its own lifecycle scripts.
   if (node.inBundle) {
     return null
   }
@@ -319,11 +319,11 @@ const isRegistryNode = (node) => {
   return /^https?:\/\/[^/]+\/.+\/-\/[^/]+-\d/.test(node.resolved)
 }
 
-// Trusted display identity for human-facing output (`npm install`
-// advisory, `npm approve-scripts --allow-scripts-pending`). Same idea as
-// getTrustedRegistryIdentity, but for DISPLAY only — version falls back
-// to node.version when the URL doesn't carry one. Must never be used
-// for policy matching.
+// Trusted display identity for human-facing output (the `npm install`
+// blocked-scripts summary and `npm approve-scripts --allow-scripts-pending`).
+// Same as getTrustedRegistryIdentity, but for display only: version
+// falls back to node.version when the URL doesn't carry one. Do not
+// use for policy matching.
 const trustedDisplay = (node) => {
   const trusted = getTrustedRegistryIdentity(node)
   /* istanbul ignore next: defensive fallbacks for nodes without name/version */

--- a/workspaces/arborist/lib/unreviewed-scripts.js
+++ b/workspaces/arborist/lib/unreviewed-scripts.js
@@ -1,0 +1,94 @@
+const isScriptAllowed = require('./script-allowed.js')
+const getInstallScripts = require('./install-scripts.js')
+
+// Shared allowScripts walk used by both the npm CLI
+// (lib/utils/check-allow-scripts.js, lib/utils/strict-allow-scripts-preflight.js)
+// and libnpmexec (npm exec / npx). It lives in arborist because that is the
+// only package both callers can import.
+//
+// Walks a tree's inventory and returns the dep nodes that have
+// install-relevant lifecycle scripts and are not yet covered (or explicitly
+// denied) by the allowScripts policy.
+//
+// Returns an array of `{ node, scripts }` entries. `scripts` is an object
+// describing the relevant lifecycle scripts that would run.
+const collectUnreviewedScripts = async ({
+  tree,
+  policy,
+  ignoreScripts = false,
+  dangerouslyAllowAllScripts = false,
+  includeWhenIgnored = false,
+} = {}) => {
+  // With ignore-scripts set, no scripts run, so execution callers bail out
+  // here. approve/deny pass includeWhenIgnored so they keep listing
+  // unreviewed packages, which is what you need to move from a blanket
+  // ignore-scripts to an allowlist. Listing never runs anything.
+  if ((ignoreScripts && !includeWhenIgnored) || dangerouslyAllowAllScripts) {
+    return []
+  }
+
+  if (!tree?.inventory) {
+    return []
+  }
+
+  const resolvedPolicy = policy || null
+
+  const unreviewed = []
+  for (const node of tree.inventory.values()) {
+    if (node.isProjectRoot || node.isWorkspace) {
+      continue
+    }
+    if (node.isLink) {
+      // Linked workspace dependencies are managed by the workspace owner.
+      continue
+    }
+    if (node.inBundle) {
+      // Bundled dependencies never run their install scripts and cannot be
+      // allowlisted, so they are never "pending". Skipping them keeps them
+      // out of the advisory warning and out of strict-allow-scripts. A
+      // package that needs a bundled dep's script must forward it as one of
+      // its own lifecycle scripts.
+      continue
+    }
+
+    const verdict = isScriptAllowed(node, resolvedPolicy)
+    if (verdict === true || verdict === false) {
+      continue
+    }
+
+    const scripts = await getInstallScripts(node)
+    if (Object.keys(scripts).length === 0) {
+      continue
+    }
+
+    unreviewed.push({ node, scripts })
+  }
+
+  return unreviewed
+}
+
+// Builds the `ESTRICTALLOWSCRIPTS` error thrown by the strict-mode preflight
+// from a list of `{ node, scripts }` entries. `remediation` is the
+// caller-specific guidance appended after the package list (npm install vs
+// npm exec have different remediation commands).
+const strictAllowScriptsError = (unreviewed, { remediation } = {}) => {
+  const lines = unreviewed.map(({ node, scripts }) => {
+    const events = Object.entries(scripts)
+      .map(([event, body]) => `${event}: ${body}`)
+      .join('; ')
+    const name = node.package?.name || node.name
+    const version = node.package?.version || ''
+    const label = version ? `${name}@${version}` : name
+    return `  ${label} (${events})`
+  }).join('\n')
+
+  return Object.assign(
+    new Error(
+      `--strict-allow-scripts: ${unreviewed.length} package(s) have install ` +
+      `scripts not covered by allowScripts:\n${lines}\n${remediation}`
+    ),
+    { code: 'ESTRICTALLOWSCRIPTS' }
+  )
+}
+
+module.exports = { collectUnreviewedScripts, strictAllowScriptsError }

--- a/workspaces/arborist/test/script-allowed.js
+++ b/workspaces/arborist/test/script-allowed.js
@@ -314,11 +314,11 @@ t.test('isRegistryNode — arborist isRegistryDependency true accepts even unusu
   t.equal(isScriptAllowed(arboristNode, { 'trusted@1.0.0': true }), true)
 })
 
-t.test('bundled deps cannot be allowlisted (Phase 1 blocks outright)', async t => {
+t.test('bundled deps cannot be allowlisted (never run)', async t => {
   // Bundled dependencies have inBundle=true and no independent resolved
-  // URL. The RFC explicitly forbids allowlisting them in Phase 1 because
-  // matching by name@version from the bundled tarball would reintroduce
-  // manifest confusion. They must always return null (unreviewed).
+  // URL. They can never be allowlisted because matching by name@version
+  // from the bundled tarball would reintroduce manifest confusion. They
+  // always return null, and their install scripts never run.
 
   const bundled = {
     name: 'bundled-pkg',
@@ -341,8 +341,8 @@ t.test('bundled deps cannot be allowlisted (Phase 1 blocks outright)', async t =
 
 t.test('bundled deps: deny entry does not match either (returns null, not false)', async t => {
   // A deny entry doesn't apply to bundled deps because they're outside
-  // the policy scope entirely. Phase 1 blocks them via the walker, not
-  // via the policy.
+  // the policy scope entirely. They're blocked because they never run,
+  // not via a policy entry.
   const bundled = {
     name: 'bundled-pkg',
     packageName: 'bundled-pkg',
@@ -376,6 +376,41 @@ t.test('inBundle: false does not affect normal matching', async t => {
     inBundle: false,
   }
   t.equal(isScriptAllowed(normal, { 'pkg@1.0.0': true }), true)
+})
+
+t.test('isolated mode (linked): bundled IsolatedNode is blocked', async t => {
+  // Regression guard: in isolated/linked mode the gate runs against
+  // IsolatedNode instances, not real Nodes. A bundled IsolatedNode must
+  // report inBundle so the gate blocks it even when its resolved URL
+  // looks like a registry identity that a name entry would otherwise
+  // match. Without inBundle on IsolatedNode the guard is silently
+  // skipped and the bundled install script runs.
+  const { IsolatedNode } = require('../lib/isolated-classes.js')
+
+  const bundled = new IsolatedNode({
+    inBundle: true,
+    location: 'node_modules/bundled-pkg',
+    name: 'bundled-pkg',
+    package: { name: 'bundled-pkg', version: '1.0.0' },
+    path: '/project/node_modules/bundled-pkg',
+    resolved: 'https://registry.npmjs.org/bundled-pkg/-/bundled-pkg-1.0.0.tgz',
+  })
+
+  t.equal(bundled.inBundle, true, 'bundled IsolatedNode reports inBundle')
+  t.equal(isScriptAllowed(bundled, { 'bundled-pkg': true }), null)
+  t.equal(isScriptAllowed(bundled, { 'bundled-pkg@1.0.0': true }), null)
+
+  const store = new IsolatedNode({
+    isInStore: true,
+    location: 'node_modules/.store/store-pkg@1.0.0/node_modules/store-pkg',
+    name: 'store-pkg',
+    package: { name: 'store-pkg', version: '1.0.0' },
+    path: '/project/node_modules/.store/store-pkg@1.0.0/node_modules/store-pkg',
+    resolved: 'https://registry.npmjs.org/store-pkg/-/store-pkg-1.0.0.tgz',
+  })
+
+  t.equal(store.inBundle, false, 'external store IsolatedNode is not bundled')
+  t.equal(isScriptAllowed(store, { 'store-pkg@1.0.0': true }), true)
 })
 
 t.test('manifest confusion: malicious tarball self-name cannot bypass allow entry', async t => {

--- a/workspaces/arborist/test/unreviewed-scripts.js
+++ b/workspaces/arborist/test/unreviewed-scripts.js
@@ -1,0 +1,169 @@
+const t = require('tap')
+const {
+  collectUnreviewedScripts,
+  strictAllowScriptsError,
+} = require('../lib/unreviewed-scripts.js')
+
+// Loads a fresh copy of the shared module with `install-scripts.js` mocked,
+// so script detection (including the synthetic node-gyp `binding.gyp` path)
+// can be controlled without touching the filesystem.
+const mockCollect = (t, getInstallScripts) =>
+  t.mock('../lib/unreviewed-scripts.js', {
+    '../lib/install-scripts.js': getInstallScripts,
+  }).collectUnreviewedScripts
+
+// Minimal tree fixture for the walk.
+const tree = (nodes) => ({
+  inventory: new Map(nodes.map((n, i) => [`node_modules/${n.name || `n${i}`}`, n])),
+})
+
+// Registry-shaped node so the real script-allowed/install-scripts helpers
+// behave deterministically (registry tarballs skip `prepare`, and the
+// identity matcher keys off the resolved URL).
+const node = ({
+  name = 'pkg',
+  version = '1.0.0',
+  scripts = {},
+  isProjectRoot = false,
+  isWorkspace = false,
+  isLink = false,
+  inBundle = false,
+  resolved,
+} = {}) => ({
+  name,
+  packageName: name,
+  version,
+  resolved: resolved ?? `https://registry.npmjs.org/${name}/-/${name}-${version}.tgz`,
+  location: `node_modules/${name}`,
+  isProjectRoot,
+  isWorkspace,
+  isLink,
+  inBundle,
+  isRegistryDependency: true,
+  package: { name, version, scripts },
+})
+
+t.test('collectUnreviewedScripts', async t => {
+  t.test('returns [] when ignoreScripts is set', async t => {
+    const result = await collectUnreviewedScripts({
+      tree: tree([node({ scripts: { install: 'x' } })]),
+      policy: null,
+      ignoreScripts: true,
+    })
+    t.strictSame(result, [])
+  })
+
+  t.test('returns [] when dangerouslyAllowAllScripts is set', async t => {
+    const result = await collectUnreviewedScripts({
+      tree: tree([node({ scripts: { install: 'x' } })]),
+      policy: null,
+      dangerouslyAllowAllScripts: true,
+    })
+    t.strictSame(result, [])
+  })
+
+  t.test('returns [] when tree has no inventory', async t => {
+    t.strictSame(await collectUnreviewedScripts({ tree: undefined }), [])
+    t.strictSame(await collectUnreviewedScripts({ tree: {} }), [])
+    t.strictSame(await collectUnreviewedScripts({}), [])
+    t.strictSame(await collectUnreviewedScripts(), [])
+  })
+
+  t.test('skips project root, workspace, linked, and bundled nodes', async t => {
+    const result = await collectUnreviewedScripts({
+      tree: tree([
+        node({ name: 'root', scripts: { install: 'x' }, isProjectRoot: true }),
+        node({ name: 'ws', scripts: { install: 'x' }, isWorkspace: true }),
+        node({ name: 'linked', scripts: { install: 'x' }, isLink: true }),
+        node({ name: 'bundled', scripts: { install: 'x' }, inBundle: true }),
+      ]),
+      policy: null,
+    })
+    t.strictSame(result, [])
+  })
+
+  t.test('skips nodes with no install-relevant scripts', async t => {
+    const result = await collectUnreviewedScripts({
+      tree: tree([node({ scripts: { test: 'jest' } })]),
+      policy: null,
+    })
+    t.strictSame(result, [])
+  })
+
+  t.test('collects unreviewed install scripts', async t => {
+    const result = await collectUnreviewedScripts({
+      tree: tree([
+        node({ name: 'a', scripts: { preinstall: 'pre' } }),
+        node({ name: 'b', scripts: { install: 'inst' } }),
+        node({ name: 'c', scripts: { postinstall: 'post' } }),
+      ]),
+      policy: null,
+    })
+    t.equal(result.length, 3)
+    t.strictSame(result[0].scripts, { preinstall: 'pre' })
+    t.strictSame(result[1].scripts, { install: 'inst' })
+    t.strictSame(result[2].scripts, { postinstall: 'post' })
+  })
+
+  t.test('skips nodes the policy allows or denies', async t => {
+    const result = await collectUnreviewedScripts({
+      tree: tree([
+        node({ name: 'allowed', version: '1.0.0', scripts: { install: 'x' } }),
+        node({ name: 'denied', version: '1.0.0', scripts: { install: 'x' } }),
+        node({ name: 'pending', version: '1.0.0', scripts: { install: 'x' } }),
+      ]),
+      policy: { allowed: true, denied: false },
+    })
+    t.equal(result.length, 1)
+    t.equal(result[0].node.name, 'pending')
+  })
+
+  t.test('detects synthetic node-gyp via binding.gyp runtime check', async t => {
+    const collect = mockCollect(t, async (n) => {
+      if (n.path === '/has-bindings') {
+        return { install: 'node-gyp rebuild' }
+      }
+      return {}
+    })
+    const result = await collect({
+      tree: tree([
+        { ...node({ name: 'native' }), path: '/has-bindings' },
+        { ...node({ name: 'pure-js' }), path: '/no-bindings' },
+      ]),
+      policy: null,
+    })
+    t.equal(result.length, 1)
+    t.equal(result[0].node.name, 'native')
+    t.strictSame(result[0].scripts, { install: 'node-gyp rebuild' })
+  })
+})
+
+t.test('strictAllowScriptsError', async t => {
+  const unreviewed = [
+    { node: { package: { name: 'a', version: '1.0.0' } }, scripts: { install: 'do-a' } },
+    { node: { package: { name: 'b', version: '2.0.0' } }, scripts: { preinstall: 'pre', postinstall: 'post' } },
+  ]
+
+  const err = strictAllowScriptsError(unreviewed, { remediation: 'FIX IT.' })
+  t.equal(err.code, 'ESTRICTALLOWSCRIPTS')
+  t.match(err.message, /2 package\(s\) have install scripts not covered by allowScripts:/)
+  t.match(err.message, /a@1\.0\.0 \(install: do-a\)/)
+  t.match(err.message, /b@2\.0\.0 \(preinstall: pre; postinstall: post\)/)
+  t.match(err.message, /FIX IT\.$/)
+})
+
+t.test('strictAllowScriptsError falls back to node.name when no package', async t => {
+  const err = strictAllowScriptsError(
+    [{ node: { name: 'c' }, scripts: { install: 'x' } }],
+    { remediation: 'go.' }
+  )
+  t.match(err.message, /\n {2}c \(install: x\)\n/)
+})
+
+t.test('strictAllowScriptsError defaults options when called without them', async t => {
+  const err = strictAllowScriptsError(
+    [{ node: { name: 'c' }, scripts: { install: 'x' } }]
+  )
+  t.equal(err.code, 'ESTRICTALLOWSCRIPTS')
+  t.match(err.message, /\n {2}c \(install: x\)\n/)
+})

--- a/workspaces/libnpmexec/lib/index.js
+++ b/workspaces/libnpmexec/lib/index.js
@@ -4,6 +4,7 @@ const { dirname, join, resolve } = require('node:path')
 const crypto = require('node:crypto')
 const { mkdir } = require('node:fs/promises')
 const Arborist = require('@npmcli/arborist')
+const strictAllowScriptsPreflight = require('./strict-allow-scripts-preflight.js')
 const ciInfo = require('ci-info')
 const { log, input } = require('proc-log')
 const npa = require('npm-package-arg')
@@ -85,6 +86,9 @@ const missingFromTree = async ({ spec, tree, flatOptions, isNpxTree, shallow }) 
     return { manifest }
   }
 }
+
+// Strict-mode pre-flight for `npm exec` / `npx` lives in
+// ./strict-allow-scripts-preflight.js
 
 // see if the package.json at `path` has an entry that matches `cmd`
 // the path is a known-local directory, not a user-supplied dep, so
@@ -301,11 +305,16 @@ const exec = async (opts) => {
           }
         }
       }
-      await withLock(lockPath, () => npxArb.reify({
-        ...flatOptions,
-        save: true,
-        add,
-      }))
+      await withLock(lockPath, async () => {
+        // Hard-fail before reify if --strict-allow-scripts is set and
+        // any node has install scripts not covered by allowScripts.
+        await strictAllowScriptsPreflight(npxArb, { ...flatOptions, add })
+        await npxArb.reify({
+          ...flatOptions,
+          save: true,
+          add,
+        })
+      })
     }
     binPaths.push(resolve(installDir, 'node_modules/.bin'))
     const pkgJson = await PackageJson.load(installDir)

--- a/workspaces/libnpmexec/lib/strict-allow-scripts-preflight.js
+++ b/workspaces/libnpmexec/lib/strict-allow-scripts-preflight.js
@@ -1,0 +1,40 @@
+const { collectUnreviewedScripts, strictAllowScriptsError } = require('@npmcli/arborist/lib/unreviewed-scripts.js')
+
+// Strict-mode pre-flight for `npm exec` / `npx`. When
+// `--strict-allow-scripts` is set, build the npx-cache ideal tree and
+// throw before reify if any node has install scripts not covered by
+// the resolved `allowScripts` policy. The arborist gate already
+// silently skips those scripts; this turns the silent skip into a
+// hard failure for CI. Bypassed by `--ignore-scripts` and
+// `--dangerously-allow-all-scripts`.
+const strictAllowScriptsPreflight = async (arb, opts) => {
+  if (!opts.strictAllowScripts) {
+    return
+  }
+  if (opts.ignoreScripts || opts.dangerouslyAllowAllScripts) {
+    return
+  }
+
+  if (!arb.idealTree) {
+    await arb.buildIdealTree(opts)
+  }
+
+  const unreviewed = await collectUnreviewedScripts({
+    tree: arb.idealTree,
+    policy: opts.allowScripts || null,
+    ignoreScripts: opts.ignoreScripts,
+    dangerouslyAllowAllScripts: opts.dangerouslyAllowAllScripts,
+  })
+
+  if (unreviewed.length === 0) {
+    return
+  }
+
+  throw strictAllowScriptsError(unreviewed, {
+    remediation:
+      'Pass --allow-scripts=<pkg> for one-off approval, or bypass this ' +
+      'check with --dangerously-allow-all-scripts.',
+  })
+}
+
+module.exports = strictAllowScriptsPreflight

--- a/workspaces/libnpmexec/test/strict-allow-scripts-preflight.js
+++ b/workspaces/libnpmexec/test/strict-allow-scripts-preflight.js
@@ -1,0 +1,82 @@
+const t = require('tap')
+
+const strictAllowScriptsPreflight = require('../lib/strict-allow-scripts-preflight.js')
+
+// a node carrying install scripts that the policy has not reviewed
+const unreviewedTree = {
+  inventory: new Map([
+    ['node_modules/has-scripts', {
+      name: 'has-scripts',
+      location: 'node_modules/has-scripts',
+      package: { scripts: { install: 'node-gyp rebuild' } },
+    }],
+  ]),
+}
+
+const fakeArb = (idealTree) => {
+  const arb = {
+    idealTree,
+    buildIdealTreeCalled: false,
+    async buildIdealTree () {
+      arb.buildIdealTreeCalled = true
+      arb.idealTree = unreviewedTree
+    },
+  }
+  return arb
+}
+
+t.test('no-op when strictAllowScripts is not set', async t => {
+  const arb = fakeArb(unreviewedTree)
+  await t.resolves(strictAllowScriptsPreflight(arb, {}))
+  t.notOk(arb.buildIdealTreeCalled, 'does not build the ideal tree')
+})
+
+t.test('bypassed by ignoreScripts', async t => {
+  const arb = fakeArb(unreviewedTree)
+  await t.resolves(strictAllowScriptsPreflight(arb,
+    { strictAllowScripts: true, ignoreScripts: true }))
+  t.notOk(arb.buildIdealTreeCalled, 'does not build the ideal tree')
+})
+
+t.test('bypassed by dangerouslyAllowAllScripts', async t => {
+  const arb = fakeArb(unreviewedTree)
+  await t.resolves(strictAllowScriptsPreflight(arb,
+    { strictAllowScripts: true, dangerouslyAllowAllScripts: true }))
+  t.notOk(arb.buildIdealTreeCalled, 'does not build the ideal tree')
+})
+
+t.test('builds the ideal tree when missing', async t => {
+  const arb = fakeArb(null)
+  await t.rejects(
+    strictAllowScriptsPreflight(arb, { strictAllowScripts: true }),
+    /install scripts/i,
+    'throws on unreviewed scripts'
+  )
+  t.ok(arb.buildIdealTreeCalled, 'builds the ideal tree')
+})
+
+t.test('throws when unreviewed scripts are present', async t => {
+  const arb = fakeArb(unreviewedTree)
+  await t.rejects(
+    strictAllowScriptsPreflight(arb, { strictAllowScripts: true }),
+    { code: 'ESTRICTALLOWSCRIPTS' },
+    'throws with the strict-allow-scripts error'
+  )
+})
+
+t.test('resolves when no unreviewed scripts are present', async t => {
+  const cleanTree = {
+    inventory: new Map([
+      ['node_modules/no-scripts', {
+        name: 'no-scripts',
+        location: 'node_modules/no-scripts',
+        package: {},
+      }],
+    ]),
+  }
+  const arb = fakeArb(cleanTree)
+  await t.resolves(
+    strictAllowScriptsPreflight(arb, { strictAllowScripts: true }),
+    'no error when nothing is unreviewed'
+  )
+})


### PR DESCRIPTION
Pulls the non-behavioral pieces out of #9424 so they can land on v11: the `collectUnreviewedScripts`/`strictAllowScriptsError` helpers, the `inBundle` fixes, and an opt-in libnpmexec preflight. Nothing changes by default here, install scripts still run. The default-deny flip stays in #9424 for v12.


## References

#9424
