### PR TITLE
fix(view): avoid wrapping array results

### DIFF
--- a/docs/lib/content/commands/npm-view.md
+++ b/docs/lib/content/commands/npm-view.md
@@ -174,7 +174,9 @@ If only a single string field for a single version is output, then it will not b
 If the field is an object, it will be output as a JavaScript object literal.
 
 If the `--json` flag is given, the outputted fields will be JSON.
-The output is always an array, even if only a single version matches.
+Scalar and object results are returned in an array, even if only a single version matches.
+When the output contains one array-valued result, that array is returned directly without an additional result wrapper.
+Multiple array-valued results remain separate items in the outer results array.
 
 If the version range matches multiple versions then each printed value will be prefixed with the version it applies to.
 

--- a/lib/commands/view.js
+++ b/lib/commands/view.js
@@ -240,11 +240,14 @@ class View extends BaseCommand {
     })
 
     if (json) {
-      // Users can expect an array .
       const first = Object.keys(res[0] || {})
       const jsonRes = first.length === 1 ? res.map(m => m[first[0]]) : res
       if (jsonRes.length === 0) {
         return
+      }
+      // Avoid wrapping a single array-valued result in another array.
+      if (jsonRes.length === 1 && Array.isArray(jsonRes[0])) {
+        return jsonRes[0]
       }
       return jsonRes
     }

