### PR TITLE
fix(reify): report added count for fresh linked installs

### DIFF
--- a/lib/utils/reify-output.js
+++ b/lib/utils/reify-output.js
@@ -66,7 +66,8 @@ const reifyOutput = (npm, arb, extras = {}) => {
             if (showDiff) {
               output.standard(`${chalk.green('add')} ${d.ideal.name} ${d.ideal.package.version}`)
             }
-            if (actualTree.inventory.has(d.ideal)) {
+            // Linked store packages live under .store, absent from the logical actualTree, so identity lookup misses them; count each store package node (non-link).
+            if (actualTree.inventory.has(d.ideal) || (d.ideal.isInStore && !d.ideal.isLink)) {
               summary.added++
               summary.add.push({
                 name: d.ideal.name,

--- a/tap-snapshots/test/lib/utils/reify-output.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/reify-output.js.test.cjs
@@ -10,6 +10,11 @@ exports[`test/lib/utils/reify-output.js TAP added packages should be looked up w
 added 1 package in {TIME}
 `
 
+exports[`test/lib/utils/reify-output.js TAP added packages should be looked up within returned tree linked store package counted though absent from actualTree > must match snapshot 1`] = `
+
+added 1 package in {TIME}
+`
+
 exports[`test/lib/utils/reify-output.js TAP added packages should be looked up within returned tree missing added pkg in inventory > must match snapshot 1`] = `
 
 up to date in {TIME}

--- a/test/lib/utils/reify-output.js
+++ b/test/lib/utils/reify-output.js
@@ -391,6 +391,25 @@ t.test('added packages should be looked up within returned tree', async t => {
 
     t.matchSnapshot(out)
   })
+
+  t.test('linked store package counted though absent from actualTree', async t => {
+    const out = await mockReify(t, {
+      actualTree: {
+        name: 'foo',
+        inventory: {
+          has: () => false,
+        },
+      },
+      diff: {
+        children: [
+          { action: 'ADD', ideal: { path: 'test/baz', name: 'baz', isInStore: true, isLink: false, package: { version: '1.0.0' } } },
+          { action: 'ADD', ideal: { path: 'test/baz-link', name: 'baz', isInStore: false, isLink: true, package: { version: '1.0.0' } } },
+        ],
+      },
+    })
+
+    t.matchSnapshot(out)
+  })
 })
 
 t.test('prints dedupe difference on dry-run', async t => {


### PR DESCRIPTION
Under `install-strategy=linked`, a fresh `npm install` that actually creates `.store` entries and symlinks printed `up to date, audited N packages` instead of `added N packages`, misleading users and CI into thinking nothing changed.

`reify-output` counts adds with `actualTree.inventory.has(d.ideal)`. Under the linked strategy the diff's `ideal` nodes belong to the isolated store tree (locations under `node_modules/.store/<key>/node_modules/<name>`), while the `actualTree` returned after reify is the logical hoisted-layout tree. The two never share node identity, so the lookup always failed and `added` stayed `0`.

The ADD branch now also counts a node when it is a real store package node (`isInStore && !isLink`), which maps 1:1 to a hoisted package add. This excludes the internal store symlinks and the top-level consumer symlink, so the count matches hoisted for registry dependencies (verified: `minimatch` 4/4, `rimraf` 12/12, `express` 69/69). Omitted/incompatible optional deps have no store entry and are still not counted, and hoisted behavior is unchanged.

Known limitations (tracked separately): workspace and `file:`/`npm link` additions are represented as links rather than store nodes under linked, so they are not yet counted here — counting them is entangled with the self-link bug (#9398) and the undeclared-workspaces bug (#9618). The `--json` `add[].path` for a counted store package points to its `.store` realpath rather than a logical `node_modules/<name>` path.

## References

Fixes #9623
