### PR TITLE
feat: graduate the linked install strategy from experimental to stable

### DIFF
--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -1189,8 +1189,8 @@ Sets the strategy for installing packages in node_modules. hoisted
 (default): Install non-duplicated in top-level, and duplicated as necessary
 within directory structure. nested: (formerly --legacy-bundling) install in
 place, no hoisting. shallow (formerly --global-style) only install direct
-deps at top-level. linked: (experimental) install in node_modules/.store,
-link in place, unhoisted.
+deps at top-level. linked: install in node_modules/.store, link in place,
+unhoisted.
 
 
 

--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -124,7 +124,6 @@ module.exports = cls => class Reifier extends cls {
       // swap out the tree with the isolated tree
       // this is currently technical debt which will be resolved in a refactor
       // of Node/Link trees
-      log.warn('reify', 'The "linked" install strategy is EXPERIMENTAL and may contain bugs.')
       this.idealTree = await this.createIsolatedTree()
       isolatedTree = this.idealTree
       if (this.actualTree) {

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -1277,8 +1277,7 @@ const definitions = {
         necessary within directory structure.
       nested: (formerly --legacy-bundling) install in place, no hoisting.
       shallow (formerly --global-style) only install direct deps at top-level.
-      linked: (experimental) install in node_modules/.store, link in place,
-        unhoisted.
+      linked: install in node_modules/.store, link in place, unhoisted.
     `,
     flatten,
   }),


### PR DESCRIPTION
Removes the experimental designation from `install-strategy=linked` (isolated mode): drops the install-time warning and the `(experimental)` note in the config docs. `linked` is now a supported, opt-in install strategy. The default stays `hoisted`.

## Why

`install-strategy=linked` (RFC-0042) has been experimental since it shipped, warning on every install. It has since been hardened extensively — the discrepancies tracked in #9608, plus ~50 earlier PRs, are resolved — and it now produces hoisted-equivalent results across `install`/`ci`/`ls`/`query`/`explain`/`audit`/`sbom`/`exec`/`run`/`link`/`uninstall`, the supply-chain controls (`allow-scripts`/`allow-remote`/`allow-git`, `--strict-allow-scripts`), and the v12 features (`npm patch`, `packageExtensions`, `.npm-extension`), with a project lockfile identical to hoisted. It has also been exercised against the [Gutenberg monorepo](https://github.com/WordPress/gutenberg/pull/75814), which powers the WordPress Block Editor. The experimental warning no longer reflects its state.

## How

- `@npmcli/arborist` (`reify.js`): remove the `The "linked" install strategy is EXPERIMENTAL and may contain bugs.` warning emitted on every linked install.
- `@npmcli/config` (`definitions.js`): drop `(experimental)` from the `install-strategy` description for `linked`.
- Regenerate the config docs snapshot to match.

The `node_modules/.store/` layout remains an internal implementation detail. This does not change the default install strategy.

## References

- Hardening tracked in #9608
- RFC-0042 (isolated mode): https://github.com/npm/rfcs/blob/main/accepted/0042-isolated-mode.md
