### PR TITLE
fix(arborist): allow audit fix to install safe downgrades

### DIFF
--- a/workspaces/arborist/lib/can-place-dep.js
+++ b/workspaces/arborist/lib/can-place-dep.js
@@ -21,6 +21,8 @@
 //     - if satisfying and preferDedupe? KEEP
 //     - else: REPLACE
 //   - if there is a newer version present, and preferDedupe, REPLACE
+//   - if there is a newer vulnerable version present during an audit fix,
+//     and the candidate is older and not vulnerable, REPLACE
 //   - if the version present satisfies the edge, KEEP
 //   - else: CONFLICT
 // - if the node is not in conflict, check each of its peers:
@@ -62,6 +64,7 @@ class CanPlaceDep {
       parent = null,
       peerPath = [],
       explicitRequest = false,
+      auditReport = null,
     } = options
 
     debug(() => {
@@ -92,6 +95,7 @@ class CanPlaceDep {
     this.target = target
     this.edge = edge
     this.explicitRequest = explicitRequest
+    this.auditReport = auditReport
 
     // preventing cycles when we check peer sets
     this.peerPath = peerPath
@@ -170,7 +174,15 @@ class CanPlaceDep {
 
     const { version: curVer } = current
     const { version: newVer } = dep
-    const tryReplace = curVer && newVer && semver.gte(newVer, curVer)
+    // Audit fix may select an older safe version within the declared range.
+    // This only makes the candidate eligible; canReplace() and peer checks
+    // below still enforce placement compatibility.
+    const auditFixDowngrade = curVer && newVer &&
+      semver.lt(newVer, curVer) &&
+      this.auditReport?.isVulnerable(current) &&
+      !this.auditReport.isVulnerable(dep)
+    const tryReplace = curVer && newVer &&
+      (semver.gte(newVer, curVer) || auditFixDowngrade)
     if (tryReplace && dep.canReplace(current)) {
       // It's extremely rare that a replaceable node would be a conflict, if
       // the current one wasn't a conflict, but it is theoretically possible
@@ -381,6 +393,7 @@ class CanPlaceDep {
         parent: this,
         edge: peerEdge,
         peerPath,
+        auditReport: this.auditReport,
         // always place peers in preferDedupe mode
         preferDedupe: true,
       })

--- a/workspaces/arborist/lib/place-dep.js
+++ b/workspaces/arborist/lib/place-dep.js
@@ -96,6 +96,7 @@ class PlaceDep {
         target,
         preferDedupe: this.preferDedupe,
         explicitRequest: this.explicitRequest,
+        auditReport: this.auditReport,
       })
       this.checks.set(target, cpd)
 

--- a/workspaces/arborist/tap-snapshots/test/can-place-dep.js.test.cjs
+++ b/workspaces/arborist/tap-snapshots/test/can-place-dep.js.test.cjs
@@ -5,6 +5,25 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/can-place-dep.js TAP basic placement check tests audit downgrade still respects peer conflicts > conflict children 1`] = `
+Array [
+  Object {
+    "canPlace": Symbol(CONFLICT),
+    "canPlaceSelf": Symbol(CONFLICT),
+    "dep": Array [
+      "a",
+      "3.0.0",
+    ],
+    "edge": Array [
+      "node_modules/b",
+      "peer",
+      "a",
+      "3",
+    ],
+  },
+]
+`
+
 exports[`test/can-place-dep.js TAP basic placement check tests basic placement of a dep, no conflicts or issues > conflict children 1`] = `
 Array []
 `
@@ -166,6 +185,14 @@ exports[`test/can-place-dep.js TAP basic placement check tests invalid shadowing
 Array []
 `
 
+exports[`test/can-place-dep.js TAP basic placement check tests keep a newer dep when an older candidate is not an audit remediation > conflict children 1`] = `
+Array []
+`
+
+exports[`test/can-place-dep.js TAP basic placement check tests keep a vulnerable dep when the older audit candidate is also vulnerable > conflict children 1`] = `
+Array []
+`
+
 exports[`test/can-place-dep.js TAP basic placement check tests keep an existing dep that could dedupe, explicit request, preferDedupe > conflict children 1`] = `
 Array []
 `
@@ -257,6 +284,10 @@ Array [
     ],
   },
 ]
+`
+
+exports[`test/can-place-dep.js TAP basic placement check tests replace a vulnerable dep with an older safe audit candidate > conflict children 1`] = `
+Array []
 `
 
 exports[`test/can-place-dep.js TAP basic placement check tests replace an existing dep > conflict children 1`] = `

--- a/workspaces/arborist/tap-snapshots/test/place-dep.js.test.cjs
+++ b/workspaces/arborist/tap-snapshots/test/place-dep.js.test.cjs
@@ -28,6 +28,43 @@ exports[`test/place-dep.js TAP placement tests accept an older transitive depend
 Array []
 `
 
+exports[`test/place-dep.js TAP placement tests audit fix replaces a vulnerable dep with an older safe version > changes to tree 1`] = `
+--- expected
++++ actual
+@@ -20,7 +20,7 @@
+   "children": Map {
+     "a" => ArboristNode {
+       "name": "a",
+-      "version": "1.2.0",
++      "version": "1.1.0",
+       "location": "node_modules/a",
+       "path": "/some/path/node_modules/a",
+       "extraneous": true,
+
+`
+
+exports[`test/place-dep.js TAP placement tests audit fix replaces a vulnerable dep with an older safe version > placements 1`] = `
+Array [
+  Object {
+    "canPlace": Symbol(REPLACE),
+    "canPlaceSelf": Symbol(REPLACE),
+    "checks": Map {
+      "" => Array [
+        Symbol(REPLACE),
+        Symbol(REPLACE),
+      ],
+    },
+    "dep": "a@1.1.0",
+    "edge": "{ ROOT prod a@^1.0.0 }",
+    "placed": "node_modules/a",
+  },
+]
+`
+
+exports[`test/place-dep.js TAP placement tests audit fix replaces a vulnerable dep with an older safe version > warnings 1`] = `
+Array []
+`
+
 exports[`test/place-dep.js TAP placement tests basic placement of a production dep > changes to tree 1`] = `
 --- expected
 +++ actual

--- a/workspaces/arborist/test/arborist/audit.js
+++ b/workspaces/arborist/test/arborist/audit.js
@@ -22,6 +22,11 @@ const createRegistry = (t) => {
   return registry
 }
 
+const mockPackage = (registry, name, packuments, times = 1) => registry.package({
+  manifest: registry.manifest({ name, packuments }),
+  times,
+})
+
 t.test('audit finds the bad deps', async t => {
   const path = resolve(fixtures, 'deprecated-dep')
   const registry = createRegistry(t, false)
@@ -158,4 +163,141 @@ t.test('audit with workspaces disabled', async t => {
 
   const auditReport = await newArb(path, { workspacesEnabled: false }).audit()
   t.notOk(auditReport.get('mkdirp'))
+})
+
+t.test('audit fix installs the highest safe version within the dependency range', async t => {
+  const path = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'audit-safe-downgrade',
+      version: '1.0.0',
+      devDependencies: { a: '^1.0.0' },
+    }),
+    'package-lock.json': JSON.stringify({
+      name: 'audit-safe-downgrade',
+      version: '1.0.0',
+      lockfileVersion: 3,
+      requires: true,
+      packages: {
+        '': {
+          name: 'audit-safe-downgrade',
+          version: '1.0.0',
+          devDependencies: { a: '^1.0.0' },
+        },
+        'node_modules/a': {
+          version: '1.0.0',
+          dev: true,
+          dependencies: { b: '~1.0.0' },
+        },
+        'node_modules/b': {
+          version: '1.0.2',
+          dev: true,
+        },
+      },
+    }),
+  })
+
+  const registry = createRegistry(t)
+  registry.audit({
+    results: {
+      b: [{
+        id: 1,
+        url: 'https://example.test/advisories/1',
+        title: 'Test vulnerability in b',
+        severity: 'low',
+        vulnerable_versions: '>=1.0.2 <1.1.0',
+      }],
+    },
+    times: 2,
+  })
+  const bPackuments = [
+    { version: '1.0.1' },
+    { version: '1.0.2' },
+    { version: '1.1.0' },
+  ]
+  const aPackuments = [
+    { version: '1.0.0', dependencies: { b: '~1.0.0' } },
+    { version: '1.1.0', dependencies: { b: '~1.1.0' } },
+  ]
+  await mockPackage(registry, 'b', bPackuments, 3)
+  await mockPackage(registry, 'a', aPackuments)
+
+  const tree = await newArb(path, { packageLockOnly: true }).audit({ fix: true })
+
+  t.equal(tree.children.get('a').version, '1.0.0',
+    'did not need to update the non-vulnerable parent')
+  t.equal(tree.children.get('b').version, '1.0.1',
+    'installed the highest safe version inside ~1.0.0')
+})
+
+t.test('audit fix removes a vulnerable transitive dependency with a safe downgrade', async t => {
+  const path = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'audit-metavuln-downgrade',
+      version: '1.0.0',
+      devDependencies: { a: '^1.0.0' },
+    }),
+    'package-lock.json': JSON.stringify({
+      name: 'audit-metavuln-downgrade',
+      version: '1.0.0',
+      lockfileVersion: 3,
+      requires: true,
+      packages: {
+        '': {
+          name: 'audit-metavuln-downgrade',
+          version: '1.0.0',
+          devDependencies: { a: '^1.0.0' },
+        },
+        'node_modules/a': {
+          version: '1.0.0',
+          dev: true,
+          dependencies: { b: '^1.0.0' },
+        },
+        'node_modules/b': {
+          version: '1.2.0',
+          dev: true,
+          dependencies: { c: '^1.0.0' },
+        },
+        'node_modules/c': {
+          version: '1.0.0',
+          dev: true,
+        },
+      },
+    }),
+  })
+
+  const registry = createRegistry(t)
+  registry.audit({
+    results: {
+      c: [{
+        id: 2,
+        url: 'https://example.test/advisories/2',
+        title: 'Test vulnerability in c',
+        severity: 'moderate',
+        vulnerable_versions: '<2.0.0',
+      }],
+    },
+    times: 2,
+  })
+  const cPackuments = [
+    { version: '1.0.0' },
+  ]
+  const bPackuments = [
+    { version: '1.0.0' },
+    { version: '1.2.0', dependencies: { c: '^1.0.0' } },
+  ]
+  const aPackuments = [
+    { version: '1.0.0', dependencies: { b: '^1.0.0' } },
+  ]
+  await mockPackage(registry, 'c', cPackuments, 2)
+  await mockPackage(registry, 'b', bPackuments, 2)
+  await mockPackage(registry, 'a', aPackuments)
+
+  const tree = await newArb(path, { packageLockOnly: true }).audit({ fix: true })
+
+  t.equal(tree.children.get('a').version, '1.0.0',
+    'left the top-level package unchanged')
+  t.equal(tree.children.get('b').version, '1.0.0',
+    'installed the safe version inside ^1.0.0')
+  t.notOk(tree.children.has('c'),
+    'pruned the dependency that caused the metavulnerability')
 })

