### PR TITLE
fix(ls): restore 100% coverage on release/v11 after #9633

### DIFF
--- a/lib/commands/ls.js
+++ b/lib/commands/ls.js
@@ -420,6 +420,7 @@ const filterLinkedStrategyEdges = ({ node, currentDepth }) => {
     }
 
     // Skip dev edges for non-root packages (store packages)
+    /* istanbul ignore next: store packages no longer carry dev edges, so this guard is not exercised by tests */
     if (currentDepth > 0 && edge.dev) {
       return false
     }


### PR DESCRIPTION
Restores the global 100% coverage gate on `release/v11`, which broke after #9633.

`filterLinkedStrategyEdges` in `lib/commands/ls.js` skips dev edges on non-root (store) packages — a guard added in #9095 to suppress false `UNMET DEPENDENCY` output in the linked strategy. #9633 fixed the root cause (store packages no longer load `devDependencies` as required edges), so the test suite no longer produces a store package with a dev edge, leaving that branch unexercised.

The guard is kept as defensive (a store package could still carry a dev edge in untested paths) and marked `istanbul ignore`, so behavior is unchanged. The full test suite passes at 100%.

This gap is invisible on direct pushes to `release/v11` because the Test matrix only runs on PRs, so it surfaces on the first PR after #9633.

## References

Follows up #9633
