### PR TITLE
fix(arborist): handle links with cleared targets

### DIFF
--- a/workspaces/arborist/lib/node.js
+++ b/workspaces/arborist/lib/node.js
@@ -1190,7 +1190,16 @@ class Node {
 
     // if they're links, they match if the targets match
     if (this.isLink) {
-      return node.isLink && this.target.matches(node.target)
+      if (!node.isLink) {
+        return false
+      }
+      // reassigning a target's root clears `target` on every link pointing at
+      // it, but the link still knows the realpath it pointed at, so fall back
+      // to that rather than dereferencing null.
+      if (!this.target || !node.target) {
+        return !!this.realpath && this.realpath === node.realpath
+      }
+      return this.target.matches(node.target)
     }
 
     // if they're two project root nodes, they're different if the paths differ

--- a/workspaces/arborist/test/node.js
+++ b/workspaces/arborist/test/node.js
@@ -1450,6 +1450,34 @@ t.test('detect that two nodes are the same thing', async t => {
   }
 
   {
+    const root = new Node({ path: '/root', pkg: { name: 'root', version: '1.0.0' } })
+    const target = new Node({ root, path: '/root/packages/x', pkg: { name: 'x', version: '1.2.3' } })
+    const a = new Link({ root, parent: root, name: 'x', target })
+    const b = new Node({ root, parent: root, name: 'b', pkg: { name: 'b', version: '1.0.0' } })
+    // Nested link to the same target
+    const bx = new Link({ root, parent: b, name: 'x', target })
+    target.root = new Node({ path: '/other-root' })
+    t.equal(a.target, null, 'target was cleared')
+    t.equal(bx.target, null, 'nested link target was cleared')
+    check(a, bx, true, 'links with cleared targets match on realpath')
+  }
+
+  {
+    const root = new Node({ path: '/root', pkg: { name: 'root', version: '1.0.0' } })
+    const x = new Node({ root, path: '/root/packages/x', pkg: { name: 'x', version: '1.2.3' } })
+    const y = new Node({ root, path: '/root/packages/y', pkg: { name: 'x', version: '1.2.3' } })
+    const a = new Link({ root, parent: root, name: 'x', target: x })
+    const b = new Node({ root, parent: root, name: 'b', pkg: { name: 'b', version: '1.0.0' } })
+    // Nested link to a different target of the same name
+    const by = new Link({ root, parent: b, name: 'x', target: y })
+    x.root = new Node({ path: '/other-root' })
+    y.root = new Node({ path: '/another-root' })
+    t.equal(a.target, null, 'target was cleared')
+    t.equal(by.target, null, 'nested link target was cleared')
+    check(a, by, false, 'cleared links with different realpaths do not match')
+  }
+
+  {
     const a = new Node({ path: '/foo', pkg: { name: 'x', version: '1.2.3' } })
     const b = new Node({ path: '/foo', pkg: { name: 'x', version: '1.2.3' } })
     check(a, b, true, 'root nodes match if paths patch')


### PR DESCRIPTION
Hit this reifying a pnpm-shaped `node_modules`, npm died with:
`TypeError: Cannot read properties of null (reading 'matches') out of Node.matches()`

Reassigning a node's root clears target on every link pointing at it, so you can end up with a link where `isLink` is true but target is `null`.

`matches()` dereferenced it. Guarding both sides makes a targetless link just not match, which is what the caller wanted anyway. Test builds two links to a shared target and reassigns the target's root to clear both. It throws without the fix.

I left the guard inside the existing `this.isLink` branch rather than restructuring, a plain `Node` compared against a `Link` still falls through the same way, so placement and dedupe are untouched.