### PR TITLE
feat(config): add --ignore-proxy flag

### DIFF
--- a/tap-snapshots/test/lib/commands/config.js.test.cjs
+++ b/tap-snapshots/test/lib/commands/config.js.test.cjs
@@ -78,6 +78,7 @@ exports[`test/lib/commands/config.js TAP config list --json > output matches sna
   "https-proxy": null,
   "if-present": false,
   "ignore-extension": false,
+  "ignore-proxy": false,
   "ignore-scripts": false,
   "include": [],
   "include-staged": false,
@@ -279,6 +280,7 @@ if-present = false
 ignore-existing = false
 ignore-extension = false
 ignore-patch-failures = false
+ignore-proxy = false
 ignore-scripts = false
 include = []
 include-attestations = false

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -1022,6 +1022,18 @@ This flag is only honored when passed on the command line; it is ignored in
 
 
 
+#### \`ignore-proxy\`
+
+* Default: false
+* Type: Boolean
+
+If set to true, all proxy settings (\`proxy\`, \`https-proxy\`) will be ignored,
+and requests will be made directly without going through any proxy. This is
+useful when you have a proxy configured globally but need to bypass it for
+certain operations.
+
+
+
 #### \`ignore-scripts\`
 
 * Default: false
@@ -2661,6 +2673,7 @@ Array [
   "https-proxy",
   "if-present",
   "ignore-extension",
+  "ignore-proxy",
   "ignore-scripts",
   "include",
   "include-staged",
@@ -2953,6 +2966,7 @@ exports[`test/lib/docs.js TAP config > keys that are not flattened 1`] = `
 Array [
   "expect-result-count",
   "expect-results",
+  "ignore-proxy",
   "init-author-email",
   "init-author-name",
   "init-author-url",

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -1026,7 +1026,9 @@ const definitions = {
       are set, proxy settings will be honored by the underlying
       \`make-fetch-happen\` library.
     `,
-    flatten,
+    flatten (key, obj, flatOptions) {
+      flatOptions.httpsProxy = obj['ignore-proxy'] ? null : obj[key]
+    },
   }),
   'if-present': new Definition('if-present', {
     default: false,
@@ -1052,6 +1054,16 @@ const definitions = {
       root-owned install-time code.
     `,
     flatten,
+  }),
+  'ignore-proxy': new Definition('ignore-proxy', {
+    default: false,
+    type: Boolean,
+    description: `
+      If set to true, all proxy settings (\`proxy\`, \`https-proxy\`) will be
+      ignored, and requests will be made directly without going through
+      any proxy. This is useful when you have a proxy configured
+      globally but need to bypass it for certain operations.
+    `,
   }),
   'ignore-scripts': new Definition('ignore-scripts', {
     default: false,
@@ -2027,7 +2039,9 @@ const definitions = {
       \`http_proxy\` environment variables are set, proxy settings will be
       honored by the underlying \`request\` library.
     `,
-    flatten,
+    flatten (key, obj, flatOptions) {
+      flatOptions.proxy = obj['ignore-proxy'] ? null : obj[key]
+    },
   }),
   'read-only': new Definition('read-only', {
     default: false,

--- a/workspaces/config/tap-snapshots/test/type-description.js.test.cjs
+++ b/workspaces/config/tap-snapshots/test/type-description.js.test.cjs
@@ -263,6 +263,9 @@ Object {
   "ignore-patch-failures": Array [
     "boolean value (true or false)",
   ],
+  "ignore-proxy": Array [
+    "boolean value (true or false)",
+  ],
   "ignore-scripts": Array [
     "boolean value (true or false)",
   ],

--- a/workspaces/config/test/definitions/definitions.js
+++ b/workspaces/config/test/definitions/definitions.js
@@ -571,6 +571,38 @@ t.test('noProxy - string', t => {
   t.end()
 })
 
+t.test('ignore-proxy - https-proxy is nullified when ignore-proxy is true', t => {
+  const obj = { 'https-proxy': 'https://proxy.example.com', 'ignore-proxy': true }
+  const flat = {}
+  mockDefs()['https-proxy'].flatten('https-proxy', obj, flat)
+  t.strictSame(flat, { httpsProxy: null })
+  t.end()
+})
+
+t.test('ignore-proxy - https-proxy is preserved when ignore-proxy is false', t => {
+  const obj = { 'https-proxy': 'https://proxy.example.com', 'ignore-proxy': false }
+  const flat = {}
+  mockDefs()['https-proxy'].flatten('https-proxy', obj, flat)
+  t.strictSame(flat, { httpsProxy: 'https://proxy.example.com' })
+  t.end()
+})
+
+t.test('ignore-proxy - proxy is nullified when ignore-proxy is true', t => {
+  const obj = { proxy: 'http://proxy.example.com', 'ignore-proxy': true }
+  const flat = {}
+  mockDefs().proxy.flatten('proxy', obj, flat)
+  t.strictSame(flat, { proxy: null })
+  t.end()
+})
+
+t.test('ignore-proxy - proxy is preserved when ignore-proxy is false', t => {
+  const obj = { proxy: 'http://proxy.example.com', 'ignore-proxy': false }
+  const flat = {}
+  mockDefs().proxy.flatten('proxy', obj, flat)
+  t.strictSame(flat, { proxy: 'http://proxy.example.com' })
+  t.end()
+})
+
 t.test('maxSockets', t => {
   const obj = { maxsockets: 123 }
   const flat = {}


### PR DESCRIPTION
## What?

Add an `ignore-proxy` boolean config that, when set to `true`, nullifies `proxy` and `https-proxy` settings.

## Why?

Closes #380. Users with a proxy configured globally (e.g., corporate `.npmrc` or environment variables) currently have no simple way to bypass it for specific operations. They must manually unset both `proxy` and `https-proxy`, which is error-prone and inconvenient.

## Approach

- Added a new `ignore-proxy` Definition (`default: false`, `type: Boolean`) in the config definitions.
- Rather than giving `ignore-proxy` its own `flatten`, the existing `proxy` and `https-proxy` flatten functions were modified to check `obj["ignore-proxy"]` and return `null` when it is truthy. This keeps the nullification co-located with the settings it affects.

## Verification

- **Unit tests added** in `workspaces/config/test/definitions/definitions.js`:
  - `https-proxy` flattens to `null` when `ignore-proxy` is `true`
  - `https-proxy` passes through when `ignore-proxy` is `false`
  - `proxy` flattens to `null` when `ignore-proxy` is `true`
  - `proxy` passes through when `ignore-proxy` is `false`
- All affected snapshots regenerated and passing (`docs`, `config list`, `type-description`).
- Full config workspace test suite passes with lint clean.