### PR TITLE
feat: warn instead of error on unknown .npmrc configs

### DIFF
--- a/lib/base-cmd.js
+++ b/lib/base-cmd.js
@@ -384,35 +384,49 @@ class BaseCommand {
         fileUnknowns.push(...this.npm.config.getUnknownConfigs(where))
       }
 
-      if (cliUnknowns.length > 0 || fileUnknowns.length > 0) {
+      // Unknown cli configs/flags/abbreviations always error. Unknown .npmrc
+      // (file) configs warn by default, matching pre-npm-12 behavior, but error
+      // when `strict-npmrc` is set.
+      const strictNpmrc = this.npm.config.get('strict-npmrc')
+      if (!strictNpmrc) {
+        for (const u of fileUnknowns) {
+          const display = u.baseKey ? `"${u.baseKey}" (${u.key})` : `"${u.key}"`
+          log.warn(
+            `Unknown ${u.where} config ${display}. This will stop working in the ` +
+            'next major version of npm. See `npm help npmrc` for supported config options.')
+        }
+      }
+
+      const errorFileUnknowns = strictNpmrc ? fileUnknowns : []
+      if (cliUnknowns.length > 0 || errorFileUnknowns.length > 0) {
         const sections = []
         if (cliUnknowns.length > 0) {
           const lines = cliUnknowns.map(u =>
             u.baseKey ? `  - --${u.baseKey} (${u.key})` : `  - --${u.key}`
           )
           sections.push(
-            `Unknown cli config${cliUnknowns.length > 1 ? 's' : ''}:`,
+            `Unknown cli flag${cliUnknowns.length > 1 ? 's' : ''}:`,
             ...lines,
             'Run `npm help config` for supported options.'
           )
         }
-        if (fileUnknowns.length > 0) {
+        if (errorFileUnknowns.length > 0) {
           if (sections.length > 0) {
             sections.push('')
           }
-          const lines = fileUnknowns.map(u => {
+          const lines = errorFileUnknowns.map(u => {
             const display = u.baseKey ? `"${u.baseKey}" (${u.key})` : `"${u.key}"`
             return `  - ${u.where} config ${display} from ${u.source}`
           })
           sections.push(
-            `Unknown npm configuration key${fileUnknowns.length > 1 ? 's' : ''}:`,
+            `Unknown npm configuration key${errorFileUnknowns.length > 1 ? 's' : ''}:`,
             ...lines,
             'See `npm help npmrc` for supported config options.'
           )
         }
         throw Object.assign(new Error(sections.join('\n')), {
           code: 'EUNKNOWNCONFIG',
-          unknownConfigs: [...cliUnknowns, ...fileUnknowns],
+          unknownConfigs: [...cliUnknowns, ...errorFileUnknowns],
         })
       }
     }

--- a/tap-snapshots/test/lib/commands/config.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/config.js.test.cjs
@@ -181,6 +181,7 @@ exports[`test/lib/commands/config.js TAP config list --json > output matches sna
   "sign-git-tag": false,
   "strict-peer-deps": false,
   "strict-allow-scripts": false,
+  "strict-npmrc": false,
   "strict-ssl": true,
   "tag-version-prefix": "v",
   "timing": false,
@@ -376,6 +377,7 @@ shell = "{SHELL}"
 sign-git-commit = false
 sign-git-tag = false
 strict-allow-scripts = false
+strict-npmrc = false
 strict-peer-deps = false
 strict-ssl = true
 ; tag = "latest" ; overridden by project

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -2084,6 +2084,19 @@ their install scripts never run.
 
 
 
+#### \`strict-npmrc\`
+
+* Default: false
+* Type: Boolean
+
+If set to \`true\`, unknown configuration keys found in \`.npmrc\` files are
+treated as a hard error instead of a warning.
+
+Unknown command line flags and abbreviated flags always error regardless of
+this setting.
+
+
+
 #### \`strict-peer-deps\`
 
 * Default: false
@@ -2753,6 +2766,7 @@ Array [
   "sign-git-tag",
   "strict-peer-deps",
   "strict-allow-scripts",
+  "strict-npmrc",
   "strict-ssl",
   "tag",
   "tag-version-prefix",
@@ -2922,6 +2936,7 @@ Array [
   "sign-git-tag",
   "strict-peer-deps",
   "strict-allow-scripts",
+  "strict-npmrc",
   "strict-ssl",
   "tag",
   "tag-version-prefix",
@@ -3115,6 +3130,7 @@ Object {
   "signGitTag": false,
   "silent": false,
   "strictAllowScripts": false,
+  "strictNpmrc": false,
   "strictPeerDeps": false,
   "strictSSL": true,
   "tagVersionPrefix": "v",

--- a/test/lib/base-cmd.js
+++ b/test/lib/base-cmd.js
@@ -146,7 +146,7 @@ t.test('flags() throws error for unknown flags', async t => {
     command.exec(),
     {
       code: 'EUNKNOWNCONFIG',
-      message: /Unknown cli config:[\s\S]*--unknown-flag/,
+      message: /Unknown cli flag:[\s\S]*--unknown-flag/,
     },
     'throws EUNKNOWNCONFIG for unknown flag'
   )
@@ -448,9 +448,9 @@ t.test('flags() throws error for multiple unknown flags with pluralization', asy
     command.exec(),
     {
       code: 'EUNKNOWNCONFIG',
-      message: /Unknown cli configs:[\s\S]*--unknown-one[\s\S]*--unknown-two/,
+      message: /Unknown cli flags:[\s\S]*--unknown-one[\s\S]*--unknown-two/,
     },
-    'throws EUNKNOWNCONFIG with pluralized "configs" for multiple unknown flags'
+    'throws EUNKNOWNCONFIG with pluralized "flags" for multiple unknown flags'
   )
 })
 
@@ -685,8 +685,8 @@ t.test('flags() does not throw when positionals is null (unlimited)', async t =>
   t.equal(flags.id, null, 'id flag uses default')
 })
 
-t.test('validateCli throws aggregated error for unknown file configs', async t => {
-  const { npm } = await loadMockNpm(t, {
+t.test('validateCli warns (does not throw) for unknown file configs', async t => {
+  const { npm, logs } = await loadMockNpm(t, {
     homeDir: {
       '.npmrc': [
         'bogus-user-key=yes',
@@ -701,21 +701,43 @@ t.test('validateCli throws aggregated error for unknown file configs', async t =
   }
 
   const command = new TestCommand(npm)
-  await t.rejects(
-    (async () => command.validateCli())(),
-    {
-      code: 'EUNKNOWNCONFIG',
-      message: /Unknown npm configuration keys:[\s\S]*bogus-user-key[\s\S]*bogus-scoped[\s\S]*npm help npmrc/,
-    },
-    'throws EUNKNOWNCONFIG aggregating plain and scoped keys'
-  )
+  t.doesNotThrow(() => command.validateCli(), 'unknown file configs do not throw')
+
+  const warningLogs = logs.warn
+  t.ok(warningLogs.some(msg => msg.includes('bogus-user-key') && msg.includes('npm help npmrc')),
+    'warns about plain unknown key')
+  t.ok(warningLogs.some(msg => msg.includes('bogus-scoped')),
+    'warns about scoped unknown key')
 })
 
-t.test('validateCli uses singular "key" when only one unknown file config', async t => {
+t.test('validateCli unknown file config warning respects loglevel suppression', async t => {
+  const { npm, logs } = await loadMockNpm(t, {
+    homeDir: {
+      '.npmrc': 'bogus-user-key=yes',
+    },
+    config: { loglevel: 'error' },
+  })
+
+  class TestCommand extends BaseCommand {
+    static name = 'test-command'
+    static description = 'Test command'
+  }
+
+  const command = new TestCommand(npm)
+  t.doesNotThrow(() => command.validateCli(), 'still does not throw')
+  t.notOk(logs.warn.some(msg => msg.includes('bogus-user-key')),
+    'unknown file config warning is suppressed at loglevel=error')
+})
+
+t.test('validateCli errors on unknown file configs when strict-npmrc is set', async t => {
   const { npm } = await loadMockNpm(t, {
     homeDir: {
-      '.npmrc': 'only-one-bad-key=yes',
+      '.npmrc': [
+        'bogus-user-key=yes',
+        '@scope:bogus-scoped=no',
+      ].join('\n'),
     },
+    config: { 'strict-npmrc': true },
   })
 
   class TestCommand extends BaseCommand {
@@ -728,10 +750,48 @@ t.test('validateCli uses singular "key" when only one unknown file config', asyn
     (async () => command.validateCli())(),
     {
       code: 'EUNKNOWNCONFIG',
-      message: /Unknown npm configuration key:\n/,
+      message: /Unknown npm configuration keys:[\s\S]*bogus-user-key[\s\S]*bogus-scoped[\s\S]*npm help npmrc/,
     },
-    'singular phrasing when only one unknown key'
+    'throws EUNKNOWNCONFIG aggregating plain and scoped keys under strict-npmrc'
   )
+})
+
+t.test('validateCli combines cli and file unknowns under strict-npmrc', async t => {
+  const { npm } = await loadMockNpm(t, {
+    homeDir: {
+      '.npmrc': [
+        'strict-npmrc=true',
+        'bogus-user-key=yes',
+      ].join('\n'),
+    },
+    npm: { argv: ['test-command', '--unknown-cli'] },
+  })
+
+  class TestCommand extends BaseCommand {
+    static name = 'test-command'
+    static description = 'Test command'
+    async exec () {
+      return this.flags()
+    }
+  }
+
+  const command = new TestCommand(npm)
+  let err
+  try {
+    command.validateCli()
+    t.fail('expected throw')
+  } catch (e) {
+    err = e
+  }
+  t.equal(err.code, 'EUNKNOWNCONFIG')
+  t.match(err.message, /Unknown cli flag:[\s\S]*--unknown-cli/,
+    'message contains the cli section')
+  t.match(err.message, /Unknown npm configuration key:[\s\S]*bogus-user-key/,
+    'message contains the singular file section')
+  t.match(err.unknownConfigs, [
+    { where: 'cli', key: 'unknown-cli' },
+    { where: 'user', key: 'bogus-user-key' },
+  ], 'structured payload contains both cli and file entries')
 })
 
 t.test('validateCli bypasses checks when skipConfigValidation is set', async t => {
@@ -751,8 +811,8 @@ t.test('validateCli bypasses checks when skipConfigValidation is set', async t =
   t.doesNotThrow(() => command.validateCli(), 'skipConfigValidation bypasses unknown-file-config check')
 })
 
-t.test('validateCli combines cli and file unknowns into a single error', async t => {
-  const { npm } = await loadMockNpm(t, {
+t.test('validateCli throws only on cli unknowns while warning on file unknowns', async t => {
+  const { npm, logs } = await loadMockNpm(t, {
     homeDir: {
       '.npmrc': 'bogus-user-key=yes',
     },
@@ -776,14 +836,15 @@ t.test('validateCli combines cli and file unknowns into a single error', async t
     err = e
   }
   t.equal(err.code, 'EUNKNOWNCONFIG')
-  t.match(err.message, /Unknown cli config:[\s\S]*--unknown-cli/,
+  t.match(err.message, /Unknown cli flag:[\s\S]*--unknown-cli/,
     'message contains the cli section')
-  t.match(err.message, /Unknown npm configuration key:[\s\S]*bogus-user-key/,
-    'message contains the file section')
+  t.notMatch(err.message, /bogus-user-key/,
+    'error message does not contain the file config')
   t.match(err.unknownConfigs, [
     { where: 'cli', key: 'unknown-cli' },
-    { where: 'user', key: 'bogus-user-key' },
-  ], 'structured payload contains both cli and file entries')
+  ], 'structured payload contains only cli entries')
+  t.ok(logs.warn.some(msg => msg.includes('bogus-user-key')),
+    'file unknown is warned, not thrown')
 })
 
 t.test('validateCli does not throw on unknown env (npm_config_*) configs', async t => {
@@ -830,7 +891,7 @@ t.test('flags() throws with scoped (nerfdart) display for unknown cli config', a
     command.exec(),
     {
       code: 'EUNKNOWNCONFIG',
-      message: /Unknown cli config:[\s\S]*--bogus \(@scope:bogus\)/,
+      message: /Unknown cli flag:[\s\S]*--bogus \(@scope:bogus\)/,
     },
     'scoped display form uses baseKey (key) layout, throws EUNKNOWNCONFIG'
   )

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -2505,6 +2505,18 @@ const definitions = {
     `,
     flatten,
   }),
+  'strict-npmrc': new Definition('strict-npmrc', {
+    default: false,
+    type: Boolean,
+    description: `
+      If set to \`true\`, unknown configuration keys found in \`.npmrc\` files
+      are treated as a hard error instead of a warning.
+
+      Unknown command line flags and abbreviated flags always error regardless
+      of this setting.
+    `,
+    flatten,
+  }),
   'strict-ssl': new Definition('strict-ssl', {
     default: true,
     type: Boolean,

--- a/workspaces/config/tap-snapshots/test/type-description.js.test.cjs
+++ b/workspaces/config/tap-snapshots/test/type-description.js.test.cjs
@@ -615,6 +615,9 @@ Object {
   "strict-allow-scripts": Array [
     "boolean value (true or false)",
   ],
+  "strict-npmrc": Array [
+    "boolean value (true or false)",
+  ],
   "strict-peer-deps": Array [
     "boolean value (true or false)",
   ],


### PR DESCRIPTION
## What / Why

Unknown configuration keys in `.npmrc` files now emit a **warning by default**, restoring pre-npm-12 behavior, instead of throwing. This reverts the file-config portion of the breaking change from 979518d (#9276).

## Details

- **Unknown `.npmrc` (file) configs** → warn by default, with the pre-npm-12 wording ("This will stop working in the next major version of npm…").
- **New `strict-npmrc` config** (Boolean, default `false`) → opts back into treating unknown file configs as a hard `EUNKNOWNCONFIG` error.
- **Unknown CLI flags and abbreviations** → continue to error regardless of this setting.
- The warning flows through npm's normal display pipeline, so it respects loglevel suppression (e.g. `--loglevel=error`, `--silent`).

## Tests

- Updated the file-config validation tests to assert warn-by-default and strict-mode error behavior.
- Added coverage for combined cli+file unknowns under `strict-npmrc`, cli-only errors, and loglevel suppression.
- Regenerated `docs.js` and `config.js` snapshots for the new config option.