### PR TITLE
fix(arborist): validate peerOptional conflicts in no-save mutations

### DIFF
--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -103,6 +103,7 @@ module.exports = cls => class IdealTreeBuilder extends cls {
   #mutateTree = false
   #packageExtensions = null
   #npmExtension = null
+  #requestedTreeMutation = false
   // a map of each module in a peer set to the thing that depended on
   // that set of peers in the first place.  Use a WeakMap so that we
   // don't hold onto references for nodes that are garbage collected.
@@ -401,12 +402,13 @@ module.exports = cls => class IdealTreeBuilder extends cls {
 
     // set if we add anything, but also set here if we know we'll make
     // changes and thus have to maybe prune later.
-    this.#mutateTree = !!(
+    this.#requestedTreeMutation = !!(
       options.add ||
       options.rm ||
       update.all ||
       update.names.length
     )
+    this.#mutateTree = this.#requestedTreeMutation
   }
 
   // load the initial tree, either the virtualTree from a shrinkwrap,
@@ -484,7 +486,9 @@ module.exports = cls => class IdealTreeBuilder extends cls {
           filter: node => node,
           visit: node => {
             for (const edge of node.edgesOut.values()) {
-              const skipPeerOptional = edge.type === 'peerOptional' && this.options.save === false
+              const skipPeerOptional = edge.type === 'peerOptional' &&
+                this.options.save === false &&
+                !this.#requestedTreeMutation
               if (!skipPeerOptional && (!edge.to || !edge.valid)) {
                 this.#depsQueue.push(node)
                 break // no need to continue the loop after the first hit
@@ -1176,9 +1180,16 @@ This is a one-time fix-up, please be patient...
               }
               const { from, valid, peerConflicted } = edgeIn
               if (!peerConflicted && !valid) {
-                if (this.#depsSeen.has(from) && this.options.save) {
-                  // Re-queue already-processed nodes when a newly placed dep creates an invalid edge during npm install (save=true).
-                  // This handles the case where a peerOptional dep was valid (missing) when the node was first processed, but becomes invalid when the dep is later placed by another path with a version that doesn't satisfy the peer spec.
+                if (this.#depsSeen.has(from) &&
+                  (this.options.save ||
+                    (this.options.save === false && this.#requestedTreeMutation))) {
+                  // Re-queue already-processed nodes when a newly placed dep
+                  // creates an invalid edge during npm install or another
+                  // lockfile-mutating operation. This handles the case where a
+                  // peerOptional dep was valid (missing) when the node was
+                  // first processed, but becomes invalid when the dep is later
+                  // placed by another path with a version that doesn't satisfy
+                  // the peer spec.
                   // See npm/cli#8726.
                   this.#depsSeen.delete(from)
                   this.#depsQueue.push(from)
@@ -1384,11 +1395,16 @@ This is a one-time fix-up, please be patient...
         continue
       }
 
-      // If the edge has an error, there's a problem, unless it's peerOptional and we're not saving (e.g. npm ci), in which case we trust the lockfile and skip re-resolution.
-      // When saving (npm install), peerOptional invalid edges ARE treated as problems so the lockfile gets fixed.
+      // If the edge has an error, there's a problem, unless it's peerOptional
+      // and we're not saving or otherwise mutating (e.g. npm ci), in which
+      // case we trust the lockfile and skip re-resolution. When saving (npm
+      // install) or updating, peerOptional invalid edges ARE treated as
+      // problems so the lockfile gets fixed.
       // See npm/cli#8726.
       if (!edge.valid) {
-        if (edge.type !== 'peerOptional' || this.options.save !== false) {
+        if (edge.type !== 'peerOptional' ||
+          this.options.save !== false ||
+          this.#requestedTreeMutation) {
           problems.push(edge)
         }
         continue

--- a/workspaces/arborist/test/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/test/arborist/build-ideal-tree.js
@@ -4541,14 +4541,53 @@ t.test('re-queue already-seen nodes when placed dep invalidates peerOptional (sa
   t.ok(tree.children.get('shared'), 'shared is in the tree')
 })
 
-t.test('skip invalid peerOptional edges in problemEdges when save=false (#8726)', async t => {
-  // With save=false (npm ci behavior), invalid peerOptional edges should NOT be treated as problems.
-  // We use update.names to force alpha into #problemEdges while shared@1.1.0 (invalid for alpha's peerOptional spec of 1.0.0) is already in the tree from the lockfile.
+t.test('re-queue already-seen nodes when save=false update invalidates peerOptional', async t => {
   const registry = createRegistry(t, false)
 
-  const utilPacks = registry.packuments(['1.0.0', '1.0.1'], 'util')
-  const utilManifest = registry.manifest({ name: 'util', packuments: utilPacks })
-  await registry.package({ manifest: utilManifest })
+  const alphaPack = registry.packument({
+    name: 'alpha',
+    version: '1.0.0',
+    peerDependencies: { shared: '1.0.0' },
+    peerDependenciesMeta: { shared: { optional: true } },
+  })
+  const alphaManifest = registry.manifest({ name: 'alpha', packuments: [alphaPack] })
+  await registry.package({ manifest: alphaManifest })
+
+  const betaPack = registry.packument({
+    name: 'beta',
+    version: '1.0.0',
+    dependencies: { shared: '^1.0.0' },
+  })
+  const betaManifest = registry.manifest({ name: 'beta', packuments: [betaPack] })
+  await registry.package({ manifest: betaManifest })
+
+  const sharedPacks = registry.packuments(['1.0.0', '1.1.0'], 'shared')
+  const sharedManifest = registry.manifest({ name: 'shared', packuments: sharedPacks })
+  await registry.package({ manifest: sharedManifest, times: 2 })
+
+  const path = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'test-8726-save-false-update',
+      version: '1.0.0',
+      dependencies: {
+        alpha: '1.0.0',
+        beta: '1.0.0',
+      },
+    }),
+  })
+
+  const arb = newArb(path, { save: false })
+  const tree = await arb.buildIdealTree({ update: true })
+
+  t.ok(tree.children.get('alpha'), 'alpha is in the tree')
+  t.ok(tree.children.get('beta'), 'beta is in the tree')
+  t.ok(tree.children.get('shared'), 'shared is in the tree')
+})
+
+t.test('skip invalid peerOptional edges when save=false and not mutating (#8726)', async t => {
+  // With save=false and no tree mutation (npm ci behavior), invalid peerOptional
+  // edges should NOT be treated as problems. The locked tree is trusted as-is.
+  createRegistry(t, false)
 
   const path = t.testdir({
     'package.json': JSON.stringify({
@@ -4573,7 +4612,6 @@ t.test('skip invalid peerOptional edges in problemEdges when save=false (#8726)'
         'node_modules/alpha': {
           version: '1.0.0',
           resolved: 'https://registry.npmjs.org/alpha/-/alpha-1.0.0.tgz',
-          dependencies: { util: '^1.0.0' },
           peerDependencies: { shared: '1.0.0' },
           peerDependenciesMeta: { shared: { optional: true } },
         },
@@ -4586,22 +4624,178 @@ t.test('skip invalid peerOptional edges in problemEdges when save=false (#8726)'
           version: '1.1.0',
           resolved: 'https://registry.npmjs.org/shared/-/shared-1.1.0.tgz',
         },
-        'node_modules/util': {
+      },
+    }),
+  })
+
+  const arb = newArb(path, { save: false })
+  const tree = await arb.buildIdealTree()
+
+  t.ok(tree.children.get('alpha'), 'alpha is in the tree')
+  t.ok(tree.children.get('beta'), 'beta is in the tree')
+  t.equal(tree.children.get('shared').version, '1.1.0',
+    'shared stays at 1.1.0 - peerOptional mismatch is not treated as a problem')
+})
+
+t.test('save=false non-mutating build ignores invalid peerOptional problem edges', async t => {
+  const registry = createRegistry(t, false)
+
+  const gammaPack = registry.packument({
+    name: 'gamma',
+    version: '1.0.0',
+  })
+  const gammaManifest = registry.manifest({ name: 'gamma', packuments: [gammaPack] })
+  await registry.package({ manifest: gammaManifest })
+
+  const path = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'test-8726-save-false-non-mutating-problem-edges',
+      version: '1.0.0',
+      dependencies: {
+        alpha: '1.0.0',
+      },
+    }),
+    'package-lock.json': JSON.stringify({
+      name: 'test-8726-save-false-non-mutating-problem-edges',
+      version: '1.0.0',
+      lockfileVersion: 3,
+      requires: true,
+      packages: {
+        '': {
+          name: 'test-8726-save-false-non-mutating-problem-edges',
           version: '1.0.0',
-          resolved: 'https://registry.npmjs.org/util/-/util-1.0.0.tgz',
+          dependencies: { alpha: '1.0.0' },
+        },
+        'node_modules/alpha': {
+          version: '1.0.0',
+          resolved: 'https://registry.npmjs.org/alpha/-/alpha-1.0.0.tgz',
+          dependencies: { gamma: '1.0.0' },
+          peerDependencies: { shared: '1.0.0' },
+          peerDependenciesMeta: { shared: { optional: true } },
+        },
+        'node_modules/shared': {
+          version: '1.1.0',
+          resolved: 'https://registry.npmjs.org/shared/-/shared-1.1.0.tgz',
         },
       },
     }),
   })
 
   const arb = newArb(path, { save: false })
-  const tree = await arb.buildIdealTree({ update: { names: ['util'] } })
+  const tree = await arb.buildIdealTree()
 
-  t.ok(tree.children.get('alpha'), 'alpha is in the tree')
-  t.ok(tree.children.get('beta'), 'beta is in the tree')
-  t.equal(tree.children.get('shared').version, '1.1.0',
-    'shared stays at 1.1.0 - peerOptional mismatch is not treated as a problem')
-  t.ok(tree.children.get('util'), 'util is in the tree')
+  t.ok(tree.children.get('gamma'), 'missing non-peer dependency is resolved')
+})
+
+t.test('update does not leave invalid peerOptional edges when save=false', async t => {
+  // npm update defaults to save=false because it should not rewrite package.json
+  // ranges. It still mutates and writes the lockfile, so it cannot use the
+  // npm-ci behavior of trusting invalid peerOptional edges in the locked tree.
+  const registry = createRegistry(t, false)
+
+  const alphaPacks = [
+    registry.packument({ name: 'alpha', version: '1.0.0' }),
+    registry.packument({
+      name: 'alpha',
+      version: '1.1.0',
+      peerDependencies: { shared: '^1.0.0' },
+      peerDependenciesMeta: { shared: { optional: true } },
+    }),
+  ]
+  const alphaManifest = registry.manifest({ name: 'alpha', packuments: alphaPacks })
+  await registry.package({ manifest: alphaManifest })
+
+  const sharedPacks = registry.packuments(['1.0.0', '2.0.0', '2.0.1'], 'shared')
+  const sharedManifest = registry.manifest({ name: 'shared', packuments: sharedPacks })
+  await registry.package({ manifest: sharedManifest, times: 2 })
+
+  const path = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'test-peer-optional-update',
+      version: '1.0.0',
+      dependencies: {
+        alpha: '^1.0.0',
+        shared: '^2.0.0',
+      },
+    }),
+    'package-lock.json': JSON.stringify({
+      name: 'test-peer-optional-update',
+      version: '1.0.0',
+      lockfileVersion: 3,
+      requires: true,
+      packages: {
+        '': {
+          name: 'test-peer-optional-update',
+          version: '1.0.0',
+          dependencies: { alpha: '^1.0.0', shared: '^2.0.0' },
+        },
+        'node_modules/alpha': {
+          version: '1.0.0',
+          resolved: 'https://registry.npmjs.org/alpha/-/alpha-1.0.0.tgz',
+        },
+        'node_modules/shared': {
+          version: '2.0.0',
+          resolved: 'https://registry.npmjs.org/shared/-/shared-2.0.0.tgz',
+        },
+      },
+    }),
+  })
+
+  const arb = newArb(path, { save: false })
+  await t.rejects(arb.buildIdealTree({ update: true }), {
+    code: 'ERESOLVE',
+  }, 'lockfile-mutating update should reject instead of keeping an invalid peerOptional edge')
+})
+
+t.test('add does not leave invalid peerOptional edges when save=false', async t => {
+  // npm install <pkg> --no-save also mutates and writes the lockfile without
+  // changing package.json. It should not use npm-ci behavior either.
+  const registry = createRegistry(t, false)
+
+  const alphaPack = registry.packument({
+    name: 'alpha',
+    version: '1.0.0',
+    peerDependencies: { shared: '^1.0.0' },
+    peerDependenciesMeta: { shared: { optional: true } },
+  })
+  const alphaManifest = registry.manifest({ name: 'alpha', packuments: [alphaPack] })
+  await registry.package({ manifest: alphaManifest })
+
+  const sharedPacks = registry.packuments(['1.0.0', '2.0.0'], 'shared')
+  const sharedManifest = registry.manifest({ name: 'shared', packuments: sharedPacks })
+  await registry.package({ manifest: sharedManifest, times: 2 })
+
+  const path = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'test-peer-optional-add',
+      version: '1.0.0',
+      dependencies: {
+        shared: '^2.0.0',
+      },
+    }),
+    'package-lock.json': JSON.stringify({
+      name: 'test-peer-optional-add',
+      version: '1.0.0',
+      lockfileVersion: 3,
+      requires: true,
+      packages: {
+        '': {
+          name: 'test-peer-optional-add',
+          version: '1.0.0',
+          dependencies: { shared: '^2.0.0' },
+        },
+        'node_modules/shared': {
+          version: '2.0.0',
+          resolved: 'https://registry.npmjs.org/shared/-/shared-2.0.0.tgz',
+        },
+      },
+    }),
+  })
+
+  const arb = newArb(path, { save: false })
+  await t.rejects(arb.buildIdealTree({ add: ['alpha@1.0.0'] }), {
+    code: 'ERESOLVE',
+  }, 'lockfile-mutating add should reject instead of keeping an invalid peerOptional edge')
 })
 
 t.test('peerOptional prefers existing tree node over registry fetch (#9249)', async t => {


### PR DESCRIPTION
## Problem

Arborist currently treats `save=false` as a signal that invalid `peerOptional` edges from the lockfile can be trusted and skipped. That is correct for non-mutating lockfile reads such as `npm ci`, but it is wrong for commands that still mutate the ideal tree and write a new lockfile while leaving `package.json` unchanged.

For example, `npm update` runs with `save=false`, but it can still update package versions in `package-lock.json`. If one of those updates introduces or exposes an invalid optional peer relationship, Arborist can finish successfully and write a lockfile that a later plain `npm install` rejects with `ERESOLVE`.

## Fix

This separates two concepts that were previously conflated:

- `#requestedTreeMutation`: whether the command explicitly requested an add, remove, or update operation.
- `#mutateTree`: whether the ideal-tree build has actually changed the tree during placement.

Invalid `peerOptional` policy now uses `#requestedTreeMutation` instead of `#mutateTree`:

- `save=false` + explicit add/rm/update: invalid `peerOptional` edges are treated as resolver problems.
- `save=false` + no requested mutation: invalid `peerOptional` edges remain trusted, preserving the existing `npm ci`-style behavior.

The requeue path also uses `#requestedTreeMutation`, so a `save=false` update can reprocess an already-seen node when a later placement invalidates one of its `peerOptional` edges.

## Behavior Changed

This fixes bad lockfile output for `save=false` commands that mutate the dependency graph, including:

- `npm update`
- `npm install <pkg> --no-save`
- other explicit add/rm/update Arborist builds with `save=false`

Those commands should not silently produce an ideal tree or lockfile containing invalid `peerOptional` edges that a subsequent install rejects.

## Behavior Preserved

Non-mutating `save=false` builds continue to trust the lockfile. In those cases, an invalid `peerOptional` edge is still ignored rather than forcing re-resolution, preserving the behavior needed by `npm ci`-style lockfile reads.

Fixes #9604.

## Tests

Added regression coverage for:

- `npm update`-style `save=false` mutation rejecting an invalid `peerOptional` graph instead of writing a bad lockfile.
- `npm install <pkg> --no-save`-style mutation rejecting the same class of invalid graph.
- `save=false` update requeueing an already-seen node when later placement invalidates its `peerOptional` edge.
- non-mutating `save=false` builds continuing to ignore invalid `peerOptional` problem edges.

Validated with:

```sh
git diff --check
npm exec -- tap # from workspaces/arborist
npm run lint --workspace=@npmcli/arborist
```
