### PR TITLE
fix(exec): suppress run-script notices

### DIFF
--- a/lib/npm.js
+++ b/lib/npm.js
@@ -100,6 +100,7 @@ class Npm {
     const command = deref(commandArg)
 
     await this.#display.load({
+      command,
       loglevel: this.config.get('loglevel'),
       stdoutColor: this.color,
       stderrColor: this.logColor,

--- a/lib/utils/display.js
+++ b/lib/utils/display.js
@@ -171,6 +171,7 @@ class Display {
   #progress
 
   // options
+  #command
   #levelIndex
   #timing
   #json
@@ -213,6 +214,7 @@ class Display {
   }
 
   async load ({
+    command,
     heading,
     json,
     loglevel,
@@ -235,6 +237,7 @@ class Display {
     this.#stderrChalk = stderrColor ? new Chalk({ level }) : this.#noColorChalk
     this.#logColors = COLOR_PALETTE({ chalk: this.#stderrChalk })
 
+    this.#command = command
     this.#levelIndex = LEVEL_OPTIONS[loglevel].index
     this.#timing = timing
     this.#json = json
@@ -382,6 +385,16 @@ class Display {
       // Also (and this is a really inexcusable kludge), we patch the log.warn() method so that when we see a peerDep override explanation from Arborist, we can replace the object with a highly abbreviated explanation of what's being overridden.
       // TODO: this could probably be moved to arborist now that display is refactored
       const [heading, message, expl] = args
+      // exec has always suppressed the run-script banner, since the command
+      // being executed owns the terminal output. run-script@11 logs those
+      // banners as `notice run` messages instead of standard output.
+      if (
+        level === log.KEYS.notice &&
+        heading === 'run' &&
+        ['exec', 'explore'].includes(this.#command)
+      ) {
+        return
+      }
       if (level === log.KEYS.warn && heading === 'ERESOLVE' && expl && typeof expl === 'object') {
         this.#writeLog(level, meta, heading, message)
         this.#writeLog(level, meta, '', explain(expl, this.#stderrChalk, 2))

--- a/test/lib/utils/display.js
+++ b/test/lib/utils/display.js
@@ -203,6 +203,18 @@ t.test('notice deduplication does not apply in verbose mode', async t => {
   ])
 })
 
+t.test('exec suppresses run-script notices', async t => {
+  const { log, logs } = await mockDisplay(t, {
+    load: { command: 'exec' },
+  })
+
+  log.notice('run', 'cypress@1.0.0 npx')
+  log.notice('run', 'cypress --version')
+  log.notice('', 'a regular notice')
+
+  t.strictSame(logs.notice, ['a regular notice'])
+})
+
 t.test('Display.clean', async (t) => {
   const { output, outputs, clearOutput } = await mockDisplay(t)
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
## What / Why

Restore the previous `npx` / `npm exec` behavior of suppressing internal run-script banners.

`@npmcli/run-script@11` emits execution banners as `npm notice run ...` log messages. These notices are currently shown before the executed command’s output, for example with `npx cypress --version`.

This change suppresses `notice run` messages only for `exec` and `explore`, while preserving regular notices and the executed command’s own output.

Added a regression test to verify that run-script notices are suppressed for `exec`.



## References
Fixes #9893 
<!-- Examples:
  Related to #9893 
  Depends on #0
  Blocked by #0
  Fixes #9893 
  Closes #9893 
-->