--- a/workspaces/arborist/test/can-place-dep.js
+++ b/workspaces/arborist/test/can-place-dep.js
@@ -35,6 +35,8 @@ t.test('basic placement check tests', t => {
     peerSet,
     // is this dep the thing that the user is explicitly installing?
     explicitRequest,
+    // an audit report, telling us which nodes are vulnerable
+    auditReport,
   }) => {
     const target = tree.inventory.get(targetLoc)
     const node = tree.inventory.get(nodeLoc)
@@ -74,6 +76,7 @@ t.test('basic placement check tests', t => {
         dep,
         preferDedupe,
         explicitRequest,
+        auditReport,
       })
       // dump a comment if the assertion fails.
       // would put it in the diags, but yaml stringifies Set objects
@@ -300,6 +303,95 @@ t.test('basic placement check tests', t => {
     nodeLoc: 'node_modules/c',
     dep: new Node({ pkg: { name: 'b', version: '2.0.0' } }),
     expect: REPLACE,
+    preferDedupe: true,
+  })
+
+  runTest('replace a vulnerable dep with an older safe audit candidate', {
+    tree: new Node({
+      path,
+      pkg: {
+        name: 'project',
+        version: '1.0.0',
+        dependencies: { a: '^1.0.0' },
+      },
+      children: [{ pkg: { name: 'a', version: '1.2.0' } }],
+    }),
+    targetLoc: '',
+    nodeLoc: '',
+    dep: new Node({ pkg: { name: 'a', version: '1.1.0' } }),
+    auditReport: {
+      isVulnerable: node => node.name === 'a' && node.version === '1.2.0',
+    },
+    expect: REPLACE,
+  })
+
+  runTest('keep a newer dep when an older candidate is not an audit remediation', {
+    tree: new Node({
+      path,
+      pkg: {
+        name: 'project',
+        version: '1.0.0',
+        dependencies: { a: '^1.0.0' },
+      },
+      children: [{ pkg: { name: 'a', version: '1.2.0' } }],
+    }),
+    targetLoc: '',
+    nodeLoc: '',
+    dep: new Node({ pkg: { name: 'a', version: '1.1.0' } }),
+    expect: KEEP,
+  })
+
+  runTest('keep a vulnerable dep when the older audit candidate is also vulnerable', {
+    tree: new Node({
+      path,
+      pkg: {
+        name: 'project',
+        version: '1.0.0',
+        dependencies: { a: '^1.0.0' },
+      },
+      children: [{ pkg: { name: 'a', version: '1.2.0' } }],
+    }),
+    targetLoc: '',
+    nodeLoc: '',
+    dep: new Node({ pkg: { name: 'a', version: '1.1.0' } }),
+    auditReport: {
+      isVulnerable: node =>
+        node.name === 'a' && (node.version === '1.2.0' || node.version === '1.1.0'),
+    },
+    expect: KEEP,
+  })
+
+  runTest('audit downgrade still respects peer conflicts', {
+    tree: new Node({
+      path,
+      pkg: {
+        name: 'project',
+        version: '1.0.0',
+        dependencies: { a: '1', c: '2.0.0' },
+      },
+      children: [
+        { pkg: { name: 'b', version: '2.3.4' } },
+        { pkg: { name: 'c', version: '2.0.0', dependencies: { b: '2.0.0' } } },
+        { pkg: { name: 'a', version: '1.2.3', dependencies: { b: '2' } } },
+      ],
+    }),
+    targetLoc: '',
+    nodeLoc: 'node_modules/c',
+    dep: new Node({
+      pkg: {
+        name: 'b',
+        version: '2.0.0',
+        peerDependencies: { a: '3' },
+      },
+    }),
+    peerSet: [
+      { pkg: { name: 'a', version: '3.0.0' } },
+    ],
+    auditReport: {
+      isVulnerable: node => node.name === 'b' && node.version === '2.3.4',
+    },
+    expect: CONFLICT,
+    expectSelf: REPLACE,
     preferDedupe: true,
   })
 

--- a/workspaces/arborist/test/place-dep.js
+++ b/workspaces/arborist/test/place-dep.js
@@ -484,6 +484,27 @@ t.test('placement tests', t => {
     },
   })
 
