### PR TITLE
chore: clarify unknown-config breaking change note in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@
 * `npm` now supports node `^22.22.2 || ^24.15.0 || >=26.0.0`
 * allow-git and allow-remote now default to "none"; set them to "all" (or "root") to install git or user-supplied tarball-URL dependencies.
 * root \`preinstall\` now runs before dependencies are installed.
-* unknown configs in .npmrc, unknown CLI flags, abbreviated flags, and single-hyphen multi-char shorthands now throw instead of warning.
+* unknown CLI flags, abbreviated flags, and single-hyphen multi-char shorthands now throw instead of warning. (Unknown `.npmrc` configs still warn by default; opt into erroring with the new `strict-npmrc` config.)
 ### Features
 * [`ce7681f`](https://github.com/npm/cli/commit/ce7681fe7dbcc20abb5f1379558e14ddd069654f) [#9496](https://github.com/npm/cli/pull/9496) packageExtensions for root-owned dependency manifest repairs (#9496) (@manzoorwanijk)
 * [`1db885c`](https://github.com/npm/cli/commit/1db885c84b2dfc5126ab663abb12262b533922c1) [#9439](https://github.com/npm/cli/pull/9439) native dependency patching (npm patch add/commit/update/ls/rm) (#9439) (@manzoorwanijk)


### PR DESCRIPTION
## What / Why

#9729 reverts the `.npmrc` file-config half of the breaking change from `979518d` (#9276): unknown `.npmrc` configs warn by default again, and the new `strict-npmrc` config opts back into erroring. Unknown CLI flags and abbreviations still throw.

The `12.0.0-pre.1` changelog entry still carried the original wording, which claimed unknown `.npmrc` configs now throw. Since release-please aggregates every prerelease `BREAKING CHANGE` note into the eventual stable `v12.0.0` release notes, that stale line would surface (inaccurately) in the 12.0.0 notes. This corrects the wording in place.

## Change

Edits the single breaking-changes bullet in the `## [12.0.0-pre.1]` section:

> unknown CLI flags, abbreviated flags, and single-hyphen multi-char shorthands now throw instead of warning. (Unknown `.npmrc` configs still warn by default; opt into erroring with the new `strict-npmrc` config.)

## Notes

- Manual, targeted edit to an already-released, release-please-generated section — this does not disturb release-please, which derives versions from git tags + commit history and only prepends new sections. Precedent: #8298 (`chore: add contributor to changelog entry`).
- Best merged alongside / after #9729 so the corrected note reflects shipped behavior.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>