--- a/test/lib/commands/view.js
+++ b/test/lib/commands/view.js
@@ -189,14 +189,37 @@ const packument = (nv, opts) => {
     },
     purple: {
       name: 'purple',
+      'dist-tags': {
+        latest: '1.0.0',
+      },
       versions: {
         '1.0.0': {
+          version: '1.0.0',
           foo: 1,
+          metadata: {
+            channels: ['latest', 'next'],
+            empty: [],
+            release: {
+              stable: true,
+            },
+          },
+          items: [
+            { tags: ['one', 'two'] },
+          ],
           maintainers: [
             { name: 'claudia' },
           ],
         },
-        '1.0.1': {},
+        '1.0.1': {
+          version: '1.0.1',
+          metadata: {
+            channels: ['next'],
+            empty: [],
+            release: {
+              stable: false,
+            },
+          },
+        },
       },
     },
     green: {
@@ -508,6 +531,118 @@ t.test('package with --json and single string arg', async t => {
   t.strictSame(JSON.parse(joinedOutput()), ['1.0.0'], 'returns single string value as array')
 })
 
+t.test('package with --json and array-valued field', async t => {
+  const { view, joinedOutput } = await loadMockNpm(t, { config: { json: true } })
+  await view.exec(['blue', 'versions'])
+  t.strictSame(
+    JSON.parse(joinedOutput()),
+    ['1.0.0', '1.0.1'],
+    'returns the field value without an additional result wrapper'
+  )
+})
+
+t.test('package with --json and array-valued field from multiple matches', async t => {
+  const { view, joinedOutput } = await loadMockNpm(t, { config: { json: true } })
+  await view.exec(['blue@^1', 'versions'])
+  t.strictSame(
+    JSON.parse(joinedOutput()),
+    [
+      ['1.0.0', '1.0.1'],
+      ['1.0.0', '1.0.1'],
+    ],
+    'preserves the result boundary for each matching version'
+  )
+})
+
+t.test('package field access with --json preserves value shapes', async t => {
+  const cases = [
+    {
+      name: 'nested scalar field',
+      args: ['purple@1.0.0', 'metadata.release.stable'],
+      expected: [true],
+    },
+    {
+      name: 'nested object field',
+      args: ['purple@1.0.0', 'metadata.release'],
+      expected: [{ stable: true }],
+    },
+    {
+      name: 'nested empty array field',
+      args: ['purple@1.0.0', 'metadata.empty'],
+      expected: [],
+    },
+    {
+      name: 'nested single-item array field',
+      args: ['purple@1.0.1', 'metadata.channels'],
+      expected: ['next'],
+    },
+    {
+      name: 'nested multi-item array field',
+      args: ['purple@1.0.0', 'metadata.channels'],
+      expected: ['latest', 'next'],
+    },
+    {
+      name: 'array field with bracket notation',
+      args: ['purple@1.0.0', 'metadata[channels]'],
+      expected: ['latest', 'next'],
+    },
+    {
+      name: 'indexed array element',
+      args: ['purple@1.0.0', 'metadata.channels[0]'],
+      expected: ['latest'],
+    },
+    {
+      name: 'expanded array subfield',
+      args: ['pink@1.0.0', 'maintainers.url'],
+      expected: [{
+        'maintainers[0].url': 'http://c.pink.com',
+        'maintainers[1].url': 'http://i.pink.com',
+      }],
+    },
+    {
+      name: 'expanded array-valued subfield',
+      args: ['purple@1.0.0', 'items.tags'],
+      expected: ['one', 'two'],
+    },
+    {
+      name: 'multiple requested fields',
+      args: ['purple@1.0.0', 'metadata.channels', 'metadata.release'],
+      expected: [{
+        'metadata.channels': ['latest', 'next'],
+        'metadata.release': { stable: true },
+      }],
+    },
+    {
+      name: 'multiple requested fields with one missing',
+      args: ['purple@1.0.0', 'metadata.channels', 'missing'],
+      expected: ['latest', 'next'],
+    },
+    {
+      name: 'array field from multiple matching versions',
+      args: ['purple@^1', 'metadata.channels'],
+      expected: [
+        ['latest', 'next'],
+        ['next'],
+      ],
+    },
+    {
+      name: 'array field present in one of multiple matching versions',
+      args: ['purple@^1', 'items'],
+      expected: [
+        { tags: ['one', 'two'] },
+      ],
+    },
+  ]
+
+  for (const { name, args, expected } of cases) {
+    await t.test(name, async t => {
+      const { view, joinedOutput } = await loadMockNpm(t, { config: { json: true } })
+      await view.exec(args)
+      t.strictSame(JSON.parse(joinedOutput()), expected)
+    })
+  }
+})
+
 t.test('package with single version', async t => {
   t.test('full json', async t => {
     const { view, joinedOutput } = await loadMockNpm(t, { config: { json: true } })
@@ -519,7 +654,7 @@ t.test('package with single version', async t => {
     const { view, joinedOutput } = await loadMockNpm(t, { config: { json: true } })
     await view.exec(['single-version', 'versions'])
     const parsed = JSON.parse(joinedOutput())
-    t.strictSame(parsed, [['1.0.0']], 'does not unwrap single item arrays in json')
+    t.strictSame(parsed, ['1.0.0'], 'preserves the array-valued field')
   })
 
   t.test('no json and versions arg', async t => {
@@ -764,6 +899,18 @@ t.test('workspaces', async t => {
     })
     await view.exec(['.', 'name'])
     t.matchSnapshot(joinedOutput())
+  })
+
+  t.test('all workspaces array field --json', async t => {
+    const { view, joinedOutput } = await loadMockNpm(t, {
+      prefixDir,
+      config: { unicode: false, workspaces: true, json: true },
+    })
+    await view.exec(['.', 'versions'])
+    t.strictSame(JSON.parse(joinedOutput()), {
+      green: ['1.0.0', '1.0.1'],
+      orange: ['1.0.0', '1.0.1'],
+    })
   })
 
   t.test('single workspace --json', async t => {


### PR DESCRIPTION
npm 12.0.0 breaks downstream updaters by returning nested arrays for `npm view <pkg> versions --json`.

## The bug

On npm 12.0.0, a single array-valued field is wrapped in the outer results array:

```
$ npm view abbrev versions --json
[["1.0.3","1.0.4", ...]]   # should be ["1.0.3","1.0.4", ...]
```

This happens in `lib/commands/view.js` `#packageOutput`: for a single-field query it maps to `res.map(m => m[first[0]])`, and when that field's value is itself an array (e.g. `versions`), it gets double-wrapped.

## The fix

Return a sole array-valued JSON result directly instead of adding a second result wrapper. Existing output shapes are preserved:

- scalar and object results still return in an array (`["1.0.0"]`, `[{...}]`)
- multiple matching versions keep the result boundary (`[[...],[...]]`)
- a single array-valued result is returned directly (`["1.0.0","1.0.1"]`)

Docs and tests updated to cover flat array, nested array, object-wrapper, workspace, and multi-match cases.
