### PR TITLE
chore(arborist): add missing registry mock in bin links reify test

### DIFF
--- a/workspaces/arborist/test/arborist/reify.js
+++ b/workspaces/arborist/test/arborist/reify.js
@@ -1255,6 +1255,7 @@ t.test('bin links adding and removing', t => {
   const path = t.testdir({
     'package.json': JSON.stringify({}),
   })
+  createRegistry(t, true)
   const rbin = resolve(path, 'node_modules/.bin/rimraf')
   return reify(path, { add: ['rimraf@2.7.1'] })
     .then(() => fs.statSync(rbin)) // should be there


### PR DESCRIPTION
The `bin links adding and removing` test in `workspaces/arborist/test/arborist/reify.js` reifies `rimraf@2.7.1` without setting up a mock registry.

This adds `createRegistry(t, true)` so the test uses the mock registry instead of depending on the real one.