### PR TITLE
fix(arborist): apply registry-tarball allow-remote exemption in linked strategy

### DIFF
--- a/workspaces/arborist/lib/arborist/isolated-reifier.js
+++ b/workspaces/arborist/lib/arborist/isolated-reifier.js
@@ -42,6 +42,7 @@ module.exports = cls => class IsolatedReifier extends cls {
     const newChild = new IsolatedNode({
       isInStore,
       inBundle,
+      isRegistryDependency: node.isRegistryDependency,
       location,
       name: node.packageName || node.name,
       optional: node.optional,
@@ -153,6 +154,9 @@ module.exports = cls => class IsolatedReifier extends cls {
     result.optional = node.optional
     result.resolved = node.resolved
     result.version = node.version
+    // Carry the source node's registry-dependency flag so the store node retains it.
+    // IsolatedNode has no edges to recompute it from, and reify's registry-tarball allow-remote exemption depends on it.
+    result.isRegistryDependency = node.isRegistryDependency
     return result
   }
 

--- a/workspaces/arborist/lib/isolated-classes.js
+++ b/workspaces/arborist/lib/isolated-classes.js
@@ -20,6 +20,7 @@ class IsolatedNode {
   inventory = new IsolatedInventory()
   isInStore = false
   inBundle = false
+  isRegistryDependency = false
   linksIn = new Set()
   meta = { loadedFromDisk: false }
   optional = false
@@ -49,6 +50,9 @@ class IsolatedNode {
     }
     if (options.inBundle) {
       this.inBundle = true
+    }
+    if (options.isRegistryDependency) {
+      this.isRegistryDependency = true
     }
     if (options.optional) {
       this.optional = true

--- a/workspaces/arborist/test/arborist/reify.js
+++ b/workspaces/arborist/test/arborist/reify.js
@@ -3854,6 +3854,56 @@ t.test('should preserve exact ranges, missing actual tree', async (t) => {
     await t.resolves(arb.reify(), 'same-origin tarball is allowed for registry root')
   })
 
+  t.test('allowRemote=none allows registry tarball under linked install strategy', async t => {
+    // The linked strategy extracts store nodes as IsolatedNode, which has no edges to recompute isRegistryDependency from.
+    // The flag must be carried from the source tree node so the registry-tarball allow-remote exemption still applies.
+    const abbrevPackument5 = JSON.stringify({
+      _id: 'abbrev',
+      _rev: 'lkjadflkjasdf',
+      name: 'abbrev',
+      'dist-tags': { latest: '1.1.1' },
+      versions: {
+        '1.1.1': {
+          name: 'abbrev',
+          version: '1.1.1',
+          dist: {
+            tarball: 'https://registry.example.com/npm/abbrev/-/abbrev-1.1.1.tgz',
+          },
+        },
+      },
+    })
+
+    const testdir = t.testdir({
+      project: {
+        'package.json': JSON.stringify({
+          name: 'myproject',
+          version: '1.0.0',
+          dependencies: {
+            abbrev: '1.1.1',
+          },
+        }),
+      },
+    })
+
+    tnock(t, 'https://registry.example.com')
+      .get('/npm/abbrev')
+      .reply(200, abbrevPackument5)
+
+    tnock(t, 'https://registry.example.com')
+      .get('/npm/abbrev/-/abbrev-1.1.1.tgz')
+      .reply(200, abbrevTGZ)
+
+    const arb = new Arborist({
+      path: resolve(testdir, 'project'),
+      registry: 'https://registry.example.com/npm',
+      cache: resolve(testdir, 'cache'),
+      allowRemote: 'none',
+      installStrategy: 'linked',
+    })
+
+    await t.resolves(arb.reify(), 'registry tarball is allowed under linked strategy')
+  })
+
   t.test('registry with different protocol should swap protocol', async (t) => {
     const abbrevPackument4 = JSON.stringify({
       _id: 'abbrev',

--- a/workspaces/arborist/test/script-allowed.js
+++ b/workspaces/arborist/test/script-allowed.js
@@ -402,6 +402,7 @@ t.test('isolated mode (linked): bundled IsolatedNode is blocked', async t => {
 
   const store = new IsolatedNode({
     isInStore: true,
+    isRegistryDependency: true, // carried from the source node by #externalProxy
     location: 'node_modules/.store/store-pkg@1.0.0/node_modules/store-pkg',
     name: 'store-pkg',
     package: { name: 'store-pkg', version: '1.0.0' },


### PR DESCRIPTION
In continuation of our exploration of using `install-strategy=linked` in the [Gutenberg monorepo](https://github.com/WordPress/gutenberg/pull/75814), which powers the WordPress Block Editor.

Under `install-strategy=linked`, a fresh install fails with `EALLOWREMOTE` on ordinary registry dependencies whose lockfile `resolved` is a full registry tarball URL, even though `allow-remote=none` is meant to permit registry-mediated tarballs. The standard (hoisted) reifier installs the same dependency fine; only the linked strategy rejects it.

```
npm error code EALLOWREMOTE
npm error Fetching packages of type "remote" have been disabled
npm error Refusing to fetch "minimatch@https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz"
```

## Why

Both strategies extract through the same `pacote.extract` in `reify.js`, which exempts registry tarballs from the allow-remote gate via `#isRegistryResolvedTarball`. That check first requires `node.isRegistryDependency`. In the linked strategy, store nodes are `IsolatedNode` instances — a standalone class that emulates `lib/node.js` but has no `isRegistryDependency` getter and no edges to recompute it from. So `node.isRegistryDependency` was `undefined`, the exemption short-circuited to `false`, the `allowRemote: 'all'` override was never applied, and pacote rejected the same-origin registry tarball.

This is the second half of the allow-remote registry-tarball handling: the URL-matching half was hardened previously (origin + registry-path-prefix); this fixes the `isRegistryDependency` half for the linked path. The origin/path security check still runs unchanged on the linked path — a tampered lockfile pointing at a foreign host is still blocked.

## How

Carry the registry-dependency flag from the source tree node onto the store node, rather than weakening the guard:

1. `IsolatedNode` gains an `isRegistryDependency` field (default `false`), settable from constructor options.
2. `#externalProxy` copies `node.isRegistryDependency` from the real tree node onto the proxy.
3. `#generateChild` passes it through to the store `IsolatedNode`.

This preserves exact parity with the hoisted reifier: registry deps are exempt, user-pinned off-registry URLs are not. It also makes the linked strategy's `isScriptAllowed` matching more accurate — store nodes now carry the trustworthy edge-based flag instead of falling back to guessing registry-ness from the resolved URL.

## References

Fixes #9494
