### PR TITLE
fix(patch): explain out-of-sync lockfile after --ignore-patch-failures

### DIFF
--- a/lib/utils/validate-lockfile.js
+++ b/lib/utils/validate-lockfile.js
@@ -26,8 +26,19 @@ function validateLockfile (virtualTree, idealTree) {
     // a patch whose on-disk hash or path diverges from the lockfile is out of sync
     if ((lock.patched?.integrity || null) !== (entry.patched?.integrity || null) ||
       (lock.patched?.path || null) !== (entry.patched?.path || null)) {
-      errors.push(`Invalid: patch for ${entry.name}@${entry.version} does not ` +
-      `match the patch recorded in the lock file`)
+      if (entry.patched && !lock.patched) {
+        // package.json declares a patch the lockfile lacks: newly added, or skipped via --ignore-patch-failures
+        errors.push(`Invalid: package.json declares a patch for ${entry.name}@${entry.version} ` +
+        `that the lock file does not record (it may have been skipped with --ignore-patch-failures). ` +
+        `Fix the patch and reinstall, or remove its patchedDependencies entry`)
+      } else if (lock.patched && !entry.patched) {
+        // describe the lock file's own version, which can differ from the ideal tree's when the version also drifted
+        errors.push(`Invalid: lock file records a patch for ${lock.name}@${lock.version} ` +
+        `that package.json no longer declares`)
+      } else {
+        errors.push(`Invalid: patch for ${entry.name}@${entry.version} does not ` +
+        `match the patch recorded in the lock file`)
+      }
     }
   }
   return errors

--- a/tap-snapshots/test/lib/utils/validate-lockfile.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/validate-lockfile.js.test.cjs
@@ -19,11 +19,17 @@ exports[`test/lib/utils/validate-lockfile.js TAP identical inventory for both id
 Array []
 `
 
+exports[`test/lib/utils/validate-lockfile.js TAP lock file records a patch package.json no longer declares > should report a stray lock file patch 1`] = `
+Array [
+  "Invalid: lock file records a patch for foo@1.0.0 that package.json no longer declares",
+]
+`
+
 exports[`test/lib/utils/validate-lockfile.js TAP mismatching patch integrity or path > should error on integrity drift, path drift, and a newly added patch 1`] = `
 Array [
   "Invalid: patch for foo@1.0.0 does not match the patch recorded in the lock file",
   "Invalid: patch for bar@2.0.0 does not match the patch recorded in the lock file",
-  "Invalid: patch for baz@3.0.0 does not match the patch recorded in the lock file",
+  "Invalid: package.json declares a patch for baz@3.0.0 that the lock file does not record (it may have been skipped with --ignore-patch-failures). Fix the patch and reinstall, or remove its patchedDependencies entry",
 ]
 `
 

--- a/test/lib/utils/validate-lockfile.js
+++ b/test/lib/utils/validate-lockfile.js
@@ -182,6 +182,20 @@ t.test('mismatching patch integrity or path', async t => {
   )
 })
 
+t.test('lock file records a patch package.json no longer declares', async t => {
+  t.matchSnapshot(
+    validateLockfile(
+      new Map([
+        ['foo', { name: 'foo', version: '1.0.0', patched: { path: 'patches/foo.patch', integrity: 'sha512-aaa' } }],
+      ]),
+      new Map([
+        ['foo', { name: 'foo', version: '1.0.0' }],
+      ])
+    ),
+    'should report a stray lock file patch'
+  )
+})
+
 t.test('missing virtualTree inventory', async t => {
   t.matchSnapshot(
     validateLockfile(

--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -788,6 +788,8 @@ module.exports = cls => class Reifier extends cls {
         }
         log.warn('patch', `failed to apply ${patchPath} to ${node.name}: ${er.message}`)
         // the patch was not applied, so do not record it in the lockfile
+        // the lockfile and package.json now disagree, so warn that npm ci will reject the tree
+        log.warn('patch', `${node.name} was installed unpatched; package.json still declares this patch, so the lockfile is out of sync and \`npm ci\` will fail until the patch is fixed or its patchedDependencies entry is removed`)
         node.patched = null
         return
       }

--- a/workspaces/arborist/test/arborist/reify-patch.js
+++ b/workspaces/arborist/test/arborist/reify-patch.js
@@ -157,6 +157,11 @@ t.test('ignorePatchFailures downgrades EPATCHFAILED to a warning', async t => {
     patchedDependencies: { [`${PKG_NAME}@${PKG_VERSION}`]: `patches/${PKG_NAME}@${PKG_VERSION}.patch` },
   })
 
+  const warnings = []
+  const onLog = (level, prefix, msg) => level === 'warn' && warnings.push(`${prefix} ${msg}`)
+  process.on('log', onLog)
+  t.teardown(() => process.removeListener('log', onLog))
+
   await t.resolves(newArb({ path, ignorePatchFailures: true }).reify(),
     'failure is downgraded and reify continues')
   // file remains as extracted since the patch was skipped
@@ -166,6 +171,9 @@ t.test('ignorePatchFailures downgrades EPATCHFAILED to a warning', async t => {
   const lock = JSON.parse(fs.readFileSync(resolve(path, 'package-lock.json'), 'utf8'))
   t.notOk(lock.packages[`node_modules/${PKG_NAME}`].patched,
     'unapplied patch is not written to the lockfile')
+  // the user is told the lockfile is now out of sync with package.json
+  t.match(warnings.join('\n'), /out of sync and `npm ci` will fail/,
+    'warns that the lockfile no longer matches package.json')
 })
 
 t.test('missing patch file throws EPATCHNOTFOUND', async t => {


### PR DESCRIPTION
When `--ignore-patch-failures` skips a broken patch, the package installs unpatched and the lockfile records no `patched` entry, but `package.json` still declares it. A later `npm ci` then fails with a generic out-of-sync `EUSAGE` whose "run `npm install`" advice is wrong (a plain install just re-fails with `EPATCHFAILED`).

The state can't be reconciled automatically — recording the patch would be a lie, and rewriting `package.json` would discard the user's intent. So this PR makes the out-of-sync state self-explanatory:

- `reify.js`: when a patch is skipped, warn that the lockfile is now out of sync with `package.json` and `npm ci` will fail until the patch is fixed or its `patchedDependencies` entry is removed.
- `validate-lockfile.js`: make the patch mismatch error direction-aware. A patch declared in `package.json` but missing from the lockfile names `--ignore-patch-failures` and gives remediation; a patch in the lockfile that `package.json` dropped says so; integrity/path drift keeps the existing message. This flows into the `npm ci` `EUSAGE`.

## References

Fixes #9573
