### PR TITLE
fix: prevent duplicate process.exit() on concurrent unhandledRejections

### DIFF
--- a/lib/cli/exit-handler.js
+++ b/lib/cli/exit-handler.js
@@ -138,6 +138,11 @@ class ExitHandler {
   }
 
   #handleExit = (err) => {
+    // Ignore re-entrant calls: concurrent unhandledRejections (e.g. multiple
+    // simultaneous fetch timeouts) must not each schedule their own process.exit().
+    if (this.#exited) {
+      return
+    }
     this.#exited = true
 
     // No npm at all

--- a/test/lib/cli/exit-handler.js
+++ b/test/lib/cli/exit-handler.js
@@ -678,6 +678,36 @@ t.test('exits uncleanly when only emitting exit event', async (t) => {
   t.equal(process.exitCode, 1, 'exitCode coerced to 1')
 })
 
+t.test('re-entrant calls to exit handler are ignored (concurrent unhandledRejections)', async (t) => {
+  // Defers stderr.write via setImmediate to open the same race window that
+  // concurrent ETIMEDOUT rejections create in production: without the guard,
+  // each rejection queues its own process.exit() and the second one fires
+  // after #exited has been reset, producing "Exit handler never called!".
+  const { logs } = await mockExitHandler(t, {
+    globals: {
+      'process.stderr': Object.assign(Object.create(process.stderr), {
+        write (chunk, cb) {
+          setImmediate(cb)
+          return true
+        },
+      }),
+    },
+  })
+
+  let exitCount = 0
+  process.on('exit', () => exitCount++)
+
+  process.emit('unhandledRejection', err('ETIMEDOUT first', 'ETIMEDOUT'))
+  process.emit('unhandledRejection', err('ETIMEDOUT second', 'ETIMEDOUT'))
+
+  await new Promise(res => process.once('exit', res))
+  await new Promise(res => setImmediate(res))
+
+  t.equal(exitCount, 1, 'process.exit() should only be called once')
+  t.notMatch(logs.error, ['Exit handler never called!'],
+    'should not emit "Exit handler never called!" on re-entrant call')
+})
+
 t.test('do no fancy handling for shellouts', async t => {
   const mockShelloutExit = (t, opts) => mockExitHandler(t, {
     command: 'exec',


### PR DESCRIPTION
When multiple package downloads time out simultaneously (e.g. from a private
Artifactory registry), Node.js fires multiple `unhandledRejection` events in
quick succession. Each one enters `#handleExit`, which defers `process.exit()`
via a `stderr.write → stdout.write` callback chain.

Without a re-entrancy guard, both deferred callbacks complete independently:

1. First rejection sets `#exited = true`, queues a deferred `process.exit()`.
2. Second rejection enters `#handleExit` before any I/O callback has run,
   sets `#exited = true` again, queues a second deferred `process.exit()`.
3. First `process.exit()` fires → emits `'exit'` → `#handleProcessExitAndReset`
   resets `#exited` back to `false`.
4. Second `process.exit()` fires → emits `'exit'` → `#handleProcessExit` sees
   `#exited === false` → logs **"Exit handler never called!"**.

Fix adds a two-line re-entrancy guard at the top of `#handleExit` so only the
first rejection ever schedules a `process.exit()`.

The regression test defers `stderr.write` via `setImmediate` to open the same
race window that real I/O creates in production, fires two `unhandledRejection`
events synchronously, and asserts `process.exit()` was called exactly once.
The test fails without the fix and passes with it.

## References

Fixes #9739