### PR TITLE
feat: differentiate GitHub Actions environments in user-agent

### DIFF
--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -2476,25 +2476,37 @@ const definitions = {
     `,
     flatten (key, obj, flatOptions) {
       const value = obj[key]
-      let ciName = ciInfo.name?.toLowerCase().split(' ').join('-') || null
+      const ciName = ciInfo.name?.toLowerCase().split(' ').join('-') || null
+      // A more specific sub-category for the detected CI, appended to the
+      // ci token as `ci/{ci-name}/{sub-ci-name}` when present.
+      let subCiName = null
       if (ciInfo.GITHUB_ACTIONS) {
         // Env vars can be absent, empty, or whitespace; normalize before use.
         const serverUrl = (process.env.GITHUB_SERVER_URL || '').trim()
         const runnerEnv = (process.env.RUNNER_ENVIRONMENT || '').trim()
-        if (serverUrl === 'https://github.com') {
+        let serverHost = ''
+        try {
+          serverHost = new URL(serverUrl).hostname.toLowerCase()
+        } catch {
+          serverHost = ''
+        }
+        if (serverHost === 'github.com') {
           if (runnerEnv === 'github-hosted') {
-            ciName = 'github-actions-dotcom-hosted'
+            subCiName = 'dotcom-hosted'
           } else if (runnerEnv === 'self-hosted') {
-            ciName = 'github-actions-dotcom-selfhosted'
+            subCiName = 'dotcom-selfhosted'
           } else {
-            ciName = 'github-actions-dotcom'
+            subCiName = 'dotcom'
           }
-        } else if (serverUrl.endsWith('.ghe.com')) {
-          ciName = 'github-actions-ghecom'
-        } else if (serverUrl) {
-          ciName = 'github-actions-ghes'
+        } else if (serverHost === 'ghe.com' || serverHost.endsWith('.ghe.com')) {
+          subCiName = 'ghecom'
+        } else if (serverHost) {
+          subCiName = 'ghes'
         }
       }
+      const ci = ciName
+        ? `ci/${ciName}${subCiName ? `/${subCiName}` : ''}`
+        : ''
       let inWorkspaces = false
       if (obj.workspaces || obj.workspace && obj.workspace.length) {
         inWorkspaces = true
@@ -2505,7 +2517,7 @@ const definitions = {
           .replace(/\{platform\}/gi, process.platform)
           .replace(/\{arch\}/gi, process.arch)
           .replace(/\{workspaces\}/gi, inWorkspaces)
-          .replace(/\{ci\}/gi, ciName ? `ci/${ciName}` : '')
+          .replace(/\{ci\}/gi, ci)
           .trim()
 
       // We can't clobber the original or else subsequent flattening will fail

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -2476,7 +2476,25 @@ const definitions = {
     `,
     flatten (key, obj, flatOptions) {
       const value = obj[key]
-      const ciName = ciInfo.name?.toLowerCase().split(' ').join('-') || null
+      let ciName = ciInfo.name?.toLowerCase().split(' ').join('-') || null
+      if (ciInfo.GITHUB_ACTIONS) {
+        // Env vars can be absent, empty, or whitespace; normalize before use.
+        const serverUrl = (process.env.GITHUB_SERVER_URL || '').trim()
+        const runnerEnv = (process.env.RUNNER_ENVIRONMENT || '').trim()
+        if (serverUrl === 'https://github.com') {
+          if (runnerEnv === 'github-hosted') {
+            ciName = 'github-actions-dotcom-hosted'
+          } else if (runnerEnv === 'self-hosted') {
+            ciName = 'github-actions-dotcom-selfhosted'
+          } else {
+            ciName = 'github-actions-dotcom'
+          }
+        } else if (serverUrl.endsWith('.ghe.com')) {
+          ciName = 'github-actions-ghecom'
+        } else if (serverUrl) {
+          ciName = 'github-actions-ghes'
+        }
+      }
       let inWorkspaces = false
       if (obj.workspaces || obj.workspace && obj.workspace.length) {
         inWorkspaces = true

--- a/workspaces/config/test/definitions/definitions.js
+++ b/workspaces/config/test/definitions/definitions.js
@@ -869,32 +869,42 @@ t.test('user-agent github actions ci variants', t => {
     {
       name: 'dotcom + github-hosted runner',
       env: { GITHUB_SERVER_URL: 'https://github.com', RUNNER_ENVIRONMENT: 'github-hosted' },
-      expect: `${base} ci/github-actions-dotcom-hosted`,
+      expect: `${base} ci/github-actions/dotcom-hosted`,
     },
     {
       name: 'dotcom + self-hosted runner',
       env: { GITHUB_SERVER_URL: 'https://github.com', RUNNER_ENVIRONMENT: 'self-hosted' },
-      expect: `${base} ci/github-actions-dotcom-selfhosted`,
+      expect: `${base} ci/github-actions/dotcom-selfhosted`,
     },
     {
       name: 'dotcom + missing runner environment',
       env: { GITHUB_SERVER_URL: 'https://github.com', RUNNER_ENVIRONMENT: undefined },
-      expect: `${base} ci/github-actions-dotcom`,
+      expect: `${base} ci/github-actions/dotcom`,
     },
     {
       name: 'dotcom + whitespace runner environment',
       env: { GITHUB_SERVER_URL: 'https://github.com', RUNNER_ENVIRONMENT: '   ' },
-      expect: `${base} ci/github-actions-dotcom`,
+      expect: `${base} ci/github-actions/dotcom`,
     },
     {
       name: 'ghe.com tenant',
       env: { GITHUB_SERVER_URL: 'https://octocorp.ghe.com', RUNNER_ENVIRONMENT: 'github-hosted' },
-      expect: `${base} ci/github-actions-ghecom`,
+      expect: `${base} ci/github-actions/ghecom`,
+    },
+    {
+      name: 'bare ghe.com host',
+      env: { GITHUB_SERVER_URL: 'https://ghe.com', RUNNER_ENVIRONMENT: 'github-hosted' },
+      expect: `${base} ci/github-actions/ghecom`,
+    },
+    {
+      name: 'ghe.com only in path is treated as ghes',
+      env: { GITHUB_SERVER_URL: 'https://evil.example/x.ghe.com', RUNNER_ENVIRONMENT: 'self-hosted' },
+      expect: `${base} ci/github-actions/ghes`,
     },
     {
       name: 'ghes (non-empty, non github.com, non ghe.com)',
       env: { GITHUB_SERVER_URL: 'https://github.example.com', RUNNER_ENVIRONMENT: 'self-hosted' },
-      expect: `${base} ci/github-actions-ghes`,
+      expect: `${base} ci/github-actions/ghes`,
     },
     {
       name: 'missing server url stays generic',
@@ -911,16 +921,15 @@ t.test('user-agent github actions ci variants', t => {
   for (const { name, env, expect } of cases) {
     t.test(name, t => {
       mockGlobals(t, { 'process.env': env })
+      const defs = mockDefs({
+        'ci-info': { isCi: true, name: 'GitHub Actions', GITHUB_ACTIONS: true },
+      })
       const obj = {
         'npm-version': npmVersion,
-        'user-agent': mockDefs({
-          'ci-info': { isCi: true, name: 'GitHub Actions', GITHUB_ACTIONS: true },
-        })['user-agent'].default,
+        'user-agent': defs['user-agent'].default,
       }
       const flat = {}
-      mockDefs({
-        'ci-info': { isCi: true, name: 'GitHub Actions', GITHUB_ACTIONS: true },
-      })['user-agent'].flatten('user-agent', obj, flat)
+      defs['user-agent'].flatten('user-agent', obj, flat)
       t.equal(flat.userAgent, expect)
       t.equal(process.env.npm_config_user_agent, flat.userAgent, 'npm_user_config environment is set')
       t.end()
@@ -931,16 +940,15 @@ t.test('user-agent github actions ci variants', t => {
     mockGlobals(t, {
       'process.env': { GITHUB_SERVER_URL: 'https://github.com', RUNNER_ENVIRONMENT: 'github-hosted' },
     })
+    const defs = mockDefs({
+      'ci-info': { isCi: true, name: 'Travis CI', GITHUB_ACTIONS: false },
+    })
     const obj = {
       'npm-version': npmVersion,
-      'user-agent': mockDefs({
-        'ci-info': { isCi: true, name: 'Travis CI', GITHUB_ACTIONS: false },
-      })['user-agent'].default,
+      'user-agent': defs['user-agent'].default,
     }
     const flat = {}
-    mockDefs({
-      'ci-info': { isCi: true, name: 'Travis CI', GITHUB_ACTIONS: false },
-    })['user-agent'].flatten('user-agent', obj, flat)
+    defs['user-agent'].flatten('user-agent', obj, flat)
     t.equal(flat.userAgent, `${base} ci/travis-ci`)
     t.end()
   })

--- a/workspaces/config/test/definitions/definitions.js
+++ b/workspaces/config/test/definitions/definitions.js
@@ -860,6 +860,94 @@ t.test('user-agent', t => {
   t.end()
 })
 
+t.test('user-agent github actions ci variants', t => {
+  const npmVersion = '1.2.3'
+  const base = `npm/${npmVersion} node/${process.version} ` +
+    `${process.platform} ${process.arch} workspaces/false`
+
+  const cases = [
+    {
+      name: 'dotcom + github-hosted runner',
+      env: { GITHUB_SERVER_URL: 'https://github.com', RUNNER_ENVIRONMENT: 'github-hosted' },
+      expect: `${base} ci/github-actions-dotcom-hosted`,
+    },
+    {
+      name: 'dotcom + self-hosted runner',
+      env: { GITHUB_SERVER_URL: 'https://github.com', RUNNER_ENVIRONMENT: 'self-hosted' },
+      expect: `${base} ci/github-actions-dotcom-selfhosted`,
+    },
+    {
+      name: 'dotcom + missing runner environment',
+      env: { GITHUB_SERVER_URL: 'https://github.com', RUNNER_ENVIRONMENT: undefined },
+      expect: `${base} ci/github-actions-dotcom`,
+    },
+    {
+      name: 'dotcom + whitespace runner environment',
+      env: { GITHUB_SERVER_URL: 'https://github.com', RUNNER_ENVIRONMENT: '   ' },
+      expect: `${base} ci/github-actions-dotcom`,
+    },
+    {
+      name: 'ghe.com tenant',
+      env: { GITHUB_SERVER_URL: 'https://octocorp.ghe.com', RUNNER_ENVIRONMENT: 'github-hosted' },
+      expect: `${base} ci/github-actions-ghecom`,
+    },
+    {
+      name: 'ghes (non-empty, non github.com, non ghe.com)',
+      env: { GITHUB_SERVER_URL: 'https://github.example.com', RUNNER_ENVIRONMENT: 'self-hosted' },
+      expect: `${base} ci/github-actions-ghes`,
+    },
+    {
+      name: 'missing server url stays generic',
+      env: { GITHUB_SERVER_URL: undefined, RUNNER_ENVIRONMENT: undefined },
+      expect: `${base} ci/github-actions`,
+    },
+    {
+      name: 'whitespace server url stays generic',
+      env: { GITHUB_SERVER_URL: '   ', RUNNER_ENVIRONMENT: 'github-hosted' },
+      expect: `${base} ci/github-actions`,
+    },
+  ]
+
+  for (const { name, env, expect } of cases) {
+    t.test(name, t => {
+      mockGlobals(t, { 'process.env': env })
+      const obj = {
+        'npm-version': npmVersion,
+        'user-agent': mockDefs({
+          'ci-info': { isCi: true, name: 'GitHub Actions', GITHUB_ACTIONS: true },
+        })['user-agent'].default,
+      }
+      const flat = {}
+      mockDefs({
+        'ci-info': { isCi: true, name: 'GitHub Actions', GITHUB_ACTIONS: true },
+      })['user-agent'].flatten('user-agent', obj, flat)
+      t.equal(flat.userAgent, expect)
+      t.equal(process.env.npm_config_user_agent, flat.userAgent, 'npm_user_config environment is set')
+      t.end()
+    })
+  }
+
+  t.test('non github-actions ci is unchanged', t => {
+    mockGlobals(t, {
+      'process.env': { GITHUB_SERVER_URL: 'https://github.com', RUNNER_ENVIRONMENT: 'github-hosted' },
+    })
+    const obj = {
+      'npm-version': npmVersion,
+      'user-agent': mockDefs({
+        'ci-info': { isCi: true, name: 'Travis CI', GITHUB_ACTIONS: false },
+      })['user-agent'].default,
+    }
+    const flat = {}
+    mockDefs({
+      'ci-info': { isCi: true, name: 'Travis CI', GITHUB_ACTIONS: false },
+    })['user-agent'].flatten('user-agent', obj, flat)
+    t.equal(flat.userAgent, `${base} ci/travis-ci`)
+    t.end()
+  })
+
+  t.end()
+})
+
 t.test('save-prefix', t => {
   const obj = {
     'save-exact': true,


### PR DESCRIPTION
Updates the `user-agent` to specify github-actions runner.