### PR TITLE
fix: exempt explicit pack targets from allow-directory

### DIFF
--- a/lib/commands/pack.js
+++ b/lib/commands/pack.js
@@ -45,6 +45,7 @@ class Pack extends BaseCommand {
       ) ? { ...this.npm.flatOptions, before: null } : this.npm.flatOptions
       const manifest = await pacote.manifest(spec, {
         ...options,
+        ...(spec.type === 'directory' && { allowDirectory: 'all' }),
         Arborist,
         preferOnline: true,
         _isRoot: true,

--- a/test/lib/commands/pack.js
+++ b/test/lib/commands/pack.js
@@ -112,6 +112,25 @@ t.test('dry run', async t => {
   t.throws(() => fs.statSync(path.resolve(npm.prefix, filename)))
 })
 
+for (const allowDirectory of ['none', 'root']) {
+  t.test(`dry run with allow-directory=${allowDirectory}`, async t => {
+    const { npm, outputs } = await loadMockNpm(t, {
+      prefixDir: {
+        'package.json': JSON.stringify({
+          name: 'test-package',
+          version: '1.0.0',
+        }),
+      },
+      config: {
+        'allow-directory': allowDirectory,
+        'dry-run': true,
+      },
+    })
+    await npm.exec('pack', [])
+    t.strictSame(outputs, ['test-package-1.0.0.tgz'])
+  })
+}
+
 t.test('foreground-scripts defaults to true', async t => {
   const { npm, outputs, logs } = await loadMockNpm(t, {
     prefixDir: {

--- a/test/lib/commands/publish.js
+++ b/test/lib/commands/publish.js
@@ -151,6 +151,25 @@ t.test('dry-run', async t => {
   t.matchSnapshot(logs.notice)
 })
 
+for (const allowDirectory of ['none', 'root']) {
+  t.test(`dry-run with allow-directory=${allowDirectory}`, async t => {
+    const { joinedOutput, npm, registry } = await loadNpmWithRegistry(t, {
+      config: {
+        'allow-directory': allowDirectory,
+        'dry-run': true,
+        ...auth,
+      },
+      prefixDir: {
+        'package.json': JSON.stringify(pkgJson, null, 2),
+      },
+      authorization: token,
+    })
+    registry.publish(pkg, { noPut: true })
+    await npm.exec('publish', [])
+    t.equal(joinedOutput(), `+ ${pkg}@1.0.0`)
+  })
+}
+
 t.test('foreground-scripts defaults to true', async t => {
   const { outputs, npm, logs, registry } = await loadNpmWithRegistry(t, {
     config: {

--- a/workspaces/libnpmpack/lib/index.js
+++ b/workspaces/libnpmpack/lib/index.js
@@ -12,6 +12,11 @@ async function pack (spec = 'file:.', opts = {}) {
   // gets spec
   spec = npa(spec)
 
+  // An explicit directory is the package being packed, not a dependency fetch.
+  if (spec.type === 'directory') {
+    opts = { ...opts, allowDirectory: 'all' }
+  }
+
   const manifest = await pacote.manifest(spec, { ...opts, Arborist, _isRoot: true })
 
   if (spec.type === 'directory') {

--- a/workspaces/libnpmpack/test/index.js
+++ b/workspaces/libnpmpack/test/index.js
@@ -36,6 +36,20 @@ t.test('packs from local directory', async t => {
   })
 })
 
+for (const allowDirectory of ['none', 'root']) {
+  t.test(`packs an explicit local directory with allow-directory=${allowDirectory}`, async t => {
+    const testDir = t.testdir({
+      'package.json': JSON.stringify({
+        name: 'my-cool-pkg',
+        version: '1.0.0',
+      }, null, 2),
+    })
+
+    const tarball = await pack(testDir, { allowDirectory })
+    t.ok(tarball)
+  })
+}
+
 t.test('flattens path separators in name so tarball stays in packDestination', async t => {
   const testDir = t.testdir({
     src: {


### PR DESCRIPTION
## Summary

- allow explicit directory targets through `npm pack` and `npm publish` when `allow-directory` is `none` or `root`
- keep dependency fetch policies unchanged and cover the shared library plus both CLI commands

## Why

`allow-directory` restricts directory dependencies, but the local package selected for packing or publishing is the command target. The current flow applies the dependency policy to that target during manifest or tarball preparation.

Closes #9755.

## Validation

- `node . run test` - passed (123 test files, 100% coverage)
- `node . run test -w libnpmpack` - passed (100% coverage)
- dry-run `pack` and `publish` smokes with `allow-directory=none|root` - passed
