### PR TITLE
fix(ls): restore 100% coverage on latest after #9626

### DIFF
--- a/test/lib/commands/ls.js
+++ b/test/lib/commands/ls.js
@@ -5462,6 +5462,37 @@ t.test('ls --install-strategy=linked', async t => {
     t.match(output, /nopt/, 'should list the dependency')
   })
 
+  t.test('should not report devDeps of linked transitive packages as UNMET DEPENDENCY', async t => {
+    const { result, ls } = await mockLs(t, {
+      config: {
+        'install-strategy': 'linked',
+        all: true,
+      },
+      prefixDir: {
+        'package.json': JSON.stringify({
+          name: 'test-linked-transitive',
+          version: '1.0.0',
+          dependencies: { 'pkg-a': 'file:./pkg-a' },
+        }),
+        'pkg-a': {
+          'package.json': JSON.stringify({
+            name: 'pkg-a',
+            version: '1.0.0',
+            devDependencies: { tap: '^16.0.0' },
+          }),
+        },
+        node_modules: {
+          'pkg-a': t.fixture('symlink', '../pkg-a'),
+        },
+      },
+    })
+    await ls.exec([])
+    const output = cleanCwd(result())
+    t.notMatch(output, /UNMET DEPENDENCY/, 'should not report devDeps of linked transitive packages')
+    t.notMatch(output, /tap/, 'should not traverse devDeps of linked transitive packages')
+    t.match(output, /pkg-a/, 'should list the dependency')
+  })
+
   t.test('should still report declared workspace as UNMET DEPENDENCY when missing', async t => {
     const { ls } = await mockLs(t, {
       config: {


### PR DESCRIPTION
Restores the global 100% coverage gate on `latest`, which broke after #9626.

`filterLinkedStrategyEdges` in `lib/commands/ls.js` skips dev edges on non-root packages — a guard added in #9095 to suppress false `UNMET DEPENDENCY` output in the linked strategy. #9626 fixed the root cause for store packages (they no longer load `devDependencies` as required edges), so the store-based test no longer produces a dev edge, leaving that branch unexercised.

Rather than ignore the line, this adds a regression test that genuinely exercises the guard: arborist still loads dev edges for a `file:`-linked transitive package, so listing one with `--all` under the linked strategy reaches the guard at depth > 0 and confirms its devDependency is suppressed instead of reported as `UNMET DEPENDENCY`. The full test suite passes at 100%.

This is the `latest` counterpart of #9636, which restored coverage on `release/v11` via an `istanbul ignore`.

## References

Follows up #9626
