### PR TITLE
docs: fix grammar and missing brackets in document

### DIFF
--- a/docs/lib/content/configuring-npm/package-json.md
+++ b/docs/lib/content/configuring-npm/package-json.md
@@ -391,7 +391,7 @@ would be the same as this:
 }
 ```
 
-Please make sure that your file(s) referenced in `bin` starts with `#!/usr/bin/env node`; otherwise, the scripts are started without the node executable!
+Please make sure that your file(s) referenced in `bin` start with `#!/usr/bin/env node`; otherwise, the scripts are started without the node executable!
 
 Note that you can also set the executable files using [directories.bin](#directoriesbin).
 

--- a/docs/lib/content/using-npm/config.md
+++ b/docs/lib/content/using-npm/config.md
@@ -14,7 +14,7 @@ npm gets its configuration values from the following sources, sorted by priority
 #### Command Line Flags
 
 Putting `--foo bar` on the command line sets the `foo` configuration parameter to `"bar"`.
-A `--` argument tells the cli parser to stop reading flags.
+A `--` argument tells the CLI parser to stop reading flags.
 Using `--flag` without specifying any value will set the value to `true`.
 
 Example: `--flag1 --flag2` will set both configuration parameters to `true`, while `--flag1 --flag2 bar` will set `flag1` to `true`, and `flag2` to `bar`.

--- a/docs/lib/content/using-npm/dependency-selectors.md
+++ b/docs/lib/content/using-npm/dependency-selectors.md
@@ -92,7 +92,7 @@ The `:outdated` pseudo selector retrieves data from the registry and returns inf
 The type parameter may be one of the following:
 
 - `any` (default) a version exists that is greater than the current one
-- `in-range` a version exists that is greater than the current one, and satisfies at least one if its parent's dependencies
+- `in-range` a version exists that is greater than the current one, and satisfies at least one of its parent's dependencies
 - `out-of-range` a version exists that is greater than the current one, does not satisfy at least one of its parent's dependencies
 - `major` a version exists that is a semver major greater than the current one
 - `minor` a version exists that is a semver minor greater than the current one
@@ -128,7 +128,7 @@ Some examples:
 
 - `:root > .prod:vuln` returns direct production dependencies with any known vulnerability
 - `:vuln([severity=high])` returns only dependencies with a vulnerability with a `high` severity.
-- `:vuln([severity=high],[severity=moderate])` returns only dependencies with a vulnerability with a `high`  or `moderate` severity.
+- `:vuln([severity=high],[severity=moderate])` returns only dependencies with a vulnerability with a `high` or `moderate` severity.
 - `:vuln([cwe=1333])` returns only dependencies with a vulnerability that includes CWE-1333 (ReDoS)
 
 #### [Attribute Selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors)

--- a/docs/lib/content/using-npm/registry.md
+++ b/docs/lib/content/using-npm/registry.md
@@ -17,7 +17,7 @@ Use of someone else's registry may be governed by their terms of use.
 
 npm's package registry implementation supports several write APIs as well, to allow for publishing packages and managing user account information.
 
-The registry URL used is determined by the scope of the package (see [`scope`](/using-npm/scope).
+The registry URL used is determined by the scope of the package (see [`scope`](/using-npm/scope)).
 If no scope is specified, the default registry is used, which is supplied by the [`registry` config](/using-npm/config#registry) parameter.
 See [`npm config`](/commands/npm-config), [`npmrc`](/configuring-npm/npmrc), and [`config`](/using-npm/config) for more on managing npm's configuration.
 Authentication configuration such as auth tokens and certificates are configured specifically scoped to an individual registry.

--- a/docs/lib/content/using-npm/scripts.md
+++ b/docs/lib/content/using-npm/scripts.md
@@ -175,7 +175,7 @@ with linked packages)
 #### [`npm restart`](/commands/npm-restart)
 
 If there is a `restart` script defined, these events are run; otherwise,
-`stop` and `start` are both run if present, including their `pre` and `post` iterations)
+`stop` and `start` are both run if present, including their `pre` and `post` iterations
 
 * `prerestart`
 * `restart`


### PR DESCRIPTION
<!-- What / Why -->
### What?
Fix several documentation issues across the npm documentation, including missing or unnecessary parentheses, grammar errors, and minor wording inconsistencies.

### Why?
These changes improve the clarity, consistency, and overall quality of the documentation without changing any technical behavior.
<!-- Describe the request in detail. What it does and why it's being changed. -->


<!--## References-->
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
