### PR TITLE
fix(cli): scope install-scripts warning to packages touched by this reify

### DIFF
--- a/lib/utils/reify-finish.js
+++ b/lib/utils/reify-finish.js
@@ -5,10 +5,12 @@ const ini = require('ini')
 const { writeFile } = require('node:fs/promises')
 const { resolve } = require('node:path')
 
-// Collect the set of node locations touched (added or changed) by this reify
-// run, using arb.diff. Pre-existing untouched packages don't run their install
-// scripts this run, so we shouldn't flag them as "blocked" (npm/cli#9797).
-const collectTouchedLocations = (diff) => {
+// Collect the set of node locations that reify will build. Most build
+// candidates are added or changed diff nodes, but reify also rebuilds directly
+// managed links in diff.unchanged (see Arborist's _build()). For links, the
+// build candidate is the target node returned by checkAllowScripts, not only
+// the link location in the diff.
+const collectBuildCandidateLocations = (diff) => {
   const touched = new Set()
   if (!diff) {
     return null
@@ -17,15 +19,29 @@ const collectTouchedLocations = (diff) => {
   while (stack.length) {
     const d = stack.pop()
     if (d.action === 'ADD' || d.action === 'CHANGE') {
-      const location = d.ideal?.location
-      if (location != null) {
-        touched.add(location)
+      const ideal = d.ideal
+      for (const location of [ideal?.location, ideal?.target?.location]) {
+        if (location != null) {
+          touched.add(location)
+        }
       }
     }
     if (d.children?.length) {
       for (const child of d.children) {
         if (child) {
           stack.push(child)
+        }
+      }
+    }
+  }
+  for (const node of diff.unchanged || []) {
+    const root = node?.root?.target
+    const linkedFromRoot = node?.isLink &&
+      ((node.parent === root && !node.inert) || node.target?.fsTop === root)
+    if (linkedFromRoot) {
+      for (const location of [node.location, node.target?.location]) {
+        if (location != null) {
+          touched.add(location)
         }
       }
     }
@@ -49,7 +65,7 @@ const reifyFinish = async (npm, arb) => {
   const allUnreviewed = await checkAllowScripts({ arb, npm })
   // Only warn about install scripts on packages this reify actually touched;
   // untouched pre-existing packages don't run scripts here (npm/cli#9797).
-  const touched = collectTouchedLocations(arb.diff)
+  const touched = collectBuildCandidateLocations(arb.diff)
   const unreviewedScripts = touched
     ? allUnreviewed.filter(({ node }) => touched.has(node.location))
     : allUnreviewed

--- a/lib/utils/reify-finish.js
+++ b/lib/utils/reify-finish.js
@@ -5,6 +5,34 @@ const ini = require('ini')
 const { writeFile } = require('node:fs/promises')
 const { resolve } = require('node:path')
 
+// Collect the set of node locations touched (added or changed) by this reify
+// run, using arb.diff. Pre-existing untouched packages don't run their install
+// scripts this run, so we shouldn't flag them as "blocked" (npm/cli#9797).
+const collectTouchedLocations = (diff) => {
+  const touched = new Set()
+  if (!diff) {
+    return null
+  }
+  const stack = [diff]
+  while (stack.length) {
+    const d = stack.pop()
+    if (d.action === 'ADD' || d.action === 'CHANGE') {
+      const location = d.ideal?.location
+      if (location != null) {
+        touched.add(location)
+      }
+    }
+    if (d.children?.length) {
+      for (const child of d.children) {
+        if (child) {
+          stack.push(child)
+        }
+      }
+    }
+  }
+  return touched
+}
+
 const reifyFinish = async (npm, arb) => {
   // if we are using a builtin config, and just installed npm as a top-level global package, we have to preserve that config.
   if (arb.options.global) {
@@ -18,7 +46,13 @@ const reifyFinish = async (npm, arb) => {
     }
   }
   warnWorkspaceAllowScripts(arb.actualTree)
-  const unreviewedScripts = await checkAllowScripts({ arb, npm })
+  const allUnreviewed = await checkAllowScripts({ arb, npm })
+  // Only warn about install scripts on packages this reify actually touched;
+  // untouched pre-existing packages don't run scripts here (npm/cli#9797).
+  const touched = collectTouchedLocations(arb.diff)
+  const unreviewedScripts = touched
+    ? allUnreviewed.filter(({ node }) => touched.has(node.location))
+    : allUnreviewed
   reifyOutput(npm, arb, { unreviewedScripts })
 }
 

--- a/test/lib/utils/reify-finish.js
+++ b/test/lib/utils/reify-finish.js
@@ -11,7 +11,14 @@ const readRc = async (dir) => {
   return cleanNewlines(res).trim()
 }
 
-const mockReififyFinish = async (t, { actualTree = {}, otherDirs = {}, ...config }) => {
+const mockReififyFinish = async (t, {
+  actualTree = {},
+  otherDirs = {},
+  diff,
+  unreviewedNodes,
+  captureReifyOutput,
+  ...config
+} = {}) => {
   const mock = await mockNpm(t, {
     npm: ({ other }) => ({
       npmRoot: other,
@@ -23,12 +30,18 @@ const mockReififyFinish = async (t, { actualTree = {}, otherDirs = {}, ...config
     config,
   })
 
-  const reifyFinish = tmock(t, '{LIB}/utils/reify-finish.js', {
-    '{LIB}/utils/reify-output.js': () => {},
-  })
+  const mocks = {
+    '{LIB}/utils/reify-output.js': captureReifyOutput || (() => {}),
+  }
+  if (unreviewedNodes !== undefined) {
+    mocks['{LIB}/utils/check-allow-scripts.js'] = async () =>
+      unreviewedNodes.map((node) => ({ node, scripts: { install: 'x' } }))
+  }
+  const reifyFinish = tmock(t, '{LIB}/utils/reify-finish.js', mocks)
 
   await reifyFinish(mock.npm, {
     options: { global: mock.npm.global },
+    diff,
     actualTree: typeof actualTree === 'function' ? actualTree(mock) : actualTree,
   })
 
@@ -92,4 +105,63 @@ t.test('should write if everything above passes', async t => {
 
   const newFile = await readRc(join(mock.other, 'new-npm'))
   t.equal(mock.builtinRc.raw, newFile)
+})
+
+t.test('unreviewedScripts filtered to nodes touched by this reify (npm/cli#9797)', async t => {
+  const captured = []
+  const touched = { location: 'node_modules/touched', name: 'touched' }
+  const untouched = { location: 'node_modules/untouched', name: 'untouched' }
+  await mockReififyFinish(t, {
+    global: false,
+    unreviewedNodes: [touched, untouched],
+    diff: {
+      children: [
+        { action: 'ADD', ideal: touched, children: [] },
+        { action: 'REMOVE', actual: { location: 'node_modules/removed' }, children: [] },
+      ],
+    },
+    captureReifyOutput: (_npm, _arb, extras) => captured.push(extras),
+  })
+  t.equal(captured.length, 1)
+  t.equal(captured[0].unreviewedScripts.length, 1,
+    'untouched package is filtered out; only touched package is warned about')
+  t.equal(captured[0].unreviewedScripts[0].node.name, 'touched')
+})
+
+t.test('unreviewedScripts pass through when there is no diff (defensive)', async t => {
+  const captured = []
+  const a = { location: 'node_modules/a', name: 'a' }
+  await mockReififyFinish(t, {
+    global: false,
+    unreviewedNodes: [a],
+    captureReifyOutput: (_npm, _arb, extras) => captured.push(extras),
+  })
+  t.equal(captured[0].unreviewedScripts.length, 1)
+})
+
+t.test('diff walker handles CHANGE, nested children, and nullish diff entries', async t => {
+  const captured = []
+  const changed = { location: 'node_modules/changed', name: 'changed' }
+  const nested = { location: 'node_modules/nested', name: 'nested' }
+  const untouched = { location: 'node_modules/untouched', name: 'untouched' }
+  await mockReififyFinish(t, {
+    global: false,
+    unreviewedNodes: [changed, nested, untouched],
+    diff: {
+      children: [
+        null,
+        { action: 'CHANGE', ideal: changed, children: [] },
+        {
+          action: 'ADD',
+          ideal: { location: null },
+          children: [
+            { action: 'ADD', ideal: nested },
+          ],
+        },
+      ],
+    },
+    captureReifyOutput: (_npm, _arb, extras) => captured.push(extras),
+  })
+  const names = captured[0].unreviewedScripts.map(u => u.node.name).sort()
+  t.strictSame(names, ['changed', 'nested'])
 })

--- a/test/lib/utils/reify-finish.js
+++ b/test/lib/utils/reify-finish.js
@@ -165,3 +165,28 @@ t.test('diff walker handles CHANGE, nested children, and nullish diff entries', 
   const names = captured[0].unreviewedScripts.map(u => u.node.name).sort()
   t.strictSame(names, ['changed', 'nested'])
 })
+
+t.test('build candidates include link targets and directly managed unchanged links', async t => {
+  const captured = []
+  const link = { location: 'node_modules/foo', name: 'foo', isLink: true }
+  const linkTarget = { location: 'packages/foo', name: 'foo-target' }
+  link.target = linkTarget
+  const unchangedLink = { location: 'node_modules/bar', name: 'bar', isLink: true }
+  const unchangedTarget = { location: 'packages/bar', name: 'bar-target', fsTop: '/project' }
+  unchangedLink.target = unchangedTarget
+  const root = { target: { location: '', fsTop: '/project' } }
+  unchangedLink.root = root
+  unchangedLink.parent = root.target
+  const untouched = { location: 'node_modules/untouched', name: 'untouched' }
+  await mockReififyFinish(t, {
+    global: false,
+    unreviewedNodes: [linkTarget, unchangedTarget, untouched],
+    diff: {
+      children: [{ action: 'ADD', ideal: link, children: [] }],
+      unchanged: [unchangedLink],
+    },
+    captureReifyOutput: (_npm, _arb, extras) => captured.push(extras),
+  })
+  const names = captured[0].unreviewedScripts.map(u => u.node.name).sort()
+  t.strictSame(names, ['bar-target', 'foo-target'])
+})


### PR DESCRIPTION
## Description

`npm update -g <pkg>` (and other partial installs) warns about install scripts that are "blocked" on pre-existing global packages that this run never touched. Example from the issue:

```
$ npm install -g --allow-scripts=opencode-ai opencode-ai
$ npm install -g --allow-scripts=yarn yarn
$ npm update -g --allow-scripts=opencode-ai opencode-ai
npm warn install-scripts 1 package had install scripts blocked because they are not covered by allowScripts:
npm warn install-scripts   yarn@1.22.22 (preinstall: ...)
```

`yarn` is already installed, already sitting on disk, and `npm update -g opencode-ai` is not going to run its scripts this session. It gets flagged only because `checkAllowScripts` walks the entire `actualTree` after reify.

The strict-allow-scripts preflight is intentionally whole-tree (it hard-fails installs), so I left that alone. This change only tightens the advisory warning shown after a successful reify.

### Fix

In `lib/utils/reify-finish.js`, after collecting unreviewed nodes, filter them against the set of locations that appear as `ADD` or `CHANGE` in `arb.diff`. Untouched packages don't run install scripts this reify, so we don't flag them. When there is no diff (defensive fallback), behavior is unchanged.

## Existing Issue

Fixes #9797

## Screenshots

Not applicable, terminal warning output change only.

## Test Coverage

Added three new subtests to `test/lib/utils/reify-finish.js`:

- unreviewed packages are filtered to nodes actually touched by this reify (added / changed) so untouched globals are no longer warned about
- when `arb.diff` is absent, behavior falls back to the previous whole-tree list
- the diff walker traverses `CHANGE` actions, nested children, and tolerates nullish diff entries

I verified both directions: the new tests fail on `main` (untouched packages still leak through) and pass with this patch. `reify-finish.js` stays at 100% line / branch / function / statement coverage. Only changed files were linted (eslint clean).

## AI disclosure

This change was written with the assistance of Claude. I have reviewed the diff and the tests and take responsibility for the code.
