### PR TITLE
fix(help): join wrapped multi-line flag descriptions in getUsage

### DIFF
--- a/lib/base-cmd.js
+++ b/lib/base-cmd.js
@@ -104,7 +104,12 @@ class BaseCommand {
         fullUsage.push('')
         for (const def of cmdDefs) {
           if (def.description) {
-            const desc = def.description.trim().split('\n')[0]
+            const desc = def.description
+              .trim()
+              .split('\n\n')[0]
+              .split('\n')
+              .map(l => l.trim())
+              .join(' ')
             const shortcuts = def.short ? `-${def.short}` : ''
             const aliases = (def.alias || []).map(v => `--${v}`).join('|')
             const mainFlag = `--${def.key}`

--- a/test/lib/base-cmd.js
+++ b/test/lib/base-cmd.js
@@ -263,6 +263,35 @@ t.test('getUsage() with both params and definitions', async t => {
   t.ok(usage.includes('--river'), 'includes river flag')
 })
 
+t.test('getUsage() with multi-line wrapped flag descriptions', async t => {
+  class TestCommand extends BaseCommand {
+    static name = 'test-command'
+    static description = 'Test command description'
+    static params = ['mountain']
+
+    static definitions = [
+      new Definition('mountain', {
+        type: String,
+        default: 'everest',
+        description: `
+          If you ask for a mountain and do not specify height,
+          then the default mountain will be returned.
+
+          See mountain guide for more information.
+        `,
+        usage: '--mountain=<mountain>',
+      }),
+    ]
+  }
+
+  const usage = TestCommand.describeUsage
+
+  t.ok(
+    usage.includes('If you ask for a mountain and do not specify height, then the default mountain will be returned.'),
+    'includes full joined first paragraph of description without truncation'
+  )
+})
+
 t.test('getUsage() with subcommand without description', async t => {
   class SubCommandWithDesc extends BaseCommand {
     static name = 'with-desc'


### PR DESCRIPTION
### Description
Fixes an issue where subcommand help outputs (e.g. `npm stage publish --help`) truncated flag descriptions mid-sentence.

In `lib/base-cmd.js`, `def.description.trim().split('\n')[0]` was taking only the very first line of multi-line wrapped descriptions from `@npmcli/config`. This change joins the lines of the first paragraph with spaces so full sentences are displayed properly.

Fixes #9518

### Testing
- Added unit test in `test/lib/base-cmd.js` to ensure multi-line wrapped flag descriptions are joined and not truncated.
- Verified `node . stage publish --help` renders full descriptions.
