### PR TITLE
fix(outdated): skip registry lookup for workspace deps

### DIFF
--- a/lib/commands/outdated.js
+++ b/lib/commands/outdated.js
@@ -177,6 +177,11 @@ class Outdated extends ArboristWorkspaceCmd {
       return
     }
 
+    // local workspaces are never fetched from the registry
+    if (edge.to?.isWorkspace) {
+      return
+    }
+
     // if it's not a range, version, or tag, skip it
     if (!safeNpa(`${edge.name}@${edge.spec}`)?.registry) {
       return null

--- a/test/lib/commands/outdated.js
+++ b/test/lib/commands/outdated.js
@@ -57,6 +57,11 @@ const packument = spec => {
         },
       },
     },
+    unpublished: {
+      name: 'unpublished',
+      'dist-tags': {},
+      versions: {},
+    },
     timed: {
       name: 'timed',
       'dist-tags': {
@@ -620,6 +625,43 @@ t.test('workspaces', async t => {
 
   await t.test('should display missing deps when filtering by ws', t =>
     mockWorkspaces(t, { workspace: 'c', exitCode: 1 }))
+
+  await t.test('should ignore ws dep sharing a name with an unpublished package', async t => {
+    const testDir = {
+      'package.json': JSON.stringify({
+        name: 'workspaces-project',
+        version: '1.0.0',
+        workspaces: ['packages/*'],
+      }),
+      node_modules: {
+        a: t.fixture('symlink', '../packages/a'),
+        unpublished: t.fixture('symlink', '../packages/unpublished'),
+      },
+      packages: {
+        a: {
+          'package.json': JSON.stringify({
+            name: 'a',
+            version: '1.0.0',
+            dependencies: {
+              unpublished: '^1.0.0',
+            },
+          }),
+        },
+        unpublished: {
+          'package.json': JSON.stringify({
+            name: 'unpublished',
+            version: '1.0.0',
+          }),
+        },
+      },
+    }
+
+    const { outdated, joinedOutput } = await mockNpm(t, {
+      prefixDir: testDir,
+    })
+    await outdated.exec([])
+    t.equal(joinedOutput(), '', 'no logs')
+  })
 })
 
 t.test('aliases', async t => {


### PR DESCRIPTION
## Summary

`npm outdated` crashes with `ENOVERSIONS` in a workspace project when a local workspace package shares its name with a package that was published and later unpublished from the registry.

`#getOutdatedInfo` hits the registry for every dependency edge with a registry-style spec, including edges that resolve to a local workspace. Usually the registry answers 404 and the error is swallowed, so nobody notices. An unpublished name answers 200 with a packument that has no versions, and `pickManifest` throws `ENOVERSIONS`, which isn't in the ignored list, so the whole command dies.

Workspace links always resolve to the local copy, so their version never comes from the registry. This skips the lookup for them.

## Testing

Added a workspaces test where a local package name resolves to an empty packument. It throws `ENOVERSIONS` before the change and reports nothing outdated after it.

Fixes #9852