### PR TITLE
fix(arborist): expose store node_modules via NODE_PATH for linked-strategy install scripts

### DIFF
--- a/workspaces/arborist/lib/arborist/rebuild.js
+++ b/workspaces/arborist/lib/arborist/rebuild.js
@@ -11,7 +11,7 @@ const { depth: dfwalk } = require('treeverse')
 const { isNodeGypPackage, defaultGypInstallScript } = require('@npmcli/node-gyp')
 const { promiseRetry } = require('@gar/promise-retry')
 const { log, time } = require('proc-log')
-const { resolve } = require('node:path')
+const { resolve, delimiter } = require('node:path')
 const { isScriptAllowed } = require('../script-allowed.js')
 
 const boolEnv = b => b ? '1' : ''
@@ -307,6 +307,7 @@ module.exports = cls => class Builder extends cls {
     await promiseCallLimit(queue.map(node => async () => {
       const {
         path,
+        name,
         integrity,
         resolved,
         optional,
@@ -315,6 +316,7 @@ module.exports = cls => class Builder extends cls {
         devOptional,
         package: pkg,
         location,
+        isInStore,
       } = node.target
 
       // skip any that we know we'll be deleting
@@ -335,6 +337,12 @@ module.exports = cls => class Builder extends cls {
         npm_package_peer: boolEnv(peer),
         npm_package_dev_optional:
           boolEnv(devOptional && !dev && !optional),
+      }
+      // In the linked strategy a store package's dependencies are symlinked siblings in its store node_modules.
+      // A separate bin invoked by the script (e.g. napi-postinstall) resolves modules from its own realpath in the store and cannot see those deps, so expose them via NODE_PATH.
+      if (isInStore) {
+        const storeNodeModules = resolve(path, ...name.split('/').map(() => '..'))
+        env.NODE_PATH = [storeNodeModules, process.env.NODE_PATH].filter(Boolean).join(delimiter)
       }
       const runOpts = {
         event,

--- a/workspaces/arborist/test/arborist/reify.js
+++ b/workspaces/arborist/test/arborist/reify.js
@@ -1,4 +1,4 @@
-const { join, resolve, basename } = require('node:path')
+const { join, resolve, basename, delimiter } = require('node:path')
 const t = require('tap')
 const runScript = require('@npmcli/run-script')
 const localeCompare = require('@isaacs/string-locale-compare')('en')
@@ -4137,6 +4137,76 @@ t.test('install strategy linked', async (t) => {
       'packages/b should remain absent after reinstall'
     )
   })
+})
+
+t.test('linked strategy exposes store node_modules via NODE_PATH for lifecycle scripts', async t => {
+  // Regression for #9549. In the linked strategy a store package's deps are symlinked siblings in its store node_modules.
+  // A separate bin invoked by the script (e.g. napi-postinstall) resolves modules from its own store realpath and cannot see them, so npm exposes them via NODE_PATH.
+  const Arborist = require('../../lib/index.js')
+  const pacote = require('pacote')
+
+  const testdir = t.testdir({
+    src: {
+      'package.json': JSON.stringify({
+        name: 'has-postinstall',
+        version: '1.0.0',
+        scripts: { postinstall: 'node -e ""' },
+      }),
+    },
+    project: {
+      'package.json': JSON.stringify({
+        name: 'myproject',
+        version: '1.0.0',
+        dependencies: { 'has-postinstall': '1.0.0' },
+      }),
+    },
+  })
+
+  const tgz = await pacote.tarball(resolve(testdir, 'src'), { Arborist })
+
+  const packument = JSON.stringify({
+    _id: 'has-postinstall',
+    name: 'has-postinstall',
+    'dist-tags': { latest: '1.0.0' },
+    versions: {
+      '1.0.0': {
+        name: 'has-postinstall',
+        version: '1.0.0',
+        hasInstallScript: true,
+        scripts: { postinstall: 'node -e ""' },
+        dist: {
+          tarball: 'https://registry.npmjs.org/has-postinstall/-/has-postinstall-1.0.0.tgz',
+        },
+      },
+    },
+  })
+
+  tnock(t, 'https://registry.npmjs.org')
+    .get('/has-postinstall')
+    .reply(200, packument)
+
+  tnock(t, 'https://registry.npmjs.org')
+    .get('/has-postinstall/-/has-postinstall-1.0.0.tgz')
+    .reply(200, tgz)
+
+  const path = resolve(testdir, 'project')
+  const arb = new Arborist({
+    path,
+    registry: 'https://registry.npmjs.org',
+    cache: resolve(testdir, 'cache'),
+    installStrategy: 'linked',
+    dangerouslyAllowAllScripts: true,
+  })
+  await arb.reify()
+
+  const run = [...arb.scriptsRun]
+    .find(s => s.pkg.name === 'has-postinstall' && s.event === 'postinstall')
+  t.ok(run, 'postinstall ran for the store package')
+  t.match(run.path, /[\\/]\.store[\\/]/, 'script ran on the store entry')
+  // Assert the leading entry: the fix prepends the store node_modules to any pre-existing NODE_PATH (e.g. the coverage harness on Windows CI).
+  const [firstNodePath] = run.env.NODE_PATH.split(delimiter)
+  t.equal(firstNodePath, resolve(run.path, '..'),
+    'NODE_PATH leads with the store node_modules holding the package deps')
 })
 
 t.test('workspace installs retain existing versions with newer package specs', async t => {


### PR DESCRIPTION
In continuation of our exploration of using `install-strategy=linked` in the [Gutenberg monorepo](https://github.com/WordPress/gutenberg/pull/75814), which powers the WordPress Block Editor.

Under `install-strategy=linked`, a package whose install script invokes a separate helper bin to locate a native binding fails (e.g. `unrs-resolver` via `napi-postinstall`, and the wider `napi-postinstall` family). The helper bin is reached via a `.bin` symlink, so Node resolves it to its own realpath in its own store dir, from which it can't `require.resolve` the host's binding — so it declares it missing and re-downloads (fatal on a restricted registry/proxy). Hoisted works because the binding is hoisted onto the helper's resolution path.

## How

When running a store node's lifecycle script, set `NODE_PATH` to the host package's store `node_modules` so a script-invoked bin can resolve the host's sibling deps:

```js
if (isInStore) {
  const storeNodeModules = resolve(path, ...name.split('/').map(() => '..'))
  env.NODE_PATH = [storeNodeModules, process.env.NODE_PATH].filter(Boolean).join(delimiter)
}
```

`NODE_PATH` is fallback-only (can't shadow working resolution), added only to the script's env (never `process.env`), and scoped to the store-local `node_modules` — install-time only, runtime isolation untouched.

## References

Fixes #9549
