### PR TITLE
feat: differentiate GitHub Actions environments in user-agent (#9517)

### DIFF
--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -2499,6 +2499,36 @@ const definitions = {
     flatten (key, obj, flatOptions) {
       const value = obj[key]
       const ciName = ciInfo.name?.toLowerCase().split(' ').join('-') || null
+      // A more specific sub-category for the detected CI, appended to the
+      // ci token as `ci/{ci-name}/{sub-ci-name}` when present.
+      let subCiName = null
+      if (ciInfo.GITHUB_ACTIONS) {
+        // Env vars can be absent, empty, or whitespace; normalize before use.
+        const serverUrl = (process.env.GITHUB_SERVER_URL || '').trim()
+        const runnerEnv = (process.env.RUNNER_ENVIRONMENT || '').trim()
+        let serverHost = ''
+        try {
+          serverHost = new URL(serverUrl).hostname.toLowerCase()
+        } catch {
+          serverHost = ''
+        }
+        if (serverHost === 'github.com') {
+          if (runnerEnv === 'github-hosted') {
+            subCiName = 'dotcom-hosted'
+          } else if (runnerEnv === 'self-hosted') {
+            subCiName = 'dotcom-selfhosted'
+          } else {
+            subCiName = 'dotcom'
+          }
+        } else if (serverHost === 'ghe.com' || serverHost.endsWith('.ghe.com')) {
+          subCiName = 'ghecom'
+        } else if (serverHost) {
+          subCiName = 'ghes'
+        }
+      }
+      const ci = ciName
+        ? `ci/${ciName}${subCiName ? `/${subCiName}` : ''}`
+        : ''
       let inWorkspaces = false
       if (obj.workspaces || obj.workspace && obj.workspace.length) {
         inWorkspaces = true
@@ -2509,7 +2539,7 @@ const definitions = {
           .replace(/\{platform\}/gi, process.platform)
           .replace(/\{arch\}/gi, process.arch)
           .replace(/\{workspaces\}/gi, inWorkspaces)
-          .replace(/\{ci\}/gi, ciName ? `ci/${ciName}` : '')
+          .replace(/\{ci\}/gi, ci)
           .trim()
 
       // We can't clobber the original or else subsequent flattening will fail

--- a/workspaces/config/test/definitions/definitions.js
+++ b/workspaces/config/test/definitions/definitions.js
@@ -866,6 +866,102 @@ t.test('user-agent', t => {
   t.end()
 })
 
+t.test('user-agent github actions ci variants', t => {
+  const npmVersion = '1.2.3'
+  const base = `npm/${npmVersion} node/${process.version} ` +
+    `${process.platform} ${process.arch} workspaces/false`
+
+  const cases = [
+    {
+      name: 'dotcom + github-hosted runner',
+      env: { GITHUB_SERVER_URL: 'https://github.com', RUNNER_ENVIRONMENT: 'github-hosted' },
+      expect: `${base} ci/github-actions/dotcom-hosted`,
+    },
+    {
+      name: 'dotcom + self-hosted runner',
+      env: { GITHUB_SERVER_URL: 'https://github.com', RUNNER_ENVIRONMENT: 'self-hosted' },
+      expect: `${base} ci/github-actions/dotcom-selfhosted`,
+    },
+    {
+      name: 'dotcom + missing runner environment',
+      env: { GITHUB_SERVER_URL: 'https://github.com', RUNNER_ENVIRONMENT: undefined },
+      expect: `${base} ci/github-actions/dotcom`,
+    },
+    {
+      name: 'dotcom + whitespace runner environment',
+      env: { GITHUB_SERVER_URL: 'https://github.com', RUNNER_ENVIRONMENT: '   ' },
+      expect: `${base} ci/github-actions/dotcom`,
+    },
+    {
+      name: 'ghe.com tenant',
+      env: { GITHUB_SERVER_URL: 'https://octocorp.ghe.com', RUNNER_ENVIRONMENT: 'github-hosted' },
+      expect: `${base} ci/github-actions/ghecom`,
+    },
+    {
+      name: 'bare ghe.com host',
+      env: { GITHUB_SERVER_URL: 'https://ghe.com', RUNNER_ENVIRONMENT: 'github-hosted' },
+      expect: `${base} ci/github-actions/ghecom`,
+    },
+    {
+      name: 'ghe.com only in path is treated as ghes',
+      env: { GITHUB_SERVER_URL: 'https://evil.example/x.ghe.com', RUNNER_ENVIRONMENT: 'self-hosted' },
+      expect: `${base} ci/github-actions/ghes`,
+    },
+    {
+      name: 'ghes (non-empty, non github.com, non ghe.com)',
+      env: { GITHUB_SERVER_URL: 'https://github.example.com', RUNNER_ENVIRONMENT: 'self-hosted' },
+      expect: `${base} ci/github-actions/ghes`,
+    },
+    {
+      name: 'missing server url stays generic',
+      env: { GITHUB_SERVER_URL: undefined, RUNNER_ENVIRONMENT: undefined },
+      expect: `${base} ci/github-actions`,
+    },
+    {
+      name: 'whitespace server url stays generic',
+      env: { GITHUB_SERVER_URL: '   ', RUNNER_ENVIRONMENT: 'github-hosted' },
+      expect: `${base} ci/github-actions`,
+    },
+  ]
+
+  for (const { name, env, expect } of cases) {
+    t.test(name, t => {
+      mockGlobals(t, { 'process.env': env })
+      const defs = mockDefs({
+        'ci-info': { isCi: true, name: 'GitHub Actions', GITHUB_ACTIONS: true },
+      })
+      const obj = {
+        'npm-version': npmVersion,
+        'user-agent': defs['user-agent'].default,
+      }
+      const flat = {}
+      defs['user-agent'].flatten('user-agent', obj, flat)
+      t.equal(flat.userAgent, expect)
+      t.equal(process.env.npm_config_user_agent, flat.userAgent, 'npm_user_config environment is set')
+      t.end()
+    })
+  }
+
+  t.test('non github-actions ci is unchanged', t => {
+    mockGlobals(t, {
+      'process.env': { GITHUB_SERVER_URL: 'https://github.com', RUNNER_ENVIRONMENT: 'github-hosted' },
+    })
+    const defs = mockDefs({
+      'ci-info': { isCi: true, name: 'Travis CI', GITHUB_ACTIONS: false },
+    })
+    const obj = {
+      'npm-version': npmVersion,
+      'user-agent': defs['user-agent'].default,
+    }
+    const flat = {}
+    defs['user-agent'].flatten('user-agent', obj, flat)
+    t.equal(flat.userAgent, `${base} ci/travis-ci`)
+    t.end()
+  })
+
+  t.end()
+})
+
 t.test('save-prefix', t => {
   const obj = {
     'save-exact': true,


### PR DESCRIPTION
Backport of #9517 to `release/v11` so the change ships in v11 (not just the v12 pre-release).

Updates the `user-agent` to specify the github-actions runner sub-category, emitted as `ci/{ci-name}/{sub-ci-name}` (e.g. `ci/github-actions/dotcom-hosted`, `dotcom-selfhosted`, `dotcom`, `ghecom`, `ghes`). Env vars are normalized to guard against absent/empty/whitespace values, and an empty/unparseable server URL keeps the plain `ci/github-actions` token.

Cherry-picked cleanly from f6a9aad; config definitions tests pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>