### PR TITLE
fix(link): scope `npm link <path> --workspace` to the workspace, not the root

### DIFF
--- a/lib/commands/link.js
+++ b/lib/commands/link.js
@@ -125,6 +125,8 @@ class Link extends ArboristWorkspaceCmd {
       prune: false,
       path: this.npm.prefix,
       save,
+      // Arborist reads this.options.workspaces (set at construction) to decide which node receives the add, so it must be set here, not only at reify time.
+      workspaces: this.workspaceNames,
       allowScripts: allowScriptsPolicy,
     })
     await localArb.reify({

--- a/test/lib/commands/link.js
+++ b/test/lib/commands/link.js
@@ -289,6 +289,44 @@ t.test('link global linked pkg to local workspace using args', async t => {
   t.matchSnapshot(await printLinks(), 'should create a local symlink to global pkg')
 })
 
+t.test('link --workspace --save targets the workspace manifest, not the root', async t => {
+  const { link, prefix } = await mockLink(t, {
+    globalPrefixDir: {
+      node_modules: {
+        a: {
+          'package.json': JSON.stringify({
+            name: 'a',
+            version: '1.0.0',
+          }),
+        },
+      },
+    },
+    prefixDir: {
+      'package.json': JSON.stringify({
+        name: 'my-project',
+        version: '1.0.0',
+        workspaces: ['packages/*'],
+      }),
+      packages: {
+        x: {
+          'package.json': JSON.stringify({
+            name: 'x',
+            version: '1.0.0',
+          }),
+        },
+      },
+    },
+    config: { workspace: 'x', save: true },
+  })
+
+  await link.exec(['a'])
+
+  const root = JSON.parse(fs.readFileSync(join(prefix, 'package.json'), 'utf8'))
+  const ws = JSON.parse(fs.readFileSync(join(prefix, 'packages', 'x', 'package.json'), 'utf8'))
+  t.notOk(root.dependencies, 'root manifest should not get the dependency')
+  t.match(ws.dependencies, { a: /^file:/ }, 'workspace manifest should get the file: dependency')
+})
+
 t.test('link pkg already in global space', async t => {
   const { npm, link, printLinks, prefix } = await mockLink(t, {
     globalPrefixDir: {


### PR DESCRIPTION
In continuation of our exploration of using `install-strategy=linked` in the [Gutenberg monorepo](https://github.com/WordPress/gutenberg/pull/75814), which powers the WordPress Block Editor.

`npm link <path> --workspace=<ws>` did not scope the operation to the target workspace.
The linked dependency was attached to the root project instead, and with `--save` (or `--save-dev`/`--save-optional`/etc.) the `file:` spec was written to the root `package.json` rather than `<ws>/package.json`.
`npm install <path> --workspace=<ws> --save` behaved correctly, so only `npm link` was affected.

The cause is in `Link.linkInstall()` in `lib/commands/link.js`, which built the local Arborist without the `workspaces` option and passed `workspaces` only to `reify()`.
Arborist decides which node receives the `add` request from `this.options.workspaces`, which is captured at construction time, not from the reify-time option.
`buildIdealTree` merges reify options into a local variable and `#parseSettings` never copies `options.workspaces` into `this.options`, so the reify-time value never reached `#applyUserRequests`.
With `this.options.workspaces` left empty, the `add` and the save were applied to the root node.

The fix passes `workspaces: this.workspaceNames` to the local Arborist constructor, matching how `lib/commands/install.js` already does it.
Physical placement is unchanged: under the default `hoisted` strategy the symlink still hoists to the root `node_modules`, identical to `npm install --workspace`.

## References

<!-- List any relevant issues, pull requests, or external references -->
Fixes #9590
Related #9589
