### PR TITLE
docs: clarify release age behavior for npm ci

### DIFF
--- a/docs/lib/content/commands/npm-ci.md
+++ b/docs/lib/content/commands/npm-ci.md
@@ -21,6 +21,9 @@ The main differences between using `npm install` and `npm ci` are:
 * If a `node_modules` is already present, it will be automatically removed before `npm ci` begins its install.
 * It will never write to `package.json` or `package-lock.json`:
   installs are essentially frozen.
+* `--before` and `--min-release-age` do not affect `npm ci`, which installs
+  the versions recorded in the lockfile without resolving versions or checking
+  release dates.
 
 NOTE: If you create your `package-lock.json` file by running `npm install` with flags that can affect the shape of your dependency tree, such as
 `--legacy-peer-deps` or `--install-links`, you _must_ provide the same flags to `npm ci` or you are likely to encounter errors.

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -360,6 +360,10 @@ const definitions = {
 
       Packages whose names match \`min-release-age-exclude\` are exempt from
       this filter.
+
+      NOTE: \`npm ci\` does not apply this setting. It installs the versions
+      recorded in the lockfile without resolving versions or checking release
+      dates.
     `,
     flatten,
   }),
@@ -1563,6 +1567,10 @@ const definitions = {
 
        Packages whose names match \`min-release-age-exclude\` are exempt from
        this filter.
+
+       NOTE: \`npm ci\` does not apply this setting. It installs the versions
+       recorded in the lockfile without resolving versions or checking release
+       dates.
     `,
     flatten: (key, obj, flatOptions) => {
       const age = obj['min-release-age']


### PR DESCRIPTION
Relates to #9281 

The documentation should explicitly define the behavior described in #9281, regarding `npm ci` ignoring the `before` and `min-release-age` config options.

Here's why I think this is a good addition :smile: 
1. I assumed `npm ci` honored all config options in an `.npmrc`
2. The documentation currently instructs users to pass flags that affect the shape of the dependency tree when using `npm ci`, but it does not work as expected with `before` and `min-release-age`
3. The documentation for the flags do not explicitly define the current behavior
4. This appears to be intentional behavior, as seen in #9281 

This is also security _adjacent_. Most people configure release age requirements as a defense against supply chain attacks. Having this behavior undocumented likely leaves a lot of maintainers believing their CI systems are protected, when there's still an attack path. A malicious actor can update the lockfile with a malicious package that doesn't meet the release age requirements, and that will run in CI if the build system uses `npm ci`.

Longer term, I would also recommend logging a warning when there's a config that `npm ci` cannot honor.