### PR TITLE
feat: add min-release-age-exclude config

### DIFF
--- a/lib/commands/install.js
+++ b/lib/commands/install.js
@@ -39,6 +39,7 @@ class Install extends ArboristWorkspaceCmd {
     'audit',
     'before',
     'min-release-age',
+    'min-release-age-exclude',
     'bin-links',
     'fund',
     'dry-run',

--- a/lib/commands/outdated.js
+++ b/lib/commands/outdated.js
@@ -4,6 +4,7 @@ const pacote = require('pacote')
 const table = require('text-table')
 const npa = require('npm-package-arg')
 const pickManifest = require('npm-pick-manifest')
+const { isReleaseAgeExcluded } = require('@npmcli/arborist/lib/release-age-exclude.js')
 const { output } = require('proc-log')
 const localeCompare = require('@isaacs/string-locale-compare')('en')
 const ArboristWorkspaceCmd = require('../arborist-cmd.js')
@@ -32,6 +33,7 @@ class Outdated extends ArboristWorkspaceCmd {
     'workspace',
     'before',
     'min-release-age',
+    'min-release-age-exclude',
   ]
 
   #tree
@@ -183,8 +185,14 @@ class Outdated extends ArboristWorkspaceCmd {
     try {
       const packument = await this.#getPackument(spec)
       const expected = alias ? alias.fetchSpec : edge.spec
-      const wanted = pickManifest(packument, expected, this.npm.flatOptions)
-      const latest = pickManifest(packument, '*', this.npm.flatOptions)
+      const { minReleaseAgeExclude } = this.npm.flatOptions
+      // Packages matching `min-release-age-exclude` resolve to their newest
+      // version, so drop the `before` constraint for them.
+      const pickOpts = isReleaseAgeExcluded(packument.name, minReleaseAgeExclude)
+        ? { ...this.npm.flatOptions, before: null }
+        : this.npm.flatOptions
+      const wanted = pickManifest(packument, expected, pickOpts)
+      const latest = pickManifest(packument, '*', pickOpts)
       if (!current || current !== wanted.version || wanted.version !== latest.version) {
         this.#list.push({
           name: alias ? edge.spec.replace('npm', edge.name) : edge.name,

--- a/lib/commands/query.js
+++ b/lib/commands/query.js
@@ -49,6 +49,9 @@ class Query extends BaseCommand {
     'include-workspace-root',
     'package-lock-only',
     'expect-results',
+    'before',
+    'min-release-age',
+    'min-release-age-exclude',
   ]
 
   constructor (...args) {

--- a/lib/commands/update.js
+++ b/lib/commands/update.js
@@ -27,6 +27,7 @@ class Update extends ArboristWorkspaceCmd {
     'audit',
     'before',
     'min-release-age',
+    'min-release-age-exclude',
     'bin-links',
     'fund',
     'dry-run',

--- a/smoke-tests/tap-snapshots/test/index.js.test.cjs
+++ b/smoke-tests/tap-snapshots/test/index.js.test.cjs
@@ -107,7 +107,7 @@ npm error   --allow-scripts
 npm error     Comma-separated list of packages whose install-time lifecycle scripts
 npm error
 npm error   --strict-allow-scripts
-npm error     If \`true\`, turn the install-script policy from a silent skip into a
+npm error     If \`true\`, turn the install-script policy from a warning into a hard
 npm error
 npm error   --dangerously-allow-all-scripts
 npm error     If \`true\`, bypass the \`allowScripts\` policy entirely and run every

--- a/tap-snapshots/test/lib/commands/config.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/config.js.test.cjs
@@ -111,6 +111,7 @@ exports[`test/lib/commands/config.js TAP config list --json > output matches sna
   "maxsockets": 15,
   "message": "%s",
   "min-release-age": null,
+  "min-release-age-exclude": [],
   "node-gyp": "{CWD}/node_modules/node-gyp/bin/node-gyp.js",
   "node-options": null,
   "noproxy": [
@@ -299,6 +300,7 @@ logs-max = 10
 maxsockets = 15
 message = "%s"
 min-release-age = null
+min-release-age-exclude = []
 name = null
 node-gyp = "{CWD}/node_modules/node-gyp/bin/node-gyp.js"
 node-options = null

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -410,6 +410,9 @@ sources, the standard precedence applies (cli > env > project > user >
 global), so a higher-priority source can always relax or override a
 lower-priority one.
 
+Packages whose names match \`min-release-age-exclude\` are exempt from this
+filter.
+
 
 
 #### \`bin-links\`
@@ -1300,6 +1303,37 @@ your \`.npmrc\` is preserved when npm internally spawns a sub-process with
 apply, \`before\` wins within a single source and across sources the standard
 precedence rules apply.
 
+Packages whose names match \`min-release-age-exclude\` are exempt from this
+filter.
+
+This value is not exported to the environment for child processes.
+
+#### \`min-release-age-exclude\`
+
+* Default:
+* Type: String (can be set multiple times)
+
+A list of package names or \`minimatch\` glob patterns that are exempt from
+the \`min-release-age\` (and \`before\`) filter. A matching package can always
+resolve to its newest version, even when a release-age window is set.
+
+For example, to apply a release-age window to third-party dependencies while
+letting internally maintained packages update immediately:
+
+\`\`\`
+min-release-age=7
+min-release-age-exclude[]=@myorg/*
+min-release-age-exclude[]=my-internal-pkg
+\`\`\`
+
+Only the named package is exempt; its own dependencies still follow the
+release-age policy unless they also match a pattern. Patterns match against
+the package name, so \`@myorg/*\` matches \`@myorg/shared-utils\`.
+
+Excluding a package does not change which registry it is fetched from. You
+should own your private scope on the public registry so that nobody else can
+publish a package with the same name.
+
 This value is not exported to the environment for child processes.
 
 #### \`name\`
@@ -1912,13 +1946,13 @@ this to work properly.
 * Default: false
 * Type: Boolean
 
-If \`true\`, turn the install-script policy from a silent skip into a hard
-error: any dependency with install scripts not covered by \`allowScripts\`
-will fail the install instead of being silently skipped.
+If \`true\`, turn the install-script policy from a warning into a hard error:
+any dependency with install scripts that is not covered by \`allowScripts\`
+will fail the install instead of being blocked with a warning.
 
-By default, dependencies whose install scripts are not approved in
-\`allowScripts\` are silently skipped; this setting promotes that silent skip
-into a hard failure, which is the recommended posture for CI.
+Dependencies explicitly denied with \`false\` in \`allowScripts\` are always
+silently skipped; this setting only affects unreviewed entries (packages
+with install scripts that are neither approved nor denied).
 \`--ignore-scripts\` and \`--dangerously-allow-all-scripts\` both override this
 setting.
 
@@ -2513,6 +2547,7 @@ Array [
   "maxsockets",
   "message",
   "min-release-age",
+  "min-release-age-exclude",
   "node-gyp",
   "node-options",
   "noproxy",
@@ -2679,6 +2714,7 @@ Array [
   "maxsockets",
   "message",
   "min-release-age",
+  "min-release-age-exclude",
   "node-gyp",
   "noproxy",
   "offline",
@@ -2856,6 +2892,7 @@ Object {
   "logColor": false,
   "maxSockets": 15,
   "message": "%s",
+  "minReleaseAgeExclude": Array [],
   "name": null,
   "nodeBin": "{NODE}",
   "nodeGyp": "{CWD}/node_modules/node-gyp/bin/node-gyp.js",
@@ -3284,7 +3321,7 @@ Options:
     Comma-separated list of packages whose install-time lifecycle scripts
 
   --strict-allow-scripts
-    If \`true\`, turn the install-script policy from a silent skip into a
+    If \`true\`, turn the install-script policy from a warning into a hard
 
   --dangerously-allow-all-scripts
     If \`true\`, bypass the \`allowScripts\` policy entirely and run every
@@ -3846,7 +3883,7 @@ Options:
     Comma-separated list of packages whose install-time lifecycle scripts
 
   --strict-allow-scripts
-    If \`true\`, turn the install-script policy from a silent skip into a
+    If \`true\`, turn the install-script policy from a warning into a hard
 
   --dangerously-allow-all-scripts
     If \`true\`, bypass the \`allowScripts\` policy entirely and run every
@@ -4231,8 +4268,10 @@ Options:
 [--allow-remote <all|none|root>]
 [--allow-scripts <package-list> [--allow-scripts <package-list> ...]]
 [--strict-allow-scripts] [--dangerously-allow-all-scripts] [--no-audit]
-[--before <date>] [--min-release-age <days>] [--no-bin-links] [--no-fund]
-[--dry-run] [--cpu <cpu>] [--os <os>] [--libc <libc>]
+[--before <date>] [--min-release-age <days>]
+[--min-release-age-exclude <pkg|glob> [--min-release-age-exclude <pkg|glob> ...]]
+[--no-bin-links] [--no-fund] [--dry-run] [--cpu <cpu>] [--os <os>]
+[--libc <libc>]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [--workspaces] [--include-workspace-root] [--install-links]
 
@@ -4294,7 +4333,7 @@ Options:
     Comma-separated list of packages whose install-time lifecycle scripts
 
   --strict-allow-scripts
-    If \`true\`, turn the install-script policy from a silent skip into a
+    If \`true\`, turn the install-script policy from a warning into a hard
 
   --dangerously-allow-all-scripts
     If \`true\`, bypass the \`allowScripts\` policy entirely and run every
@@ -4307,6 +4346,9 @@ Options:
 
   --min-release-age
     If set, npm will build the npm tree such that only versions that were
+
+  --min-release-age-exclude
+    A list of package names or \`minimatch\` glob patterns that are exempt
 
   --bin-links
     Tells npm to create symlinks (or \`.cmd\` shims on Windows) for package
@@ -4373,6 +4415,7 @@ aliases: add, i, in, ins, inst, insta, instal, isnt, isnta, isntal, isntall
 #### \`audit\`
 #### \`before\`
 #### \`min-release-age\`
+#### \`min-release-age-exclude\`
 #### \`bin-links\`
 #### \`fund\`
 #### \`dry-run\`
@@ -4444,7 +4487,7 @@ Options:
     Comma-separated list of packages whose install-time lifecycle scripts
 
   --strict-allow-scripts
-    If \`true\`, turn the install-script policy from a silent skip into a
+    If \`true\`, turn the install-script policy from a warning into a hard
 
   --dangerously-allow-all-scripts
     If \`true\`, bypass the \`allowScripts\` policy entirely and run every
@@ -4527,8 +4570,10 @@ Options:
 [--allow-remote <all|none|root>]
 [--allow-scripts <package-list> [--allow-scripts <package-list> ...]]
 [--strict-allow-scripts] [--dangerously-allow-all-scripts] [--no-audit]
-[--before <date>] [--min-release-age <days>] [--no-bin-links] [--no-fund]
-[--dry-run] [--cpu <cpu>] [--os <os>] [--libc <libc>]
+[--before <date>] [--min-release-age <days>]
+[--min-release-age-exclude <pkg|glob> [--min-release-age-exclude <pkg|glob> ...]]
+[--no-bin-links] [--no-fund] [--dry-run] [--cpu <cpu>] [--os <os>]
+[--libc <libc>]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [--workspaces] [--include-workspace-root] [--install-links]
 
@@ -4590,7 +4635,7 @@ Options:
     Comma-separated list of packages whose install-time lifecycle scripts
 
   --strict-allow-scripts
-    If \`true\`, turn the install-script policy from a silent skip into a
+    If \`true\`, turn the install-script policy from a warning into a hard
 
   --dangerously-allow-all-scripts
     If \`true\`, bypass the \`allowScripts\` policy entirely and run every
@@ -4603,6 +4648,9 @@ Options:
 
   --min-release-age
     If set, npm will build the npm tree such that only versions that were
+
+  --min-release-age-exclude
+    A list of package names or \`minimatch\` glob patterns that are exempt
 
   --bin-links
     Tells npm to create symlinks (or \`.cmd\` shims on Windows) for package
@@ -4669,6 +4717,7 @@ alias: it
 #### \`audit\`
 #### \`before\`
 #### \`min-release-age\`
+#### \`min-release-age-exclude\`
 #### \`bin-links\`
 #### \`fund\`
 #### \`dry-run\`
@@ -5115,6 +5164,7 @@ Options:
 [-a|--all] [--json] [-l|--long] [-p|--parseable] [-g|--global]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [--before <date>] [--min-release-age <days>]
+[--min-release-age-exclude <pkg|glob> [--min-release-age-exclude <pkg|glob> ...]]
 
   -a|--all
     Show or act on all packages, not just the ones your project directly
@@ -5140,6 +5190,9 @@ Options:
   --min-release-age
     If set, npm will build the npm tree such that only versions that were
 
+  --min-release-age-exclude
+    A list of package names or \`minimatch\` glob patterns that are exempt
+
 
 Run "npm help outdated" for more info
 
@@ -5155,6 +5208,7 @@ npm outdated [<package-spec> ...]
 #### \`workspace\`
 #### \`before\`
 #### \`min-release-age\`
+#### \`min-release-age-exclude\`
 `
 
 exports[`test/lib/docs.js TAP usage owner > must match snapshot 1`] = `
@@ -5510,7 +5564,9 @@ Options:
 [-g|--global]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [--workspaces] [--include-workspace-root] [--package-lock-only]
-[--expect-results|--expect-result-count <count>]
+[--expect-results|--expect-result-count <count>] [--before <date>]
+[--min-release-age <days>]
+[--min-release-age-exclude <pkg|glob> [--min-release-age-exclude <pkg|glob> ...]]
 
   -g|--global
     Operates in "global" mode, so that packages are installed into the
@@ -5530,6 +5586,15 @@ Options:
   --expect-results
     Tells npm whether or not to expect results from the command.
 
+  --before
+    If passed to \`npm install\`, will rebuild the npm tree such that only
+
+  --min-release-age
+    If set, npm will build the npm tree such that only versions that were
+
+  --min-release-age-exclude
+    A list of package names or \`minimatch\` glob patterns that are exempt
+
 
 Run "npm help query" for more info
 
@@ -5544,6 +5609,9 @@ npm query <selector>
 #### \`package-lock-only\`
 #### \`expect-results\`
 #### \`expect-result-count\`
+#### \`before\`
+#### \`min-release-age\`
+#### \`min-release-age-exclude\`
 `
 
 exports[`test/lib/docs.js TAP usage rebuild > must match snapshot 1`] = `
@@ -5575,7 +5643,7 @@ Options:
     Comma-separated list of packages whose install-time lifecycle scripts
 
   --strict-allow-scripts
-    If \`true\`, turn the install-script policy from a silent skip into a
+    If \`true\`, turn the install-script policy from a warning into a hard
 
   --dangerously-allow-all-scripts
     If \`true\`, bypass the \`allowScripts\` policy entirely and run every
@@ -6351,8 +6419,9 @@ Options:
 [--ignore-scripts]
 [--allow-scripts <package-list> [--allow-scripts <package-list> ...]]
 [--strict-allow-scripts] [--dangerously-allow-all-scripts] [--no-audit]
-[--before <date>] [--min-release-age <days>] [--no-bin-links] [--no-fund]
-[--dry-run]
+[--before <date>] [--min-release-age <days>]
+[--min-release-age-exclude <pkg|glob> [--min-release-age-exclude <pkg|glob> ...]]
+[--no-bin-links] [--no-fund] [--dry-run]
 [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
 [--workspaces] [--include-workspace-root] [--install-links]
 
@@ -6393,7 +6462,7 @@ Options:
     Comma-separated list of packages whose install-time lifecycle scripts
 
   --strict-allow-scripts
-    If \`true\`, turn the install-script policy from a silent skip into a
+    If \`true\`, turn the install-script policy from a warning into a hard
 
   --dangerously-allow-all-scripts
     If \`true\`, bypass the \`allowScripts\` policy entirely and run every
@@ -6406,6 +6475,9 @@ Options:
 
   --min-release-age
     If set, npm will build the npm tree such that only versions that were
+
+  --min-release-age-exclude
+    A list of package names or \`minimatch\` glob patterns that are exempt
 
   --bin-links
     Tells npm to create symlinks (or \`.cmd\` shims on Windows) for package
@@ -6456,6 +6528,7 @@ aliases: u, up, upgrade, udpate
 #### \`audit\`
 #### \`before\`
 #### \`min-release-age\`
+#### \`min-release-age-exclude\`
 #### \`bin-links\`
 #### \`fund\`
 #### \`dry-run\`

--- a/test/lib/commands/outdated.js
+++ b/test/lib/commands/outdated.js
@@ -57,6 +57,24 @@ const packument = spec => {
         },
       },
     },
+    timed: {
+      name: 'timed',
+      'dist-tags': {
+        latest: '2.0.0',
+      },
+      versions: {
+        '1.0.0': {
+          version: '1.0.0',
+        },
+        '2.0.0': {
+          version: '2.0.0',
+        },
+      },
+      time: {
+        '1.0.0': '2020-01-01T00:00:00.000Z',
+        '2.0.0': '2020-06-01T00:00:00.000Z',
+      },
+    },
   }
 
   if (spec.name === 'eta') {
@@ -729,5 +747,59 @@ t.test('dependent location', async t => {
       joinedOutput(),
       'should display dependent location when using --long and --json'
     )
+  })
+})
+
+t.test('min-release-age-exclude', async t => {
+  const prefixDir = {
+    'package.json': JSON.stringify({
+      name: 'project',
+      version: '1.0.0',
+      dependencies: {
+        timed: '^1.0.0',
+      },
+    }, null, 2),
+    node_modules: {
+      timed: {
+        'package.json': JSON.stringify({
+          name: 'timed',
+          version: '1.0.0',
+        }, null, 2),
+      },
+    },
+  }
+
+  await t.test('before hides the newer version', async t => {
+    const { outdated, joinedOutput } = await mockNpm(t, {
+      prefixDir,
+      config: { before: new Date('2020-03-01') },
+    })
+    await outdated.exec([])
+    t.notMatch(joinedOutput(), 'timed', 'newer version filtered out by before')
+  })
+
+  await t.test('exact-name exclude restores the newer version', async t => {
+    const { outdated, joinedOutput } = await mockNpm(t, {
+      prefixDir,
+      config: {
+        before: new Date('2020-03-01'),
+        'min-release-age-exclude': ['timed'],
+      },
+    })
+    await outdated.exec([])
+    t.match(joinedOutput(), 'timed', 'excluded package is reported as outdated')
+    t.match(joinedOutput(), '2.0.0', 'latest 2.0.0 is surfaced')
+  })
+
+  await t.test('glob exclude restores the newer version', async t => {
+    const { outdated, joinedOutput } = await mockNpm(t, {
+      prefixDir,
+      config: {
+        before: new Date('2020-03-01'),
+        'min-release-age-exclude': ['tim*'],
+      },
+    })
+    await outdated.exec([])
+    t.match(joinedOutput(), '2.0.0', 'glob-excluded package shows newer version')
   })
 })

--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -24,6 +24,7 @@ const PlaceDep = require('../place-dep.js')
 const debug = require('../debug.js')
 const fromPath = require('../from-path.js')
 const calcDepFlags = require('../calc-dep-flags.js')
+const { isReleaseAgeExcluded, trustedSpecName } = require('../release-age-exclude.js')
 const Shrinkwrap = require('../shrinkwrap.js')
 const { defaultLockfileVersion } = Shrinkwrap
 const Node = require('../node.js')
@@ -533,7 +534,11 @@ module.exports = cls => class IdealTreeBuilder extends cls {
       // look up the names of file/directory/git specs
       if (!spec.name || isTag) {
         const _isRoot = tree.isProjectRoot || tree.isWorkspace
-        const mani = await pacote.manifest(spec, { ...this.options, _isRoot })
+        const mani = await pacote.manifest(spec, {
+          ...this.options,
+          _isRoot,
+          before: this.#releaseAgeBefore(spec),
+        })
         if (isTag) {
           // translate tag to a version
           spec = npa(`${mani.name}@${mani.version}`)
@@ -777,6 +782,7 @@ This is a one-time fix-up, please be patient...
             resolved: resolved,
             integrity: integrity,
             fullMetadata: false,
+            before: this.#releaseAgeBefore(spec),
           })
           node.package = { ...mani, _id: `${mani.name}@${mani.version}` }
         } catch (er) {
@@ -1263,6 +1269,19 @@ This is a one-time fix-up, please be patient...
     return problems
   }
 
+  // The effective `before` filter for a package, applying `min-release-age-exclude`.
+  // Returns null (no age filter) for an exempted package, otherwise the
+  // configured `before`. The exemption is keyed on the spec's trusted registry
+  // identity (alias targets are unwrapped) so an `npm:` alias key cannot disable
+  // the filter for the package it actually resolves to.
+  #releaseAgeBefore (spec) {
+    const { before, minReleaseAgeExclude } = this.options
+    if (!before) {
+      return before
+    }
+    return isReleaseAgeExcluded(trustedSpecName(spec), minReleaseAgeExclude) ? null : before
+  }
+
   async #fetchManifest (spec, parent, edge) {
     // Enforce allow-* gates before consulting the manifest cache so a cached entry from a different edge cannot bypass the policy.
     this.#checkAllow(spec, edge)
@@ -1270,6 +1289,7 @@ This is a one-time fix-up, please be patient...
       ...this.options,
       avoid: this.#avoidRange(spec.name),
       fullMetadata: true,
+      before: this.#releaseAgeBefore(spec),
       _isRoot: !!(edge?.from?.isProjectRoot || edge?.from?.isWorkspace),
     }
     // get the intended spec and stored metadata from yarn.lock file,

--- a/workspaces/arborist/lib/query-selector-all.js
+++ b/workspaces/arborist/lib/query-selector-all.js
@@ -9,6 +9,7 @@ const npa = require('npm-package-arg')
 const pacote = require('pacote')
 const semver = require('semver')
 const npmFetch = require('npm-registry-fetch')
+const { isReleaseAgeExcluded } = require('./release-age-exclude.js')
 
 // handle results for parsed query asts, results are stored in a map that has a
 // key that points to each ast selector node and stores the resulting array of
@@ -889,8 +890,9 @@ const getPackageVersions = async (name, opts) => {
   let candidates = Object.keys(packument.versions).sort(semver.compare)
 
   // if the packument has a time property, and the user passed a before flag, then
-  // we filter this list down to only those versions that existed before the specified date
-  if (packument.time && opts.before) {
+  // we filter this list down to only those versions that existed before the specified date.
+  // packages matching `min-release-age-exclude` are exempt from this filter.
+  if (packument.time && opts.before && !isReleaseAgeExcluded(name, opts.minReleaseAgeExclude)) {
     candidates = candidates.filter((version) => {
       // this version isn't found in the times at all, drop it
       if (!packument.time[version]) {

--- a/workspaces/arborist/lib/release-age-exclude.js
+++ b/workspaces/arborist/lib/release-age-exclude.js
@@ -1,0 +1,45 @@
+// Determine whether a package name is exempt from the `min-release-age` /
+// `before` release-age filter, based on the `min-release-age-exclude` config.
+//
+// Patterns are exact package names or `minimatch` globs (e.g. `@myorg/*`), and
+// match against the package name only. This is a "named-only" exemption: a
+// matched package's own dependencies still follow the filter unless they match
+// a pattern too.
+//
+// Callers must match against the resolved registry identity of a package, not
+// the self-reported alias or dependency-edge name. For `npm:` aliases the
+// fetched package is the alias target, so run specs through `trustedSpecName`
+// first; otherwise an alias key could match an exclude pattern and turn the
+// filter off for the unrelated package it resolves to.
+const { minimatch } = require('minimatch')
+
+// This list only ever widens the exemption (turns the security filter off for a
+// package), so disable pattern features that could silently turn it into a
+// match-all: `nonegate` keeps a leading `!` literal (so a stray `!foo` exempts
+// nothing instead of everything-but-foo), `nocomment` keeps a leading `#`
+// literal, and `noext` disables extglobs.
+const minimatchOptions = { nonegate: true, nocomment: true, noext: true }
+
+const isReleaseAgeExcluded = (name, patterns) => {
+  if (!name || !Array.isArray(patterns) || patterns.length === 0) {
+    return false
+  }
+  return patterns.some(pattern =>
+    name === pattern || minimatch(name, pattern, minimatchOptions))
+}
+
+// Resolve the trusted registry name for an npa spec. For `npm:` aliases (e.g.
+// `"x": "npm:other@1"`) the installed/fetched package is the alias target
+// (`subSpec`), not the alias key, so the exemption must be keyed on the
+// underlying package name. Mirrors `nameFromEdges` in script-allowed.js.
+const trustedSpecName = (spec) => {
+  if (!spec) {
+    return undefined
+  }
+  if (spec.type === 'alias' && spec.subSpec && spec.subSpec.registry) {
+    return spec.subSpec.name
+  }
+  return spec.name
+}
+
+module.exports = { isReleaseAgeExcluded, trustedSpecName }

--- a/workspaces/arborist/test/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/test/arborist/build-ideal-tree.js
@@ -2852,6 +2852,69 @@ t.test('avoid dedupe when a dep is bundled', async t => {
   })
 })
 
+t.test('min-release-age-exclude exempts matched packages from the before filter', async t => {
+  // The dupes-b fixture publishes 2.0.0 at 16:23:59 and 2.1.0 at 16:25:15.
+  // A `before` of 16:24:00 normally filters 2.1.0 out, leaving 2.0.0.
+  const before = new Date('2021-04-23T16:24:00Z')
+  const pkg = '@isaacs/testing-bundle-dupes-b'
+  const mkPath = () => t.testdir({
+    'package.json': JSON.stringify({
+      dependencies: { [pkg]: '2' },
+    }),
+  })
+
+  await t.test('without exclude, before filters to the older version', async t => {
+    createRegistry(t, true)
+    const tree = await buildIdeal(mkPath(), { before })
+    t.equal(tree.children.get(pkg).version, '2.0.0', 'before filter applied')
+  })
+
+  await t.test('exact name in exclude bypasses the before filter', async t => {
+    createRegistry(t, true)
+    const tree = await buildIdeal(mkPath(), {
+      before,
+      minReleaseAgeExclude: [pkg],
+    })
+    t.equal(tree.children.get(pkg).version, '2.1.0', 'newest version installed')
+  })
+
+  await t.test('glob pattern in exclude bypasses the before filter', async t => {
+    createRegistry(t, true)
+    const tree = await buildIdeal(mkPath(), {
+      before,
+      minReleaseAgeExclude: ['@isaacs/*'],
+    })
+    t.equal(tree.children.get(pkg).version, '2.1.0', 'newest version installed')
+  })
+
+  await t.test('non-matching exclude leaves the before filter in place', async t => {
+    createRegistry(t, true)
+    const tree = await buildIdeal(mkPath(), {
+      before,
+      minReleaseAgeExclude: ['some-other-pkg', '@other/*'],
+    })
+    t.equal(tree.children.get(pkg).version, '2.0.0', 'before filter still applied')
+  })
+
+  await t.test('an npm: alias key cannot bypass the filter for its target', async t => {
+    // The exclude must match the resolved registry identity, not the alias key.
+    // Here the alias key `dupes` matches the exclude but the fetched package
+    // `pkg` does not, so the before filter must still apply.
+    createRegistry(t, true)
+    const aliasPath = t.testdir({
+      'package.json': JSON.stringify({
+        dependencies: { dupes: `npm:${pkg}@2` },
+      }),
+    })
+    const tree = await buildIdeal(aliasPath, {
+      before,
+      minReleaseAgeExclude: ['dupes'],
+    })
+    t.equal(tree.children.get('dupes').version, '2.0.0',
+      'before filter still applied to the aliased package')
+  })
+})
+
 t.test('upgrade a partly overlapping peer set', async t => {
   const path = t.testdir({
     'package.json': JSON.stringify({

--- a/workspaces/arborist/test/query-selector-all.js
+++ b/workspaces/arborist/test/query-selector-all.js
@@ -1035,9 +1035,37 @@ t.test('query-selector-all', async t => {
     ['#a, #bar:semver(2), #foo:semver(2.2.2)', ['a@1.0.0', 'bar@2.0.0', 'foo@2.2.2']],
     ['#b *', ['a@1.0.0', 'bar@2.0.0', 'baz@1.0.0', 'lorem@1.0.0', 'moo@3.0.0']],
   ])
-})
 
-// Simulates the linked install strategy layout where packages live in node_modules/.store/ and are symlinked from node_modules/.
+  // :outdated combined with --before and min-release-age-exclude.
+  // bar's 2.0.0 was published today, so `before: yesterday` normally filters it
+  // out and bar drops off the outdated list. Excluding bar bypasses the filter
+  // for that package so its newer version is considered again.
+  await t.test(':outdated honors min-release-age-exclude (exact name)', async t => {
+    const res = await querySelectorAll(tree, ':outdated', {
+      before: yesterday,
+      minReleaseAgeExclude: ['bar'],
+    })
+    t.same(res, [
+      'abbrev@1.1.1',
+      'baz@1.0.0',
+      'dash-separated-pkg@1.0.0',
+      'bar@1.4.0', // not filtered by before because bar is excluded
+    ], 'excluded package is not filtered by before')
+  })
+
+  await t.test(':outdated honors min-release-age-exclude (glob)', async t => {
+    const res = await querySelectorAll(tree, ':outdated', {
+      before: yesterday,
+      minReleaseAgeExclude: ['b*'],
+    })
+    t.same(res, [
+      'abbrev@1.1.1',
+      'baz@1.0.0',
+      'dash-separated-pkg@1.0.0',
+      'bar@1.4.0', // glob matches bar, bypassing the before filter
+    ], 'glob pattern excludes bar from the before filter')
+  })
+})
 t.test('linked strategy: :root > * excludes transitive deps and store nodes', async t => {
   /*
    fixture tree (linked strategy layout):

--- a/workspaces/arborist/test/release-age-exclude.js
+++ b/workspaces/arborist/test/release-age-exclude.js
@@ -1,0 +1,71 @@
+const t = require('tap')
+const npa = require('npm-package-arg')
+const { isReleaseAgeExcluded, trustedSpecName } = require('../lib/release-age-exclude.js')
+
+t.test('returns false when there are no patterns', t => {
+  t.equal(isReleaseAgeExcluded('lodash', []), false, 'empty array')
+  t.equal(isReleaseAgeExcluded('lodash', undefined), false, 'undefined')
+  t.equal(isReleaseAgeExcluded('lodash', null), false, 'null')
+  t.end()
+})
+
+t.test('returns false when the name is missing', t => {
+  t.equal(isReleaseAgeExcluded(undefined, ['*']), false, 'undefined name')
+  t.equal(isReleaseAgeExcluded('', ['*']), false, 'empty name')
+  t.end()
+})
+
+t.test('matches exact package names', t => {
+  t.equal(isReleaseAgeExcluded('lodash', ['lodash']), true, 'unscoped exact')
+  t.equal(isReleaseAgeExcluded('@myorg/utils', ['@myorg/utils']), true, 'scoped exact')
+  t.equal(isReleaseAgeExcluded('react', ['lodash', 'react', 'vue']), true, 'one of many')
+  t.equal(isReleaseAgeExcluded('react-dom', ['react']), false, 'no partial match')
+  t.end()
+})
+
+t.test('matches glob patterns', t => {
+  t.equal(isReleaseAgeExcluded('@myorg/utils', ['@myorg/*']), true, 'scope wildcard')
+  t.equal(isReleaseAgeExcluded('@myorg/shared-utils', ['@myorg/*']), true, 'scope wildcard 2')
+  t.equal(isReleaseAgeExcluded('@other/utils', ['@myorg/*']), false, 'different scope')
+  t.equal(isReleaseAgeExcluded('lodash', ['lo*']), true, 'prefix wildcard')
+  t.equal(isReleaseAgeExcluded('react', ['@myorg/*', 'lodash']), false, 'no pattern matches')
+  t.end()
+})
+
+t.test('negation and comment patterns cannot invert into a match-all', t => {
+  // A leading `!` must be treated literally (no package name can contain `!`),
+  // so it exempts nothing rather than everything-but-the-listed-name. Likewise
+  // a leading `#` must not be swallowed as a comment.
+  t.equal(isReleaseAgeExcluded('lodash', ['!react']), false, 'negation does not match others')
+  t.equal(isReleaseAgeExcluded('react', ['!react']), false, 'negation does not match itself')
+  t.equal(isReleaseAgeExcluded('lodash', ['#lodash']), false, 'comment matches nothing')
+  t.end()
+})
+
+t.test('trustedSpecName unwraps npm: aliases to the resolved package', t => {
+  t.equal(trustedSpecName(npa.resolve('lodash', '^4.17.0')), 'lodash', 'plain registry range')
+  t.equal(trustedSpecName(npa.resolve('@scope/pkg', '^1.0.0')), '@scope/pkg', 'scoped registry range')
+  // For an alias the fetched package is the alias target, not the alias key.
+  t.equal(
+    trustedSpecName(npa.resolve('@myorg/x', 'npm:attacker-pkg@1.0.0')),
+    'attacker-pkg',
+    'alias resolves to the underlying package name'
+  )
+  t.equal(trustedSpecName(undefined), undefined, 'missing spec')
+  t.end()
+})
+
+t.test('an alias key cannot match an exclude pattern for its target', t => {
+  // Victim excludes their own scope; a malicious dep aliases an attacker package
+  // under a name in that scope (`"@myorg/x": "npm:attacker-pkg@1"`). The exempt
+  // decision must be keyed on the resolved target, not the alias key, so the
+  // age filter is NOT disabled for attacker-pkg.
+  const spec = npa.resolve('@myorg/x', 'npm:attacker-pkg@1.0.0')
+  t.equal(isReleaseAgeExcluded(spec.name, ['@myorg/*']), true,
+    'the raw alias key would wrongly match')
+  t.equal(isReleaseAgeExcluded(trustedSpecName(spec), ['@myorg/*']), false,
+    'the trusted target name does not match')
+  t.end()
+})
+
+t.end()

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -353,6 +353,9 @@ const definitions = {
       Across sources, the standard precedence applies (cli > env > project >
       user > global), so a higher-priority source can always relax or
       override a lower-priority one.
+
+      Packages whose names match \`min-release-age-exclude\` are exempt from
+      this filter.
     `,
     flatten,
   }),
@@ -1507,6 +1510,9 @@ const definitions = {
        spawns a sub-process with \`--before\` while preparing a \`git:\` or
        \`github:\` dependency); when both apply, \`before\` wins within a
        single source and across sources the standard precedence rules apply.
+
+       Packages whose names match \`min-release-age-exclude\` are exempt from
+       this filter.
     `,
     flatten: (key, obj, flatOptions) => {
       const age = obj['min-release-age']
@@ -1515,6 +1521,45 @@ const definitions = {
       if (age != null && !Object.hasOwn(obj, 'before')) {
         flatOptions.before = age ? new Date(Date.now() - (86400000 * age)) : null
       }
+    },
+  }),
+  'min-release-age-exclude': new Definition('min-release-age-exclude', {
+    default: [],
+    hint: '<pkg|glob>',
+    type: [Array, String],
+    envExport: false,
+    description: `
+       A list of package names or \`minimatch\` glob patterns that are exempt
+       from the \`min-release-age\` (and \`before\`) filter. A matching package
+       can always resolve to its newest version, even when a release-age window
+       is set.
+
+       For example, to apply a release-age window to third-party dependencies
+       while letting internally maintained packages update immediately:
+
+       \`\`\`
+       min-release-age=7
+       min-release-age-exclude[]=@myorg/*
+       min-release-age-exclude[]=my-internal-pkg
+       \`\`\`
+
+       Only the named package is exempt; its own dependencies still follow the
+       release-age policy unless they also match a pattern. Patterns match
+       against the package name, so \`@myorg/*\` matches \`@myorg/shared-utils\`.
+
+       Excluding a package does not change which registry it is fetched from. You
+       should own your private scope on the public registry so that nobody else
+       can publish a package with the same name.
+    `,
+    flatten: (key, obj, flatOptions) => {
+      // The config layer always resolves this to an array (nopt and .npmrc both
+      // coerce `[Array, String]` to a list, default `[]`), so treat it as one.
+      // A single value may still pack multiple names as a comma string.
+      const list = obj[key]
+        .flatMap(v => String(v).split(','))
+        .map(v => v.trim())
+        .filter(Boolean)
+      flatOptions.minReleaseAgeExclude = [...new Set(list)]
     },
   }),
   'node-gyp': new Definition('node-gyp', {

--- a/workspaces/config/tap-snapshots/test/type-description.js.test.cjs
+++ b/workspaces/config/tap-snapshots/test/type-description.js.test.cjs
@@ -379,6 +379,10 @@ Object {
     null,
     "numeric value",
   ],
+  "min-release-age-exclude": Array [
+    Function Array(),
+    Function String(),
+  ],
   "name": Array [
     null,
     Function String(),

--- a/workspaces/config/test/index.js
+++ b/workspaces/config/test/index.js
@@ -2316,6 +2316,75 @@ t.test('CLI --min-release-age beats env npm_config_min_release_age', async t => 
   )
 })
 
+t.test('min-release-age-exclude', async t => {
+  t.test('defaults to an empty array', async t => {
+    const path = t.testdir()
+    const config = new Config({
+      npmPath: `${path}/npm`,
+      env: {},
+      argv: [process.execPath, __filename],
+      cwd: path,
+      definitions,
+      shorthands,
+      flatten,
+    })
+    await config.load()
+    t.same(config.flat.minReleaseAgeExclude, [], 'flattens to []')
+  })
+
+  t.test('a single value flattens to a one-element array', async t => {
+    const path = t.testdir()
+    const config = new Config({
+      npmPath: `${path}/npm`,
+      env: {},
+      argv: [process.execPath, __filename, '--min-release-age-exclude=@myorg/*'],
+      cwd: path,
+      definitions,
+      shorthands,
+      flatten,
+    })
+    await config.load()
+    t.same(config.flat.minReleaseAgeExclude, ['@myorg/*'], 'single pattern')
+  })
+
+  t.test('repeated flags accumulate into an array', async t => {
+    const path = t.testdir()
+    const config = new Config({
+      npmPath: `${path}/npm`,
+      env: {},
+      argv: [
+        process.execPath,
+        __filename,
+        '--min-release-age-exclude=@myorg/*',
+        '--min-release-age-exclude=lodash',
+      ],
+      cwd: path,
+      definitions,
+      shorthands,
+      flatten,
+    })
+    await config.load()
+    t.same(config.flat.minReleaseAgeExclude, ['@myorg/*', 'lodash'], 'two patterns')
+  })
+
+  t.test('a comma-delimited string is split, trimmed, and deduped', async t => {
+    const dir = t.testdir({
+      '.npmrc': 'min-release-age-exclude = @myorg/* , lodash ,@myorg/*',
+    })
+    const config = new Config({
+      npmPath: __dirname,
+      env: { HOME: dir },
+      argv: [process.execPath, __filename],
+      cwd: dir,
+      definitions,
+      shorthands,
+      flatten,
+    })
+    await config.load()
+    t.same(config.flat.minReleaseAgeExclude, ['@myorg/*', 'lodash'], 'normalized list')
+  })
+})
+
 t.test('global-ignore-file defaults to ${prefix}/etc/npmignore', async t => {
   const path = t.testdir()
   const config = new Config({


### PR DESCRIPTION
Exempt packages (name or glob) from the `min-release-age` / `before` filter. Applies in install, update, outdated, and query.

## References

Closes https://github.com/npm/cli/issues/8994
Supersedes https://github.com/npm/cli/pull/9175
Related:
- https://github.com/npm/rfcs/issues/895
- https://github.com/npm/cli/pull/8825
