### PR TITLE
fix(arborist): match allowScripts keys for local paths

### DIFF
--- a/lib/utils/allow-scripts-writer.js
+++ b/lib/utils/allow-scripts-writer.js
@@ -2,6 +2,7 @@ const npa = require('npm-package-arg')
 const { log } = require('proc-log')
 const {
   getTrustedRegistryIdentity,
+  matchesResolvedSource,
   resolvedSourceSpecs,
 } = require('@npmcli/arborist/lib/script-allowed.js')
 
@@ -180,8 +181,7 @@ const keyTargetsNode = (key, node) => {
     case 'file':
     case 'directory':
     case 'remote':
-      return resolvedSourceSpecs(node)
-        .some(resolved => resolved === parsed.saveSpec || resolved === parsed.fetchSpec)
+      return matchesResolvedSource(node, parsed)
     default:
       return false
   }

--- a/workspaces/arborist/lib/script-allowed.js
+++ b/workspaces/arborist/lib/script-allowed.js
@@ -328,8 +328,15 @@ const matchGit = (node, parsed) => {
 }
 
 const matchFileOrDir = (node, parsed) => {
+  // A local dep's `resolved` is built by consistent-resolve.js as `file:`
+  // glued onto the absolute fetchSpec, so it keeps the platform separators.
+  // npa's saveSpec stays relative when the key is relative and is always
+  // forward-slashed, so neither form matches it on Windows.
+  const resolvedSpec = `file:${parsed.fetchSpec}`
   return resolvedSourceSpecs(node)
-    .some(resolved => resolved === parsed.saveSpec || resolved === parsed.fetchSpec)
+    .some(resolved => resolved === parsed.saveSpec ||
+      resolved === parsed.fetchSpec ||
+      resolved === resolvedSpec)
 }
 
 const matchRemote = (node, parsed) => {

--- a/workspaces/arborist/lib/script-allowed.js
+++ b/workspaces/arborist/lib/script-allowed.js
@@ -85,9 +85,8 @@ const matches = (node, key, failClosed) => {
       return matchGit(node, parsed)
     case 'file':
     case 'directory':
-      return matchFileOrDir(node, parsed)
     case 'remote':
-      return matchRemote(node, parsed)
+      return matchesResolvedSource(node, parsed)
     case 'alias':
       // Disallowed: aliases as policy keys do not match anything.
       // The user has to address the real package name.
@@ -327,21 +326,17 @@ const matchGit = (node, parsed) => {
   return nodeCommittish.startsWith(keyCommittish)
 }
 
-const matchFileOrDir = (node, parsed) => {
-  // A local dep's `resolved` is built by consistent-resolve.js as `file:`
-  // glued onto the absolute fetchSpec, so it keeps the platform separators.
-  // npa's saveSpec stays relative when the key is relative and is always
-  // forward-slashed, so neither form matches it on Windows.
-  const resolvedSpec = `file:${parsed.fetchSpec}`
+// A local dep's `resolved` is built by consistent-resolve.js as `file:`
+// glued onto the absolute fetchSpec. npa keeps saveSpec in the form the key
+// was written in and always forward-slashes it, so a relative key never
+// equals that spec, and on Windows no key form does. Relative keys resolve
+// against the cwd npa was called from, the project root for `npm install`.
+const matchesResolvedSource = (node, parsed) => {
+  const absoluteFileSpec = `file:${parsed.fetchSpec}`
   return resolvedSourceSpecs(node)
     .some(resolved => resolved === parsed.saveSpec ||
       resolved === parsed.fetchSpec ||
-      resolved === resolvedSpec)
-}
-
-const matchRemote = (node, parsed) => {
-  return resolvedSourceSpecs(node)
-    .some(resolved => resolved === parsed.fetchSpec || resolved === parsed.saveSpec)
+      resolved === absoluteFileSpec)
 }
 
 const isRegistryNode = (node) => {
@@ -388,4 +383,5 @@ module.exports.matches = matches
 module.exports.isExactVersionDisjunction = isExactVersionDisjunction
 module.exports.getTrustedRegistryIdentity = getTrustedRegistryIdentity
 module.exports.resolvedSourceSpecs = resolvedSourceSpecs
+module.exports.matchesResolvedSource = matchesResolvedSource
 module.exports.trustedDisplay = trustedDisplay

--- a/workspaces/arborist/test/script-allowed.js
+++ b/workspaces/arborist/test/script-allowed.js
@@ -196,6 +196,21 @@ t.test('local tarball key — npa parses *.tgz paths as type=file', t => {
   t.end()
 })
 
+t.test('local tarball key — relative key matches an absolute resolved', t => {
+  // The installed tree carries the absolutized `file:` spec that
+  // consistent-resolve.js builds, with platform-native separators, while
+  // the key in package.json is the relative one from the lockfile.
+  const tgzNode = node({
+    name: 'local-pkg',
+    packageName: 'local-pkg',
+    version: '1.0.0',
+    resolved: `file:${require('node:path').resolve('local-pkg.tgz')}`,
+  })
+  t.equal(isScriptAllowed(tgzNode, { 'file:local-pkg.tgz': true }), true)
+  t.equal(isScriptAllowed(tgzNode, { 'file:other-pkg.tgz': true }), null)
+  t.end()
+})
+
 t.test('remote tarball — exact resolved match', t => {
   const remoteNode = node({
     name: 'pkg',

--- a/workspaces/arborist/test/script-allowed.js
+++ b/workspaces/arborist/test/script-allowed.js
@@ -185,7 +185,7 @@ t.test('directory key — npa parses absolute paths as type=directory', t => {
 
 t.test('local tarball key — npa parses *.tgz paths as type=file', t => {
   // npa treats `*.tgz` paths as { type: 'file' }, separate from
-  // 'directory'. Both share the matchFileOrDir body.
+  // 'directory'. Both share the matchesResolvedSource body.
   const tgzNode = node({
     name: 'local-pkg',
     packageName: 'local-pkg',
@@ -198,15 +198,17 @@ t.test('local tarball key — npa parses *.tgz paths as type=file', t => {
 
 t.test('local tarball key — relative key matches an absolute resolved', t => {
   // The installed tree carries the absolutized `file:` spec that
-  // consistent-resolve.js builds, with platform-native separators, while
-  // the key in package.json is the relative one from the lockfile.
+  // consistent-resolve.js builds, while the allowScripts key keeps the
+  // relative form the user wrote.
+  const tgzPath = require('node:path').resolve('local-pkg.tgz')
   const tgzNode = node({
     name: 'local-pkg',
     packageName: 'local-pkg',
     version: '1.0.0',
-    resolved: `file:${require('node:path').resolve('local-pkg.tgz')}`,
+    resolved: `file:${tgzPath}`,
   })
   t.equal(isScriptAllowed(tgzNode, { 'file:local-pkg.tgz': true }), true)
+  t.equal(isScriptAllowed(tgzNode, { [`file:${tgzPath}`]: true }), true)
   t.equal(isScriptAllowed(tgzNode, { 'file:other-pkg.tgz': true }), null)
   t.end()
 })


### PR DESCRIPTION
## What / Why

An `allowScripts` entry for a local dependency never matches it, so the install scripts stay blocked whichever form of the path is used as the key. On Windows that includes the absolute path from the error message, which is what this issue reports; on every platform it also includes the relative form the lockfile stores.

`matchFileOrDir` in `workspaces/arborist/lib/script-allowed.js` compared `node.resolved` against npa's `saveSpec` and `fetchSpec`. The loaded tree gets its `resolved` from `consistentResolve`, which returns `file:` glued onto the absolute `fetchSpec` and therefore keeps backslashes on Windows. npa's `saveSpec` is always forward-slashed and stays relative when the key is relative, and `fetchSpec` never carries the `file:` prefix, so neither side lines up. The matcher now also compares against `file:${parsed.fetchSpec}`, the same string `consistentResolve` builds.

`keyTargetsNode` in `lib/utils/allow-scripts-writer.js` carried its own copy of that comparison and drifted the same way, which left `npm install-scripts approve` writing a key it could not then recognise. Both call sites now share one exported helper, so they cannot disagree again.

Matching a local tarball by bare package name is deliberately still unsupported: a local tarball's name comes from its own manifest, so `matchRegistry` rejects it, and `nameKeyFor` refuses to write one for the same reason.

## Testing

New case in `workspaces/arborist/test/script-allowed.js`, next to the existing local-tarball one: a node resolved to an absolute `file:` path matches both the relative and the absolute key. It fails without the change. Also checked by hand, installing a local tgz with an install script and `"allowScripts": { "file:scripty-1.0.0.tgz": true }`: blocked before, script runs after.

## References

Fixes #9900
