### PR TITLE
fix: redact json output value by value so a url cannot corrupt it

### DIFF
--- a/lib/utils/display.js
+++ b/lib/utils/display.js
@@ -101,7 +101,21 @@ const getArrayOrObject = (items) => {
   return Object.assign({}, ...items.filter(o => isPlainObject(o)))
 }
 
-const redactValue = (obj) => JSON.parse(redactLog(JSON.stringify(obj)))
+const redactStrings = (obj) => {
+  if (typeof obj === 'string') {
+    return redactLog(obj)
+  }
+  if (Array.isArray(obj)) {
+    return obj.map(redactStrings)
+  }
+  if (isPlainObject(obj)) {
+    return Object.fromEntries(Object.entries(obj).map(([k, v]) => [k, redactStrings(v)]))
+  }
+  return obj
+}
+
+// Redact one string at a time. Redacting the serialized document instead lets a url in one value match across the punctuation around it and corrupt the json
+const redactValue = (obj) => redactStrings(JSON.parse(JSON.stringify(obj)))
 
 const getJsonBuffer = ({ [JSON_ERROR_KEY]: metaError }, buffer) => {
   const items = []

--- a/test/lib/utils/display.js
+++ b/test/lib/utils/display.js
@@ -300,6 +300,36 @@ t.test('json output redacts by default', async t => {
     'inline redact: false preserves uuid values')
 })
 
+t.test('json output with a url inside a value stays valid json', async t => {
+  const { META } = require('proc-log')
+  const { output, outputs } = await mockDisplay(t)
+
+  output.buffer({
+    dependencies: {
+      '@esbuild-kit/esm-loader': {
+        deprecated: 'Merged into tsx: https://tsx.hirok.io',
+        dev: true,
+        _id: '@esbuild-kit/esm-loader@2.6.5',
+      },
+    },
+    registry: 'https://user:hunter2@registry.npmjs.org/',
+    versions: ['2.6.5'],
+    before: new Date('2024-01-01'),
+  })
+  output.flush({ [META]: true, json: true })
+
+  t.equal(outputs.length, 1, 'one output')
+  const parsed = JSON.parse(outputs[0])
+  const dep = parsed.dependencies['@esbuild-kit/esm-loader']
+  t.equal(dep.deprecated, 'Merged into tsx: https://tsx.hirok.io',
+    'a url in one value does not swallow the values after it')
+  t.equal(dep._id, '@esbuild-kit/esm-loader@2.6.5', 'the following values are intact')
+  t.strictSame(parsed.versions, ['2.6.5'], 'arrays are walked too')
+  t.equal(parsed.registry, 'https://user:***@registry.npmjs.org/',
+    'url passwords are still redacted')
+  t.equal(parsed.before, '2024-01-01T00:00:00.000Z', 'toJSON values are still serialized')
+})
+
 t.test('prompt functionality', async t => {
   t.test('regular prompt completion works', async t => {
     const { input } = await mockDisplay(t)


### PR DESCRIPTION
## What / Why

`npm ls --json --long` prints nothing and exits 1 when the tree holds a package whose `deprecated` message contains a url, for example `@esbuild-kit/esm-loader@2.6.5` ("Merged into tsx: https://tsx.hirok.io"). Tools that shell out to it, like `@cyclonedx/cyclonedx-npm`, fail with "failed to parse npm-ls response".

`redactValue` in `lib/utils/display.js` redacted the whole serialized document: `JSON.parse(redactLog(JSON.stringify(obj)))`. Compact json has no whitespace, so the url matcher in `@npmcli/redact` reads from `https://` all the way to the next `@` (here the `_id` of a scoped package) and treats everything between as `user:password@`. What comes back is no longer json, `JSON.parse` throws inside the flush, and the error is swallowed. Pretty printed output never hit this because the newlines stop the matcher, which is why it only appeared once redaction moved to compact `JSON.stringify` in 11.15.0.

The document is still serialized the same way, so `toJSON` and dropped keys behave as before, but redaction now runs over the parsed value one string at a time. Punctuation around a value can never be pulled into a match. Object keys are left alone, which in npm's json output means config names, package names and script names.

## Testing

New case in `test/lib/utils/display.js`: a deprecation message with a url next to a scoped `_id` stays intact, arrays are walked, a `Date` still serializes, and a url password is still redacted. It throws the same `SyntaxError` without the change.

## References

Fixes #9873