### PR TITLE
chore: parse pack --json object output in node integration

### DIFF
--- a/.github/workflows/node-integration.yml
+++ b/.github/workflows/node-integration.yml
@@ -107,7 +107,7 @@ jobs:
           echo "::group::packing npm release $npmVersion"
           pushd "$npmDir" >/dev/null
           node scripts/resetdeps.js
-          npmtarball="$(node . pack --loglevel=silent --json | jq -r .[0].filename)"
+          npmtarball="$(node . pack --loglevel=silent --json | jq -r 'to_entries[0].value.filename')"
           tar czf "$npmFile" -C "$npmDir" .
           popd >/dev/null
           echo "npm=$npmFile" >> $GITHUB_OUTPUT

--- a/scripts/template-oss/node-integration-yml.hbs
+++ b/scripts/template-oss/node-integration-yml.hbs
@@ -105,7 +105,7 @@ jobs:
           echo "::group::packing npm release $npmVersion"
           pushd "$npmDir" >/dev/null
           node scripts/resetdeps.js
-          npmtarball="$(node . pack --loglevel=silent --json | jq -r .[0].filename)"
+          npmtarball="$(node . pack --loglevel=silent --json | jq -r 'to_entries[0].value.filename')"
           tar czf "$npmFile" -C "$npmDir" .
           popd >/dev/null
           echo "npm=$npmFile" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

The `build nodejs` jobs in `Release Integration / publish` fail at `.github/workflows/node-integration.yml`:

```
node . pack --loglevel=silent --json | jq -r .[0].filename
→ jq: error (at <stdin>:9859): Cannot index object with number
→ Process completed with exit code 5
```

As of #9247 (sync json output of pack and publish), `npm pack --json` no longer outputs an array. `logTar` now buffers `{ [tar.name]: tarball }`, so the output is an object keyed by package name:

```json
{ "npm": { "filename": "npm-12.0.1.tgz", ... } }
```

The workflow still parsed it with `.[0].filename`, which errors on an object. npm 12.0.x is the first release carrying this change, so the release integration only started breaking now.

## Fix

Parse the filename from the object instead of an array index:

```diff
-npmtarball="$(node . pack --loglevel=silent --json | jq -r .[0].filename)"
+npmtarball="$(node . pack --loglevel=silent --json | jq -r 'to_entries[0].value.filename')"
```

Verified locally: returns `npm-12.0.1.tgz`.