### PR TITLE
docs: clarify versioned override parent behavior

### DIFF
--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -981,7 +981,7 @@ overriding its children, set `"."` explicitly:
   },
   "overrides": {
     "@npm/bar@2.0.0": {
-      ".": "$bar",
+      ".": "$@npm/bar",
       "@npm/foo": "1.0.0"
     }
   }
@@ -1002,9 +1002,9 @@ To make this limitation easier to deal with, overrides may also be defined as a 
     // GOOD, specs match so override is allowed
     // "foo": "^1.0.0"
     // BEST, the override is defined as a reference to the dependency
-    "@npm/foo": "$foo",
+    "@npm/foo": "$@npm/foo",
     // the referenced package does not need to match the overridden one
-    "@npm/bar": "$foo"
+    "@npm/bar": "$@npm/foo"
   }
 }
 ```

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -1001,11 +1001,6 @@ The referenced package can also differ from the override target.
     "@npm/foo": "^1.0.0"
   },
   "overrides": {
-    // BAD, will throw an EOVERRIDE error
-    // "foo": "^2.0.0"
-    // GOOD, specs match so override is allowed
-    // "foo": "^1.0.0"
-    // You can still reference a different direct dependency for the override
     "@npm/foo": "$@npm/foo",
     "@npm/bar": "$@npm/foo"
   }

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -991,8 +991,7 @@ You may not set an override for a package that you directly depend on unless bot
 To make this limitation easier to deal with, overrides may also be defined as a reference to a spec for a direct dependency by prefixing the name of the package you wish the version to match with a `$`.
 
 For scoped dependencies, the `$` reference must be the full scoped package name.
-Using only the unscoped package name, like `$foo`, does not match `@scope/foo`,
-and the referenced package can differ from the override target.
+Using only the unscoped package name, like `$foo`, does not match `@scope/foo`.
 
 ```json
 {

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -990,7 +990,7 @@ overriding its children, set `"."` explicitly:
 You may not set an override for a package that you directly depend on unless both the dependency and the override itself share the exact same spec.
 You can resolve a child override against a direct dependency by using a `$` prefix with the full package name.
 For scoped packages, keep the scope: use `$@scope/name`.
-In this example, `@npm/bar` inherits its direct dependency spec from `@npm/foo` and is also overridden at the same time:
+In this example, `@npm/bar` uses `$@npm/foo` so it inherits the spec from `@npm/foo` while still being overridden itself:
 
 ```json
 {

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -1003,7 +1003,7 @@ To make this limitation easier to deal with, overrides may also be defined as a 
     // "foo": "^1.0.0"
     // BEST, the override is defined as a reference to the dependency
     // For scoped packages, use the full scoped name in the reference.
-    // Using "$bar" (without the scope) is not valid for scoped packages.
+    // Use "$@npm/foo" instead of "$foo", and use "$@npm/bar" instead of "$bar".
     "@npm/foo": "$@npm/foo",
     // the referenced package does not need to match the overridden one
     "@npm/bar": "$@npm/foo"

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -988,10 +988,8 @@ overriding its children, set `"."` explicitly:
 ```
 
 You may not set an override for a package that you directly depend on unless both the dependency and the override itself share the exact same spec.
-To make this limitation easier to deal with, overrides may also be defined as a reference to a spec for a direct dependency by prefixing the name of the package you wish the version to match with a `$`.
-
-For scoped dependencies, the `$` reference must be the full scoped package name.
-Using only the unscoped package name, like `$foo`, does not match `@scope/foo`.
+You can resolve a child override against a direct dependency by using a `$` prefix with the full package name.
+For scoped packages, keep the scope: use `$@scope/name`.
 
 ```json
 {

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -991,6 +991,9 @@ overriding its children, set `"."` explicitly:
 You may not set an override for a package that you directly depend on unless both the dependency and the override itself share the exact same spec.
 To make this limitation easier to deal with, overrides may also be defined as a reference to a spec for a direct dependency by prefixing the name of the package you wish the version to match with a `$`.
 
+For scoped dependencies, the `$` reference must be the full scoped package name.
+Using only the unscoped package name, like `$foo`, does not match `@scope/foo`.
+
 ```json
 {
   "dependencies": {
@@ -1004,9 +1007,8 @@ To make this limitation easier to deal with, overrides may also be defined as a 
     // BEST, the override is defined as a reference to the dependency
     // For scoped packages, use the full scoped name in the reference.
     // BAD, will not resolve scoped package references.
-    // Do not use unscoped references for scoped dependencies.
-    // Use "$@npm/foo" instead of "$foo", and use "$@npm/bar" instead of "$bar".
-    // "$foo" and "$bar" are unscoped references and will not match scoped packages.
+    // Use "$@npm/foo" instead of "$foo".
+    // "$foo" is an unscoped reference and will not match @npm/foo.
     // "@npm/foo": "$foo",
     // "@npm/bar": "$bar",
     "@npm/foo": "$@npm/foo",

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -1002,6 +1002,7 @@ To make this limitation easier to deal with, overrides may also be defined as a 
     // GOOD, specs match so override is allowed
     // "foo": "^1.0.0"
     // BEST, the override is defined as a reference to the dependency
+    // For scoped packages, use the full scoped name in the reference.
     "@npm/foo": "$@npm/foo",
     // the referenced package does not need to match the overridden one
     "@npm/bar": "$@npm/foo"

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -1010,7 +1010,7 @@ To make this limitation easier to deal with, overrides may also be defined as a 
     // `$foo` and `$bar` are unscoped references and will not match scoped packages.
     "@npm/foo": "$@npm/foo",
     // the referenced package does not need to match the overridden one
-    "@npm/bar": "$@npm/foo"
+    "@npm/bar": "$@npm/bar"
   }
 }
 ```

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -988,9 +988,7 @@ overriding its children, set `"."` explicitly:
 ```
 
 You may not set an override for a package that you directly depend on unless both the dependency and the override itself share the exact same spec.
-You can resolve a child override against a direct dependency by using a `$` prefix with the full package name.
-For scoped packages, keep the scope: use `$@scope/name`.
-In this example, `@npm/bar` uses `$@npm/foo` so it inherits the spec from `@npm/foo` while still being overridden itself:
+You can resolve a child override against a direct dependency by using a `$` prefix with the full package name (`$@scope/name`), so the overridden package inherits that direct spec:
 
 ```json
 {

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -990,6 +990,7 @@ overriding its children, set `"."` explicitly:
 You may not set an override for a package that you directly depend on unless both the dependency and the override itself share the exact same spec.
 You can resolve a child override against a direct dependency by using a `$` prefix with the full package name.
 For scoped packages, keep the scope: use `$@scope/name`.
+That allows, for example, `@npm/bar` to inherit the direct dependency spec from `@npm/foo` while still overriding `@npm/bar` at the same time:
 
 ```json
 {

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -1003,6 +1003,7 @@ To make this limitation easier to deal with, overrides may also be defined as a 
     // "foo": "^1.0.0"
     // BEST, the override is defined as a reference to the dependency
     // For scoped packages, use the full scoped name in the reference.
+    // Using "$bar" (without the scope) is not valid for scoped packages.
     "@npm/foo": "$@npm/foo",
     // the referenced package does not need to match the overridden one
     "@npm/bar": "$@npm/foo"

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -992,7 +992,8 @@ To make this limitation easier to deal with, overrides may also be defined as a 
 
 For scoped dependencies, the `$` reference must be the full scoped package name.
 Using only the unscoped package name, like `$foo`, does not match `@scope/foo`,
-and the referenced package can differ from the override target.
+and the referenced package can differ from the override target. This lets
+`@npm/bar` keep the spec from `@npm/foo`, which must be direct dependency.
 
 ```json
 {

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -1004,6 +1004,7 @@ To make this limitation easier to deal with, overrides may also be defined as a 
     // BEST, the override is defined as a reference to the dependency
     // For scoped packages, use the full scoped name in the reference.
     // Use "$@npm/foo" instead of "$foo", and use "$@npm/bar" instead of "$bar".
+    // `$foo` and `$bar` are unscoped references and will not match scoped packages.
     "@npm/foo": "$@npm/foo",
     // the referenced package does not need to match the overridden one
     "@npm/bar": "$@npm/foo"

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -993,6 +993,7 @@ To make this limitation easier to deal with, overrides may also be defined as a 
 
 For scoped dependencies, the `$` reference must be the full scoped package name.
 Using only the unscoped package name, like `$foo`, does not match `@scope/foo`.
+The referenced package can also differ from the override target.
 
 ```json
 {
@@ -1004,9 +1005,7 @@ Using only the unscoped package name, like `$foo`, does not match `@scope/foo`.
     // "foo": "^2.0.0"
     // GOOD, specs match so override is allowed
     // "foo": "^1.0.0"
-    // BEST, the override is defined as a reference to the dependency
     "@npm/foo": "$@npm/foo",
-    // The referenced package can differ from the override target
     "@npm/bar": "$@npm/foo"
   }
 }

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -990,6 +990,7 @@ overriding its children, set `"."` explicitly:
 You may not set an override for a package that you directly depend on unless both the dependency and the override itself share the exact same spec.
 You can resolve a child override against a direct dependency by using a `$` prefix with the full package name.
 For scoped packages, keep the scope: use `$@scope/name`.
+In this example, `@npm/bar` intentionally inherits the direct dependency spec from `@npm/foo`.
 That allows, for example, `@npm/bar` to inherit the direct dependency spec from `@npm/foo` while still overriding `@npm/bar` at the same time:
 
 ```json

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -992,8 +992,7 @@ To make this limitation easier to deal with, overrides may also be defined as a 
 
 For scoped dependencies, the `$` reference must be the full scoped package name.
 Using only the unscoped package name, like `$foo`, does not match `@scope/foo`,
-and the referenced package can differ from the override target. This lets
-`@npm/bar` keep the spec from `@npm/foo`, which must be direct dependency.
+and the referenced package can differ from the override target.
 
 ```json
 {

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -965,6 +965,29 @@ To override `@npm/foo` to `1.0.0`, but only when it's a child of `@npm/bar@2.0.0
 }
 ```
 
+Versioned override keys do not just limit when nested overrides apply.
+They also replace the matched package with that version or range.
+In the example above, `@npm/bar@2.0.0` both matches `@npm/bar` at `2.0.0`
+and keeps `@npm/bar` on `2.0.0` while applying the nested `@npm/foo`
+override.
+
+If you want to keep the parent package on its existing spec while only
+overriding its children, set `"."` explicitly:
+
+```json
+{
+  "dependencies": {
+    "@npm/bar": "^2.0.0"
+  },
+  "overrides": {
+    "@npm/bar@2.0.0": {
+      ".": "$bar",
+      "@npm/foo": "1.0.0"
+    }
+  }
+}
+```
+
 You may not set an override for a package that you directly depend on unless both the dependency and the override itself share the exact same spec.
 To make this limitation easier to deal with, overrides may also be defined as a reference to a spec for a direct dependency by prefixing the name of the package you wish the version to match with a `$`.
 

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -1006,7 +1006,7 @@ Using only the unscoped package name, like `$foo`, does not match `@scope/foo`.
     // "foo": "^1.0.0"
     // BEST, the override is defined as a reference to the dependency
     "@npm/foo": "$@npm/foo",
-    // the referenced package does not need to match the overridden one
+    // The referenced package can differ from the override target
     "@npm/bar": "$@npm/foo"
   }
 }

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -1003,6 +1003,9 @@ To make this limitation easier to deal with, overrides may also be defined as a 
     // "foo": "^1.0.0"
     // BEST, the override is defined as a reference to the dependency
     // For scoped packages, use the full scoped name in the reference.
+    // BAD, will not resolve scoped package references.
+    // "@npm/foo": "$foo",
+    // "@npm/bar": "$bar",
     // Use "$@npm/foo" instead of "$foo", and use "$@npm/bar" instead of "$bar".
     // `$foo` and `$bar` are unscoped references and will not match scoped packages.
     "@npm/foo": "$@npm/foo",

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -1004,10 +1004,11 @@ To make this limitation easier to deal with, overrides may also be defined as a 
     // BEST, the override is defined as a reference to the dependency
     // For scoped packages, use the full scoped name in the reference.
     // BAD, will not resolve scoped package references.
+    // Do not use unscoped references for scoped dependencies.
+    // Use "$@npm/foo" instead of "$foo", and use "$@npm/bar" instead of "$bar".
+    // "$foo" and "$bar" are unscoped references and will not match scoped packages.
     // "@npm/foo": "$foo",
     // "@npm/bar": "$bar",
-    // Use "$@npm/foo" instead of "$foo", and use "$@npm/bar" instead of "$bar".
-    // `$foo` and `$bar` are unscoped references and will not match scoped packages.
     "@npm/foo": "$@npm/foo",
     // the referenced package does not need to match the overridden one
     "@npm/bar": "$@npm/bar"

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -1013,7 +1013,7 @@ Using only the unscoped package name, like `$foo`, does not match `@scope/foo`.
     // "@npm/bar": "$bar",
     "@npm/foo": "$@npm/foo",
     // the referenced package does not need to match the overridden one
-    "@npm/bar": "$@npm/bar"
+    "@npm/bar": "$@npm/foo"
   }
 }
 ```

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -1005,12 +1005,6 @@ Using only the unscoped package name, like `$foo`, does not match `@scope/foo`.
     // GOOD, specs match so override is allowed
     // "foo": "^1.0.0"
     // BEST, the override is defined as a reference to the dependency
-    // For scoped packages, use the full scoped name in the reference.
-    // BAD, will not resolve scoped package references.
-    // Use "$@npm/foo" instead of "$foo".
-    // "$foo" is an unscoped reference and will not match @npm/foo.
-    // "@npm/foo": "$foo",
-    // "@npm/bar": "$bar",
     "@npm/foo": "$@npm/foo",
     // the referenced package does not need to match the overridden one
     "@npm/bar": "$@npm/foo"

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -990,8 +990,7 @@ overriding its children, set `"."` explicitly:
 You may not set an override for a package that you directly depend on unless both the dependency and the override itself share the exact same spec.
 You can resolve a child override against a direct dependency by using a `$` prefix with the full package name.
 For scoped packages, keep the scope: use `$@scope/name`.
-In this example, `@npm/bar` intentionally inherits the direct dependency spec from `@npm/foo`.
-That allows, for example, `@npm/bar` to inherit the direct dependency spec from `@npm/foo` while still overriding `@npm/bar` at the same time:
+In this example, `@npm/bar` inherits its direct dependency spec from `@npm/foo` and is also overridden at the same time:
 
 ```json
 {

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -967,9 +967,8 @@ To override `@npm/foo` to `1.0.0`, but only when it's a child of `@npm/bar@2.0.0
 
 Versioned override keys do not just limit when nested overrides apply.
 They also replace the matched package with that version or range.
-In the example above, `@npm/bar@2.0.0` both matches `@npm/bar` at `2.0.0`
-and keeps `@npm/bar` on `2.0.0` while applying the nested `@npm/foo`
-override.
+In this example, the parent key both matches and preserves `@npm/bar@2.0.0`
+while applying the nested `@npm/foo` override.
 
 If you want to keep the parent package on its existing spec while only
 overriding its children, set `"."` explicitly:

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -1005,6 +1005,7 @@ The referenced package can also differ from the override target.
     // "foo": "^2.0.0"
     // GOOD, specs match so override is allowed
     // "foo": "^1.0.0"
+    // You can still reference a different direct dependency for the override
     "@npm/foo": "$@npm/foo",
     "@npm/bar": "$@npm/foo"
   }

--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -991,8 +991,8 @@ You may not set an override for a package that you directly depend on unless bot
 To make this limitation easier to deal with, overrides may also be defined as a reference to a spec for a direct dependency by prefixing the name of the package you wish the version to match with a `$`.
 
 For scoped dependencies, the `$` reference must be the full scoped package name.
-Using only the unscoped package name, like `$foo`, does not match `@scope/foo`.
-The referenced package can also differ from the override target.
+Using only the unscoped package name, like `$foo`, does not match `@scope/foo`,
+and the referenced package can differ from the override target.
 
 ```json
 {


### PR DESCRIPTION
## Summary
- clarify that a versioned parent override key also applies that spec to the matched parent package
- document how to keep the parent package on its existing spec with `"."` while only overriding children
- add a focused example that addresses the confusion in #9121

## Testing
- docs-only change
- attempted local validation, but the fresh clone does not have npm/cli dev dependencies bootstrapped (`node ./scripts/resetdeps.js` is required before broader checks can run)