### PR TITLE
fix(arborist): skip extraneous orphans in strict-allow-scripts gate

### DIFF
--- a/test/lib/utils/strict-allow-scripts-preflight.js
+++ b/test/lib/utils/strict-allow-scripts-preflight.js
@@ -9,6 +9,7 @@ const node = ({
   name = 'pkg',
   version = '1.0.0',
   scripts = { install: 'node-gyp rebuild' },
+  extraneous = false,
 } = {}) => ({
   name,
   resolved: `https://registry.npmjs.org/${name}/-/${name}-${version}.tgz`,
@@ -17,6 +18,7 @@ const node = ({
   isProjectRoot: false,
   isWorkspace: false,
   isLink: false,
+  extraneous,
   package: { name, version, scripts },
 })
 
@@ -87,6 +89,20 @@ t.test('passes when the only unreviewed node is inert (platform-incompatible opt
     idealTreeOpts: {},
   })
   t.pass('no error thrown for inert node')
+})
+
+t.test('passes when the only unreviewed node is an extraneous orphan', async t => {
+  // Lockfile-only workspace orphans are pruned before scripts run and must not
+  // make the command-level strict preflight reject an install (npm/cli#9680).
+  const orphan = node({ name: 'core-js', extraneous: true })
+  orphan.isRegistryDependency = false
+  const arb = makeArb({ ideal: tree([orphan]) })
+  await preflight({
+    arb,
+    npm: { flatOptions: { strictAllowScripts: true } },
+    idealTreeOpts: {},
+  })
+  t.pass('no error thrown for extraneous orphan')
 })
 
 t.test('passes when all install-script nodes are explicitly approved', async t => {

--- a/workspaces/arborist/lib/unreviewed-scripts.js
+++ b/workspaces/arborist/lib/unreviewed-scripts.js
@@ -57,6 +57,16 @@ const collectUnreviewedScripts = async ({
       // must not be flagged (npm/cli#9562).
       continue
     }
+    if (node.extraneous) {
+      // Extraneous = the node has no incoming dep edge from a real
+      // dependency, so it is slated for pruning before reify runs any
+      // install scripts. buildIdealTree drops top-level orphans, but can
+      // retain an orphan registry node nested inside a workspace's
+      // node_modules. In every case the script never executes, so the
+      // strict-allow-scripts gate must not surface it as unreviewed
+      // (npm/cli#9680).
+      continue
+    }
 
     const verdict = isScriptAllowed(node, resolvedPolicy)
     if (verdict === true || verdict === false) {

--- a/workspaces/arborist/lib/unreviewed-scripts.js
+++ b/workspaces/arborist/lib/unreviewed-scripts.js
@@ -58,13 +58,8 @@ const collectUnreviewedScripts = async ({
       continue
     }
     if (node.extraneous) {
-      // Extraneous = the node has no incoming dep edge from a real
-      // dependency, so it is slated for pruning before reify runs any
-      // install scripts. buildIdealTree drops top-level orphans, but can
-      // retain an orphan registry node nested inside a workspace's
-      // node_modules. In every case the script never executes, so the
-      // strict-allow-scripts gate must not surface it as unreviewed
-      // (npm/cli#9680).
+      // Extraneous nodes are orphans pruned before reify runs any install script, so their scripts never execute.
+      // buildIdealTree drops top-level orphans but can retain one nested in a workspace's node_modules, so this gate must skip them (npm/cli#9680).
       continue
     }
 

--- a/workspaces/arborist/test/unreviewed-scripts.js
+++ b/workspaces/arborist/test/unreviewed-scripts.js
@@ -29,6 +29,7 @@ const node = ({
   isLink = false,
   inBundle = false,
   inert = false,
+  extraneous = false,
   resolved,
 } = {}) => ({
   name,
@@ -41,6 +42,7 @@ const node = ({
   isLink,
   inBundle,
   inert,
+  extraneous,
   isRegistryDependency: true,
   package: { name, version, scripts },
 })
@@ -88,6 +90,35 @@ t.test('collectUnreviewedScripts', async t => {
     const result = await collectUnreviewedScripts({
       tree: tree([node({ name: 'fsevents', scripts: { install: 'x' }, inert: true })]),
       policy: null,
+    })
+    t.strictSame(result, [])
+  })
+
+  t.test('skips extraneous (orphan) registry nodes', async t => {
+    // An extraneous node has no incoming edges and is slated to be pruned
+    // before reify runs any install scripts, so it must not gate the install
+    // under strict-allow-scripts even when the policy neither allows nor
+    // denies it. Buildup walks the ideal tree and can retain a nested orphan
+    // when nothing in the workspace depends on it (npm/cli#9680).
+    const result = await collectUnreviewedScripts({
+      tree: tree([
+        node({ name: 'orphan', scripts: { install: 'x' }, extraneous: true }),
+      ]),
+      policy: null,
+    })
+    t.strictSame(result, [])
+  })
+
+  t.test('skips extraneous nodes even when policy denies by name', async t => {
+    // Same orphan, but the user has a name-only deny entry. An extraneous
+    // registry node typically has no resolved URL the matcher can verify
+    // against, so the deny would not match and the node would fall through
+    // to "unreviewed". It still must not gate the install (npm/cli#9680).
+    const orphan = node({ name: 'esbuild', scripts: { install: 'x' }, extraneous: true })
+    orphan.isRegistryDependency = false
+    const result = await collectUnreviewedScripts({
+      tree: tree([orphan]),
+      policy: { esbuild: false },
     })
     t.strictSame(result, [])
   })

--- a/workspaces/arborist/test/unreviewed-scripts.js
+++ b/workspaces/arborist/test/unreviewed-scripts.js
@@ -95,11 +95,7 @@ t.test('collectUnreviewedScripts', async t => {
   })
 
   t.test('skips extraneous (orphan) registry nodes', async t => {
-    // An extraneous node has no incoming edges and is slated to be pruned
-    // before reify runs any install scripts, so it must not gate the install
-    // under strict-allow-scripts even when the policy neither allows nor
-    // denies it. Buildup walks the ideal tree and can retain a nested orphan
-    // when nothing in the workspace depends on it (npm/cli#9680).
+    // An extraneous orphan is pruned before reify runs any install script, so it must not gate the install even when the policy neither allows nor denies it (npm/cli#9680).
     const result = await collectUnreviewedScripts({
       tree: tree([
         node({ name: 'orphan', scripts: { install: 'x' }, extraneous: true }),
@@ -110,10 +106,9 @@ t.test('collectUnreviewedScripts', async t => {
   })
 
   t.test('skips extraneous nodes even when policy denies by name', async t => {
-    // Same orphan, but the user has a name-only deny entry. An extraneous
-    // registry node typically has no resolved URL the matcher can verify
-    // against, so the deny would not match and the node would fall through
-    // to "unreviewed". It still must not gate the install (npm/cli#9680).
+    // Same orphan, but with a name-only deny entry.
+    // An extraneous registry node usually has no resolved URL for the matcher to verify, so the deny misses and it falls through to "unreviewed".
+    // It still must not gate the install (npm/cli#9680).
     const orphan = node({ name: 'esbuild', scripts: { install: 'x' }, extraneous: true })
     orphan.isRegistryDependency = false
     const result = await collectUnreviewedScripts({


### PR DESCRIPTION
### Description

`strict-allow-scripts` aborts `npm install` with `ESTRICTALLOWSCRIPTS` on an extraneous (edgeless) registry node that lives only as a nested `package-lock.json` entry inside a workspace's `node_modules`. The reporter's table makes the asymmetry obvious: a real `esbuild` copy with 10 incoming edges is correctly denied by name, while the orphan `esbuild` copy (0 incoming edges, `extraneous: true`) trips the preflight as unreviewed. `npm install-scripts ls`, which walks the actual on-disk tree, reports the same project as fully covered — so the strict gate and the advisory listing disagree on the same node.

An extraneous node has no incoming dependency edge and is slated for pruning before `reify` runs any install script:

- `buildIdealTree` drops extraneous nodes from the ideal tree (`#idealTreePrune` clears `parent`).
- `rebuild` schedules install scripts only for nodes from `loadActual()` (the on-disk tree), and an extraneous orphan that exists only in the lockfile is not on disk.

In the workspace case the reporter hit, the orphan can survive the ideal-tree prune (top-level orphans are dropped, nested-in-workspace orphans are retained), but it still never executes a script because it is not present in the actual tree. The strict-allow-scripts gate therefore must not surface it.

The fix is a one-arm continue in `collectUnreviewedScripts`, alongside the existing `inBundle` and `inert` skips that protect the same property ("this node's install script is never going to run"). With that, the strict preflight and `npm install-scripts ls` agree on the same tree.

The repro from the issue (`core-js` standing in for `esbuild`) now installs cleanly under `strict-allow-scripts=true` + `{ "allowScripts": { "core-js": false } }`. The matcher logic in `script-allowed.js` is unchanged — the orphan still has no resolved registry URL the matcher can verify, so the right place to short-circuit is the upstream filter, not the matcher.

### Existing Issue

Fixes #9680

### Screenshots / Test Coverage

Two regression tests added to `workspaces/arborist/test/unreviewed-scripts.js`:

- `skips extraneous (orphan) registry nodes` — basic case, no policy.
- `skips extraneous nodes even when policy denies by name` — covers the reporter's scenario where the orphan has no resolved URL the registry matcher can verify, so the deny falls through and the node would otherwise be reported as unreviewed.

Both fail on `latest` and pass with the fix:

```
$ tap --no-coverage workspaces/arborist/test/unreviewed-scripts.js
ok 1 - test/unreviewed-scripts.js   # 12/12 ok, was 10/12 before the fix
```

Adjacent suites stay green:

```
$ tap --no-coverage workspaces/arborist/test/script-allowed.js \
                    workspaces/arborist/test/install-scripts.js \
                    test/lib/utils/strict-allow-scripts-preflight.js \
                    workspaces/libnpmexec/test/strict-allow-scripts-preflight.js
```

### AI disclosure

This change was written with the assistance of Claude (drafting the diff, the regression test, and this PR description). I reviewed the diff and the test and take responsibility for the code.
