### PR TITLE
fix: honor node-gyp config in dependency lifecycle scripts

### DIFF
--- a/workspaces/arborist/lib/arborist/rebuild.js
+++ b/workspaces/arborist/lib/arborist/rebuild.js
@@ -350,6 +350,7 @@ module.exports = cls => class Builder extends cls {
         pkg,
         stdio,
         env,
+        nodeGyp: this.options.nodeGyp,
         scriptShell: this.options.scriptShell,
       }
       const p = runScript(runOpts).catch(er => {

--- a/workspaces/arborist/test/arborist/rebuild.js
+++ b/workspaces/arborist/test/arborist/rebuild.js
@@ -553,7 +553,8 @@ t.test('rebuild node-gyp dependencies lacking both preinstall and install script
       },
     }),
   })
-  const arb = new Arborist({ path, dangerouslyAllowAllScripts: true })
+  const nodeGyp = '/test/node-gyp.js'
+  const arb = new Arborist({ path, dangerouslyAllowAllScripts: true, nodeGyp })
   await arb.rebuild()
   t.match(RUNS, [
     {
@@ -569,6 +570,7 @@ t.test('rebuild node-gyp dependencies lacking both preinstall and install script
         npm_package_peer: '',
         npm_package_dev_optional: '',
       },
+      nodeGyp,
       scriptShell: undefined,
     },
   ])


### PR DESCRIPTION
## Summary

- pass Arborist's configured `nodeGyp` path to `@npmcli/run-script`
- preserve custom `node-gyp` selection for dependency lifecycle scripts, including synthetic `node-gyp rebuild` installs
- add regression coverage to the existing synthetic node-gyp rebuild test

Closes #9826

## Test plan

- `tap test/arborist/rebuild.js --no-coverage --no-check-coverage` from `workspaces/arborist` (32 subtests passed)
- `eslint workspaces/arborist/lib/arborist/rebuild.js workspaces/arborist/test/arborist/rebuild.js`
- `git diff --check`