### PR TITLE
fix(arborist): regression of workspace overrides

### DIFF
--- a/workspaces/arborist/lib/node.js
+++ b/workspaces/arborist/lib/node.js
@@ -1320,6 +1320,11 @@ class Node {
       this[_changePath](newPath)
     }
 
+    // Apply workspace overrides to packages
+    if (parent.overrides) {
+      this.overrides = parent.overrides.getNodeRule(this)
+    }
+
     // clobbers anything at that path, resets all appropriate references
     this.root = parent.root
   }


### PR DESCRIPTION
This reverts https://github.com/npm/cli/commit/091742184d3be69694ce93bbbbc3a5077202f019#diff-4e00e62cbcb655399ea5f1c3869d23ca15b59e69fccf95e16a60a9075f6de2de which was included in https://github.com/npm/cli/pull/8089

Which caused a regression since npm 11.2.0 which prevents any override from being applied when working with workspaces 

Fixes #8258 