### PR TITLE
fix(ci): allow omitted bundled dependencies in lockfile validation

### DIFF
--- a/lib/utils/validate-lockfile.js
+++ b/lib/utils/validate-lockfile.js
@@ -14,7 +14,11 @@ function validateLockfile (virtualTree, idealTree) {
     const lock = virtualTree.get(key)
 
     if (!lock) {
-      errors.push(`Missing: ${entry.name}@${entry.version} from lock file`)
+      // Bundled dependencies are extracted from their parent's tarball and
+      // may not have independent lockfile entries.
+      if (!entry.inBundle) {
+        errors.push(`Missing: ${entry.name}@${entry.version} from lock file`)
+      }
       continue
     }
 

--- a/test/lib/utils/validate-lockfile.js
+++ b/test/lib/utils/validate-lockfile.js
@@ -131,6 +131,27 @@ t.test('extra inventory items on idealTree', async t => {
   )
 })
 
+t.test('missing bundled inventory items do not invalidate lockfile', async t => {
+  const errors = validateLockfile(
+    new Map([
+      ['node_modules/bundle', { name: 'bundle', version: '1.0.0' }],
+    ]),
+    new Map([
+      ['node_modules/bundle', { name: 'bundle', version: '1.0.0' }],
+      ['node_modules/bundle/node_modules/embedded', {
+        name: 'embedded',
+        version: '1.0.0',
+        inBundle: true,
+      }],
+      ['node_modules/missing', { name: 'missing', version: '2.0.0' }],
+    ])
+  )
+
+  t.strictSame(errors, [
+    'Missing: missing@2.0.0 from lock file',
+  ], 'bundled nodes are supplied by their parent tarball, while ordinary nodes remain required')
+})
+
 t.test('extra inventory items on virtualTree', async t => {
   t.matchSnapshot(
     validateLockfile(


### PR DESCRIPTION
## What / Why

`npm ci` can reject a lockfile that `npm install` just generated when a dependency tarball contains bundled packages that are not independently recorded in the lockfile.

The ideal tree exposes those extracted nodes with `inBundle: true`, but `validateLockfile` currently treats every ideal-tree node without a virtual-tree entry as missing. This reports `EUSAGE` even though the parent tarball supplies the node and a clean install can proceed without resolving it from the registry.

## Change

- Ignore absent ideal-tree entries only when Arborist marks them `inBundle`.
- Keep reporting ordinary missing dependencies.
- Add focused regression coverage for both cases in the same validation pass.

## Testing

- `node . run test -- test/lib/utils/validate-lockfile.js --no-coverage`
- `node . run test`
- Reproduced the issue's `@aws-amplify/data-construct@1.17.7` sequence locally: two `npm install` runs followed by `npm ci`. The unpatched CLI reports four missing `@opentelemetry/core@2.0.0` entries; this branch completes `npm ci` and installs 219 packages.

## References

Fixes #9821

## AI assistance

This change was developed with AI assistance. I reproduced the issue against the current `latest` branch, reviewed the implementation and diff, and ran the checks above locally.
