### PR TITLE
fix(arborist): strip path separators from version in store key

### DIFF
--- a/workspaces/arborist/lib/arborist/isolated-reifier.js
+++ b/workspaces/arborist/lib/arborist/isolated-reifier.js
@@ -33,7 +33,11 @@ const getKey = (startNode) => {
     .replace(/=+$/m, '')
   // a patched entry gets a distinct, identifiable side-store key so unpatched consumers keep sharing the original
   const patchSuffix = startNode.patched ? '+patch' : ''
-  return `${startNode.packageName}@${startNode.version}-${hash}${patchSuffix}`
+  // version comes straight from an untrusted package.json and this key becomes a
+  // path segment below (join('node_modules', '.store', key, ...)); strip separators
+  // so a crafted version can't traverse out of the store, matching packageName
+  const version = String(startNode.version).replace(/[/\\]/g, '_')
+  return `${startNode.packageName}@${version}-${hash}${patchSuffix}`
 }
 
 module.exports = cls => class IsolatedReifier extends cls {


### PR DESCRIPTION
1. In linked/isolated mode `getKey` builds the `.store` key as `name@version-hash`; `packageName` is already run through `nameFromFolder` (per the comment right above it) but `version` is interpolated raw.
2. `version` is `package.version` straight from a dependency manifest, and the key becomes a path segment in `join('node_modules', '.store', key, ...)`, so a git/file/tarball dep with a version like `1.0.0/../../../../tmp/x` lets `path.join` collapse the `..` and escape the store before `pacote.extract` writes there.

Stripped `/` and `\` from `version` in `getKey`, matching the existing `packageName` handling. Valid semver has no separators so store keys are unchanged, and the isolated-mode suite stays green.