### PR TITLE
docs: clarify npm 12 unknown-config breaking change in changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 * `npm` now supports node `^22.22.2 || ^24.15.0 || >=26.0.0`
 * allow-git and allow-remote now default to "none"; set them to "all" (or "root") to install git or user-supplied tarball-URL dependencies.
 * root \`preinstall\` now runs before dependencies are installed.
-* unknown configs in .npmrc, unknown CLI flags, abbreviated flags, and single-hyphen multi-char shorthands now throw instead of warning.
+* unknown CLI flags, abbreviated flags, and single-hyphen multi-char shorthands now throw instead of warning. (Unknown `.npmrc` configs still warn by default; opt into erroring with the new `strict-npmrc` config.)
 ### Chores
 * [`b77b532`](https://github.com/npm/cli/commit/b77b5321bd6dc8d4c028b89f3e4bc9c9a2209f8f) [#9735](https://github.com/npm/cli/pull/9735) remove pre-release mode from npm 12 and workspaces (#9735) (@reggi, @Copilot)
 

--- a/workspaces/config/CHANGELOG.md
+++ b/workspaces/config/CHANGELOG.md
@@ -6,7 +6,7 @@
 * The default license for `npm init` has been changed from "ISC" to an empty string. If not set, the license field will be omitted from new packages.
 * `npm` now supports node `^22.22.2 || ^24.15.0 || >=26.0.0`
 * allow-git and allow-remote now default to "none"; set them to "all" (or "root") to install git or user-supplied tarball-URL dependencies.
-* unknown configs in .npmrc, unknown CLI flags, abbreviated flags, and single-hyphen multi-char shorthands now throw instead of warning.
+* unknown CLI flags, abbreviated flags, and single-hyphen multi-char shorthands now throw instead of warning. (Unknown `.npmrc` configs still warn by default; opt into erroring with the new `strict-npmrc` config.)
 ### Features
 * [`5b83698`](https://github.com/npm/cli/commit/5b83698a4f76e3f2962b9954dddb180fa85d4c77) [#9737](https://github.com/npm/cli/pull/9737) trigger release process (#9737) (@reggi)
 
@@ -29,7 +29,7 @@
 * The default license for `npm init` has been changed from "ISC" to an empty string. If not set, the license field will be omitted from new packages.
 * `npm` now supports node `^22.22.2 || ^24.15.0 || >=26.0.0`
 * allow-git and allow-remote now default to "none"; set them to "all" (or "root") to install git or user-supplied tarball-URL dependencies.
-* unknown configs in .npmrc, unknown CLI flags, abbreviated flags, and single-hyphen multi-char shorthands now throw instead of warning.
+* unknown CLI flags, abbreviated flags, and single-hyphen multi-char shorthands now throw instead of warning. (Unknown `.npmrc` configs still warn by default; opt into erroring with the new `strict-npmrc` config.)
 ### Features
 * [`1db885c`](https://github.com/npm/cli/commit/1db885c84b2dfc5126ab663abb12262b533922c1) [#9439](https://github.com/npm/cli/pull/9439) native dependency patching (npm patch add/commit/update/ls/rm) (#9439) (@manzoorwanijk)
 * [`fc80bb3`](https://github.com/npm/cli/commit/fc80bb359502699bb0a055157e01eaedd5bd73c8) [#9234](https://github.com/npm/cli/pull/9234) remove default license for npm init (@owlstronaut)


### PR DESCRIPTION
## Summary

Fixes #9802.

Before the npm 12 stable cut, #9729 restored warn-by-default for unknown `.npmrc` keys (with `strict-npmrc` to opt into errors). #9733 updated the `12.0.0-pre.1` changelog bullet to match, but the aggregated stable `12.0.0` / `@npmcli/config@11.0.0` breaking-change notes (and the config package's `pre.1` note) still said unknown `.npmrc` configs throw.

That stale line also shipped in the published [v12.0.0 GitHub release notes](https://github.com/npm/cli/releases/tag/v12.0.0).

This aligns those changelog bullets with the corrected wording:

> unknown CLI flags, abbreviated flags, and single-hyphen multi-char shorthands now throw instead of warning. (Unknown `.npmrc` configs still warn by default; opt into erroring with the new `strict-npmrc` config.)

Maintainers may also want to refresh the published `v12.0.0` release body to match; that cannot be updated via this PR alone.

## References

- #9729 (warn instead of error on unknown `.npmrc` configs)
- #9733 (clarified the `pre.1` changelog note)

