### PR TITLE
fix(sbom): escape dots in spdx ids to avoid component collisions

### DIFF
--- a/lib/utils/sbom-spdx.js
+++ b/lib/utils/sbom-spdx.js
@@ -188,6 +188,13 @@ const toSpdxID = (node) => {
   // Strip leading @ for scoped packages
   name = name.replace(/^@/, '')
 
+  // Escape literal dots before mapping the scope separator to a dot, so a
+  // scoped name and an unscoped name that only differ by `/` vs `.` (e.g.
+  // `@a/b` and `a.b`) don't collapse to the same SPDXID. A collision there
+  // would drop one of the two distinct packages from the document, since the
+  // identifier is used to dedupe components.
+  name = name.replace(/\./g, '..')
+
   // Replace slashes with dots
   name = name.replace(/\//g, '.')
 

--- a/test/lib/utils/sbom-spdx.js
+++ b/test/lib/utils/sbom-spdx.js
@@ -241,6 +241,35 @@ t.test('single node - linked', t => {
   t.end()
 })
 
+t.test('scoped and dotted unscoped deps get distinct SPDXIDs', t => {
+  // `@a/b` and `a.b` are different packages but both used to map to
+  // SPDXRef-Package-a.b-1.0.0, so the second collided with the first and was
+  // dropped from the document during component dedup.
+  const scoped = {
+    packageName: '@a/b',
+    version: '1.0.0',
+    pkgid: '@a/b@1.0.0',
+    package: {},
+    location: 'node_modules/@a/b',
+    edgesOut: [],
+  }
+  const dotted = {
+    packageName: 'a.b',
+    version: '1.0.0',
+    pkgid: 'a.b@1.0.0',
+    package: {},
+    location: 'node_modules/a.b',
+    edgesOut: [],
+  }
+  const node = { ...root, edgesOut: [{ to: scoped }, { to: dotted }] }
+  const res = spdxOutput({ npm, nodes: [node, scoped, dotted] })
+  const ids = res.packages.map(p => p.SPDXID)
+  t.equal(res.packages.length, 3, 'both deps and the root are present')
+  t.equal(new Set(ids).size, ids.length, 'every package has a unique SPDXID')
+  t.equal(ids.filter(id => id === 'SPDXRef-Package-a.b-1.0.0').length, 1)
+  t.end()
+})
+
 t.test('node - with deps', t => {
   const node = { ...root,
     edgesOut: [


### PR DESCRIPTION
toSpdxID strips a scoped package's leading @ and turns / into ., so `@a/b` and an unscoped `a.b` both produce SPDXRef-Package-a.b-1.0.0. spdxOutput dedupes components by that identifier, so two distinct installed packages collapse into one and a real component silently disappears from the generated SBOM, which can hide a dependency from anything that audits the SBOM. Escaping literal dots before the slash mapping keeps the identifiers distinct; CycloneDX already records the full name@version and isn't affected.