### PR TITLE
docs: mention lifecycle script blocking in npm 12 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * allow-git and allow-remote now default to "none"; set them to "all" (or "root") to install git or user-supplied tarball-URL dependencies.
 * root \`preinstall\` now runs before dependencies are installed.
 * unknown configs in .npmrc, unknown CLI flags, abbreviated flags, and single-hyphen multi-char shorthands now throw instead of warning.
+* lifecycle scripts not covered by `allowScripts` are now blocked by default instead of executing with a warning. Projects relying on package lifecycle scripts may need to explicitly allow those scripts in their configuration.
 ### Chores
 * [`b77b532`](https://github.com/npm/cli/commit/b77b5321bd6dc8d4c028b89f3e4bc9c9a2209f8f) [#9735](https://github.com/npm/cli/pull/9735) remove pre-release mode from npm 12 and workspaces (#9735) (@reggi, @Copilot)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 * allow-git and allow-remote now default to "none"; set them to "all" (or "root") to install git or user-supplied tarball-URL dependencies.
 * root \`preinstall\` now runs before dependencies are installed.
 * unknown configs in .npmrc, unknown CLI flags, abbreviated flags, and single-hyphen multi-char shorthands now throw instead of warning.
-* lifecycle scripts not covered by `allowScripts` are now blocked by default instead of executing with a warning. Projects relying on package lifecycle scripts may need to explicitly allow those scripts in their configuration.
+* Lifecycle scripts not covered by `allowScripts` are now blocked by default instead of executing with a warning. To allow them for project installs, add entries to `package.json#allowScripts` via `npm install-scripts approve`. For global installs, use the `--allow-scripts` flag or set `allow-scripts` in `.npmrc`.
 ### Chores
 * [`b77b532`](https://github.com/npm/cli/commit/b77b5321bd6dc8d4c028b89f3e4bc9c9a2209f8f) [#9735](https://github.com/npm/cli/pull/9735) remove pre-release mode from npm 12 and workspaces (#9735) (@reggi, @Copilot)
 


### PR DESCRIPTION
## Summary

Document the npm v12 behavior change where lifecycle scripts not covered by `allowScripts` are now blocked by default instead of executing with a warning.

This update adds a note to the release documentation to make users aware that projects relying on package lifecycle scripts may need to explicitly allow those scripts in their configuration.

Fixes #9750
