### PR TITLE
docs: clarify devDependencies installation for git protocol

### DIFF
--- a/docs/lib/content/using-npm/scripts.md
+++ b/docs/lib/content/using-npm/scripts.md
@@ -46,7 +46,7 @@ during `npm publish` and `npm pack`
 * Runs AFTER `prepublishOnly` and `prepack`, but BEFORE `postpack`
 * Runs for a package if it's being installed as a link through `npm install <folder>`
 
-* NOTE: If a package being installed through git contains a `prepare` script, its `dependencies` and `devDependencies` will be installed, and the prepare script will be run, before the package is packaged and installed.
+* NOTE: If a package being installed through git contains a `prepare` or `prepack` script, its `dependencies` and `devDependencies` will be installed, and the prepare script will be run, before the package is packaged and installed. See [A Note on Git Dependencies](#a-note-on-git-dependencies) for more details.
 
 * As of `npm@7` these scripts run in the background.
   To see the output, run with: `--foreground-scripts`.
@@ -213,6 +213,15 @@ If there is a `server.js` file in the root of your package, then npm will defaul
 * `preversion`
 * `version`
 * `postversion`
+#### A Note on Git Dependencies
+
+When installing a package through the git protocol (e.g., `npm install <git-url>`), the process differs from installing a published package from the registry. npm (via `pacote`) clones the repository and runs a local `npm install` inside the cloned directory to prepare the environment.
+
+This local installation will install **both `dependencies` and `devDependencies`**. This happens regardless of the scripts present, because npm needs the full dependency tree—including build tools defined in `devDependencies`—to successfully run the package's lifecycle scripts.
+
+After this full installation, npm triggers the `prepack` and `prepare` lifecycle scripts to build the package. Once the scripts complete, npm packs the built result into a tarball and installs it into your project's `node_modules` directory.
+
+
 
 #### A Note on a lack of [`npm uninstall`](/commands/npm-uninstall) scripts
 


### PR DESCRIPTION
<!-- What / Why -->
This PR clarifies the documentation around how `devDependencies` are installed when a package is installed via the git protocol.

Previously, the docs only mentioned that a `prepare` script would trigger the installation of `dependencies` and `devDependencies`. However, the actual code implementation in `pacote/lib/git.js` triggers this behavior during other lifecycle stages (like `prepack`) as well, since the package needs to be built from source. 

<!-- Describe the request in detail. What it does and why it's being changed. -->

-Updated the `NOTE` under the `prepare` section to mention `prepack` and link to a new explanatory section.

- Added a new section `#### A Note on Git Dependencies` detailing why both `dependencies` and `devDependencies` are installed (to provide build tools) and which lifecycle stages trigger this.


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes  #7328 
-->
