### PR TITLE
feat(install-scripts): use install-scripts as the warning log title (backport to v11)

### DIFF
--- a/lib/utils/allow-scripts-writer.js
+++ b/lib/utils/allow-scripts-writer.js
@@ -50,7 +50,7 @@ const versionedKeyFor = (node) => {
     // parse (private-registry mirror, alternate CDN URL shape). Leave a
     // breadcrumb so users notice when policy keys are silently pruned.
     log.silly(
-      'allow-scripts',
+      'install-scripts',
       `unable to derive trusted versioned key for ${node.path || node.name || '<unknown>'} ` +
       `(resolved: ${resolved}); key will be pruned on next save`
     )

--- a/lib/utils/reify-output.js
+++ b/lib/utils/reify-output.js
@@ -259,7 +259,7 @@ const unreviewedScriptsMessage = (npm, unreviewedScripts) => {
   })
 
   log.warn(
-    'allow-scripts',
+    'install-scripts',
     [
       header,
       ...lines,

--- a/lib/utils/resolve-allow-scripts.js
+++ b/lib/utils/resolve-allow-scripts.js
@@ -46,7 +46,7 @@ const validatePolicy = (policy, sourceLabel) => {
     try {
       parsed = npa(key)
     } catch {
-      log.warn('allow-scripts', `${sourceLabel}: ignoring unparseable entry "${key}"`)
+      log.warn('install-scripts', `${sourceLabel}: ignoring unparseable entry "${key}"`)
       continue
     }
     if (parsed.type === 'tag') {
@@ -54,7 +54,7 @@ const validatePolicy = (policy, sourceLabel) => {
       // only — the matcher has no way to verify what the tag points at
       // when scripts run. Reject for the same reason as semver ranges.
       log.warn(
-        'allow-scripts',
+        'install-scripts',
         `${sourceLabel}: ignoring "${key}" — dist-tag specs (@latest, @next, ...) are not allowed; ` +
         'use exact versions joined by "||", or the bare package name, instead'
       )
@@ -66,7 +66,7 @@ const validatePolicy = (policy, sourceLabel) => {
         || parsed.rawSpec === '*'
       if (!isNameOnly && !isExactVersionDisjunction(parsed.fetchSpec)) {
         log.warn(
-          'allow-scripts',
+          'install-scripts',
           `${sourceLabel}: ignoring "${key}" — semver ranges (^, ~, >=, <) are not allowed; ` +
           'use exact versions joined by "||" instead'
         )
@@ -137,7 +137,7 @@ const resolveAllowScripts = async (npm, { skipProjectConfig = false } = {}) => {
         }
       }
     } catch (err) {
-      log.silly('allow-scripts', 'no package.json at prefix', err.message)
+      log.silly('install-scripts', 'no package.json at prefix', err.message)
     }
   }
 
@@ -154,7 +154,7 @@ const resolveAllowScripts = async (npm, { skipProjectConfig = false } = {}) => {
     // set, package.json is never consulted.
     if (rc) {
       log.warn(
-        'allow-scripts',
+        'install-scripts',
         '.npmrc allow-scripts setting is being ignored because --allow-scripts was passed on the command line'
       )
     }
@@ -164,7 +164,7 @@ const resolveAllowScripts = async (npm, { skipProjectConfig = false } = {}) => {
   if (pkg) {
     if (rc) {
       log.warn(
-        'allow-scripts',
+        'install-scripts',
         '.npmrc allow-scripts setting is being ignored because package.json declares its own allowScripts field'
       )
     }

--- a/lib/utils/warn-workspace-allow-scripts.js
+++ b/lib/utils/warn-workspace-allow-scripts.js
@@ -28,7 +28,7 @@ const warnWorkspaceAllowScripts = (tree) => {
   for (const node of findWorkspaceAllowScripts(tree)) {
     const name = node.packageName || node.name
     log.warn(
-      'allow-scripts',
+      'install-scripts',
       `allowScripts in workspace ${name} (${node.path}) is ignored. ` +
       'Move the field to the project root package.json.'
     )

--- a/test/lib/commands/approve-scripts.js
+++ b/test/lib/commands/approve-scripts.js
@@ -627,7 +627,7 @@ t.test('forbidden semver range in package.json#allowScripts is dropped with a wa
   })
   await mock.npm.exec('approve-scripts', [])
 
-  const warnings = mock.logs.warn.byTitle('allow-scripts')
+  const warnings = mock.logs.warn.byTitle('install-scripts')
   t.ok(
     warnings.some(m => /semver ranges/.test(m) && /canvas@\^0\.33\.0/.test(m)),
     'resolver emits warning about forbidden range'

--- a/test/lib/utils/reify-output.js
+++ b/test/lib/utils/reify-output.js
@@ -499,7 +499,7 @@ t.test('prints unreviewed install scripts summary', async t => {
   ]
 
   const mock = await mockReifyWithExtras(t, baseReify, { unreviewedScripts })
-  const warn = mock.logs.warn.byTitle('allow-scripts').join('\n')
+  const warn = mock.logs.warn.byTitle('install-scripts').join('\n')
   t.match(warn, /2 packages have install scripts not yet covered/)
   t.match(warn, /canvas@2\.11\.0 \(install: node-gyp rebuild\)/)
   t.match(warn, /sharp@0\.33\.2 \(preinstall: pre; postinstall: post\)/)
@@ -531,7 +531,7 @@ t.test('global install suggests --allow-scripts, not approve-scripts', async t =
   ]
 
   const mock = await mockReifyWithExtras(t, baseReify, { unreviewedScripts }, { global: true })
-  const warn = mock.logs.warn.byTitle('allow-scripts').join('\n')
+  const warn = mock.logs.warn.byTitle('install-scripts').join('\n')
   t.match(warn, /2 packages have install scripts not yet covered/)
   t.match(warn, /canvas@2\.11\.0 \(install: node-gyp rebuild\)/)
   t.match(warn, /npm install -g --allow-scripts=canvas,sharp/)
@@ -557,7 +557,7 @@ t.test('single unreviewed script uses singular wording', async t => {
       }],
     }
   )
-  t.match(mock.logs.warn.byTitle('allow-scripts').join('\n'), /1 package has install scripts/)
+  t.match(mock.logs.warn.byTitle('install-scripts').join('\n'), /1 package has install scripts/)
 })
 
 t.test('json output includes unreviewedScripts', async t => {
@@ -593,7 +593,7 @@ t.test('unreviewed script with node.name only (no packageName) still renders', a
     }],
   })
   mock.npm.finish()
-  t.match(mock.logs.warn.byTitle('allow-scripts').join('\n'), / fallback \(install: cmd\)/)
+  t.match(mock.logs.warn.byTitle('install-scripts').join('\n'), / fallback \(install: cmd\)/)
 })
 
 t.test('json output includes node.name when packageName is missing', async t => {

--- a/test/lib/utils/resolve-allow-scripts.js
+++ b/test/lib/utils/resolve-allow-scripts.js
@@ -119,7 +119,7 @@ t.test('package.json wins over .npmrc setting (RFC layer 2 > layer 3)', async t 
   t.equal(result.source, 'package.json')
   t.strictSame(result.policy, { sharp: true })
   t.match(
-    mock.logs.warn.byTitle('allow-scripts'),
+    mock.logs.warn.byTitle('install-scripts'),
     [/\.npmrc allow-scripts setting is being ignored because package.json/]
   )
 })
@@ -150,7 +150,7 @@ t.test('--allow-scripts CLI flag is accepted via skipProjectConfig (npm exec)', 
   t.equal(result.source, 'cli')
   t.strictSame(result.policy, { sharp: true })
   t.match(
-    mock.logs.warn.byTitle('allow-scripts'),
+    mock.logs.warn.byTitle('install-scripts'),
     [/\.npmrc allow-scripts setting is being ignored because --allow-scripts/]
   )
 })
@@ -224,7 +224,7 @@ t.test('drops package.json entries with forbidden semver ranges and warns', asyn
     'also-good': true,
     'disjunction@1.0.0 || 2.0.0': true,
   })
-  const warnings = mock.logs.warn.byTitle('allow-scripts')
+  const warnings = mock.logs.warn.byTitle('install-scripts')
   t.equal(warnings.filter(m => /semver ranges/.test(m)).length, 3)
 })
 
