### PR TITLE
fix: respect custom viewer in npm help

### DIFF
--- a/lib/commands/help.js
+++ b/lib/commands/help.js
@@ -87,7 +87,7 @@ class Help extends BaseCommand {
       return openUrl(this.npm, this.htmlMan(man), 'help available at the following URL', true)
     }
 
-    let args = ['man', [man]]
+    let args = [viewer, [man]]
     if (viewer === 'woman') {
       args = ['emacsclient', ['-e', `(woman-find-file '${man}')`]]
     }

--- a/test/lib/commands/help.js
+++ b/test/lib/commands/help.js
@@ -111,6 +111,18 @@ t.test('npm help whoami', async t => {
   t.match(spawnArgs[0], /npm-whoami\.1$/)
 })
 
+t.test('npm help with custom viewer', async t => {
+  const { getArgs } = await mockHelp(t, {
+    exec: ['whoami'],
+    config: { viewer: 'batman' },
+  })
+
+  const [spawnBin, spawnArgs] = getArgs()
+  t.equal(spawnBin, 'batman', 'calls the configured viewer')
+  t.equal(spawnArgs.length, 1)
+  t.match(spawnArgs[0], /npm-whoami\.1$/)
+})
+
 t.test('npm help 1 install', async t => {
   const { getArgs } = await mockHelp(t, {
     exec: ['1', 'install'],


### PR DESCRIPTION
<!-- What / Why -->

Use the configured `viewer` program when opening man pages, while preserving the existing `browser` and `woman` special cases. This also adds regression coverage for a custom viewer.

## Testing

- `tap --no-coverage test/lib/commands/help.js` (16 subtests passed)
- `eslint lib/commands/help.js test/lib/commands/help.js`
- `git diff --check`

## References

Fixes #9828
