### PR TITLE
chore: add ci check requiring deps: commits for prod dependency changes

### DIFF
--- a/.github/workflows/deps-commits.yml
+++ b/.github/workflows/deps-commits.yml
@@ -1,0 +1,42 @@
+# NOTE: This file is NOT managed by @npmcli/template-oss and may be edited.
+# It enforces that production dependency changes are isolated into dedicated
+# `deps:` commits so they are visible in the git history and changelog.
+
+name: Deps Commits
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+permissions:
+  contents: read
+
+jobs:
+  deps-commits:
+    name: Check Deps Commits
+    # Skip bot-generated release PRs, which intentionally bump many
+    # inter-workspace dependency versions inside a single `chore: release` commit.
+    if: ${{ !startsWith(github.head_ref, 'release/') }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Check Deps Commits
+        run: >-
+          node scripts/check-deps-commits.js
+          --from "origin/${{ github.base_ref }}"
+          --to "${{ github.event.pull_request.head.sha }}"

--- a/.github/workflows/deps-commits.yml
+++ b/.github/workflows/deps-commits.yml
@@ -20,7 +20,10 @@ jobs:
     name: Check Deps Commits
     # Skip bot-generated release PRs, which intentionally bump many
     # inter-workspace dependency versions inside a single `chore: release` commit.
-    if: ${{ !startsWith(github.head_ref, 'release/') }}
+    if: >-
+      github.event.pull_request.user.login != 'github-actions[bot]' ||
+      github.event.pull_request.head.repo.full_name != github.repository ||
+      !startsWith(github.head_ref, 'release-please--branches--')
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/scripts/check-deps-commits.js
+++ b/scripts/check-deps-commits.js
@@ -1,0 +1,164 @@
+// Ensures that any production dependency change in a first-party manifest
+// (root package.json, workspaces/*, mock-registry, etc.) is accompanied by a
+// dedicated `deps:` commit that names the specific dependency. This prevents
+// production dependency bumps from being buried inside unrelated `fix:`/`feat:`
+// commits, which hides the change from the release/changelog tooling.
+//
+// This intentionally uses only Node builtins + git so it can run in CI without
+// a full dependency install (no resetdeps required).
+
+const { execFileSync } = require('node:child_process')
+
+// Only production dependencies are enforced. devDependencies and other fields
+// change frequently for tooling reasons and do not require a `deps:` commit.
+const DEP_TYPES = ['dependencies']
+
+// A commit is a "deps" commit if its subject uses the conventional
+// `deps:` / `deps(scope):` / `deps!:` type prefix.
+const DEPS_SUBJECT = /^deps(\([^)]*\))?!?:/
+
+const git = (...args) => execFileSync('git', args, { encoding: 'utf8' })
+
+const arg = (name, fallback) => {
+  const idx = process.argv.indexOf(name)
+  if (idx !== -1 && process.argv[idx + 1]) {
+    return process.argv[idx + 1]
+  }
+  const inline = process.argv.find((a) => a.startsWith(`${name}=`))
+  return inline ? inline.slice(name.length + 1) : fallback
+}
+
+// Read and parse a package.json at a given git ref. Returns null if the file
+// did not exist at that ref (e.g. a newly added manifest).
+const readJSONAtRef = (ref, file) => {
+  try {
+    return JSON.parse(git('show', `${ref}:${file}`))
+  } catch {
+    return null
+  }
+}
+
+// A first-party manifest is any package.json that is NOT inside a node_modules
+// directory. Bundled dependency manifests under node_modules churn as a
+// side-effect of lockfile/bundle regeneration and must be ignored.
+const isFirstPartyManifest = (file) =>
+  (file === 'package.json' || file.endsWith('/package.json')) &&
+  !file.startsWith('node_modules/') &&
+  !file.includes('/node_modules/')
+
+// Does a commit message mention this dependency by name? Historical formats:
+//   deps: undici@6.27.0
+//   deps(arborist): validate-npm-package-name ^8.0.0
+//   deps!: bump sigstore from 2.x to 3.0.0
+//   deps: remove read-package-json-fast
+// The name appears as a standalone token, optionally followed by `@version`.
+const mentionsDep = (message, dep) => {
+  const tokens = message
+    .split(/\s+/)
+    .map((t) => t.replace(/^[`'"([,]+/, '').replace(/[`'").,;:]+$/, ''))
+  return tokens.some((t) => t === dep || t.startsWith(`${dep}@`))
+}
+
+const main = () => {
+  const from = arg('--from')
+  const to = arg('--to', 'HEAD')
+
+  if (!from) {
+    throw new Error('Usage: node scripts/check-deps-commits.js --from <base> [--to <head>]')
+  }
+
+  // Net set of first-party package.json files changed by the PR.
+  const changedFiles = git('diff', '--name-only', `${from}...${to}`, '--', '*package.json')
+    .split('\n')
+    .map((f) => f.trim())
+    .filter(Boolean)
+    .filter(isFirstPartyManifest)
+
+  // Collect every production dependency whose presence or version range changed.
+  const changedDeps = new Map()
+  for (const file of changedFiles) {
+    const before = readJSONAtRef(from, file) || {}
+    const after = readJSONAtRef(to, file) || {}
+    for (const type of DEP_TYPES) {
+      const b = before[type] || {}
+      const a = after[type] || {}
+      for (const name of new Set([...Object.keys(b), ...Object.keys(a)])) {
+        if (b[name] !== a[name]) {
+          if (!changedDeps.has(name)) {
+            changedDeps.set(name, { files: new Set(), from: b[name], to: a[name] })
+          }
+          const entry = changedDeps.get(name)
+          entry.files.add(file)
+          entry.to = a[name] ?? entry.to
+        }
+      }
+    }
+  }
+
+  if (!changedDeps.size) {
+    process.stdout.write('OK: no production dependency changes detected.\n')
+    return
+  }
+
+  // Gather the `deps:` commits in the range. Records are separated by an ASCII
+  // record separator and fields by an ASCII unit separator so multi-line commit
+  // bodies are handled safely.
+  const commits = git('log', '--format=%H%x1f%B%x1e', `${from}..${to}`)
+    .split('\x1e')
+    .map((c) => c.trim())
+    .filter(Boolean)
+    .map((c) => {
+      const sep = c.indexOf('\x1f')
+      return { hash: c.slice(0, sep), message: c.slice(sep + 1) }
+    })
+  const depsCommits = commits.filter((c) => DEPS_SUBJECT.test(c.message.split('\n')[0].trim()))
+
+  const uncovered = []
+  for (const [dep, { files, to: version }] of changedDeps) {
+    if (!depsCommits.some((c) => mentionsDep(c.message, dep))) {
+      // `version` is undefined when the dependency was removed.
+      uncovered.push({ dep, files: [...files], version })
+    }
+  }
+
+  if (!uncovered.length) {
+    process.stdout.write(
+      `OK: all ${changedDeps.size} production dependency change(s) have a matching deps: commit.\n`
+    )
+    return
+  }
+
+  // Derive the conventional-commit scope from the manifest location, e.g.
+  // `workspaces/arborist/package.json` -> `arborist`. The root manifest
+  // (`package.json`) has no scope.
+  const scopeOf = (file) => {
+    if (!file.includes('/')) {
+      return null
+    }
+    return file.slice(0, file.lastIndexOf('/')).split('/').pop()
+  }
+
+  // One suggestion per (dependency, manifest) so each change is isolated into a
+  // scoped `deps(<workspace>):` commit that names the exact dependency+version.
+  const suggestions = uncovered.flatMap(({ dep, files, version }) =>
+    files.map((file) => {
+      const scope = scopeOf(file)
+      const type = scope ? `deps(${scope})` : 'deps'
+      return version ? `  ${type}: ${dep}@${version}` : `  ${type}: remove ${dep}`
+    })
+  )
+
+  const lines = [
+    'Production dependency changes must each have a dedicated `deps:` commit that names the dependency.',
+    '',
+    'The following production dependency changes are missing a matching deps: commit:',
+    ...uncovered.map(({ dep, files }) => `  - ${dep} (changed in: ${files.join(', ')})`),
+    '',
+    'Add a separate commit for each, e.g.:',
+    ...suggestions,
+  ]
+  process.stderr.write(`${lines.join('\n')}\n`)
+  process.exit(1)
+}
+
+main()

--- a/scripts/check-deps-commits.js
+++ b/scripts/check-deps-commits.js
@@ -38,25 +38,79 @@ const readJSONAtRef = (ref, file) => {
   }
 }
 
-// A first-party manifest is any package.json that is NOT inside a node_modules
-// directory. Bundled dependency manifests under node_modules churn as a
-// side-effect of lockfile/bundle regeneration and must be ignored.
-const isFirstPartyManifest = (file) =>
-  (file === 'package.json' || file.endsWith('/package.json')) &&
-  !file.startsWith('node_modules/') &&
-  !file.includes('/node_modules/')
+const workspacePatternsAtRef = (ref) => {
+  const manifest = readJSONAtRef(ref, 'package.json')
+  return Array.isArray(manifest?.workspaces) ? manifest.workspaces : []
+}
 
-// Does a commit message mention this dependency by name? Historical formats:
+// The repository's workspace patterns contain literal path segments and `*`
+// segments. Match the declared package roots without including nested fixtures.
+const matchesWorkspace = (directory, pattern) => {
+  const directoryParts = directory.split('/')
+  const patternParts = pattern.replace(/\/$/, '').split('/')
+  return directoryParts.length === patternParts.length &&
+    patternParts.every((part, index) =>
+      part === '*' || part === directoryParts[index])
+}
+
+const isFirstPartyManifest = (file, workspacePatterns) => {
+  if (file === 'package.json') {
+    return true
+  }
+  if (!file.endsWith('/package.json')) {
+    return false
+  }
+  const directory = file.slice(0, -'/package.json'.length)
+  return workspacePatterns.some((pattern) =>
+    matchesWorkspace(directory, pattern))
+}
+
+// Does a commit subject mention this dependency by name? Historical formats:
 //   deps: undici@6.27.0
 //   deps(arborist): validate-npm-package-name ^8.0.0
 //   deps!: bump sigstore from 2.x to 3.0.0
 //   deps: remove read-package-json-fast
 // The name appears as a standalone token, optionally followed by `@version`.
-const mentionsDep = (message, dep) => {
-  const tokens = message
+const mentionsDep = (subject, dep) => {
+  const tokens = subject
     .split(/\s+/)
     .map((t) => t.replace(/^[`'"([,]+/, '').replace(/[`'").,;:]+$/, ''))
   return tokens.some((t) => t === dep || t.startsWith(`${dep}@`))
+}
+
+const dependencyChanges = (from, to) => {
+  const workspacePatterns = [
+    ...new Set([
+      ...workspacePatternsAtRef(from),
+      ...workspacePatternsAtRef(to),
+    ]),
+  ]
+  const changedFiles = git('diff', '--name-only', from, to, '--', '*package.json')
+    .split('\n')
+    .map((f) => f.trim())
+    .filter(Boolean)
+    .filter((file) => isFirstPartyManifest(file, workspacePatterns))
+
+  const changes = new Map()
+  for (const file of changedFiles) {
+    const before = readJSONAtRef(from, file) || {}
+    const after = readJSONAtRef(to, file) || {}
+    for (const type of DEP_TYPES) {
+      const b = before[type] || {}
+      const a = after[type] || {}
+      for (const dep of new Set([...Object.keys(b), ...Object.keys(a)])) {
+        if (b[dep] !== a[dep]) {
+          changes.set(`${file}\0${dep}`, {
+            dep,
+            file,
+            from: b[dep],
+            to: a[dep],
+          })
+        }
+      }
+    }
+  }
+  return changes
 }
 
 const main = () => {
@@ -67,59 +121,95 @@ const main = () => {
     throw new Error('Usage: node scripts/check-deps-commits.js --from <base> [--to <head>]')
   }
 
-  // Net set of first-party package.json files changed by the PR.
-  const changedFiles = git('diff', '--name-only', `${from}...${to}`, '--', '*package.json')
-    .split('\n')
-    .map((f) => f.trim())
-    .filter(Boolean)
-    .filter(isFirstPartyManifest)
-
-  // Collect every production dependency whose presence or version range changed.
-  const changedDeps = new Map()
-  for (const file of changedFiles) {
-    const before = readJSONAtRef(from, file) || {}
-    const after = readJSONAtRef(to, file) || {}
-    for (const type of DEP_TYPES) {
-      const b = before[type] || {}
-      const a = after[type] || {}
-      for (const name of new Set([...Object.keys(b), ...Object.keys(a)])) {
-        if (b[name] !== a[name]) {
-          if (!changedDeps.has(name)) {
-            changedDeps.set(name, { files: new Set(), from: b[name], to: a[name] })
-          }
-          const entry = changedDeps.get(name)
-          entry.files.add(file)
-          entry.to = a[name] ?? entry.to
-        }
-      }
-    }
-  }
+  const mergeBase = git('merge-base', from, to).trim()
+  const changedDeps = dependencyChanges(mergeBase, to)
 
   if (!changedDeps.size) {
     process.stdout.write('OK: no production dependency changes detected.\n')
     return
   }
 
-  // Gather the `deps:` commits in the range. Records are separated by an ASCII
-  // record separator and fields by an ASCII unit separator so multi-line commit
-  // bodies are handled safely.
-  const commits = git('log', '--format=%H%x1f%B%x1e', `${from}..${to}`)
+  // The merge-base range excludes commits inherited from the base branch.
+  // Inspect every commit so dependency commits from a merged topic branch and
+  // changes introduced while resolving a merge are both validated.
+  const commits = git(
+    'log',
+    '--reverse',
+    '--topo-order',
+    '--format=%H%x1f%P%x1f%s%x1e',
+    `${mergeBase}..${to}`
+  )
     .split('\x1e')
     .map((c) => c.trim())
     .filter(Boolean)
     .map((c) => {
-      const sep = c.indexOf('\x1f')
-      return { hash: c.slice(0, sep), message: c.slice(sep + 1) }
+      const [hash, parents, subject] = c.split('\x1f')
+      return { hash, parents: parents.split(' ').filter(Boolean), subject }
     })
-  const depsCommits = commits.filter((c) => DEPS_SUBJECT.test(c.message.split('\n')[0].trim()))
 
-  const uncovered = []
-  for (const [dep, { files, to: version }] of changedDeps) {
-    if (!depsCommits.some((c) => mentionsDep(c.message, dep))) {
-      // `version` is undefined when the dependency was removed.
-      uncovered.push({ dep, files: [...files], version })
+  const initialState = new Map(
+    [...changedDeps].map(([key]) => [
+      key,
+      { covered: false, invalidCommits: [] },
+    ])
+  )
+  const stateByCommit = new Map([[mergeBase, initialState]])
+  for (const { hash, parents, subject } of commits) {
+    const state = new Map(stateByCommit.get(parents[0]))
+
+    if (parents.length > 1) {
+      for (const [key, { dep, file }] of changedDeps) {
+        const version = readJSONAtRef(hash, file)?.dependencies?.[dep]
+        const inheritedFrom = parents.find((parent) =>
+          readJSONAtRef(parent, file)?.dependencies?.[dep] === version)
+        if (inheritedFrom) {
+          state.set(key, stateByCommit.get(inheritedFrom).get(key))
+        } else {
+          const previous = state.get(key)
+          state.set(key, {
+            covered: previous.covered,
+            invalidCommits: [
+              ...previous.invalidCommits,
+              { hash, subject },
+            ],
+          })
+        }
+      }
+      stateByCommit.set(hash, state)
+      continue
     }
+
+    for (const [key, { dep }] of dependencyChanges(parents[0], hash)) {
+      if (!changedDeps.has(key)) {
+        continue
+      }
+      if (
+        DEPS_SUBJECT.test(subject) &&
+        mentionsDep(subject, dep)
+      ) {
+        state.set(key, { covered: true, invalidCommits: [] })
+      } else {
+        const previous = state.get(key)
+        state.set(key, {
+          covered: previous.covered,
+          invalidCommits: [
+            ...previous.invalidCommits,
+            { hash, subject },
+          ],
+        })
+      }
+    }
+    stateByCommit.set(hash, state)
   }
+
+  const toHash = git('rev-parse', `${to}^{commit}`).trim()
+  const finalState = stateByCommit.get(toHash)
+  const uncovered = [...changedDeps].filter(
+    ([key]) => {
+      const state = finalState.get(key)
+      return !state.covered || state.invalidCommits.length
+    }
+  )
 
   if (!uncovered.length) {
     process.stdout.write(
@@ -140,19 +230,25 @@ const main = () => {
 
   // One suggestion per (dependency, manifest) so each change is isolated into a
   // scoped `deps(<workspace>):` commit that names the exact dependency+version.
-  const suggestions = uncovered.flatMap(({ dep, files, version }) =>
-    files.map((file) => {
-      const scope = scopeOf(file)
-      const type = scope ? `deps(${scope})` : 'deps'
-      return version ? `  ${type}: ${dep}@${version}` : `  ${type}: remove ${dep}`
-    })
-  )
+  const suggestions = uncovered.map(([, { dep, file, to: version }]) => {
+    const scope = scopeOf(file)
+    const type = scope ? `deps(${scope})` : 'deps'
+    return version ? `  ${type}: ${dep}@${version}` : `  ${type}: remove ${dep}`
+  })
 
   const lines = [
     'Production dependency changes must each have a dedicated `deps:` commit that names the dependency.',
     '',
-    'The following production dependency changes are missing a matching deps: commit:',
-    ...uncovered.map(({ dep, files }) => `  - ${dep} (changed in: ${files.join(', ')})`),
+    'The following production dependency changes are not isolated in a matching deps: commit:',
+    ...uncovered.map(([key, { dep, file }]) => {
+      const invalidCommitEntries = finalState.get(key)?.invalidCommits
+      const details = invalidCommitEntries
+        ? `; also changed by ${invalidCommitEntries
+          .map(({ hash, subject }) => `${hash.slice(0, 7)} "${subject}"`)
+          .join(', ')}`
+        : ''
+      return `  - ${dep} (changed in: ${file}${details})`
+    }),
     '',
     'Add a separate commit for each, e.g.:',
     ...suggestions,

--- a/test/scripts/check-deps-commits.js
+++ b/test/scripts/check-deps-commits.js
@@ -1,0 +1,448 @@
+const t = require('tap')
+const { execFileSync, spawnSync } = require('node:child_process')
+const { resolve, join } = require('node:path')
+const { mkdirSync, unlinkSync, writeFileSync } = require('node:fs')
+
+const SCRIPT = resolve(__dirname, '../../scripts/check-deps-commits.js')
+
+const git = (cwd, ...args) =>
+  execFileSync('git', args, { cwd, encoding: 'utf8' }).trim()
+
+const writePackage = (cwd, version, extra = {}) => {
+  writeFileSync(join(cwd, 'package.json'), `${JSON.stringify({
+    name: 'test-package',
+    version: '1.0.0',
+    dependencies: {
+      foo: version,
+    },
+    ...extra,
+  }, null, 2)}\n`)
+}
+
+const setup = (t) => {
+  const cwd = t.testdir()
+  git(cwd, 'init', '--initial-branch=main')
+  git(cwd, 'config', 'user.name', 'Test User')
+  git(cwd, 'config', 'user.email', 'test@example.com')
+  git(cwd, 'config', 'commit.gpgsign', 'false')
+  git(cwd, 'config', 'core.hooksPath', '')
+  writePackage(cwd, '1.0.0')
+  git(cwd, 'add', 'package.json')
+  git(cwd, 'commit', '-m', 'chore: initial')
+  return cwd
+}
+
+const run = (cwd, ...args) =>
+  spawnSync(process.execPath, [SCRIPT, ...args], {
+    cwd,
+    encoding: 'utf8',
+  })
+
+const check = (cwd, from, to) =>
+  run(cwd, '--from', from, ...(to ? ['--to', to] : []))
+
+t.test('requires a base ref', t => {
+  const cwd = setup(t)
+  const result = run(cwd)
+
+  t.equal(result.status, 1)
+  t.match(result.stderr, /Usage: node scripts\/check-deps-commits\.js/)
+  t.end()
+})
+
+t.test('accepts inline ref arguments', t => {
+  const cwd = setup(t)
+  const from = git(cwd, 'rev-parse', 'HEAD')
+
+  writePackage(cwd, '2.0.0')
+  git(cwd, 'commit', '-am', 'deps: foo@2.0.0')
+
+  const result = run(cwd, `--from=${from}`, '--to=HEAD')
+  t.equal(result.status, 0)
+  t.match(result.stdout, 'have a matching deps: commit')
+  t.end()
+})
+
+t.test('uses the merge base for the before manifest', t => {
+  const cwd = setup(t)
+  git(cwd, 'branch', 'pr')
+
+  writePackage(cwd, '2.0.0')
+  git(cwd, 'commit', '-am', 'deps: foo@2.0.0')
+
+  git(cwd, 'checkout', 'pr')
+  writePackage(cwd, '1.0.0', { description: 'PR-only change' })
+  git(cwd, 'commit', '-am', 'docs: update package description')
+
+  const result = check(cwd, 'main', 'pr')
+  t.equal(result.status, 0)
+  t.match(result.stdout, 'no production dependency changes detected')
+  t.end()
+})
+
+t.test('accepts a dependency in a newly added workspace', t => {
+  const cwd = setup(t)
+  const from = git(cwd, 'rev-parse', 'HEAD')
+  const workspace = join(cwd, 'mock-registry')
+
+  writePackage(cwd, '1.0.0', { workspaces: ['mock-registry'] })
+  mkdirSync(workspace)
+  writePackage(workspace, '2.0.0')
+  git(cwd, 'add', 'package.json', 'mock-registry/package.json')
+  git(cwd, 'commit', '-m', 'deps(mock-registry): foo@2.0.0')
+
+  const result = check(cwd, from)
+  t.equal(result.status, 0)
+  t.match(result.stdout, 'have a matching deps: commit')
+  t.end()
+})
+
+t.test('suggests a deps commit for a deleted workspace manifest', t => {
+  const cwd = setup(t)
+  const workspace = join(cwd, 'workspaces', 'example')
+
+  writePackage(cwd, '1.0.0', { workspaces: ['workspaces/*'] })
+  mkdirSync(workspace, { recursive: true })
+  writePackage(workspace, '2.0.0')
+  git(cwd, 'add', 'package.json', 'workspaces/example/package.json')
+  git(cwd, 'commit', '-m', 'chore: add workspace')
+  const from = git(cwd, 'rev-parse', 'HEAD')
+
+  unlinkSync(join(workspace, 'package.json'))
+  git(cwd, 'add', 'workspaces/example/package.json')
+  git(cwd, 'commit', '-m', 'fix: remove workspace manifest')
+
+  const result = check(cwd, from)
+  t.equal(result.status, 1)
+  t.match(result.stderr, 'deps(example): remove foo')
+  t.end()
+})
+
+t.test('ignores changed files whose names merely end in package.json', t => {
+  const cwd = setup(t)
+  const from = git(cwd, 'rev-parse', 'HEAD')
+
+  writeFileSync(join(cwd, 'notpackage.json'), '{}\n')
+  git(cwd, 'add', 'notpackage.json')
+  git(cwd, 'commit', '-m', 'fix: add package metadata')
+
+  const result = check(cwd, from)
+  t.equal(result.status, 0)
+  t.match(result.stdout, 'no production dependency changes detected')
+  t.end()
+})
+
+t.test('ignores package manifests nested below workspace roots', t => {
+  const cwd = setup(t)
+  const from = git(cwd, 'rev-parse', 'HEAD')
+  const fixture = join(
+    cwd,
+    'workspaces',
+    'example',
+    'test',
+    'fixtures',
+    'dependency'
+  )
+
+  writePackage(cwd, '1.0.0', { workspaces: ['workspaces/*'] })
+  mkdirSync(fixture, { recursive: true })
+  writePackage(fixture, '2.0.0')
+  git(cwd, 'add', 'package.json', 'workspaces/example/test/fixtures/dependency/package.json')
+  git(cwd, 'commit', '-m', 'fix: add dependency fixture')
+
+  const result = check(cwd, from)
+  t.equal(result.status, 0)
+  t.match(result.stdout, 'no production dependency changes detected')
+  t.end()
+})
+
+t.test('ignores dependency changes that are not in the final diff', t => {
+  const cwd = setup(t)
+  const from = git(cwd, 'rev-parse', 'HEAD')
+
+  writePackage(cwd, '1.0.0', {
+    dependencies: {
+      foo: '1.0.0',
+      temporary: '1.0.0',
+    },
+  })
+  git(cwd, 'commit', '-am', 'fix: add temporary dependency')
+
+  writePackage(cwd, '2.0.0')
+  git(cwd, 'commit', '-am', 'deps: foo@2.0.0')
+
+  const result = check(cwd, from)
+  t.equal(result.status, 0)
+  t.match(result.stdout, 'have a matching deps: commit')
+  t.end()
+})
+
+t.test('rejects a dependency changed by an unrelated commit', t => {
+  const cwd = setup(t)
+  const from = git(cwd, 'rev-parse', 'HEAD')
+
+  writeFileSync(join(cwd, 'README.md'), 'documentation\n')
+  git(cwd, 'add', 'README.md')
+  git(cwd, 'commit', '-m', 'deps: foo@2.0.0')
+
+  writePackage(cwd, '2.0.0')
+  git(cwd, 'commit', '-am', 'fix: update foo')
+
+  const result = check(cwd, from)
+  t.equal(result.status, 1)
+  t.match(result.stderr, /fix: update foo/)
+  t.end()
+})
+
+t.test('rejects a deps commit that names a different dependency', t => {
+  const cwd = setup(t)
+  const from = git(cwd, 'rev-parse', 'HEAD')
+
+  writePackage(cwd, '2.0.0')
+  git(cwd, 'commit', '-am', 'deps: bar@2.0.0')
+
+  const result = check(cwd, from)
+  t.equal(result.status, 1)
+  t.match(result.stderr, /foo \(changed in: package\.json/)
+  t.end()
+})
+
+t.test('rejects a later non-deps change to the same dependency', t => {
+  const cwd = setup(t)
+  const from = git(cwd, 'rev-parse', 'HEAD')
+
+  writePackage(cwd, '2.0.0')
+  git(cwd, 'commit', '-am', 'deps: foo@2.0.0')
+
+  writePackage(cwd, '3.0.0')
+  git(cwd, 'commit', '-am', 'fix: update foo again')
+
+  const result = check(cwd, from)
+  t.equal(result.status, 1)
+  t.match(result.stderr, /fix: update foo again/)
+  t.end()
+})
+
+t.test('accepts a deps commit that supersedes an unrelated change', t => {
+  const cwd = setup(t)
+  const from = git(cwd, 'rev-parse', 'HEAD')
+
+  writePackage(cwd, '2.0.0')
+  git(cwd, 'commit', '-am', 'fix: update foo')
+
+  writePackage(cwd, '3.0.0')
+  git(cwd, 'commit', '-am', 'deps: foo@3.0.0')
+
+  const result = check(cwd, from)
+  t.equal(result.status, 0)
+  t.match(result.stdout, 'have a matching deps: commit')
+  t.end()
+})
+
+t.test('reports every unrelated change to the same dependency', t => {
+  const cwd = setup(t)
+  const from = git(cwd, 'rev-parse', 'HEAD')
+
+  writePackage(cwd, '2.0.0')
+  git(cwd, 'commit', '-am', 'fix: update foo')
+
+  writePackage(cwd, '3.0.0')
+  git(cwd, 'commit', '-am', 'fix: update foo again')
+
+  const result = check(cwd, from)
+  t.equal(result.status, 1)
+  t.match(result.stderr, /fix: update foo"/)
+  t.match(result.stderr, /fix: update foo again"/)
+  t.end()
+})
+
+t.test('rejects a dependency introduced by merge resolution', t => {
+  const cwd = setup(t)
+  const from = git(cwd, 'rev-parse', 'HEAD')
+
+  git(cwd, 'branch', 'feature')
+  writeFileSync(join(cwd, 'main.txt'), 'main\n')
+  git(cwd, 'add', 'main.txt')
+  git(cwd, 'commit', '-m', 'chore: update main')
+
+  git(cwd, 'checkout', 'feature')
+  writeFileSync(join(cwd, 'feature.txt'), 'feature\n')
+  git(cwd, 'add', 'feature.txt')
+  git(cwd, 'commit', '-m', 'feat: update feature')
+  git(cwd, 'merge', 'main', '--no-ff', '--no-commit')
+  writePackage(cwd, '2.0.0')
+  git(cwd, 'add', 'package.json')
+  git(cwd, 'commit', '-m', 'merge main')
+
+  const result = check(cwd, from)
+  t.equal(result.status, 1)
+  t.match(result.stderr, /foo \(changed in: package\.json\)/)
+  t.end()
+})
+
+t.test('rejects merge resolution changing a covered dependency again', t => {
+  const cwd = setup(t)
+  const from = git(cwd, 'rev-parse', 'HEAD')
+
+  git(cwd, 'branch', 'main-update')
+  writePackage(cwd, '2.0.0')
+  git(cwd, 'commit', '-am', 'deps: foo@2.0.0')
+
+  git(cwd, 'checkout', 'main-update')
+  writeFileSync(join(cwd, 'main.txt'), 'main\n')
+  git(cwd, 'add', 'main.txt')
+  git(cwd, 'commit', '-m', 'chore: update main')
+
+  git(cwd, 'checkout', 'main')
+  git(cwd, 'merge', 'main-update', '--no-ff', '--no-commit')
+  writePackage(cwd, '3.0.0')
+  git(cwd, 'add', 'package.json')
+  git(cwd, 'commit', '-m', 'merge main update')
+
+  const result = check(cwd, from)
+  t.equal(result.status, 1)
+  t.match(result.stderr, /merge main update/)
+  t.end()
+})
+
+t.test('accepts a dependency inherited unchanged from a merge parent', t => {
+  const cwd = setup(t)
+  const from = git(cwd, 'rev-parse', 'HEAD')
+
+  git(cwd, 'branch', 'feature')
+  writePackage(cwd, '2.0.0')
+  git(cwd, 'commit', '-am', 'deps: foo@2.0.0')
+
+  git(cwd, 'checkout', 'feature')
+  writeFileSync(join(cwd, 'feature.txt'), 'feature\n')
+  git(cwd, 'add', 'feature.txt')
+  git(cwd, 'commit', '-m', 'feat: update feature')
+  git(cwd, 'merge', 'main', '--no-ff', '-m', 'merge main')
+
+  const result = check(cwd, from)
+  t.equal(result.status, 0)
+  t.match(result.stdout, 'have a matching deps: commit')
+  t.end()
+})
+
+t.test('accepts the valid parent selected during a dependency conflict', t => {
+  const cwd = setup(t)
+  const from = git(cwd, 'rev-parse', 'HEAD')
+
+  git(cwd, 'branch', 'invalid')
+  writePackage(cwd, '3.0.0')
+  git(cwd, 'commit', '-am', 'deps: foo@3.0.0')
+
+  git(cwd, 'checkout', 'invalid')
+  writePackage(cwd, '2.0.0')
+  git(cwd, 'commit', '-am', 'fix: update foo')
+  const merge = spawnSync('git', ['merge', 'main', '--no-ff', '--no-commit'], {
+    cwd,
+    encoding: 'utf8',
+  })
+  t.equal(merge.status, 1)
+  writePackage(cwd, '3.0.0')
+  git(cwd, 'add', 'package.json')
+  git(cwd, 'commit', '-m', 'merge main')
+
+  const result = check(cwd, from)
+  t.equal(result.status, 0)
+  t.match(result.stdout, 'have a matching deps: commit')
+  t.end()
+})
+
+t.test('rejects the invalid parent selected during a dependency conflict', t => {
+  const cwd = setup(t)
+  const from = git(cwd, 'rev-parse', 'HEAD')
+
+  git(cwd, 'branch', 'invalid')
+  writePackage(cwd, '3.0.0')
+  git(cwd, 'commit', '-am', 'deps: foo@3.0.0')
+
+  git(cwd, 'checkout', 'invalid')
+  writePackage(cwd, '2.0.0')
+  git(cwd, 'commit', '-am', 'fix: update foo')
+  git(cwd, 'checkout', 'main')
+  const merge = spawnSync('git', ['merge', 'invalid', '--no-ff', '--no-commit'], {
+    cwd,
+    encoding: 'utf8',
+  })
+  t.equal(merge.status, 1)
+  writePackage(cwd, '2.0.0')
+  git(cwd, 'add', 'package.json')
+  git(cwd, 'commit', '-m', 'merge invalid')
+
+  const result = check(cwd, from)
+  t.equal(result.status, 1)
+  t.match(result.stderr, /fix: update foo/)
+  t.end()
+})
+
+t.test('tracks the same dependency separately in each manifest', t => {
+  const cwd = setup(t)
+  const from = git(cwd, 'rev-parse', 'HEAD')
+
+  writePackage(cwd, '2.0.0')
+  git(cwd, 'commit', '-am', 'deps: foo@2.0.0')
+
+  const workspace = join(cwd, 'workspaces', 'example')
+  writeFileSync(join(cwd, 'package.json'), `${JSON.stringify({
+    name: 'test-package',
+    version: '1.0.0',
+    dependencies: {
+      foo: '2.0.0',
+    },
+    workspaces: ['workspaces/*'],
+  }, null, 2)}\n`)
+  mkdirSync(workspace, { recursive: true })
+  writePackage(workspace, '2.0.0')
+  git(cwd, 'add', 'package.json', 'workspaces/example/package.json')
+  git(cwd, 'commit', '-m', 'fix: update workspace foo')
+
+  const result = check(cwd, from)
+  t.equal(result.status, 1)
+  t.match(result.stderr, /foo \(changed in: workspaces\/example\/package\.json/)
+  t.end()
+})
+
+t.test('suggests a deps commit when removing a dependency', t => {
+  const cwd = setup(t)
+  const from = git(cwd, 'rev-parse', 'HEAD')
+
+  writePackage(cwd, undefined, { dependencies: {} })
+  git(cwd, 'commit', '-am', 'fix: remove foo')
+
+  const result = check(cwd, from)
+  t.equal(result.status, 1)
+  t.match(result.stderr, 'deps: remove foo')
+  t.end()
+})
+
+t.test('accepts multiple matching changes to the same dependency', t => {
+  const cwd = setup(t)
+  const from = git(cwd, 'rev-parse', 'HEAD')
+
+  writePackage(cwd, '2.0.0')
+  git(cwd, 'commit', '-am', 'deps: foo@2.0.0')
+
+  writePackage(cwd, '3.0.0')
+  git(cwd, 'commit', '-am', 'deps: foo@3.0.0')
+
+  const result = check(cwd, from)
+  t.equal(result.status, 0)
+  t.match(result.stdout, 'have a matching deps: commit')
+  t.end()
+})
+
+t.test('accepts the commit that changes and names the dependency', t => {
+  const cwd = setup(t)
+  const from = git(cwd, 'rev-parse', 'HEAD')
+
+  writePackage(cwd, '2.0.0')
+  git(cwd, 'commit', '-am', 'deps: foo@2.0.0')
+
+  const result = check(cwd, from)
+  t.equal(result.status, 0)
+  t.match(result.stdout, 'have a matching deps: commit')
+  t.end()
+})


### PR DESCRIPTION
## What / Why

Adds a new Pull Request CI check that **rejects a PR when a production dependency is changed without a dedicated `deps:` commit** naming that dependency. This keeps dependency updates isolated in the git history and changelog, and prevents prod dep bumps from being buried inside unrelated `fix:`/`feat:`/`chore:` commits.

Motivated by #9740, where a `deps(arborist): validate-npm-package-name ^8.0.0` bump was merged inside a single `fix:` commit, obscuring why arborist needed a version bump.

## How it works

`scripts/check-deps-commits.js` (git + Node builtins only — no dependency install required):

- Diffs first-party manifests (root `package.json`, `workspaces/*`, `mock-registry`, …) across `base...head`, **excluding** `node_modules/**` bundle churn.
- Collects every changed `dependencies` entry (ignores `devDependencies`).
- Requires each changed dep to be named in a `deps:` / `deps(scope):` / `deps!:` commit in the branch.
- On failure, prints the missing deps and a suggested scoped, versioned commit derived from the diff, e.g. `deps(arborist): validate-npm-package-name@^8.0.0`.

`.github/workflows/deps-commits.yml` runs it on PRs and skips bot `release/v*` branches (which bulk-bump interdependencies in one `chore: release`). Intentionally **not** template-oss managed.

## Example (what #9740 would have shown)

```
The following production dependency changes are missing a matching deps: commit:
  - validate-npm-package-name (changed in: workspaces/arborist/package.json)

Add a separate commit for each, e.g.:
  deps(arborist): validate-npm-package-name@^8.0.0
```

## Verification

- Regression #9740 merge commit → **fails** (exit 1) ✅
- `deps: tar@7.5.19` (root prod dep bump) → **passes** ✅
- `mock-registry` arborist devDep bump → correctly **ignored** ✅
- ESLint clean; workflow YAML valid.