### PR TITLE
fix(pack): honor min-release-age-exclude

### DIFF
--- a/lib/commands/pack.js
+++ b/lib/commands/pack.js
@@ -2,6 +2,10 @@ const pacote = require('pacote')
 const libpack = require('libnpmpack')
 const npa = require('npm-package-arg')
 const { log, output } = require('proc-log')
+const {
+  isReleaseAgeExcluded,
+  trustedSpecName,
+} = require('@npmcli/arborist/lib/release-age-exclude.js')
 const { getContents, logTar } = require('../utils/tar.js')
 const BaseCommand = require('../base-cmd.js')
 
@@ -35,8 +39,12 @@ class Pack extends BaseCommand {
     const manifests = []
     for (const arg of args) {
       const spec = npa(arg)
+      const options = isReleaseAgeExcluded(
+        trustedSpecName(spec),
+        this.npm.flatOptions.minReleaseAgeExclude
+      ) ? { ...this.npm.flatOptions, before: null } : this.npm.flatOptions
       const manifest = await pacote.manifest(spec, {
-        ...this.npm.flatOptions,
+        ...options,
         Arborist,
         preferOnline: true,
         _isRoot: true,
@@ -44,14 +52,14 @@ class Pack extends BaseCommand {
       if (!manifest._id) {
         throw new Error('Invalid package, must have name and version')
       }
-      manifests.push({ arg, manifest })
+      manifests.push({ arg, manifest, options })
     }
 
     // Load tarball names up for printing afterward to isolate from the noise generated during packing
     const tarballs = []
-    for (const { arg, manifest } of manifests) {
+    for (const { arg, manifest, options } of manifests) {
       const tarballData = await libpack(arg, {
-        ...this.npm.flatOptions,
+        ...options,
         foregroundScripts: this.npm.config.isDefault('foreground-scripts')
           ? true
           : this.npm.config.get('foreground-scripts'),

--- a/test/lib/commands/pack.js
+++ b/test/lib/commands/pack.js
@@ -1,6 +1,7 @@
 const t = require('tap')
 const { load: loadMockNpm } = require('../../fixtures/mock-npm')
 const { cleanZlib } = require('../../fixtures/clean-snapshot')
+const MockRegistry = require('@npmcli/mock-registry')
 const path = require('node:path')
 const fs = require('node:fs')
 
@@ -160,6 +161,61 @@ t.test('foreground-scripts can still be set to false', async t => {
   t.strictSame(outputs, [filename], 'prepack and postpack do not log to stdout')
   t.matchSnapshot(logs.notice, 'logs pack contents')
   t.throws(() => fs.statSync(path.resolve(npm.prefix, filename)))
+})
+
+t.test('min-release-age-exclude applies to registry packages', async t => {
+  const name = '@myscope/some-package'
+  const version = '1.2.3'
+  const { npm, outputs } = await loadMockNpm(t, {
+    prefixDir: {
+      package: {
+        'package.json': JSON.stringify({ name, version }),
+      },
+    },
+    config: {
+      'min-release-age': 7,
+      'min-release-age-exclude': ['@myscope/*'],
+    },
+  })
+  const registry = new MockRegistry({
+    tap: t,
+    registry: npm.config.get('registry'),
+  })
+  const manifest = registry.manifest({ name, versions: [version] })
+  await registry.package({
+    manifest,
+    times: 2,
+    tarballs: { [version]: path.join(npm.prefix, 'package') },
+  })
+
+  await npm.exec('pack', [`${name}@${version}`])
+
+  const filename = 'myscope-some-package-1.2.3.tgz'
+  t.strictSame(outputs, [filename])
+  t.ok(fs.statSync(path.resolve(npm.prefix, filename)))
+})
+
+t.test('excluded alias name does not bypass min-release-age for its target', async t => {
+  const target = 'other-package'
+  const version = '1.2.3'
+  const { npm } = await loadMockNpm(t, {
+    config: {
+      'min-release-age': 7,
+      'min-release-age-exclude': ['@myscope/*'],
+    },
+  })
+  const registry = new MockRegistry({
+    tap: t,
+    registry: npm.config.get('registry'),
+  })
+  await registry.package({
+    manifest: registry.manifest({ name: target, versions: [version] }),
+  })
+
+  await t.rejects(
+    npm.exec('pack', [`@myscope/alias@npm:${target}@${version}`]),
+    { code: 'ETARGET' }
+  )
 })
 
 t.test('invalid packument', async t => {


### PR DESCRIPTION
Make `npm pack` honor `min-release-age-exclude` when resolving packages from a registry.

Given:

```ini
min-release-age=7
min-release-age-exclude=@myscope/*
```
 `npm pack @myscope/some-package@1.2.3`  incorrectly failed with  ETARGET  when the package was newer than seven days, despite matching the exclusion.

Root cause

`min-release-age`  is flattened into the  `before`  option consumed by  `pacote` . However,  `pacote`  does not interpret  `min-release-age-exclude` ; callers must remove  before  for matching packages.

 `npm pack`  performs two manifest resolutions:

1. Directly through `pacote.manifest`
2. Internally through  `libnpmpack` 

Both resolutions received the unmodified `before` option, so the exclusion was never applied.

Fix

Derive effective options for each package spec using the existing Arborist release-age helpers:

• Clear `before` when the package matches `min-release-age-exclude` 
• Preserve the cutoff for nonmatching packages
• Pass the same effective options to both manifest resolutions

Using the alias target prevents an excluded alias name from disabling the release-age policy for an unrelated package.

Test coverage

Added regression coverage confirming that:

• A recently published scoped package matching an exclusion glob can be packed
• An excluded alias name does not exempt its non-excluded registry target

The original scenario was also reproduced against a local registry: it failed with `ETARGET` before this change and successfully produced the tarball afterward.

References

Fixes #9759
