### PR TITLE
fix(arborist): honor gypfile:false on lockfile-driven installs

### DIFF
--- a/workspaces/arborist/lib/arborist/rebuild.js
+++ b/workspaces/arborist/lib/arborist/rebuild.js
@@ -13,6 +13,7 @@ const { promiseRetry } = require('@gar/promise-retry')
 const { log, time } = require('proc-log')
 const { resolve, delimiter } = require('node:path')
 const { isScriptAllowed } = require('../script-allowed.js')
+const { hasGypfileOptOut } = require('../gypfile.js')
 
 const boolEnv = b => b ? '1' : ''
 const sortNodes = (a, b) => (a.depth - b.depth) || localeCompare(a.path, b.path)
@@ -277,10 +278,10 @@ module.exports = cls => class Builder extends cls {
     // Rebuild node-gyp dependencies lacking an install or preinstall script
     // note that 'scripts' might be missing entirely, and the package may
     // set gypfile:false to avoid this automatic detection.
-    const isGyp = gypfile !== false &&
-      !install &&
+    const isGyp = !install &&
       !preinstall &&
-      await isNodeGypPackage(node.path)
+      await isNodeGypPackage(node.path) &&
+      !await hasGypfileOptOut(node.path, gypfile)
 
     if (bin || preinstall || install || postinstall || prepare || isGyp) {
       if (bin) {

--- a/workspaces/arborist/lib/arborist/rebuild.js
+++ b/workspaces/arborist/lib/arborist/rebuild.js
@@ -252,7 +252,7 @@ module.exports = cls => class Builder extends cls {
     }
 
     const { package: pkg, hasInstallScript } = node.target
-    const { gypfile, bin, scripts = {} } = pkg
+    const { bin, scripts = {} } = pkg
 
     const { preinstall, install, postinstall, prepare } = scripts
     const anyScript = preinstall || install || postinstall || prepare
@@ -281,7 +281,7 @@ module.exports = cls => class Builder extends cls {
     const isGyp = !install &&
       !preinstall &&
       await isNodeGypPackage(node.path) &&
-      !await hasGypfileOptOut(node.path, gypfile)
+      !await hasGypfileOptOut(node.path, pkg, node.target.name)
 
     if (bin || preinstall || install || postinstall || prepare || isGyp) {
       if (bin) {

--- a/workspaces/arborist/lib/gypfile.js
+++ b/workspaces/arborist/lib/gypfile.js
@@ -1,3 +1,5 @@
+const { readFile } = require('node:fs/promises')
+const { resolve } = require('node:path')
 const PackageJson = require('@npmcli/package-json')
 
 // `gypfile: false` opts a package out of the synthetic `node-gyp rebuild`
@@ -8,15 +10,11 @@ const PackageJson = require('@npmcli/package-json')
 // no `gypfile` field at all, so the opt-out is invisible there and has to be
 // read back off the installed package.json.
 //
-// The disk read is only trustworthy when the package.json at `path` is the
-// package the node describes. The strict allow-scripts preflight runs before
-// reify replaces `node_modules`, so `path` can still hold a different version
-// of the package, or a different package altogether. Trusting a stale
-// `gypfile: false` there would let the preflight pass while the later rebuild
-// (which sees the real package) synthesises `node-gyp rebuild` anyway. So the
-// name and the version on disk must match the node before the flag counts.
-// Without both, treat the opt-out as absent, which is what npm did before the
-// fallback existed.
+// `hasGypfileOptOut` is the read for callers whose subject is the package
+// already on disk, such as the rebuild pass, which reads `binding.gyp` from
+// the same directory in the same breath. A name and version check is all
+// that is available there, and all that is needed: there is no second copy
+// of the package for the disk copy to disagree with.
 const hasGypfileOptOut = async (path, pkg, nodeName) => {
   if (pkg.gypfile !== undefined) {
     return pkg.gypfile === false
@@ -36,4 +34,48 @@ const hasGypfileOptOut = async (path, pkg, nodeName) => {
   return content.gypfile === false
 }
 
-module.exports = { hasGypfileOptOut }
+// The identity of the package that is installed at `node.location` right now,
+// taken from the hidden lockfile, which is written to describe the current
+// contents of `node_modules`.
+const readInstalledIdentity = async (root, location) => {
+  const file = resolve(root.realpath, 'node_modules/.package-lock.json')
+  const data = await readFile(file, 'utf8').then(JSON.parse).catch(() => ({}))
+  return (data.packages || {})[location]
+}
+
+// Name and version do not identify a tarball. Two different tarballs can
+// carry the same pair, so a package on disk that answers to the node's name
+// and version is still not proof that it came from the node's source.
+const matchesInstalledSource = async (node) => {
+  const { resolved, integrity, location, root } = node
+  if (!resolved || !integrity || !location || !root) {
+    return false
+  }
+
+  const installed = await readInstalledIdentity(root, location)
+  return !!installed &&
+    installed.resolved === resolved &&
+    installed.integrity === integrity
+}
+
+// `hasVerifiedGypfileOptOut` is the read for callers that enumerate the
+// scripts a node *would* run, such as the strict allow-scripts preflight and
+// `npm install-scripts`. Those run before reify replaces `node_modules`, so
+// the subject is the node and the disk holds some other copy of the package.
+// A stale `gypfile: false` accepted there lets the preflight pass while the
+// later rebuild, which sees the real package, synthesises `node-gyp rebuild`
+// anyway. So the source of the installed copy has to match the node's own
+// before the disk read counts, and an identity we cannot establish counts as
+// a mismatch. That is what npm did before the fallback existed.
+const hasVerifiedGypfileOptOut = async (node) => {
+  /* istanbul ignore next: arborist Nodes always carry a `package` object;
+     defensive fallback for non-arborist callers. */
+  const pkg = node.package || {}
+  if (pkg.gypfile === undefined && !await matchesInstalledSource(node)) {
+    return false
+  }
+
+  return hasGypfileOptOut(node.path, pkg, node.name)
+}
+
+module.exports = { hasGypfileOptOut, hasVerifiedGypfileOptOut }

--- a/workspaces/arborist/lib/gypfile.js
+++ b/workspaces/arborist/lib/gypfile.js
@@ -7,12 +7,32 @@ const PackageJson = require('@npmcli/package-json')
 // from disk. Lockfile-derived nodes (`npm ci`, a repeat `npm install`) carry
 // no `gypfile` field at all, so the opt-out is invisible there and has to be
 // read back off the installed package.json.
-const hasGypfileOptOut = async (path, gypfile) => {
-  if (gypfile !== undefined) {
-    return gypfile === false
+//
+// The disk read is only trustworthy when the package.json at `path` is the
+// package the node describes. The strict allow-scripts preflight runs before
+// reify replaces `node_modules`, so `path` can still hold a different version
+// of the package, or a different package altogether. Trusting a stale
+// `gypfile: false` there would let the preflight pass while the later rebuild
+// (which sees the real package) synthesises `node-gyp rebuild` anyway. So the
+// name and the version on disk must match the node before the flag counts.
+// Without both, treat the opt-out as absent, which is what npm did before the
+// fallback existed.
+const hasGypfileOptOut = async (path, pkg, nodeName) => {
+  if (pkg.gypfile !== undefined) {
+    return pkg.gypfile === false
+  }
+
+  const name = pkg.name || nodeName
+  const { version } = pkg
+  if (!name || !version) {
+    return false
   }
 
   const { content } = await PackageJson.load(path).catch(() => ({ content: {} }))
+  if (content.name !== name || content.version !== version) {
+    return false
+  }
+
   return content.gypfile === false
 }
 

--- a/workspaces/arborist/lib/gypfile.js
+++ b/workspaces/arborist/lib/gypfile.js
@@ -1,0 +1,19 @@
+const PackageJson = require('@npmcli/package-json')
+
+// `gypfile: false` opts a package out of the synthetic `node-gyp rebuild`
+// install script npm adds when it finds a `binding.gyp`.
+//
+// The flag is only on the tree node when the node came from a packument or
+// from disk. Lockfile-derived nodes (`npm ci`, a repeat `npm install`) carry
+// no `gypfile` field at all, so the opt-out is invisible there and has to be
+// read back off the installed package.json.
+const hasGypfileOptOut = async (path, gypfile) => {
+  if (gypfile !== undefined) {
+    return gypfile === false
+  }
+
+  const { content } = await PackageJson.load(path).catch(() => ({ content: {} }))
+  return content.gypfile === false
+}
+
+module.exports = { hasGypfileOptOut }

--- a/workspaces/arborist/lib/install-scripts.js
+++ b/workspaces/arborist/lib/install-scripts.js
@@ -1,5 +1,6 @@
 const { isNodeGypPackage } = require('@npmcli/node-gyp')
 const PackageJson = require('@npmcli/package-json')
+const { hasGypfileOptOut } = require('./gypfile.js')
 
 // Returns the install-relevant lifecycle scripts that would run for a
 // given arborist Node, or `{}` if there are none.
@@ -65,8 +66,8 @@ const getInstallScripts = async (node) => {
   const hasExplicitGypGate = !!(collected.preinstall || collected.install)
   if (
     !hasExplicitGypGate &&
-    pkg.gypfile !== false &&
-    await isNodeGypPackage(node.path).catch(() => false)
+    await isNodeGypPackage(node.path).catch(() => false) &&
+    !await hasGypfileOptOut(node.path, pkg.gypfile)
   ) {
     collected.install = 'node-gyp rebuild'
   }

--- a/workspaces/arborist/lib/install-scripts.js
+++ b/workspaces/arborist/lib/install-scripts.js
@@ -67,7 +67,7 @@ const getInstallScripts = async (node) => {
   if (
     !hasExplicitGypGate &&
     await isNodeGypPackage(node.path).catch(() => false) &&
-    !await hasGypfileOptOut(node.path, pkg.gypfile)
+    !await hasGypfileOptOut(node.path, pkg, node.name)
   ) {
     collected.install = 'node-gyp rebuild'
   }

--- a/workspaces/arborist/lib/install-scripts.js
+++ b/workspaces/arborist/lib/install-scripts.js
@@ -1,6 +1,6 @@
 const { isNodeGypPackage } = require('@npmcli/node-gyp')
 const PackageJson = require('@npmcli/package-json')
-const { hasGypfileOptOut } = require('./gypfile.js')
+const { hasVerifiedGypfileOptOut } = require('./gypfile.js')
 
 // Returns the install-relevant lifecycle scripts that would run for a
 // given arborist Node, or `{}` if there are none.
@@ -67,7 +67,7 @@ const getInstallScripts = async (node) => {
   if (
     !hasExplicitGypGate &&
     await isNodeGypPackage(node.path).catch(() => false) &&
-    !await hasGypfileOptOut(node.path, pkg, node.name)
+    !await hasVerifiedGypfileOptOut(node)
   ) {
     collected.install = 'node-gyp rebuild'
   }

--- a/workspaces/arborist/test/arborist/rebuild.js
+++ b/workspaces/arborist/test/arborist/rebuild.js
@@ -603,6 +603,52 @@ t.test('do not rebuild node-gyp dependencies with gypfile:false', async t => {
   await arb.rebuild()
 })
 
+// ref: https://github.com/npm/cli/issues/9837
+t.test('do not rebuild node-gyp dependencies with gypfile:false from a lockfile', async t => {
+  const Arborist = t.mock('../../lib/arborist/index.js', {
+    '@npmcli/run-script': async () => {
+      throw new Error('should not run any scripts')
+    },
+  })
+  const path = t.testdir({
+    node_modules: {
+      dep: {
+        'package.json': JSON.stringify({
+          name: 'dep',
+          version: '1.0.0',
+          gypfile: false,
+        }),
+        'binding.gyp': '',
+      },
+    },
+    'package-lock.json': JSON.stringify({
+      name: 'project',
+      lockfileVersion: 3,
+      requires: true,
+      packages: {
+        '': {
+          name: 'project',
+          dependencies: {
+            dep: '1',
+          },
+        },
+        'node_modules/dep': {
+          version: '1.0.0',
+        },
+      },
+    }),
+    'package.json': JSON.stringify({
+      name: 'project',
+      dependencies: {
+        dep: '1',
+      },
+    }),
+  })
+  const arb = new Arborist({ path, dangerouslyAllowAllScripts: true })
+  const tree = await arb.loadVirtual()
+  await arb.rebuild({ nodes: [...tree.inventory.values()] })
+})
+
 // ref: https://github.com/npm/cli/issues/2905
 t.test('do not run lifecycle scripts of linked deps twice', async t => {
   const testdir = t.testdir({

--- a/workspaces/arborist/test/install-scripts.js
+++ b/workspaces/arborist/test/install-scripts.js
@@ -17,10 +17,18 @@ const node = ({
   gypfile,
   resolved = 'https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz',
   path = '/fake',
+  name = 'dep',
+  version = '1.0.0',
 } = {}) => ({
   resolved,
   path,
-  package: { scripts, ...(gypfile !== undefined ? { gypfile } : {}) },
+  name,
+  package: {
+    name,
+    version,
+    scripts,
+    ...(gypfile !== undefined ? { gypfile } : {}),
+  },
 })
 
 t.test('collects preinstall, install, postinstall', async t => {
@@ -114,6 +122,60 @@ t.test('synthetic node-gyp still detected when disk has no gypfile', async t => 
   })
   t.strictSame(
     await getInstallScripts(node({ path })),
+    { install: 'node-gyp rebuild' }
+  )
+})
+
+t.test('gypfile: false on disk ignored when the version does not match', async t => {
+  const getInstallScripts = mockGetInstallScripts(t, () => true)
+  const path = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'dep',
+      version: '1.0.0',
+      gypfile: false,
+    }),
+  })
+  // The strict allow-scripts preflight runs before reify swaps node_modules,
+  // so the opt-out on disk belongs to the version that is already installed,
+  // not to the one the node describes.
+  t.strictSame(
+    await getInstallScripts(node({ path, version: '2.0.0' })),
+    { install: 'node-gyp rebuild' }
+  )
+})
+
+t.test('gypfile: false on disk ignored when the name does not match', async t => {
+  const getInstallScripts = mockGetInstallScripts(t, () => true)
+  const path = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'other',
+      version: '1.0.0',
+      gypfile: false,
+    }),
+  })
+  t.strictSame(
+    await getInstallScripts(node({ path })),
+    { install: 'node-gyp rebuild' }
+  )
+})
+
+t.test('gypfile: false on disk ignored when the node has no identity', async t => {
+  const getInstallScripts = mockGetInstallScripts(t, () => true)
+  const path = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'dep',
+      version: '1.0.0',
+      gypfile: false,
+    }),
+  })
+  // No version to compare against, so the disk read cannot be trusted.
+  t.strictSame(
+    await getInstallScripts(node({ path, version: '' })),
+    { install: 'node-gyp rebuild' }
+  )
+  // No name either.
+  t.strictSame(
+    await getInstallScripts(node({ path, name: '' })),
     { install: 'node-gyp rebuild' }
   )
 })

--- a/workspaces/arborist/test/install-scripts.js
+++ b/workspaces/arborist/test/install-scripts.js
@@ -12,15 +12,24 @@ const mockGetInstallScripts = (t, isNodeGypResult = () => false) =>
     },
   })
 
+const RESOLVED = 'https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz'
+const INTEGRITY = 'sha512-aaaaaaaaaaaaaaaaaaaaaa=='
+
 const node = ({
   scripts = {},
   gypfile,
-  resolved = 'https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz',
+  resolved = RESOLVED,
+  integrity = INTEGRITY,
   path = '/fake',
+  root = { realpath: '/fake' },
+  location = 'node_modules/dep',
   name = 'dep',
   version = '1.0.0',
 } = {}) => ({
   resolved,
+  integrity,
+  location,
+  root,
   path,
   name,
   package: {
@@ -30,6 +39,29 @@ const node = ({
     ...(gypfile !== undefined ? { gypfile } : {}),
   },
 })
+
+// A project root holding one installed dependency, plus the hidden lockfile
+// npm writes to record what is actually in `node_modules` right now.
+const installed = (t, {
+  pkg = { name: 'dep', version: '1.0.0', gypfile: false },
+  entry = { resolved: RESOLVED, integrity: INTEGRITY },
+  lock = { packages: {} },
+} = {}) => {
+  if (lock && lock.packages && entry) {
+    lock.packages['node_modules/dep'] = entry
+  }
+  return t.testdir({
+    node_modules: {
+      dep: { 'package.json': typeof pkg === 'string' ? pkg : JSON.stringify(pkg) },
+      ...(lock ? { '.package-lock.json': JSON.stringify(lock) } : {}),
+    },
+  })
+}
+
+const installedNode = (t, dirOpts = {}, nodeOpts = {}) => {
+  const dir = installed(t, dirOpts)
+  return node({ path: `${dir}/node_modules/dep`, root: { realpath: dir }, ...nodeOpts })
+}
 
 t.test('collects preinstall, install, postinstall', async t => {
   const getInstallScripts = mockGetInstallScripts(t)
@@ -105,78 +137,119 @@ t.test('synthetic node-gyp suppressed when gypfile: false', async t => {
 
 t.test('synthetic node-gyp suppressed by gypfile: false on disk', async t => {
   const getInstallScripts = mockGetInstallScripts(t, () => true)
-  const path = t.testdir({
-    'package.json': JSON.stringify({
-      name: 'dep',
-      version: '1.0.0',
-      gypfile: false,
-    }),
-  })
-  t.strictSame(await getInstallScripts(node({ path })), {})
+  t.strictSame(await getInstallScripts(installedNode(t)), {})
 })
 
 t.test('synthetic node-gyp still detected when disk has no gypfile', async t => {
   const getInstallScripts = mockGetInstallScripts(t, () => true)
-  const path = t.testdir({
-    'package.json': JSON.stringify({ name: 'dep', version: '1.0.0' }),
-  })
+  const n = installedNode(t, { pkg: { name: 'dep', version: '1.0.0' } })
   t.strictSame(
-    await getInstallScripts(node({ path })),
+    await getInstallScripts(n),
+    { install: 'node-gyp rebuild' }
+  )
+  // Same for a package.json that cannot be read back.
+  t.strictSame(
+    await getInstallScripts(installedNode(t, { pkg: 'not json' })),
     { install: 'node-gyp rebuild' }
   )
 })
 
 t.test('gypfile: false on disk ignored when the version does not match', async t => {
   const getInstallScripts = mockGetInstallScripts(t, () => true)
-  const path = t.testdir({
-    'package.json': JSON.stringify({
-      name: 'dep',
-      version: '1.0.0',
-      gypfile: false,
-    }),
-  })
   // The strict allow-scripts preflight runs before reify swaps node_modules,
   // so the opt-out on disk belongs to the version that is already installed,
   // not to the one the node describes.
+  const n = installedNode(t, {}, { version: '2.0.0' })
   t.strictSame(
-    await getInstallScripts(node({ path, version: '2.0.0' })),
+    await getInstallScripts(n),
     { install: 'node-gyp rebuild' }
   )
 })
 
 t.test('gypfile: false on disk ignored when the name does not match', async t => {
   const getInstallScripts = mockGetInstallScripts(t, () => true)
-  const path = t.testdir({
-    'package.json': JSON.stringify({
-      name: 'other',
-      version: '1.0.0',
-      gypfile: false,
-    }),
+  const n = installedNode(t, {
+    pkg: { name: 'other', version: '1.0.0', gypfile: false },
   })
   t.strictSame(
-    await getInstallScripts(node({ path })),
+    await getInstallScripts(n),
     { install: 'node-gyp rebuild' }
   )
 })
 
 t.test('gypfile: false on disk ignored when the node has no identity', async t => {
   const getInstallScripts = mockGetInstallScripts(t, () => true)
-  const path = t.testdir({
-    'package.json': JSON.stringify({
-      name: 'dep',
-      version: '1.0.0',
-      gypfile: false,
-    }),
-  })
   // No version to compare against, so the disk read cannot be trusted.
   t.strictSame(
-    await getInstallScripts(node({ path, version: '' })),
+    await getInstallScripts(installedNode(t, {}, { version: '' })),
     { install: 'node-gyp rebuild' }
   )
   // No name either.
   t.strictSame(
-    await getInstallScripts(node({ path, name: '' })),
+    await getInstallScripts(installedNode(t, {}, { name: '' })),
     { install: 'node-gyp rebuild' }
+  )
+})
+
+t.test('gypfile: false on disk ignored when the installed tarball differs', async t => {
+  const getInstallScripts = mockGetInstallScripts(t, () => true)
+  // Same name and version, different tarball. The copy on disk opted out,
+  // its replacement does not, and reify is about to install the replacement.
+  const otherIntegrity = installedNode(t, {
+    entry: { resolved: RESOLVED, integrity: 'sha512-bbbbbbbbbbbbbbbbbbbbbb==' },
+  })
+  t.strictSame(
+    await getInstallScripts(otherIntegrity),
+    { install: 'node-gyp rebuild' }
+  )
+
+  const otherResolved = installedNode(t, {
+    entry: {
+      resolved: 'https://other.example.com/pkg/-/pkg-1.0.0.tgz',
+      integrity: INTEGRITY,
+    },
+  })
+  t.strictSame(
+    await getInstallScripts(otherResolved),
+    { install: 'node-gyp rebuild' }
+  )
+})
+
+t.test('gypfile: false on disk ignored when the installed source is unknown', async t => {
+  const getInstallScripts = mockGetInstallScripts(t, () => true)
+  const expected = { install: 'node-gyp rebuild' }
+
+  // Nothing recorded the current contents of node_modules.
+  t.strictSame(
+    await getInstallScripts(installedNode(t, { lock: null })),
+    expected
+  )
+  // A hidden lockfile that says nothing about this location.
+  t.strictSame(
+    await getInstallScripts(installedNode(t, { lock: {} })),
+    expected
+  )
+  t.strictSame(
+    await getInstallScripts(installedNode(t, { entry: null })),
+    expected
+  )
+  // The node itself carries no source to compare against, as with a link
+  // or a dependency the lockfile has no integrity for.
+  t.strictSame(
+    await getInstallScripts(installedNode(t, {}, { resolved: '' })),
+    expected
+  )
+  t.strictSame(
+    await getInstallScripts(installedNode(t, {}, { integrity: '' })),
+    expected
+  )
+  t.strictSame(
+    await getInstallScripts(installedNode(t, {}, { location: '' })),
+    expected
+  )
+  t.strictSame(
+    await getInstallScripts(installedNode(t, {}, { root: null })),
+    expected
   )
 })
 

--- a/workspaces/arborist/test/install-scripts.js
+++ b/workspaces/arborist/test/install-scripts.js
@@ -95,6 +95,29 @@ t.test('synthetic node-gyp suppressed when gypfile: false', async t => {
   )
 })
 
+t.test('synthetic node-gyp suppressed by gypfile: false on disk', async t => {
+  const getInstallScripts = mockGetInstallScripts(t, () => true)
+  const path = t.testdir({
+    'package.json': JSON.stringify({
+      name: 'dep',
+      version: '1.0.0',
+      gypfile: false,
+    }),
+  })
+  t.strictSame(await getInstallScripts(node({ path })), {})
+})
+
+t.test('synthetic node-gyp still detected when disk has no gypfile', async t => {
+  const getInstallScripts = mockGetInstallScripts(t, () => true)
+  const path = t.testdir({
+    'package.json': JSON.stringify({ name: 'dep', version: '1.0.0' }),
+  })
+  t.strictSame(
+    await getInstallScripts(node({ path })),
+    { install: 'node-gyp rebuild' }
+  )
+})
+
 t.test('synthetic node-gyp suppressed when explicit install is present', async t => {
   const getInstallScripts = mockGetInstallScripts(t, () => true)
   t.strictSame(


### PR DESCRIPTION
## Summary

`gypfile: false` opts a package out of the `node-gyp rebuild` install script npm synthesises when it finds a `binding.gyp`. That opt-out only survives when the tree node was built from a packument or read off disk. Nodes built from a lockfile carry no `gypfile` field at all, so on `npm ci`, or on any `npm install` with an existing `package-lock.json`, npm sees the `binding.gyp` and adds the script anyway.

With `better-sqlite3@13.0.2` that shows up as a spurious `install-scripts` warning. It is not only cosmetic: the synthesised script is real, so once it is covered by `allowScripts` (or on npm 10, which has no such gate) `node-gyp rebuild` actually runs against a package that ships prebuilt binaries and asked not to be rebuilt.

Both the script enumeration in `install-scripts.js` and the build set in `rebuild.js` now read the opt-out back from the installed `package.json` when the node itself does not know it.

Fixes #9837

## Testing

Against the repro in the issue, `npm ci` no longer warns, and `npm ci --dangerously-allow-all-scripts --foreground-scripts` no longer invokes node-gyp. Added regression tests for both paths.