### PR TITLE
feat(auth): open the browser immediately instead of waiting for ENTER during login

### DIFF
--- a/lib/utils/open-url.js
+++ b/lib/utils/open-url.js
@@ -1,8 +1,6 @@
 const { open } = require('@npmcli/promise-spawn')
 const { output, input, META } = require('proc-log')
 const { URL } = require('node:url')
-const readline = require('node:readline/promises')
-const { once } = require('node:events')
 
 const assertValidUrl = (url) => {
   try {
@@ -51,8 +49,8 @@ const openUrl = async (npm, url, title, isFile) => {
   }
 }
 
-// Prompt to open URL in browser if possible
-const openUrlPrompt = async (npm, url, title, prompt, { signal }) => {
+// Print the url and open it in the browser if the environment is interactive
+const openUrlPrompt = async (npm, url, title) => {
   const browser = npm.config.get('browser')
   const json = npm.config.get('json')
 
@@ -63,32 +61,12 @@ const openUrlPrompt = async (npm, url, title, prompt, { signal }) => {
     return
   }
 
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-  })
-
-  try {
-    await input.read(() => Promise.race([
-      rl.question(prompt, { signal }),
-      once(rl, 'error'),
-      once(rl, 'SIGINT').then(() => {
-        throw new Error('canceled')
-      }),
-    ]))
-    rl.close()
-    await openUrl(npm, url, 'Browser unavailable. Please open the URL manually')
-  } catch (err) {
-    rl.close()
-    if (err.name !== 'AbortError') {
-      throw err
-    }
-  }
+  await openUrl(npm, url, 'Browser unavailable. Please open the URL manually')
 }
 
-// Rearrange arguments and return a function that takes the two arguments returned from the npm-profile methods that take an opener
-const createOpener = (npm, title, prompt = 'Press ENTER to open in the browser...') =>
-  (url, opts) => openUrlPrompt(npm, url, title, prompt, opts)
+// Rearrange arguments and return a function matching the opener signature expected by the npm-profile methods
+const createOpener = (npm, title) =>
+  (url) => openUrlPrompt(npm, url, title)
 
 module.exports = {
   openUrl,

--- a/test/lib/utils/open-url.js
+++ b/test/lib/utils/open-url.js
@@ -1,7 +1,6 @@
 const t = require('tap')
 const tmock = require('../../fixtures/tmock')
 const mockNpm = require('../../fixtures/mock-npm')
-const EventEmitter = require('node:events')
 
 const mockOpenUrl = async (t, args, { openerResult, ...config } = {}) => {
   let openerUrl = null
@@ -38,11 +37,8 @@ const mockOpenUrl = async (t, args, { openerResult, ...config } = {}) => {
 }
 
 const mockOpenUrlPrompt = async (t, {
-  questionShouldResolve = true,
-  openUrlPromptInterrupted = false,
   openerResult = null,
   isTTY = true,
-  abort = false,
   url: openUrl = 'https://www.npmjs.com',
   ...config
 }) => {
@@ -67,41 +63,10 @@ const mockOpenUrlPrompt = async (t, {
         }
       },
     },
-    'node:readline/promises': {
-      createInterface: () => {
-        return Object.assign(new EventEmitter(), {
-          question: async (p, { signal } = {}) => {
-            if (questionShouldResolve !== true) {
-              await new Promise((res, rej) => {
-                if (signal) {
-                  signal.addEventListener('abort', () => {
-                    const err = new Error('abort')
-                    err.name = 'AbortError'
-                    rej(err)
-                  })
-                }
-              })
-            }
-          },
-          close: () => {},
-          once: function (event, cb) {
-            if (openUrlPromptInterrupted && event === 'SIGINT') {
-              cb()
-            }
-          },
-        })
-      },
-    },
   })
 
   let error
-  const abortController = new AbortController()
-  const args = [mock.npm, openUrl, 'npm home', 'prompt', { signal: abortController.signal }]
-  if (abort) {
-    mock.open = openUrlPrompt(...args)
-  } else {
-    await openUrlPrompt(...args).catch((er) => error = er)
-  }
+  await openUrlPrompt(mock.npm, openUrl, 'npm home').catch((er) => error = er)
 
   mock.npm.finish()
 
@@ -111,7 +76,6 @@ const mockOpenUrlPrompt = async (t, {
     openerOpts,
     OUTPUT: mock.joinedOutput(),
     error,
-    abortController,
   }
 }
 
@@ -157,20 +121,6 @@ t.test('open url prompt', async t => {
     t.same(OUTPUT, '', 'printed no output')
   })
 
-  t.test('does not open url if canceled', async t => {
-    const { openerUrl, openerOpts, open, abortController } = await mockOpenUrlPrompt(t, {
-      questionShouldResolve: false,
-      abort: true,
-    })
-
-    abortController.abort()
-
-    await open
-
-    t.equal(openerUrl, null, 'did not open')
-    t.same(openerOpts, null, 'did not open')
-  })
-
   t.test('returns error when opener errors', async t => {
     const { error, openerUrl } = await mockOpenUrlPrompt(t, {
       openerResult: Object.assign(new Error('Opener failed'), { code: 1 }),
@@ -188,16 +138,6 @@ t.test('open url prompt', async t => {
     t.notOk(error, 'Did not error')
     t.equal(openerUrl, 'https://www.npmjs.com', 'did not open')
     t.matchSnapshot(OUTPUT, 'Outputs extra Browser unavailable message and url')
-  })
-
-  t.test('throws "canceled" error on SIGINT', async t => {
-    const { open } = await mockOpenUrlPrompt(t, {
-      questionShouldResolve: false,
-      openUrlPromptInterrupted: true,
-      abort: true,
-    })
-
-    await t.rejects(open, /canceled/, 'message is canceled')
   })
 })
 


### PR DESCRIPTION
Starting December 2025, running `npm login` issues a short-lived "session token" that permanently expires after two hours.

Each time it requires you to do all of the following

1. Run `npm login`
2. Push ENTER which opens the browser
3. Click the login button on the website
4. Use passkey or otherwise
5. Switch back to terminal


## References
My own pain


## Solution

Remove step 2 so the user doesn't need to push ENTER anymore and removes this annoying prompt:

```
Press ENTER to open in the browser...
```