@@ -245,7 +245,7 @@ t.test('drops package.json entries with dist-tag specs and warns', async t => {
   const result = await resolveAllowScripts(mock.npm)
   t.equal(result.source, 'package.json')
   t.strictSame(result.policy, { 'good@1.2.3': true })
-  const warnings = mock.logs.warn.byTitle('allow-scripts')
+  const warnings = mock.logs.warn.byTitle('install-scripts')
   t.equal(warnings.filter(m => /dist-tag specs/.test(m)).length, 2)
 })
 
@@ -260,7 +260,7 @@ t.test('drops .npmrc forbidden ranges (and warns) but keeps valid entries', asyn
   const result = await resolveAllowScripts(mock.npm)
   t.equal(result.source, '.npmrc')
   t.strictSame(result.policy, { canvas: true, 'lodash@4.17.21': true })
-  const warnings = mock.logs.warn.byTitle('allow-scripts')
+  const warnings = mock.logs.warn.byTitle('install-scripts')
   t.ok(warnings.some(m => /sharp@\^0\.33\.0/.test(m) && /semver ranges/.test(m)))
 })
 
@@ -280,7 +280,7 @@ t.test('drops package.json entries that fail npa parse', async t => {
   const result = await resolveAllowScripts(mock.npm)
   t.equal(result.source, 'package.json')
   t.strictSame(result.policy, { good: true })
-  t.ok(mock.logs.warn.byTitle('allow-scripts').some(m => /unparseable/.test(m)))
+  t.ok(mock.logs.warn.byTitle('install-scripts').some(m => /unparseable/.test(m)))
 })
 
 t.test('returns null when all package.json entries are dropped as invalid', async t => {


### PR DESCRIPTION
Backport of #9697 to `release/v11`.

Renames the warning log title for install-script-policy messages from `allow-scripts` to `install-scripts`, so `npm install` prints `npm warn install-scripts …` to match the `npm install-scripts` command namespace (shipped in 11.18.0).

Only the log title changes. The `allowScripts` package.json field, the `allow-scripts` config (and the command `static params` that declare it), and message-body text that names the config are all left as-is.

## References

Backports #9697
