### PR TITLE
fix: exclude unrelated optional peers from workspace installs

### DIFF
--- a/workspaces/arborist/lib/diff.js
+++ b/workspaces/arborist/lib/diff.js
@@ -72,12 +72,19 @@ class Diff {
           const orig = node
           node = node.target
           const loc = node.location
+          // An optional peer edge does not require its provider. If an
+          // in-scope node provides the peer, its own dependency edge will
+          // include the provider in the filtered tree.
           const idealNode = ideal.inventory.get(loc)
           const ideals = !idealNode ? []
-            : [...idealNode.edgesOut.values()].filter(e => e.to).map(e => e.to)
+            : [...idealNode.edgesOut.values()]
+              .filter(e => e.to && e.type !== 'peerOptional')
+              .map(e => e.to)
           const actualNode = actual.inventory.get(loc)
           const actuals = !actualNode ? []
-            : [...actualNode.edgesOut.values()].filter(e => e.to).map(e => e.to)
+            : [...actualNode.edgesOut.values()]
+              .filter(e => e.to && e.type !== 'peerOptional')
+              .map(e => e.to)
           if (actualNode) {
             for (const child of actualNode.children.values()) {
               if (child.extraneous) {

--- a/workspaces/arborist/test/arborist/reify.js
+++ b/workspaces/arborist/test/arborist/reify.js
@@ -2768,6 +2768,88 @@ t.test('includeWorkspaceRoot in addition to workspace', async t => {
   t.equal(tree.inventory.query('name', 'once').size, 1)
 })
 
+const reifyWorkspaceWithOptionalPeer = async (t, { providePeer }) => {
+  const sources = t.testdir({
+    host: {
+      'package.json': JSON.stringify({ name: 'host', version: '1.0.0' }),
+    },
+    ...(providePeer ? {
+      peer: {
+        'package.json': JSON.stringify({ name: 'peer', version: '1.0.0' }),
+      },
+    } : {}),
+  })
+  const registry = createRegistry(t)
+  const hostManifest = registry.manifest({
+    name: 'host',
+    packuments: [{
+      version: '1.0.0',
+      peerDependencies: { peer: '*' },
+      peerDependenciesMeta: { peer: { optional: true } },
+    }],
+  })
+  const peerManifest = registry.manifest({
+    name: 'peer',
+    packuments: [{ version: '1.0.0' }],
+  })
+  await registry.package({
+    manifest: hostManifest,
+    tarballs: { '1.0.0': resolve(sources, 'host') },
+  })
+  await registry.package({
+    manifest: peerManifest,
+    tarballs: providePeer ? { '1.0.0': resolve(sources, 'peer') } : undefined,
+    times: 2,
+  })
+
+  const path = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'root',
+      version: '1.0.0',
+      dependencies: { host: '1.0.0' },
+      workspaces: ['packages/*'],
+    }),
+    packages: {
+      a: {
+        'package.json': JSON.stringify({
+          name: 'a',
+          version: '1.0.0',
+          devDependencies: { peer: '1.0.0' },
+        }),
+      },
+      b: {
+        'package.json': JSON.stringify({
+          name: 'b',
+          version: '1.0.0',
+          ...(providePeer ? { devDependencies: { peer: '1.0.0' } } : {}),
+        }),
+      },
+    },
+  })
+
+  await reify(path, { packageLockOnly: true })
+  await reify(path, {
+    includeWorkspaceRoot: true,
+    save: false,
+    workspaces: ['b'],
+  })
+
+  const message = providePeer
+    ? 'selected workspace peer is installed'
+    : 'out-of-scope workspace optional peer is not installed'
+  t.equal(fs.existsSync(resolve(path, 'node_modules/peer')), providePeer, message)
+}
+
+t.test('workspace filter handles optional peers from workspace dependencies', async t => {
+  await t.test('excludes provider only used by out-of-scope workspace', async t => {
+    await reifyWorkspaceWithOptionalPeer(t, { providePeer: false })
+  })
+
+  await t.test('retains provider required by selected workspace', async t => {
+    await reifyWorkspaceWithOptionalPeer(t, { providePeer: true })
+  })
+})
+
 t.test('no workspace', async t => {
   const path = t.testdir({
     'package.json': JSON.stringify({


### PR DESCRIPTION
## Summary

- stop filtered workspace reification from treating `peerOptional` edges as requirements on their own
- keep optional peer providers when the root or selected workspace explicitly depends on them
- add regression coverage for both the out-of-scope and explicit-provider cases

This fixes scoped `npm ci --workspace` installs pulling in a package that is only declared by an unselected workspace and then reporting it as extraneous.

## Validation

- reproduced the issue with the reporter repository on npm CLI `latest`: `sass-embedded@1.100.0` was installed and reported extraneous
- reran the same repository with this patch: `sass-embedded` is absent while `vite` and the selected `pkg-b` workspace remain installed
- `node . run test -w @npmcli/arborist` (59 suites, 100% statement/branch/function/line coverage, workspace lint passes)
- focused regression verifies an explicit selected-workspace provider remains installed

Fixes #9847