### PR TITLE
fix(arborist): warn once for workspace packageExtensions selector match

### DIFF
--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -283,7 +283,8 @@ module.exports = cls => class IdealTreeBuilder extends cls {
       return
     }
     for (const node of this.idealTree.inventory.values()) {
-      if (!node.isWorkspace) {
+      // a workspace is in the inventory as both a Link and its target node; warn once by skipping the link
+      if (!node.isWorkspace || node.isLink) {
         continue
       }
       if (node.package.packageExtensions !== undefined) {

--- a/workspaces/arborist/test/arborist/package-extensions.js
+++ b/workspaces/arborist/test/arborist/package-extensions.js
@@ -179,8 +179,11 @@ t.test('does not extend workspace members but warns', async t => {
   const tree = await buildIdeal(path)
   const ws = [...tree.inventory.values()].find(n => n.name === 'ws')
   t.notOk(ws.edgesOut.get('bar'), 'workspace member is not extended')
-  t.ok(warnings.some(w => /workspace package ws/.test(w[2])), 'warns about the workspace selector match')
-  t.ok(warnings.some(w => /in workspace ws is ignored/.test(w[2])), 'warns about non-root workspace packageExtensions')
+  // a workspace appears in the inventory as both a Link and its target node, so the warning must be deduped to fire once
+  t.equal(warnings.filter(w => /workspace package ws/.test(w[2])).length, 1,
+    'warns exactly once about the workspace selector match')
+  t.equal(warnings.filter(w => /in workspace ws is ignored/.test(w[2])).length, 1,
+    'warns exactly once about non-root workspace packageExtensions')
 })
 
 t.test('ignores packageExtensions from an installed dependency', async t => {


### PR DESCRIPTION
A workspace `packageExtensions` warning was printed twice per matching workspace. A workspace appears in the inventory as two `isWorkspace` nodes — the Link and its target — and `#warnWorkspacePackageExtensions` warned for both. The fix skips the link (`node.isLink`) so each workspace is warned once via its target node; the selector/`wouldMatch` checks are otherwise unchanged.

## References

Follow up of #9496