### PR TITLE
fix(arborist): reject uninstall args that carry a version

### DIFF
--- a/test/lib/commands/uninstall.js
+++ b/test/lib/commands/uninstall.js
@@ -143,6 +143,34 @@ t.test('remove multiple installed libs', async t => {
   t.throws(() => fs.statSync(b), 'should have removed b package from nm')
 })
 
+t.test('rejects an arg with a version spec', async t => {
+  const { uninstall } = await mockNpm(t, {
+    prefixDir: {
+      'package.json': JSON.stringify({
+        name: 'test-rm-version-spec',
+        version: '1.0.0',
+        dependencies: {
+          foo: '*',
+        },
+      }),
+      node_modules: {
+        foo: {
+          'package.json': JSON.stringify({
+            name: 'foo',
+            version: '1.0.0',
+          }),
+        },
+      },
+    },
+  })
+
+  await t.rejects(
+    uninstall(['foo@1']),
+    { code: 'ERMARGS', message: /npm rm foo/ },
+    'should throw ERMARGS instead of silently no-oping'
+  )
+})
+
 t.test('no args local', async t => {
   const { uninstall } = await mockNpm(t)
 

--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -396,6 +396,8 @@ module.exports = cls => class IdealTreeBuilder extends cls {
     }
     this[_updateNames] = update.names
 
+    this[_updateAll] = update.all
+
     // validates list of rm names, they must
     // be dep names only, no semver ranges are supported
     for (const name of options.rm || []) {
@@ -411,7 +413,6 @@ module.exports = cls => class IdealTreeBuilder extends cls {
       }
     }
 
-    this[_updateAll] = update.all
     // we prune by default unless explicitly set to boolean false
     this.#prune = options.prune !== false
 

--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -396,6 +396,21 @@ module.exports = cls => class IdealTreeBuilder extends cls {
     }
     this[_updateNames] = update.names
 
+    // validates list of rm names, they must
+    // be dep names only, no semver ranges are supported
+    for (const name of options.rm || []) {
+      const spec = npa(name)
+      const validationError =
+        new TypeError(`Remove arguments must only contain package names, eg:
+    npm uninstall ${spec.name}`)
+      validationError.code = 'ERMARGS'
+
+      // If they gave us anything other than a bare package name
+      if (spec.raw !== spec.name) {
+        throw validationError
+      }
+    }
+
     this[_updateAll] = update.all
     // we prune by default unless explicitly set to boolean false
     this.#prune = options.prune !== false

--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -402,7 +402,7 @@ module.exports = cls => class IdealTreeBuilder extends cls {
       const spec = npa(name)
       const validationError =
         new TypeError(`Remove arguments must only contain package names, eg:
-    npm uninstall ${spec.name}`)
+    npm rm ${spec.name || '<pkg>'}`)
       validationError.code = 'ERMARGS'
 
       // If they gave us anything other than a bare package name

--- a/workspaces/arborist/test/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/test/arborist/build-ideal-tree.js
@@ -2347,6 +2347,35 @@ t.test('remove deps when initializing tree from actual tree', async t => {
   t.equal(tree.children.get('foo'), undefined, 'removed foo child')
 })
 
+t.test('rm deps with a version spec', async t => {
+  const path = t.testdir({
+    node_modules: {
+      foo: {
+        'package.json': JSON.stringify({
+          name: 'foo',
+          version: '1.2.3',
+        }),
+      },
+    },
+  })
+
+  createRegistry(t, false)
+  const invalidArgs = [
+    'foo@1.2.3',
+    'foo@next',
+    'foo@^1.0.0',
+    'foo@>=2.0.0',
+    'foo@2',
+  ]
+  for (const rmName of invalidArgs) {
+    await t.rejects(
+      newArb(path).buildIdealTree({ rm: [rmName] }),
+      { code: 'ERMARGS' },
+      'should throw an error when using semver ranges'
+    )
+  }
+})
+
 t.test('detect conflicts in transitive peerOptional deps', async t => {
   const base = resolve(fixtures, 'test-conflicted-optional-peer-dep')
 

--- a/workspaces/arborist/test/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/test/arborist/build-ideal-tree.js
@@ -2347,7 +2347,7 @@ t.test('remove deps when initializing tree from actual tree', async t => {
   t.equal(tree.children.get('foo'), undefined, 'removed foo child')
 })
 
-t.test('rm deps with a version spec', async t => {
+t.test('remove deps with a version spec', async t => {
   const path = t.testdir({
     node_modules: {
       foo: {
@@ -2369,11 +2369,17 @@ t.test('rm deps with a version spec', async t => {
   ]
   for (const rmName of invalidArgs) {
     await t.rejects(
-      newArb(path).buildIdealTree({ rm: [rmName] }),
-      { code: 'ERMARGS' },
-      'should throw an error when using semver ranges'
+      buildIdeal(path, { rm: [rmName] }),
+      { code: 'ERMARGS', message: /npm rm foo/ },
+      'should throw an error when the package name has a version'
     )
   }
+
+  await t.rejects(
+    buildIdeal(path, { rm: ['./foo'] }),
+    { code: 'ERMARGS', message: /npm rm <pkg>/ },
+    'should throw an error when the package is a path'
+  )
 })
 
 t.test('detect conflicts in transitive peerOptional deps', async t => {

--- a/workspaces/arborist/test/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/test/arborist/build-ideal-tree.js
@@ -2376,6 +2376,12 @@ t.test('remove deps with a version spec', async t => {
   }
 
   await t.rejects(
+    buildIdeal(path, { rm: ['@scope/foo@1.2.3'] }),
+    { code: 'ERMARGS', message: /npm rm @scope\/foo/ },
+    'should throw an error when a scoped package name has a version'
+  )
+
+  await t.rejects(
     buildIdeal(path, { rm: ['./foo'] }),
     { code: 'ERMARGS', message: /npm rm <pkg>/ },
     'should throw an error when the package is a path'


### PR DESCRIPTION
## What / Why

`npm uninstall vite@8.2.1` neither removes the package nor complains about the argument. The spec goes straight through to Arborist as an `rm` entry, nothing in the tree is named `vite@8.2.1`, so the reify finishes with "up to date" and `npm ls` still shows `vite`.

`npm update` already validates its own argument list and throws `EUPDATEARGS` for anything that is not a bare package name. This applies the same rule to `rm`, so a version, tag or range now fails with `ERMARGS` and the message names the command to run instead.

## Testing

New case in `workspaces/arborist/test/arborist/build-ideal-tree.js`, next to the existing rm test and mirroring the update one. It covers an exact version, a tag, ranges, a scoped name carrying a version, and a filesystem path, where the suggestion falls back to `<pkg>` because there is no name to print. It fails without the change.

## References

Fixes #9880
