### PR TITLE
fix(sbom): percent-encode vcs_url qualifier in generated purls

### DIFF
--- a/lib/utils/sbom-cyclonedx.js
+++ b/lib/utils/sbom-cyclonedx.js
@@ -76,7 +76,7 @@ const toCyclonedxItem = (node, { packageType }) => {
   // Calculate purl from package spec
   let spec = npa(node.pkgid)
   spec = (spec.type === 'alias') ? spec.subSpec : spec
-  const purl = npa.toPurl(spec) + (isGitNode(node) ? `?vcs_url=${node.resolved}` : '')
+  const purl = npa.toPurl(spec) + (isGitNode(node) ? `?vcs_url=${encodeURIComponent(node.resolved)}` : '')
 
   if (node.package) {
     const toNormalize = new PackageJson()

--- a/lib/utils/sbom-spdx.js
+++ b/lib/utils/sbom-spdx.js
@@ -109,7 +109,7 @@ const toSpdxItem = (node, { packageType }) => {
   // Calculate purl from package spec
   let spec = npa(node.pkgid)
   spec = (spec.type === 'alias') ? spec.subSpec : spec
-  const purl = npa.toPurl(spec) + (isGitNode(node) ? `?vcs_url=${node.resolved}` : '')
+  const purl = npa.toPurl(spec) + (isGitNode(node) ? `?vcs_url=${encodeURIComponent(node.resolved)}` : '')
 
   /* For workspace nodes, use the location from their linkNode */
   let location = node.location

--- a/tap-snapshots/test/lib/utils/sbom-cyclonedx.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/sbom-cyclonedx.js.test.cjs
@@ -417,7 +417,7 @@ exports[`test/lib/utils/sbom-cyclonedx.js TAP single node - from git url > must 
       "version": "1.0.0",
       "scope": "required",
       "author": "Author",
-      "purl": "pkg:npm/root@1.0.0?vcs_url=https://github.com/foo/bar#1234",
+      "purl": "pkg:npm/root@1.0.0?vcs_url=https%3A%2F%2Fgithub.com%2Ffoo%2Fbar%231234",
       "properties": [],
       "externalReferences": [
         {

--- a/tap-snapshots/test/lib/utils/sbom-spdx.js.test.cjs
+++ b/tap-snapshots/test/lib/utils/sbom-spdx.js.test.cjs
@@ -414,7 +414,7 @@ exports[`test/lib/utils/sbom-spdx.js TAP single node - from git url > must match
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/root@1.0.0?vcs_url=https://github.com/foo/bar#1234"
+          "referenceLocator": "pkg:npm/root@1.0.0?vcs_url=https%3A%2F%2Fgithub.com%2Ffoo%2Fbar%231234"
         }
       ]
     }

--- a/test/lib/utils/sbom-cyclonedx.js
+++ b/test/lib/utils/sbom-cyclonedx.js
@@ -270,6 +270,17 @@ t.test('single node - from git url', t => {
   t.end()
 })
 
+t.test('git url with special chars is encoded into the vcs_url qualifier', t => {
+  const node = { ...root, type: 'git', resolved: 'https://github.com/foo/bar.git?a=b&c=d#1234' }
+  const res = cyclonedxOutput({ npm, nodes: [node] })
+  const { purl } = res.metadata.component
+  // everything after vcs_url= must be a single percent-encoded value, so the
+  // committish/query can't leak out as an extra purl qualifier or subpath
+  t.equal(purl, 'pkg:npm/root@1.0.0?vcs_url=https%3A%2F%2Fgithub.com%2Ffoo%2Fbar.git%3Fa%3Db%26c%3Dd%231234')
+  t.notMatch(purl.split('vcs_url=')[1], /[#&]/)
+  t.end()
+})
+
 t.test('single node - no package info', t => {
   const node = { ...root, package: undefined }
   const res = cyclonedxOutput({ npm, nodes: [node] })

--- a/test/lib/utils/sbom-spdx.js
+++ b/test/lib/utils/sbom-spdx.js
@@ -223,6 +223,17 @@ t.test('single node - from git url', t => {
   t.end()
 })
 
+t.test('git url with special chars is encoded into the vcs_url qualifier', t => {
+  const node = { ...root, type: 'git', resolved: 'https://github.com/foo/bar.git?a=b&c=d#1234' }
+  const res = spdxOutput({ npm, nodes: [node] })
+  const purl = res.packages
+    .find(p => p.SPDXID === 'SPDXRef-Package-root-1.0.0')
+    .externalRefs.find(r => r.referenceType === 'purl').referenceLocator
+  t.equal(purl, 'pkg:npm/root@1.0.0?vcs_url=https%3A%2F%2Fgithub.com%2Ffoo%2Fbar.git%3Fa%3Db%26c%3Dd%231234')
+  t.notMatch(purl.split('vcs_url=')[1], /[#&]/)
+  t.end()
+})
+
 t.test('single node - linked', t => {
   const node = { ...root, isLink: true, target: { edgesOut: [] } }
   const res = spdxOutput({ npm, nodes: [node] })


### PR DESCRIPTION
Both SBOM generators build a git package's purl by sticking the raw `node.resolved` straight into the `vcs_url` qualifier, so any `#` or `&` in that resolved URL escapes the qualifier value. A git dep resolving to e.g. `https://github.com/foo/bar.git?a=b&c=d#1234` produces `pkg:npm/...?vcs_url=https://github.com/foo/bar.git?a=b&c=d#1234`, where a purl parser reads `c=d` as a separate qualifier and `1234` as the subpath. Wrapping `node.resolved` in `encodeURIComponent` at both sites keeps it a single qualifier value; the existing git-url snapshots and two new assertions cover it.