### PR TITLE
feat(config): support --registry=default shorthand

### DIFF
--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -1794,9 +1794,13 @@ Rebuild bundled dependencies after installation.
 #### \`registry\`
 
 * Default: "https://registry.npmjs.org/"
-* Type: URL
+* Type: URL or "default"
 
 The base URL of the npm registry.
+
+Can be set to \`"default"\` to use the default npm registry
+(\`https://registry.npmjs.org/\`), which is useful when you have a custom
+registry configured globally but want to temporarily use the default one.
 
 
 

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -2048,7 +2048,7 @@ const definitions = {
   }),
   registry: new Definition('registry', {
     default: 'https://registry.npmjs.org/',
-    type: [url, String],
+    type: [url, 'default'],
     description: `
       The base URL of the npm registry.
 

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -2048,11 +2048,21 @@ const definitions = {
   }),
   registry: new Definition('registry', {
     default: 'https://registry.npmjs.org/',
-    type: url,
+    type: [url, String],
     description: `
       The base URL of the npm registry.
+
+      Can be set to \`"default"\` to use the default npm registry
+      (\`https://registry.npmjs.org/\`), which is useful when you have
+      a custom registry configured globally but want to temporarily
+      use the default one.
     `,
-    flatten,
+    flatten (key, obj, flatOptions) {
+      const val = obj[key]
+      flatOptions.registry = /^default$/i.test(val)
+        ? 'https://registry.npmjs.org/'
+        : val
+    },
   }),
   'replace-registry-host': new Definition('replace-registry-host', {
     default: 'npmjs',

--- a/workspaces/config/tap-snapshots/test/type-description.js.test.cjs
+++ b/workspaces/config/tap-snapshots/test/type-description.js.test.cjs
@@ -539,6 +539,7 @@ Object {
   ],
   "registry": Array [
     "full url with \\"http://\\"",
+    "default",
   ],
   "replace-registry-host": Array [
     "npmjs",

--- a/workspaces/config/test/definitions/definitions.js
+++ b/workspaces/config/test/definitions/definitions.js
@@ -592,6 +592,28 @@ t.test('scope', t => {
   t.end()
 })
 
+t.test('registry - "default" maps to default registry URL', t => {
+  const defs = mockDefs()
+
+  const flat1 = {}
+  defs.registry.flatten('registry', { registry: 'default' }, flat1)
+  t.equal(flat1.registry, 'https://registry.npmjs.org/', 'lowercase default')
+
+  const flat2 = {}
+  defs.registry.flatten('registry', { registry: 'DEFAULT' }, flat2)
+  t.equal(flat2.registry, 'https://registry.npmjs.org/', 'uppercase DEFAULT')
+
+  const flat3 = {}
+  defs.registry.flatten('registry', { registry: 'Default' }, flat3)
+  t.equal(flat3.registry, 'https://registry.npmjs.org/', 'mixed case Default')
+
+  const flat4 = {}
+  defs.registry.flatten('registry', { registry: 'https://custom.registry.com/' }, flat4)
+  t.equal(flat4.registry, 'https://custom.registry.com/', 'custom URL passes through')
+
+  t.end()
+})
+
 t.test('strictSSL', t => {
   const obj = { 'strict-ssl': false }
   const flat = {}


### PR DESCRIPTION
## What?

Support `"default"` as a special value for the `--registry` config that maps to `https://registry.npmjs.org/`.

## Why?

Closes #379. Users with a custom registry configured globally (e.g., a private Artifactory or Verdaccio instance in `.npmrc`) have no ergonomic way to temporarily switch back to the public npm registry. They must remember and type the full URL. `--registry=default` provides a memorable, self-documenting shorthand.

## Approach

- Changed the `registry` Definition type from `url` to `[url, 'default']` so that only the literal keyword `"default"` is accepted alongside URLs. Using `[url, String]` was considered but rejected because it would accept any arbitrary string (e.g., `"hello"`) and break existing validation.
- Added a custom `flatten` function that maps `/^default$/i` to `https://registry.npmjs.org/` and passes all other values through unchanged.
- The match is case-insensitive (`default`, `DEFAULT`, `Default` all work).

## Verification

- **Unit tests added** in `workspaces/config/test/definitions/definitions.js`:
  - `"default"` (lowercase) maps to the canonical registry URL
  - `"DEFAULT"` (uppercase) maps to the canonical registry URL
  - `"Default"` (mixed case) maps to the canonical registry URL
  - A custom URL passes through unchanged
- Existing `registry="hello"` validation test continues to correctly reject invalid values.
- All affected snapshots regenerated and passing (`docs` now shows `Type: URL or "default"`, `type-description`).
- Full config workspace test suite passes with lint clean.