### PR TITLE
fix: don't print the funding message for global installs

### DIFF
--- a/lib/utils/reify-output.js
+++ b/lib/utils/reify-output.js
@@ -221,7 +221,7 @@ const packagesChangedMessage = (npm, { added, removed, changed, audited }) => {
 }
 
 const packagesFundingMessage = (npm, { funding }) => {
-  if (!funding) {
+  if (!funding || npm.global) {
     return
   }
 

--- a/test/lib/utils/reify-output.js
+++ b/test/lib/utils/reify-output.js
@@ -128,6 +128,35 @@ t.test('no message when funding config is false', async t => {
   t.notMatch(out, 'looking for funding', 'should not print funding info')
 })
 
+t.test('no message when installing globally', async t => {
+  const out = await mockReify(t, {
+    actualTree: {
+      name: 'foo',
+      package: {
+        name: 'foo',
+        version: '1.0.0',
+      },
+      edgesOut: new Map([
+        ['bar', {
+          to: {
+            name: 'bar',
+            package: {
+              name: 'bar',
+              version: '1.0.0',
+              funding: { type: 'foo', url: 'http://example.com' },
+            },
+          },
+        }],
+      ]),
+    },
+    diff: {
+      children: [],
+    },
+  }, { global: true })
+
+  t.notMatch(out, 'looking for funding', 'should not print funding info')
+})
+
 t.test('print appropriate message for many packages', async t => {
   const out = await mockReify(t, {
     actualTree: {


### PR DESCRIPTION
## What / Why

A global install prints "N packages are looking for funding / run `npm fund` for details", but nothing can be done with it. `npm fund -g` fails with `EFUNDGLOBAL`, and a bare `npm fund` loads the tree at the local prefix, so outside a project it prints the directory name and nothing else.

`packagesFundingMessage` in `lib/utils/reify-output.js` never looked at `npm.global`, so the hint went out for global installs too. It now returns early in that case. Making `npm fund -g` work is a separate feature request; #3112 already splits it out that way.

## Testing

New case in `test/lib/utils/reify-output.js`, mirroring the existing `fund: false` one: with `global: true` the output no longer mentions funding. It fails without the change.

## References

Fixes #9863
Fixes #3112
