### PR TITLE
fix(config): redact proxy environment credentials

### DIFF
--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -353,7 +353,7 @@ ${defData}
         const lowerKey = key.toLowerCase()
         if (proxyEnv.includes(lowerKey) && !foundEnvVars.has(lowerKey)) {
           foundEnvVars.add(lowerKey)
-          envVars.push(`; ${key} = ${JSON.stringify(process.env[key])}`)
+          envVars.push(`; ${key} = ${JSON.stringify(redact(process.env[key]))}`)
         }
       }
 

--- a/test/lib/commands/config.js
+++ b/test/lib/commands/config.js
@@ -122,7 +122,7 @@ t.test('config list with proxy environment variables', async t => {
     }
   })
 
-  process.env.HTTP_PROXY = 'http://proxy.example.com:8080'
+  process.env.HTTP_PROXY = 'http://proxy-user:proxy-password@proxy.example.com:8080'
   process.env.HTTPS_PROXY = 'https://secure-proxy.example.com:8443'
   process.env.NO_PROXY = 'localhost,127.0.0.1'
 
@@ -136,7 +136,8 @@ t.test('config list with proxy environment variables', async t => {
 
   const output = joinedOutput()
 
-  t.match(output, 'HTTP_PROXY = "http://proxy.example.com:8080"')
+  t.match(output, 'HTTP_PROXY = "http://proxy-user:***@proxy.example.com:8080"')
+  t.notMatch(output, 'proxy-password')
   t.match(output, 'HTTPS_PROXY = "https://secure-proxy.example.com:8443"')
   t.match(output, 'NO_PROXY = "localhost,127.0.0.1"')
   t.match(output, 'environment-related config')


### PR DESCRIPTION
## Summary

- redact credentials when `npm config list` displays proxy-related environment variables
- cover a proxy URL containing username and password, and assert the raw password never appears

## Root cause

The environment-variable section rendered values with `JSON.stringify` directly, bypassing the `redact` helper already used by regular config entries.

Fixes #9773

## Validation

- `node_modules\\.bin\\tap.cmd --no-coverage test\\lib\\commands\\config.js`
- `node . run eslint -- lib/commands/config.js test/lib/commands/config.js`
- `git diff --check`

`node . run test` was also run. Its unrelated Windows baseline failures are caused by Node v24.14.0 being below this checkout's supported v24.15.0 minimum (extra engine-warning stderr), missing `touch`, and the suite's 100% global coverage gate.