### PR TITLE
fix: output all the required parameters for npm token list

### DIFF
--- a/lib/commands/token.js
+++ b/lib/commands/token.js
@@ -73,17 +73,22 @@ class Token extends BaseCommand {
     const parseable = this.npm.config.get('parseable')
     log.info('token', 'getting list')
     const tokens = await paginate('/-/npm/v1/tokens', this.npm.flatOptions)
+
+    this.generateTokenIds(tokens, 6)
+
     if (json) {
       output.buffer(tokens)
       return
     }
     if (parseable) {
-      output.standard(['key', 'token', 'created', 'readonly', 'CIDR whitelist'].join('\t'))
+      output.standard(['key', 'token', 'id', 'name', 'created', 'readonly', 'CIDR whitelist'].join('\t'))
       tokens.forEach(token => {
         output.standard(
           [
             token.key,
             token.token,
+            token.id,
+            token.name,
             token.created,
             token.readonly ? 'true' : 'false',
             token.cidr_whitelist ? token.cidr_whitelist.join(',') : '',
@@ -92,11 +97,10 @@ class Token extends BaseCommand {
       })
       return
     }
-    this.generateTokenIds(tokens, 6)
     const chalk = this.npm.chalk
     for (const token of tokens) {
       const created = String(token.created).slice(0, 10)
-      output.standard(`${chalk.blue('Token')} ${token.token}… with id ${chalk.cyan(token.id)} created ${created}`)
+      output.standard(`${chalk.blue('Token')} ${token.token}… with id ${chalk.cyan(token.id)} name ${chalk.magenta(token.name)} created ${created}`)
       if (token.cidr_whitelist) {
         output.standard(`with IP whitelist: ${chalk.green(token.cidr_whitelist.join(','))}`)
       }

--- a/test/lib/commands/token.js
+++ b/test/lib/commands/token.js
@@ -13,6 +13,7 @@ const tokens = [
   {
     key: 'abcd1234abcd1234',
     token: 'efgh5678efgh5678',
+    name: 'abcd001',
     cidr_whitelist: null,
     readonly: false,
     created: now,
@@ -21,6 +22,7 @@ const tokens = [
   {
     key: 'abcd1256',
     token: 'hgfe8765',
+    name: 'abcd002',
     cidr_whitelist: ['192.168.1.1/32'],
     readonly: true,
     created: now,
@@ -63,9 +65,9 @@ t.test('token list', async t => {
   registry.getTokens(tokens)
   await npm.exec('token', [])
   t.strictSame(outputs, [
-    `Token efgh5678efgh5678… with id abcd123 created ${now.slice(0, 10)}`,
+    `Token efgh5678efgh5678… with id abcd123 name abcd001 created ${now.slice(0, 10)}`,
     '',
-    `Token hgfe8765… with id abcd125 created ${now.slice(0, 10)}`,
+    `Token hgfe8765… with id abcd125 name abcd002 created ${now.slice(0, 10)}`,
     'with IP whitelist: 192.168.1.1/32',
     '',
   ])
@@ -104,9 +106,9 @@ t.test('token list parseable output', async t => {
   registry.getTokens(tokens)
   await npm.exec('token', [])
   t.strictSame(outputs, [
-    'key\ttoken\tcreated\treadonly\tCIDR whitelist',
-    `abcd1234abcd1234\tefgh5678efgh5678\t${now}\tfalse\t`,
-    `abcd1256\thgfe8765\t${now}\ttrue\t192.168.1.1/32`,
+    'key\ttoken\tid\tname\tcreated\treadonly\tCIDR whitelist',
+    `abcd1234abcd1234\tefgh5678efgh5678\tabcd123\tabcd001\t${now}\tfalse\t`,
+    `abcd1256\thgfe8765\tabcd125\tabcd002\t${now}\ttrue\t192.168.1.1/32`,
   ])
 })
 


### PR DESCRIPTION
### What

Added missing token metadata to `npm token list` outputs:

* Added `id` field to the `--json` output.
* Added `name` field to the default and `--parseable` outputs of `npm token list`.

### Why

Currently, token information is fragmented across different output formats:

* `npm token revoke` requires a token ID or token value, but the `--json` output does not expose the token ID.
* The default and `--parseable` outputs expose the ID but not the token name.
* This makes it difficult to automate token lifecycle management (such as identifying and revoking expired tokens) because users need information from multiple output formats. 

### How

* Updated the token listing implementation to include the token `id` in the JSON response.
* Updated the default and parseable formatters to include the token `name`.
* Ensured all output formats expose the metadata required for scripting, automation, and token revocation workflows while maintaining backward compatibility where possible. 

Fixes the issue: https://github.com/npm/cli/issues/9443