### PR TITLE
Update npm-install-scripts.md with allow-scripts info

### DIFF
--- a/docs/lib/content/commands/npm-install-scripts.md
+++ b/docs/lib/content/commands/npm-install-scripts.md
@@ -27,7 +27,7 @@ no project `package.json` to write to. To allow install scripts in those
 contexts, use the `--allow-scripts` flag at install time (for example
 `npm install -g --allow-scripts=canvas,sharp`) or persist the setting with
 `npm config set allow-scripts=canvas,sharp --location=user`.
-
+     
 There are four subcommands:
 
 ```bash


### PR DESCRIPTION
Added information about the --allow-scripts flag for npm.

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