+  runTest('audit fix replaces a vulnerable dep with an older safe version', {
+    tree: new Node({
+      path,
+      pkg: {
+        name: 'project',
+        version: '1.0.0',
+        dependencies: { a: '^1.0.0' },
+      },
+      children: [{ pkg: { name: 'a', version: '1.2.0' } }],
+    }),
+    nodeLoc: '',
+    dep: new Node({ pkg: { name: 'a', version: '1.1.0' } }),
+    auditReport: {
+      isVulnerable: node => node.name === 'a' && node.version === '1.2.0',
+    },
+    test: (t, tree) => {
+      t.equal(tree.children.get('a').version, '1.1.0',
+        'installed the older non-vulnerable candidate')
+    },
+  })
+
   // root -> (a@1, b)
   // +-- a@1.0.0
   // +-- b -> (c@link:c, a@1.1)


### PR DESCRIPTION
## What / Why

`npm audit` can report that a fix is available through `npm audit fix` when the highest safe version inside the declared dependency range is older than the installed version.

Arborist already selects that safe candidate using the advisory range, but `CanPlaceDep` rejects it because replacement candidates normally must be newer than the installed version. This causes `npm audit fix` to complete without applying the advertised remediation.

## How

- Pass the existing audit report from `PlaceDep` into `CanPlaceDep` and recursive peer placement checks.
- Permit an older candidate only when:
  - the installed node is vulnerable;
  - the candidate is not vulnerable; and
  - the candidate passes the existing replacement and peer dependency checks.
- Preserve existing no-downgrade behavior for ordinary installs and updates.
- Add synthetic, strictly mocked regressions covering:
  - compatible safe downgrades;
  - non-audit placement;
  - still-vulnerable candidates;
  - peer conflicts;
  - actual tree replacement; and
  - metavulnerability removal by pruning a vulnerable transitive dependency.

This does not change audit reporting or `--force` behavior. Fixes outside declared dependency ranges still require `npm audit fix --force`.

## Testing

- Focused Arborist placement and audit tests
- npm command-level audit tests

## References

Fixes #9557  
Fixes #9718