### PR TITLE
fix(exec): don't inherit global config when installing to the npx cache

### DIFF
--- a/workspaces/libnpmexec/lib/index.js
+++ b/workspaces/libnpmexec/lib/index.js
@@ -264,6 +264,7 @@ const exec = async (opts) => {
     const npxArb = new Arborist({
       ...flatOptions,
       path: installDir,
+      global: false,
     })
     const lockPath = join(installDir, 'concurrency.lock')
     const npxTree = await withLock(lockPath, () => npxArb.loadActual())

--- a/workspaces/libnpmexec/test/registry.js
+++ b/workspaces/libnpmexec/test/registry.js
@@ -352,7 +352,8 @@ t.test('ignore inherited global config when installing to npx cache', async t =>
   })
 
   const binPath = resolve(path, 'npxCache', hash, 'node_modules', '.bin')
-  t.ok(existsSync(binPath), 'bins should be linked inside the npx cache entry')
+  t.ok(existsSync(binPath), 'bins should be linked at npxCache')
+  t.notOk(existsSync(resolve(path, 'npxCache', 'bin')), 'bins should not be linked globally')
 
   t.match(await readOutput('@npmcli-create-index'), {
     value: 'packages-2.0.0',

--- a/workspaces/libnpmexec/test/registry.js
+++ b/workspaces/libnpmexec/test/registry.js
@@ -328,3 +328,33 @@ t.test('override save to true when installing to npx cache', async t => {
     value: 'packages-2.0.0',
   })
 })
+
+t.test('ignore inherited global config when installing to npx cache', async t => {
+  const { fixtures, package } = createPkg({ versions: ['2.0.0'] })
+
+  const hash = crypto.createHash('sha512')
+    .update('@npmcli/create-index')
+    .digest('hex')
+    .slice(0, 16)
+
+  const { exec, path, registry, readOutput } = setup(t, {
+    testdir: merge(fixtures, {
+      global: {},
+    }),
+  })
+
+  await package({ registry, path })
+
+  await exec({
+    args: ['@npmcli/create-index'],
+    globalPath: resolve(path, 'global'),
+    global: true,
+  })
+
+  const binPath = resolve(path, 'npxCache', hash, 'node_modules', '.bin')
+  t.ok(existsSync(binPath), 'bins should be linked inside the npx cache entry')
+
+  t.match(await readOutput('@npmcli-create-index'), {
+    value: 'packages-2.0.0',
+  })
+})


### PR DESCRIPTION
## What / Why

An `npx` spawned from a lifecycle script during `npm install -g` inherits `npm_config_global=true` from the script environment, so `exec()` builds the npx cache Arborist with `global: true`. On reify the installed package counts as a global top-level install, and `bin-links` puts the symlinks in `<npxCache>/bin` rather than `<installDir>/node_modules/.bin`, which is the only path `exec()` adds to `binPaths`. A warm npx cache hides the problem because nothing is reified.

On npm 10.x that surfaces the way the issue reports it, as `command not found` and a rollback of the whole global install. Since npm 11.2 the failure comes a step earlier: global mode also skips saving the ideal tree, so the `PackageJson.load(installDir)` after reify throws `Could not read package.json ... npxCache/<hash>/package.json`. Same cause either way.

The npx cache is never a global install, so its Arborist now sets `global: false` explicitly.

## Testing

New case in `workspaces/libnpmexec/test/registry.js` that runs exec with `global: true` and checks the bins end up in the cache entry's `node_modules/.bin` and not at the cache root. It fails on the current code and passes with the fix.

Also checked by hand with a cold cache: `npm_config_global=true node . exec --yes -- cowsay hello` errors on `latest` and works after the change.

## References

Fixes #9890
