### PR TITLE
chore: assert bundled production deps resolve in the packed npm

### DIFF
--- a/smoke-tests/test/bundled-deps-resolve.js
+++ b/smoke-tests/test/bundled-deps-resolve.js
@@ -1,5 +1,5 @@
 const t = require('tap')
-const { join } = require('node:path')
+const { isAbsolute, join, relative, sep } = require('node:path')
 const fs = require('node:fs')
 const { createRequire } = require('node:module')
 const setup = require('./fixtures/setup.js')
@@ -13,6 +13,7 @@ const setup = require('./fixtures/setup.js')
 // where `sigstore` went missing from the packed bundle.
 const findMissingDeps = (npmRoot) => {
   const req = createRequire(join(npmRoot, 'package.json'))
+  const bundleRoot = fs.realpathSync(npmRoot)
   const missing = []
   const seen = new Set()
   const stack = [npmRoot]
@@ -37,7 +38,15 @@ const findMissingDeps = (npmRoot) => {
         continue
       }
       try {
-        req.resolve(dep, { paths: [dir] })
+        const resolved = fs.realpathSync(req.resolve(dep, { paths: [dir] }))
+        const fromBundle = relative(bundleRoot, resolved)
+        if (
+          isAbsolute(fromBundle) ||
+          fromBundle === '..' ||
+          fromBundle.startsWith(`..${sep}`)
+        ) {
+          missing.push(`${pkg.name || dir} -> ${dep}`)
+        }
       } catch {
         missing.push(`${pkg.name || dir} -> ${dep}`)
       }
@@ -82,7 +91,7 @@ t.test('bundled production deps all resolve from the packed bundle', async t => 
   })
 
   const tarball = await npmLocalTarball()
-  await npm('install', tarball, '--global')
+  await npm('install', tarball, '--global', '--ignore-scripts')
 
   const npmRoot = join(globalNodeModules, 'npm')
   const missing = findMissingDeps(npmRoot)

--- a/smoke-tests/test/bundled-deps-resolve.js
+++ b/smoke-tests/test/bundled-deps-resolve.js
@@ -1,0 +1,95 @@
+const t = require('tap')
+const { join } = require('node:path')
+const fs = require('node:fs')
+const { createRequire } = require('node:module')
+const setup = require('./fixtures/setup.js')
+
+// Walk an installed package tree and assert that every non-optional
+// production dependency of every bundled package resolves from that
+// package's own directory. This catches deps that were dropped from the
+// hoisted bundle at pack time (e.g. a dev-only copy shadowing the real
+// production version), which unit tests miss because they run against the
+// source tree where a nested copy still resolves. See PR #9740 / #9722
+// where `sigstore` went missing from the packed bundle.
+const findMissingDeps = (npmRoot) => {
+  const req = createRequire(join(npmRoot, 'package.json'))
+  const missing = []
+  const seen = new Set()
+  const stack = [npmRoot]
+
+  while (stack.length) {
+    const dir = stack.pop()
+    if (seen.has(dir)) {
+      continue
+    }
+    seen.add(dir)
+
+    let pkg
+    try {
+      pkg = JSON.parse(fs.readFileSync(join(dir, 'package.json'), 'utf8'))
+    } catch {
+      continue
+    }
+
+    const optional = new Set(Object.keys(pkg.optionalDependencies || {}))
+    for (const dep of Object.keys(pkg.dependencies || {})) {
+      if (optional.has(dep)) {
+        continue
+      }
+      try {
+        req.resolve(dep, { paths: [dir] })
+      } catch {
+        missing.push(`${pkg.name || dir} -> ${dep}`)
+      }
+    }
+
+    const nodeModules = join(dir, 'node_modules')
+    let entries
+    try {
+      entries = fs.readdirSync(nodeModules, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const entry of entries) {
+      if (entry.name === '.bin') {
+        continue
+      }
+      const entryPath = join(nodeModules, entry.name)
+      if (entry.name.startsWith('@')) {
+        for (const scoped of fs.readdirSync(entryPath, { withFileTypes: true })) {
+          stack.push(join(entryPath, scoped.name))
+        }
+      } else {
+        stack.push(entryPath)
+      }
+    }
+  }
+
+  return missing.sort()
+}
+
+t.test('bundled production deps all resolve from the packed bundle', async t => {
+  const {
+    npm,
+    npmLocalTarball,
+    paths: { globalNodeModules },
+  } = await setup(t, {
+    testdir: {
+      project: {
+        'package.json': { name: 'npm', version: '999.999.999' },
+      },
+    },
+  })
+
+  const tarball = await npmLocalTarball()
+  await npm('install', tarball, '--global')
+
+  const npmRoot = join(globalNodeModules, 'npm')
+  const missing = findMissingDeps(npmRoot)
+
+  t.strictSame(
+    missing,
+    [],
+    'every non-optional production dependency resolves in the packed bundle'
+  )
+})


### PR DESCRIPTION
## What

Adds a smoke test (`smoke-tests/test/bundled-deps-resolve.js`) that packs npm, installs it globally into an isolated testdir, then walks the installed bundle and `require.resolve()`s every non-optional production dependency from its owning package. If any hoisted dependency can't resolve, the test fails and names the culprit (`<pkg> -> <dep>`).

## Why

In #9722/#9740, `sigstore` went missing from the packed npm bundle: a stale `@npmcli/arborist@^9.1.2` pin in `mock-registry` couldn't be satisfied by the local v10 workspace, so arborist was pulled from the registry, dragging in a dev-only `sigstore@4` that hoisted to the root `node_modules` and marked it `dev`. At pack time the dev-only copy was stripped and libnpmpublish's real `sigstore@5` was nested (not root-bundled), so the published npm shipped with **no** `node_modules/sigstore` and `npm publish --provenance` failed with `Cannot find module 'sigstore'`.

Unit tests didn't catch it because they run against the source tree (where a nested copy still resolves) and mock `sigstore` anyway. Only the **packed** shape exposes the bug.

## Approach

- Runs against the packed/installed bundle, **not** the dev tree — the dev tree yields ~115 false positives from dev-only `@types/*`/peer deps.
- Skips `optionalDependencies` (legitimately absent sometimes).
- Reuses the existing `setup.js` / `npmLocalTarball()` infra; the `--global` install is fully isolated via testdir-scoped `--prefix`/`--cache`/config and redirected `HOME` (same pattern as `npm-replace-global.js`).

## Verification

- ✅ Passes against the current bundle (0 missing).
- ✅ Fails when `node_modules/sigstore` is removed from the packed bundle (reports `libnpmpublish -> sigstore`, `pacote -> sigstore`).
- ✅ eslint clean.

Generic: catches any dropped hoisted production dep, not just sigstore.