### PR TITLE
fix(ci): ignore inert nodes during lockfile validation

### DIFF
--- a/lib/utils/validate-lockfile.js
+++ b/lib/utils/validate-lockfile.js
@@ -11,6 +11,10 @@ function validateLockfile (virtualTree, idealTree) {
   // for each package compares the versions with the version stored in the
   // package-lock and adds an error to the list in case of mismatches
   for (const [key, entry] of idealTree.entries()) {
+    if (entry.inert) {
+      continue
+    }
+
     const lock = virtualTree.get(key)
 
     if (!lock) {

--- a/test/lib/commands/ci.js
+++ b/test/lib/commands/ci.js
@@ -413,6 +413,45 @@ t.test('should throw error when ideal inventory mismatches virtual', async t => 
   t.equal(fs.existsSync(nmTestFile), true, 'does not remove node_modules')
 })
 
+t.test('accepts a lock file with an unavailable optional dependency', async t => {
+  const missingOptional = 'missing-optional'
+  const { npm, registry } = await loadMockNpm(t, {
+    config: {
+      audit: false,
+      'dry-run': true,
+      'ignore-scripts': true,
+    },
+    prefixDir: {
+      'package.json': JSON.stringify({
+        name: 'test-package',
+        version: '1.0.0',
+        dependencies: { 'optional-parent': '1.0.0' },
+      }),
+      'package-lock.json': JSON.stringify({
+        name: 'test-package',
+        version: '1.0.0',
+        lockfileVersion: 3,
+        requires: true,
+        packages: {
+          '': {
+            name: 'test-package',
+            version: '1.0.0',
+            dependencies: { 'optional-parent': '1.0.0' },
+          },
+          'node_modules/optional-parent': {
+            version: '1.0.0',
+            resolved: 'https://registry.npmjs.org/optional-parent/-/optional-parent-1.0.0.tgz',
+            optionalDependencies: { [missingOptional]: '1.0.0' },
+          },
+        },
+      }),
+    },
+  })
+  registry.nock.get(`/${missingOptional}`).reply(404, { error: 'Not found' })
+
+  await npm.exec('ci', [])
+})
+
 t.test('should remove dirty node_modules with unhoisted workspace module', async t => {
   const { npm, registry, assert } = await loadMockNpm(t, {
     prefixDir: workspaceMock(t, {

--- a/test/lib/utils/validate-lockfile.js
+++ b/test/lib/utils/validate-lockfile.js
@@ -131,6 +131,24 @@ t.test('extra inventory items on idealTree', async t => {
   )
 })
 
+t.test('inert inventory items on idealTree', async t => {
+  t.strictSame(
+    validateLockfile(
+      new Map(),
+      new Map([
+        ['missing-optional', {
+          name: 'missing-optional',
+          version: '',
+          optional: true,
+          inert: true,
+        }],
+      ])
+    ),
+    [],
+    'does not require lock file entries for inert optional dependencies'
+  )
+})
+
 t.test('extra inventory items on virtualTree', async t => {
   t.matchSnapshot(
     validateLockfile(


### PR DESCRIPTION
Fixes #9846.

When `npm ci` rebuilt the ideal tree, unavailable optional dependencies remained as inert nodes. These nodes are intentionally omitted from `package-lock.json`, but lockfile validation still treated them as missing entries.

Ignore inert nodes during lockfile validation. Ordinary missing dependencies continue to produce an error.

## Testing

- `node . test -- --no-check-coverage test/lib/utils/validate-lockfile.js test/lib/commands/ci.js`
- `node . run eslint -- lib/utils/validate-lockfile.js test/lib/utils/validate-lockfile.js test/lib/commands/ci.js`
- `git diff --check`
