### PR TITLE
chore: pass nodedir to node-gyp via npm_package_config env in node integration

### DIFF
--- a/.github/workflows/node-integration.yml
+++ b/.github/workflows/node-integration.yml
@@ -407,7 +407,8 @@ jobs:
         working-directory: ${{ steps.download.outputs.target }}
         run: |
           set +e
-          npm install --nodedir="${{steps.install.outputs.nodedir }}" ${{ matrix.install_flags }}
+          export npm_package_config_node_gyp_nodedir="${{ steps.install.outputs.nodedir }}"
+          npm install ${{ matrix.install_flags }}
           exitcode=$?
           if [[ $exitcode -ne 0 && "${{ matrix.knownFailure }}" == "true" ]]; then
             echo "::warning ::npm install failed, exit $exitcode"
@@ -445,7 +446,7 @@ jobs:
           FINALEXIT=0
           STEPEXIT=0
 
-          export npm_config_nodedir="${{ steps.install.outputs.nodedir }}"
+          export npm_package_config_node_gyp_nodedir="${{ steps.install.outputs.nodedir }}"
 
           # inlining some patches to make tests run
           if [[ "${{ matrix.package }}" == "undici" ]]; then

--- a/scripts/template-oss/node-integration-yml.hbs
+++ b/scripts/template-oss/node-integration-yml.hbs
@@ -405,7 +405,8 @@ jobs:
         working-directory: $\{{ steps.download.outputs.target }}
         run: |
           set +e
-          npm install --nodedir="$\{{steps.install.outputs.nodedir }}" $\{{ matrix.install_flags }}
+          export npm_package_config_node_gyp_nodedir="$\{{ steps.install.outputs.nodedir }}"
+          npm install $\{{ matrix.install_flags }}
           exitcode=$?
           if [[ $exitcode -ne 0 && "$\{{ matrix.knownFailure }}" == "true" ]]; then
             echo "::warning ::npm install failed, exit $exitcode"
@@ -443,7 +444,7 @@ jobs:
           FINALEXIT=0
           STEPEXIT=0
 
-          export npm_config_nodedir="$\{{ steps.install.outputs.nodedir }}"
+          export npm_package_config_node_gyp_nodedir="$\{{ steps.install.outputs.nodedir }}"
 
           # inlining some patches to make tests run
           if [[ "$\{{ matrix.package }}" == "undici" ]]; then


### PR DESCRIPTION
## What / Why

The `node-integration` workflow passed `--nodedir` as an npm **CLI flag** to `npm install`. In npm 12 unknown configs are no longer accepted, so this now fails with `EUNKNOWNCONFIG`:

```
npm error code EUNKNOWNCONFIG
npm error Unknown cli flag:
npm error   - --nodedir
```

(seen in the Release Integration citgm jobs, e.g. `citgm - bcrypt@6.0.0`).

`nodedir` is a **node-gyp** option, not an npm config — it only ever worked via npm's old "accept arbitrary config and re-export as `npm_config_*`" behavior, which node-gyp itself notes was deprecated in npm v11 ([nodejs/node-gyp#3156](https://github.com/nodejs/node-gyp/issues/3156)).

## Change

Export `npm_package_config_node_gyp_nodedir` instead of using the CLI flag. This is node-gyp's preferred prefix since npm v11: node-gyp reads it directly from the environment, and npm does **not** warn on it — unlike `npm_config_nodedir`, which currently warns and is slated to error in npm 13.

This also matches how upstream [nodejs/citgm](https://github.com/nodejs/citgm) supplies `nodedir` (via env, not a CLI flag).

Applied to both the generated `.github/workflows/node-integration.yml` and its `scripts/template-oss/node-integration-yml.hbs` template; `template-oss-apply --lint` passes.