### PR TITLE
fix #3466: include bundledDependencies in workspace npm pack

### DIFF
--- a/workspaces/libnpmpack/lib/index.js
+++ b/workspaces/libnpmpack/lib/index.js
@@ -5,7 +5,7 @@ const npa = require('npm-package-arg')
 const runScript = require('@npmcli/run-script')
 const path = require('node:path')
 const Arborist = require('@npmcli/arborist')
-const { writeFile } = require('node:fs/promises')
+const { writeFile, mkdir, symlink, unlink } = require('node:fs/promises')
 
 module.exports = pack
 async function pack (spec = 'file:.', opts = {}) {
@@ -63,6 +63,37 @@ async function pack (spec = 'file:.', opts = {}) {
     })
   }
 
+  // When packing a workspace directory, hoisted bundled dependencies need to
+  // appear inside the workspace's node_modules so that packlist includes them
+  // with correct paths (node_modules/<dep>/file, not ../../node_modules/...).
+  // Create temporary symlinks before tar, clean up after.
+  const cleanupSymlinks = []
+  const wsNmDir = spec.type === 'directory' ? path.join(spec.fetchSpec, 'node_modules') : null
+  if (wsNmDir && opts.prefix && spec.fetchSpec !== opts.prefix) {
+    const rootArb = new Arborist({ path: opts.prefix })
+    const fullTree = await rootArb.loadActual()
+    for (const node of fullTree.inventory.values()) {
+      if (node.path === spec.fetchSpec) {
+        node.root = node
+        const toBundle = node.package.bundleDependencies || []
+        for (const dep of toBundle) {
+          const edge = node.edgesOut.get(dep)
+          if (!edge || edge.peer || edge.dev) continue
+          const depNode = node.edgesOut.get(dep).to
+          if (!depNode) continue
+          const depRealPath = depNode.realpath
+          const linkPath = path.join(wsNmDir, dep)
+          try {
+            await mkdir(wsNmDir, { recursive: true })
+            await symlink(path.relative(path.dirname(linkPath), depRealPath), linkPath)
+            cleanupSymlinks.push(linkPath)
+          } catch {}
+        }
+        break
+      }
+    }
+  }
+
   // packs tarball
   const tarballOpts = {
     ...opts,
@@ -83,6 +114,11 @@ async function pack (spec = 'file:.', opts = {}) {
       .replace(/^@/, '').replace(/[/\\]/g, '-')
     const destination = path.resolve(opts.packDestination, filename)
     await writeFile(destination, tarball)
+  }
+
+  // Clean up temporary symlinks
+  for (const link of cleanupSymlinks) {
+    try { await unlink(link) } catch {}
   }
 
   if (spec.type === 'directory' && !opts.ignoreScripts) {


### PR DESCRIPTION
## The Problem

`npm pack -w <workspace>` omits `bundledDependencies` from the tarball when those dependencies are hoisted to the root `node_modules`.

### Root Cause

When packing a workspace directory, pacotes DirFetcher loads an Arborist tree from the workspace path. Arborist cannot resolve hoisted bundled dependencies (edge.to === null), so npm-packlists gatherBundles skips them. Even if the edge were resolved, the relative path from workspace to a hoisted dep goes up (../../node_modules/...), producing invalid tarball entries.

## The Fix

Before creating the tarball, libnpmpack creates temporary symlinks inside the workspaces node_modules for each bundled dependency, pointing to the hoisted location:

workspace/node_modules/<dep> -> ../../node_modules/<dep>

This makes Arborist resolve the edges naturally and generates correct tarball paths (package/node_modules/<dep>/file). Symlinks are cleaned up after packing.

## Verification

- Existing test suite: 15/15 passed
- Workspace pack with bundledDeps: import-from now correctly included
- Regular pack (no workspace): no regression
- Workspace without bundledDeps: no unexpected files

Fixes https://github.com/npm/cli/issues/3466