### PR TITLE
fix(arborist): don't fetch packuments for uninstallable optional peer deps

### DIFF
--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -1607,10 +1607,15 @@ This is a one-time fix-up, please be patient...
 
       if (!edge.to) {
         if (!parentEdge) {
-          // a missing peerOptional is valid and will never be placed from
-          // here, so don't waste a packument fetch resolving it
+          // the peer is missing from the virtual root; check the real tree before skipping.
+          // we can avoid a fetch for an optional peer, or a compatible provider, though
+          // an incompatible provider still has to be resolved here so that the
+          // optional peer set nests instead of displacing required peers.
           if (edge.type === 'peerOptional') {
-            continue
+            const current = node.parent.sourceReference.resolve(edge.name)
+            if (!current || current.satisfies(edge)) {
+              continue
+            }
           }
           // easy, just put the thing there
           await this.#nodeFromEdge(edge, node.parent, null, required)

--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -1607,6 +1607,11 @@ This is a one-time fix-up, please be patient...
 
       if (!edge.to) {
         if (!parentEdge) {
+          // a missing peerOptional is valid and will never be placed from
+          // here, so don't waste a packument fetch resolving it
+          if (edge.type === 'peerOptional') {
+            continue
+          }
           // easy, just put the thing there
           await this.#nodeFromEdge(edge, node.parent, null, required)
           continue

--- a/workspaces/arborist/tap-snapshots/test/arborist/build-ideal-tree.js.test.cjs
+++ b/workspaces/arborist/tap-snapshots/test/arborist/build-ideal-tree.js.test.cjs
@@ -16755,11 +16755,11 @@ ArboristNode {
 exports[`test/arborist/build-ideal-tree.js TAP detect conflicts in transitive peerOptional deps nest when peerOptional conflicts > must match snapshot 1`] = `
 ArboristNode {
   "children": Map {
-    "@isaacs/test-conflicted-optional-peer-dep-has-peer" => ArboristNode {
+    "@isaacs/test-conflicted-optional-peer-dep-has-peer-optional" => ArboristNode {
       "edgesIn": Set {
         EdgeIn {
-          "from": "node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer",
-          "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer",
+          "from": "node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional",
+          "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
           "spec": "1",
           "type": "prod",
         },
@@ -16767,18 +16767,59 @@ ArboristNode {
       "edgesOut": Map {
         "@isaacs/test-conflicted-optional-peer-dep-peer" => EdgeOut {
           "name": "@isaacs/test-conflicted-optional-peer-dep-peer",
-          "spec": "1",
+          "spec": "2",
           "to": "node_modules/@isaacs/test-conflicted-optional-peer-dep-peer",
-          "type": "peer",
+          "type": "peerOptional",
         },
       },
-      "location": "node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer",
-      "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer",
-      "path": "{CWD}/test/fixtures/test-conflicted-optional-peer-dep/nest-peer-optional/node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer",
-      "resolved": "https://registry.npmjs.org/@isaacs/test-conflicted-optional-peer-dep-has-peer/-/test-conflicted-optional-peer-dep-has-peer-1.0.0.tgz",
+      "location": "node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
+      "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
+      "path": "{CWD}/test/fixtures/test-conflicted-optional-peer-dep/nest-peer-optional/node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
+      "resolved": "https://registry.npmjs.org/@isaacs/test-conflicted-optional-peer-dep-has-peer-optional/-/test-conflicted-optional-peer-dep-has-peer-optional-1.0.0.tgz",
       "version": "1.0.0",
     },
     "@isaacs/test-conflicted-optional-peer-dep-meta-peer" => ArboristNode {
+      "children": Map {
+        "@isaacs/test-conflicted-optional-peer-dep-has-peer" => ArboristNode {
+          "edgesIn": Set {
+            EdgeIn {
+              "from": "node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer",
+              "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer",
+              "spec": "1",
+              "type": "prod",
+            },
+          },
+          "edgesOut": Map {
+            "@isaacs/test-conflicted-optional-peer-dep-peer" => EdgeOut {
+              "name": "@isaacs/test-conflicted-optional-peer-dep-peer",
+              "spec": "1",
+              "to": "node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer/node_modules/@isaacs/test-conflicted-optional-peer-dep-peer",
+              "type": "peer",
+            },
+          },
+          "location": "node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer/node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer",
+          "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer",
+          "path": "{CWD}/test/fixtures/test-conflicted-optional-peer-dep/nest-peer-optional/node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer/node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer",
+          "resolved": "https://registry.npmjs.org/@isaacs/test-conflicted-optional-peer-dep-has-peer/-/test-conflicted-optional-peer-dep-has-peer-1.0.0.tgz",
+          "version": "1.0.0",
+        },
+        "@isaacs/test-conflicted-optional-peer-dep-peer" => ArboristNode {
+          "edgesIn": Set {
+            EdgeIn {
+              "from": "node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer/node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer",
+              "name": "@isaacs/test-conflicted-optional-peer-dep-peer",
+              "spec": "1",
+              "type": "peer",
+            },
+          },
+          "location": "node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer/node_modules/@isaacs/test-conflicted-optional-peer-dep-peer",
+          "name": "@isaacs/test-conflicted-optional-peer-dep-peer",
+          "path": "{CWD}/test/fixtures/test-conflicted-optional-peer-dep/nest-peer-optional/node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer/node_modules/@isaacs/test-conflicted-optional-peer-dep-peer",
+          "peer": true,
+          "resolved": "https://registry.npmjs.org/@isaacs/test-conflicted-optional-peer-dep-peer/-/test-conflicted-optional-peer-dep-peer-1.0.0.tgz",
+          "version": "1.0.0",
+        },
+      },
       "edgesIn": Set {
         EdgeIn {
           "from": "",
@@ -16791,7 +16832,7 @@ ArboristNode {
         "@isaacs/test-conflicted-optional-peer-dep-has-peer" => EdgeOut {
           "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer",
           "spec": "1",
-          "to": "node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer",
+          "to": "node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer/node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer",
           "type": "prod",
         },
       },
@@ -16802,49 +16843,6 @@ ArboristNode {
       "version": "1.0.0",
     },
     "@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional" => ArboristNode {
-      "children": Map {
-        "@isaacs/test-conflicted-optional-peer-dep-has-peer-optional" => ArboristNode {
-          "edgesIn": Set {
-            EdgeIn {
-              "from": "node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional",
-              "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
-              "spec": "1",
-              "type": "prod",
-            },
-          },
-          "edgesOut": Map {
-            "@isaacs/test-conflicted-optional-peer-dep-peer" => EdgeOut {
-              "name": "@isaacs/test-conflicted-optional-peer-dep-peer",
-              "spec": "2",
-              "to": "node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional/node_modules/@isaacs/test-conflicted-optional-peer-dep-peer",
-              "type": "peerOptional",
-            },
-          },
-          "location": "node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional/node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
-          "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
-          "path": "{CWD}/test/fixtures/test-conflicted-optional-peer-dep/nest-peer-optional/node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional/node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
-          "resolved": "https://registry.npmjs.org/@isaacs/test-conflicted-optional-peer-dep-has-peer-optional/-/test-conflicted-optional-peer-dep-has-peer-optional-1.0.0.tgz",
-          "version": "1.0.0",
-        },
-        "@isaacs/test-conflicted-optional-peer-dep-peer" => ArboristNode {
-          "edgesIn": Set {
-            EdgeIn {
-              "from": "node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional/node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
-              "name": "@isaacs/test-conflicted-optional-peer-dep-peer",
-              "spec": "2",
-              "type": "peerOptional",
-            },
-          },
-          "extraneous": true,
-          "location": "node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional/node_modules/@isaacs/test-conflicted-optional-peer-dep-peer",
-          "name": "@isaacs/test-conflicted-optional-peer-dep-peer",
-          "optional": true,
-          "path": "{CWD}/test/fixtures/test-conflicted-optional-peer-dep/nest-peer-optional/node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional/node_modules/@isaacs/test-conflicted-optional-peer-dep-peer",
-          "peer": true,
-          "resolved": "https://registry.npmjs.org/@isaacs/test-conflicted-optional-peer-dep-peer/-/test-conflicted-optional-peer-dep-peer-2.0.0.tgz",
-          "version": "2.0.0",
-        },
-      },
       "edgesIn": Set {
         EdgeIn {
           "from": "",
@@ -16857,7 +16855,7 @@ ArboristNode {
         "@isaacs/test-conflicted-optional-peer-dep-has-peer-optional" => EdgeOut {
           "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
           "spec": "1",
-          "to": "node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional/node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
+          "to": "node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
           "type": "prod",
         },
       },
@@ -16870,18 +16868,20 @@ ArboristNode {
     "@isaacs/test-conflicted-optional-peer-dep-peer" => ArboristNode {
       "edgesIn": Set {
         EdgeIn {
-          "from": "node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer",
+          "from": "node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
           "name": "@isaacs/test-conflicted-optional-peer-dep-peer",
-          "spec": "1",
-          "type": "peer",
+          "spec": "2",
+          "type": "peerOptional",
         },
       },
+      "extraneous": true,
       "location": "node_modules/@isaacs/test-conflicted-optional-peer-dep-peer",
       "name": "@isaacs/test-conflicted-optional-peer-dep-peer",
+      "optional": true,
       "path": "{CWD}/test/fixtures/test-conflicted-optional-peer-dep/nest-peer-optional/node_modules/@isaacs/test-conflicted-optional-peer-dep-peer",
       "peer": true,
-      "resolved": "https://registry.npmjs.org/@isaacs/test-conflicted-optional-peer-dep-peer/-/test-conflicted-optional-peer-dep-peer-1.0.0.tgz",
-      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/test-conflicted-optional-peer-dep-peer/-/test-conflicted-optional-peer-dep-peer-2.0.0.tgz",
+      "version": "2.0.0",
     },
   },
   "edgesOut": Map {

--- a/workspaces/arborist/tap-snapshots/test/arborist/build-ideal-tree.js.test.cjs
+++ b/workspaces/arborist/tap-snapshots/test/arborist/build-ideal-tree.js.test.cjs
@@ -16755,11 +16755,11 @@ ArboristNode {
 exports[`test/arborist/build-ideal-tree.js TAP detect conflicts in transitive peerOptional deps nest when peerOptional conflicts > must match snapshot 1`] = `
 ArboristNode {
   "children": Map {
-    "@isaacs/test-conflicted-optional-peer-dep-has-peer-optional" => ArboristNode {
+    "@isaacs/test-conflicted-optional-peer-dep-has-peer" => ArboristNode {
       "edgesIn": Set {
         EdgeIn {
-          "from": "node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional",
-          "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
+          "from": "node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer",
+          "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer",
           "spec": "1",
           "type": "prod",
         },
@@ -16767,59 +16767,18 @@ ArboristNode {
       "edgesOut": Map {
         "@isaacs/test-conflicted-optional-peer-dep-peer" => EdgeOut {
           "name": "@isaacs/test-conflicted-optional-peer-dep-peer",
-          "spec": "2",
+          "spec": "1",
           "to": "node_modules/@isaacs/test-conflicted-optional-peer-dep-peer",
-          "type": "peerOptional",
+          "type": "peer",
         },
       },
-      "location": "node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
-      "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
-      "path": "{CWD}/test/fixtures/test-conflicted-optional-peer-dep/nest-peer-optional/node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
-      "resolved": "https://registry.npmjs.org/@isaacs/test-conflicted-optional-peer-dep-has-peer-optional/-/test-conflicted-optional-peer-dep-has-peer-optional-1.0.0.tgz",
+      "location": "node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer",
+      "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer",
+      "path": "{CWD}/test/fixtures/test-conflicted-optional-peer-dep/nest-peer-optional/node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer",
+      "resolved": "https://registry.npmjs.org/@isaacs/test-conflicted-optional-peer-dep-has-peer/-/test-conflicted-optional-peer-dep-has-peer-1.0.0.tgz",
       "version": "1.0.0",
     },
     "@isaacs/test-conflicted-optional-peer-dep-meta-peer" => ArboristNode {
-      "children": Map {
-        "@isaacs/test-conflicted-optional-peer-dep-has-peer" => ArboristNode {
-          "edgesIn": Set {
-            EdgeIn {
-              "from": "node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer",
-              "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer",
-              "spec": "1",
-              "type": "prod",
-            },
-          },
-          "edgesOut": Map {
-            "@isaacs/test-conflicted-optional-peer-dep-peer" => EdgeOut {
-              "name": "@isaacs/test-conflicted-optional-peer-dep-peer",
-              "spec": "1",
-              "to": "node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer/node_modules/@isaacs/test-conflicted-optional-peer-dep-peer",
-              "type": "peer",
-            },
-          },
-          "location": "node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer/node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer",
-          "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer",
-          "path": "{CWD}/test/fixtures/test-conflicted-optional-peer-dep/nest-peer-optional/node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer/node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer",
-          "resolved": "https://registry.npmjs.org/@isaacs/test-conflicted-optional-peer-dep-has-peer/-/test-conflicted-optional-peer-dep-has-peer-1.0.0.tgz",
-          "version": "1.0.0",
-        },
-        "@isaacs/test-conflicted-optional-peer-dep-peer" => ArboristNode {
-          "edgesIn": Set {
-            EdgeIn {
-              "from": "node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer/node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer",
-              "name": "@isaacs/test-conflicted-optional-peer-dep-peer",
-              "spec": "1",
-              "type": "peer",
-            },
-          },
-          "location": "node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer/node_modules/@isaacs/test-conflicted-optional-peer-dep-peer",
-          "name": "@isaacs/test-conflicted-optional-peer-dep-peer",
-          "path": "{CWD}/test/fixtures/test-conflicted-optional-peer-dep/nest-peer-optional/node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer/node_modules/@isaacs/test-conflicted-optional-peer-dep-peer",
-          "peer": true,
-          "resolved": "https://registry.npmjs.org/@isaacs/test-conflicted-optional-peer-dep-peer/-/test-conflicted-optional-peer-dep-peer-1.0.0.tgz",
-          "version": "1.0.0",
-        },
-      },
       "edgesIn": Set {
         EdgeIn {
           "from": "",
@@ -16832,7 +16791,7 @@ ArboristNode {
         "@isaacs/test-conflicted-optional-peer-dep-has-peer" => EdgeOut {
           "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer",
           "spec": "1",
-          "to": "node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer/node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer",
+          "to": "node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer",
           "type": "prod",
         },
       },
@@ -16843,6 +16802,49 @@ ArboristNode {
       "version": "1.0.0",
     },
     "@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional" => ArboristNode {
+      "children": Map {
+        "@isaacs/test-conflicted-optional-peer-dep-has-peer-optional" => ArboristNode {
+          "edgesIn": Set {
+            EdgeIn {
+              "from": "node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional",
+              "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
+              "spec": "1",
+              "type": "prod",
+            },
+          },
+          "edgesOut": Map {
+            "@isaacs/test-conflicted-optional-peer-dep-peer" => EdgeOut {
+              "name": "@isaacs/test-conflicted-optional-peer-dep-peer",
+              "spec": "2",
+              "to": "node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional/node_modules/@isaacs/test-conflicted-optional-peer-dep-peer",
+              "type": "peerOptional",
+            },
+          },
+          "location": "node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional/node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
+          "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
+          "path": "{CWD}/test/fixtures/test-conflicted-optional-peer-dep/nest-peer-optional/node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional/node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
+          "resolved": "https://registry.npmjs.org/@isaacs/test-conflicted-optional-peer-dep-has-peer-optional/-/test-conflicted-optional-peer-dep-has-peer-optional-1.0.0.tgz",
+          "version": "1.0.0",
+        },
+        "@isaacs/test-conflicted-optional-peer-dep-peer" => ArboristNode {
+          "edgesIn": Set {
+            EdgeIn {
+              "from": "node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional/node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
+              "name": "@isaacs/test-conflicted-optional-peer-dep-peer",
+              "spec": "2",
+              "type": "peerOptional",
+            },
+          },
+          "extraneous": true,
+          "location": "node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional/node_modules/@isaacs/test-conflicted-optional-peer-dep-peer",
+          "name": "@isaacs/test-conflicted-optional-peer-dep-peer",
+          "optional": true,
+          "path": "{CWD}/test/fixtures/test-conflicted-optional-peer-dep/nest-peer-optional/node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional/node_modules/@isaacs/test-conflicted-optional-peer-dep-peer",
+          "peer": true,
+          "resolved": "https://registry.npmjs.org/@isaacs/test-conflicted-optional-peer-dep-peer/-/test-conflicted-optional-peer-dep-peer-2.0.0.tgz",
+          "version": "2.0.0",
+        },
+      },
       "edgesIn": Set {
         EdgeIn {
           "from": "",
@@ -16855,7 +16857,7 @@ ArboristNode {
         "@isaacs/test-conflicted-optional-peer-dep-has-peer-optional" => EdgeOut {
           "name": "@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
           "spec": "1",
-          "to": "node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
+          "to": "node_modules/@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional/node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
           "type": "prod",
         },
       },
@@ -16868,20 +16870,18 @@ ArboristNode {
     "@isaacs/test-conflicted-optional-peer-dep-peer" => ArboristNode {
       "edgesIn": Set {
         EdgeIn {
-          "from": "node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer-optional",
+          "from": "node_modules/@isaacs/test-conflicted-optional-peer-dep-has-peer",
           "name": "@isaacs/test-conflicted-optional-peer-dep-peer",
-          "spec": "2",
-          "type": "peerOptional",
+          "spec": "1",
+          "type": "peer",
         },
       },
-      "extraneous": true,
       "location": "node_modules/@isaacs/test-conflicted-optional-peer-dep-peer",
       "name": "@isaacs/test-conflicted-optional-peer-dep-peer",
-      "optional": true,
       "path": "{CWD}/test/fixtures/test-conflicted-optional-peer-dep/nest-peer-optional/node_modules/@isaacs/test-conflicted-optional-peer-dep-peer",
       "peer": true,
-      "resolved": "https://registry.npmjs.org/@isaacs/test-conflicted-optional-peer-dep-peer/-/test-conflicted-optional-peer-dep-peer-2.0.0.tgz",
-      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/test-conflicted-optional-peer-dep-peer/-/test-conflicted-optional-peer-dep-peer-1.0.0.tgz",
+      "version": "1.0.0",
     },
   },
   "edgesOut": Map {

--- a/workspaces/arborist/test/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/test/arborist/build-ideal-tree.js
@@ -4885,6 +4885,35 @@ t.test('circular peer back-off does not crash when node is detached mid-resoluti
     'backs off to plugin@1.0.0 to satisfy the optional peer instead of crashing')
 })
 
+t.test('does not fetch packuments for peerOptional deps that will not be installed', async t => {
+  const registry = createRegistry(t, false)
+
+  const hostPack = registry.packument({
+    name: 'host',
+    version: '1.0.0',
+    peerDependencies: { plugin: '^1.0.0' },
+    peerDependenciesMeta: { plugin: { optional: true } },
+  })
+  const hostManifest = registry.manifest({ name: 'host', packuments: [hostPack] })
+  await registry.package({ manifest: hostManifest })
+
+  const path = t.testdir({
+    'package.json': JSON.stringify({
+      dependencies: { host: '^1.0.0' },
+    }),
+  })
+
+  const arb = newArb(path)
+  const tree = await arb.buildIdealTree()
+
+  t.equal(tree.children.get('host').version, '1.0.0', 'installed host')
+  t.equal(tree.children.get('plugin'), undefined, 'did not install the optional peer')
+  const edge = tree.children.get('host').edgesOut.get('plugin')
+  t.equal(edge.type, 'peerOptional')
+  t.equal(edge.to, null, 'peerOptional edge left unresolved')
+  t.ok(edge.valid, 'missing peerOptional edge is valid')
+})
+
 t.test('peerOptional prefers existing tree node over registry fetch (#9249)', async t => {
   // Reproduction: ts-jest has peerOptional jest-util@"^29||^30".
   // @types/jest@28 → expect@28 → jest-util@28 placed at root first.
@@ -4930,7 +4959,7 @@ t.test('peerOptional prefers existing tree node over registry fetch (#9249)', as
   // Only publish 28, 29, and 30.
   const jestUtilPacks = registry.packuments(['28.0.0', '29.0.0', '30.0.0'], 'jest-util')
   const jestUtilManifest = registry.manifest({ name: 'jest-util', packuments: jestUtilPacks })
-  await registry.package({ manifest: jestUtilManifest, times: 3 })
+  await registry.package({ manifest: jestUtilManifest, times: 2 })
 
   const path = t.testdir({
     'package.json': JSON.stringify({

--- a/workspaces/arborist/test/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/test/arborist/build-ideal-tree.js
@@ -2355,19 +2355,42 @@ t.test('detect conflicts in transitive peerOptional deps', async t => {
     createRegistry(t, true)
     const tree = await buildIdeal(path)
     t.matchSnapshot(printTree(tree))
-    const name = '@isaacs/test-conflicted-optional-peer-dep-peer'
-    const peers = tree.inventory.query('name', name)
+    const peerName = '@isaacs/test-conflicted-optional-peer-dep-peer'
+    const requiredHostName = '@isaacs/test-conflicted-optional-peer-dep-has-peer'
+    const optionalHostName = '@isaacs/test-conflicted-optional-peer-dep-has-peer-optional'
+    const optionalMetaName = '@isaacs/test-conflicted-optional-peer-dep-meta-peer-optional'
+
+    const peers = tree.inventory.query('name', peerName)
     t.equal(peers.size, 2, 'installed the peer dep twice to avoid conflict')
-    t.strictSame(
-      [...peers].map(p => p.version).sort(),
-      ['1.0.0', '2.0.0'],
-      'both conflicting versions are present'
+
+    const rootPeer = tree.children.get(peerName)
+    const requiredHost = tree.children.get(requiredHostName)
+    const optionalMeta = tree.children.get(optionalMetaName)
+    const optionalHost = optionalMeta?.children.get(optionalHostName)
+    const nestedPeer = optionalMeta?.children.get(peerName)
+
+    t.equal(rootPeer?.version, '1.0.0', 'required peer retains the root slot')
+    t.equal(
+      requiredHost?.edgesOut.get(peerName)?.to,
+      rootPeer,
+      'required peer edge resolves to the root provider'
     )
-    for (const peer of peers) {
-      for (const edge of peer.edgesIn) {
-        t.ok(edge.valid, `edge from ${edge.from.name} is valid`)
-      }
-    }
+
+    t.notOk(
+      tree.children.get(optionalHostName),
+      'optional peer dependent is not hoisted to the root'
+    )
+    t.ok(optionalHost, 'optional peer dependent is nested under its branch')
+    t.equal(
+      nestedPeer?.version,
+      '2.0.0',
+      'compatible optional peer is nested with its dependent'
+    )
+    t.equal(
+      optionalHost?.edgesOut.get(peerName)?.to,
+      nestedPeer,
+      'optional peer edge resolves to its nested provider'
+    )
   })
 
   await t.test('omit peerOptionals when not needed for conflicts', async t => {

--- a/workspaces/arborist/test/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/test/arborist/build-ideal-tree.js
@@ -4987,6 +4987,50 @@ t.test('resolves peerOptional deps installed by another dependent', async t => {
   t.ok(edge.valid, 'peerOptional edge is valid')
 })
 
+t.test('does not fetch packuments for peerOptional deps satisfied by the actual tree', async t => {
+  const registry = createRegistry(t, false)
+
+  const hostPack = registry.packument({
+    name: 'host',
+    version: '1.0.0',
+    peerDependencies: { plugin: '^1.0.0' },
+    peerDependenciesMeta: { plugin: { optional: true } },
+  })
+  const hostManifest = registry.manifest({ name: 'host', packuments: [hostPack] })
+  await registry.package({ manifest: hostManifest })
+
+  const path = t.testdir({
+    node_modules: {
+      other: {
+        'package.json': JSON.stringify({
+          name: 'other',
+          version: '1.0.0',
+          dependencies: { plugin: '^1.0.0' },
+        }),
+      },
+      plugin: {
+        'package.json': JSON.stringify({
+          name: 'plugin',
+          version: '1.0.0',
+        }),
+      },
+    },
+    'package.json': JSON.stringify({
+      dependencies: { other: '^1.0.0' },
+    }),
+  })
+
+  const arb = newArb(path)
+  const tree = await arb.buildIdealTree({ add: ['host@^1.0.0'] })
+
+  const plugin = tree.children.get('plugin')
+  t.equal(plugin.version, '1.0.0', 'kept the already installed plugin')
+  const edge = tree.children.get('host').edgesOut.get('plugin')
+  t.equal(edge.type, 'peerOptional')
+  t.equal(edge.to, plugin, 'peerOptional edge resolved to the existing plugin')
+  t.ok(edge.valid, 'peerOptional edge is valid')
+})
+
 t.test('peerOptional prefers existing tree node over registry fetch (#9249)', async t => {
   // Reproduction: ts-jest has peerOptional jest-util@"^29||^30".
   // @types/jest@28 → expect@28 → jest-util@28 placed at root first.

--- a/workspaces/arborist/test/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/test/arborist/build-ideal-tree.js
@@ -2358,6 +2358,16 @@ t.test('detect conflicts in transitive peerOptional deps', async t => {
     const name = '@isaacs/test-conflicted-optional-peer-dep-peer'
     const peers = tree.inventory.query('name', name)
     t.equal(peers.size, 2, 'installed the peer dep twice to avoid conflict')
+    t.strictSame(
+      [...peers].map(p => p.version).sort(),
+      ['1.0.0', '2.0.0'],
+      'both conflicting versions are present'
+    )
+    for (const peer of peers) {
+      for (const edge of peer.edgesIn) {
+        t.ok(edge.valid, `edge from ${edge.from.name} is valid`)
+      }
+    }
   })
 
   await t.test('omit peerOptionals when not needed for conflicts', async t => {
@@ -4912,6 +4922,46 @@ t.test('does not fetch packuments for peerOptional deps that will not be install
   t.equal(edge.type, 'peerOptional')
   t.equal(edge.to, null, 'peerOptional edge left unresolved')
   t.ok(edge.valid, 'missing peerOptional edge is valid')
+})
+
+t.test('resolves peerOptional deps installed by another dependent', async t => {
+  const registry = createRegistry(t, false)
+
+  const hostPack = registry.packument({
+    name: 'host',
+    version: '1.0.0',
+    peerDependencies: { plugin: '^1.0.0' },
+    peerDependenciesMeta: { plugin: { optional: true } },
+  })
+  const hostManifest = registry.manifest({ name: 'host', packuments: [hostPack] })
+  await registry.package({ manifest: hostManifest })
+
+  const otherPack = registry.packument({
+    name: 'other',
+    version: '1.0.0',
+    dependencies: { plugin: '^1.0.0' },
+  })
+  const otherManifest = registry.manifest({ name: 'other', packuments: [otherPack] })
+  await registry.package({ manifest: otherManifest })
+
+  const pluginManifest = registry.manifest({ name: 'plugin' })
+  await registry.package({ manifest: pluginManifest })
+
+  const path = t.testdir({
+    'package.json': JSON.stringify({
+      dependencies: { host: '^1.0.0', other: '^1.0.0' },
+    }),
+  })
+
+  const arb = newArb(path)
+  const tree = await arb.buildIdealTree()
+
+  const plugin = tree.children.get('plugin')
+  t.ok(plugin, 'installed the plugin for the dependent that requires it')
+  const edge = tree.children.get('host').edgesOut.get('plugin')
+  t.equal(edge.type, 'peerOptional')
+  t.equal(edge.to, plugin, 'peerOptional edge resolved to the installed plugin')
+  t.ok(edge.valid, 'peerOptional edge is valid')
 })
 
 t.test('peerOptional prefers existing tree node over registry fetch (#9249)', async t => {


### PR DESCRIPTION
this is a PR aimed to skip fetching packuments for optional peers that won't be installed. this can be extremely costly.

for example, with an empty cache, `npm install vite` into an empty project installs 10 packages but fetches full packuments for `playwright` (16.6MB), `@types/node` (11MB), `webdriverio`, `jsdom`, `sass`, `less`, `terser`, and (via `vite`'s optional peer on `vitest`) all of vitest's optional peers too:

| | before | after |
| - | - | - |
| registry requests | 86 | 54 |
| cached registry data | ~121MB | ~72MB |

`loadPeerSet` resolves unmet optional peer edges into the virtual root, even though they won't be used and in fact be pruned later on

the fix is very simple; we just skip `peerOptional` edges if they have no current resolution and no parent edge. ~~if something else ends up installing the package, the edge is still validated at placement time.~~

having said all of that, I'm a relative newcomer to the npm cli, so do let me know if there's a reason for this fetching that I'm missing 🙏

> [!NOTE]
> ~~the `nest when peerOptional conflicts` snapshot did change shape.~~
>
> ~~imo it was a bug before - the unmet optional peer was eagerly placed and 'won' the top-level slot, forcing the _required_ peer chain to nest, but **now** the required chain wins and the optional subtree nests instead.~~
>
> ~~both before/after were valid trees (two copies of the conflicted peer, all edges valid, etc). I've added assertions for this, but it's worth noting that installs with conflicting optional peers can produce a differently shaped `node_modules` than before.~~

(ht to @pi0, who spotted this)

## References

Fixes https://github.com/npm/cli/issues/9876
