### PR TITLE
fix: deterministic lockfile and process reaping for lifecycle scripts

### DIFF
--- a/node_modules/@npmcli/run-script/lib/make-spawn-args.js
+++ b/node_modules/@npmcli/run-script/lib/make-spawn-args.js
@@ -44,6 +44,10 @@ const makeSpawnArgs = options => {
     stdio,
     cwd: path,
     shell: scriptShell,
+    // When the subprocess inherits stdio, detach it into its own process
+    // group so the signal manager can kill the entire tree (child + any
+    // grandchildren like webpack workers) in one process.kill(-pid, sig).
+    detached: stdio === 'inherit',
   }
 
   return [cmd, args, spawnOpts]

--- a/node_modules/@npmcli/run-script/lib/run-script-pkg.js
+++ b/node_modules/@npmcli/run-script/lib/run-script-pkg.js
@@ -74,7 +74,7 @@ const runScriptPkg = async options => {
     path,
   })
 
-  if (stdio === 'inherit') {
+  if (p.process) {
     signalManager.add(p.process)
   }
 

--- a/node_modules/@npmcli/run-script/lib/signal-manager.js
+++ b/node_modules/@npmcli/run-script/lib/signal-manager.js
@@ -11,7 +11,17 @@ const forwardedSignals = [
 // to ourselves. see the catch handler at the bottom of run-script-pkg.js
 const handleSignal = signal => {
   for (const proc of runningProcs) {
-    proc.kill(signal)
+    // Kill the entire process group rooted at the child so that
+    // grandchildren (e.g. webpack-dev-server -> workers) are also
+    // terminated, preventing ghost processes that hold ports.
+    // Negated pid targets the process group; fall back to the direct
+    // child when the group does not exist or on platforms where
+    // process-group signalling is unsupported (Windows).
+    try {
+      process.kill(-proc.pid, signal)
+    } catch {
+      proc.kill(signal)
+    }
   }
 }
 

--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -487,7 +487,6 @@ module.exports = cls => class IdealTreeBuilder extends cls {
           visit: node => {
             for (const edge of node.edgesOut.values()) {
               const skipPeerOptional = edge.type === 'peerOptional' &&
-                this.options.save === false &&
                 !this.#requestedTreeMutation
               if (!skipPeerOptional && (!edge.to || !edge.valid)) {
                 this.#depsQueue.push(node)
@@ -1180,16 +1179,13 @@ This is a one-time fix-up, please be patient...
               }
               const { from, valid, peerConflicted } = edgeIn
               if (!peerConflicted && !valid) {
-                if (this.#depsSeen.has(from) &&
-                  (this.options.save ||
-                    (this.options.save === false && this.#requestedTreeMutation))) {
+                if (this.#depsSeen.has(from) && this.#requestedTreeMutation) {
                   // Re-queue already-processed nodes when a newly placed dep
-                  // creates an invalid edge during npm install or another
-                  // lockfile-mutating operation. This handles the case where a
-                  // peerOptional dep was valid (missing) when the node was
-                  // first processed, but becomes invalid when the dep is later
-                  // placed by another path with a version that doesn't satisfy
-                  // the peer spec.
+                  // creates an invalid edge during an explicit tree mutation.
+                  // This handles the case where a peerOptional dep was valid
+                  // (missing) when the node was first processed, but becomes
+                  // invalid when the dep is later placed by another path with
+                  // a version that doesn't satisfy the peer spec.
                   // See npm/cli#8726.
                   this.#depsSeen.delete(from)
                   this.#depsQueue.push(from)
@@ -1396,15 +1392,12 @@ This is a one-time fix-up, please be patient...
       }
 
       // If the edge has an error, there's a problem, unless it's peerOptional
-      // and we're not saving or otherwise mutating (e.g. npm ci), in which
-      // case we trust the lockfile and skip re-resolution. When saving (npm
-      // install) or updating, peerOptional invalid edges ARE treated as
-      // problems so the lockfile gets fixed.
-      // See npm/cli#8726.
+      // and the user did not explicitly request a tree mutation (--add, --rm,
+      // --update, audit fix). For a no-op install we trust the lockfile and
+      // skip re-resolution so the lockfile stays stable across identical runs.
+      // See npm/cli#8726, npm/cli#9776.
       if (!edge.valid) {
-        if (edge.type !== 'peerOptional' ||
-          this.options.save !== false ||
-          this.#requestedTreeMutation) {
+        if (edge.type !== 'peerOptional' || this.#requestedTreeMutation) {
           problems.push(edge)
         }
         continue


### PR DESCRIPTION
## Description

### What

Two distinct bugs in the npm lifecycle that cause non-deterministic installs and ghost processes:

1. **Silent lockfile mutations**: `package-lock.json` hash changes between identical `npm install` runs with no changes to `package.json`, because peerOptional dependency edges are unconditionally re-resolved from the registry.
2. **Ghost processes (inadequate reaping)**: After `npm run start` and Ctrl+C, lingering `node`/`webpack` processes hold ports (EADDRINUSE). The signal manager only kills direct children — grandchildren survive. Install-time lifecycle scripts running with `stdio: 'pipe'` are never tracked by the signal manager, so interrupting `npm install` during the build phase also orphans subprocesses.

### Where

**Lockfile integrity** — `workspaces/arborist/lib/arborist/build-ideal-tree.js` in three locations:

| Location | Line | Old gate |
|---|---|---|
| `#initTree()` — virtual tree edge validation | ~489 | `this.options.save === false` |
| `#problemEdges()` — edge problem detection | ~1400 | `this.options.save !== false` |
| PlaceDep visitor — node re-queuing | ~1182 | `this.options.save \|\| (...)` |

**Process reaping** — `node_modules/@npmcli/run-script/lib/` in three files:

| File | Line | Problem |
|---|---|---|
| `signal-manager.js` | 13 | `proc.kill(signal)` only kills direct child |
| `run-script-pkg.js` | 77 | `signalManager.add()` gated on `stdio === 'inherit'` |
| `make-spawn-args.js` | 41 | No `detached` option in spawn |

### How

**Lockfile integrity**: Replaced `this.options.save` with `this.#requestedTreeMutation` in all three locations. `#requestedTreeMutation` is `true` only when the user explicitly asks for changes (`--add`, `--rm`, `--update`, `npm audit fix`). For a bare `npm install` with no arguments, it's `false`, and the code trusts the lockfile rather than re-resolving peerOptional edges.

**Process reaping**:
- `signal-manager.js`: Changed `handleSignal` to call `process.kill(-proc.pid, signal)` which targets the entire process group, with try/catch fallback to `proc.kill(signal)` for platforms or edge cases where process-group signalling is unsupported.
- `make-spawn-args.js`: Added `detached: true` to spawn options when `stdio === 'inherit'`, so the child becomes its own process-group leader (required for `-pid` to work).
- `run-script-pkg.js`: Removed the `stdio === 'inherit'` gate on `signalManager.add()` so that all subprocesses — including install-time lifecycle scripts running with `stdio: 'pipe'` — are tracked and terminated when signals arrive.

### Why this method over others

**Lockfile**: `#requestedTreeMutation` already existed in the codebase and was wired to `--add`, `--rm`, and `--update`. It precisely captures "did the user ask for changes?" — which is what should gate re-resolution — versus `save` which captures "should the lockfile be written?". The fix is a one-term removal from three conditions, reusing existing infrastructure with no new state.

**Process reaping**: The `detached` + `-pid` pattern is the standard Unix mechanism for tree-kill. `detached: true` creates a new process group with the child as leader, and `process.kill(-pid, signal)` atomically terminates every process in that group — the shell, `webpack-dev-server`, and all its workers. The try/catch fallback preserves existing behavior when no process group exists (e.g. on Windows). Alternatives considered: tree-kill libraries (adds a dependency), `taskkill /T` (Windows-only), iterating `/proc` (non-portable, racy).

### How to test

**Lockfile stability**:
```bash
rm -rf node_modules package-lock.json
npm ci
cp package-lock.json package-lock.bak
npm install                              # no changes to package.json
diff package-lock.json package-lock.bak  # should be empty
```

**Process reaping**:
```bash
npm run start &
sleep 3
kill -INT %1                             # Ctrl+C
ps aux | grep -E "webpack|node"          # no lingering processes
npm run start                            # no EADDRINUSE
```

**Idempotent install**:
```bash
npm install && sha256sum package-lock.json > hash1
npm install && sha256sum package-lock.json > hash2
diff hash1 hash2                         # should be empty
```

---

## References

Fixes: #9776