### PR TITLE
fix(arborist): match allowScripts keys for local paths

### DIFF
--- a/lib/utils/allow-scripts-writer.js
+++ b/lib/utils/allow-scripts-writer.js
@@ -2,6 +2,7 @@ const npa = require('npm-package-arg')
 const { log } = require('proc-log')
 const {
   getTrustedRegistryIdentity,
+  matchFileOrDir,
   resolvedSourceSpecs,
 } = require('@npmcli/arborist/lib/script-allowed.js')
 
@@ -150,7 +151,7 @@ const isNameOnlyKey = (key) => {
 const keyTargetsNode = (key, node) => {
   let parsed
   try {
-    parsed = npa(key)
+    parsed = npa(key, node?.root?.path)
   } catch {
     return false
   }
@@ -179,6 +180,7 @@ const keyTargetsNode = (key, node) => {
     }
     case 'file':
     case 'directory':
+      return matchFileOrDir(node, parsed)
     case 'remote':
       return resolvedSourceSpecs(node)
         .some(resolved => resolved === parsed.saveSpec || resolved === parsed.fetchSpec)

--- a/test/lib/utils/allow-scripts-prune.js
+++ b/test/lib/utils/allow-scripts-prune.js
@@ -1,4 +1,5 @@
 const t = require('tap')
+const path = require('node:path')
 const { classifyUnusedEntries } = require('../../../lib/utils/allow-scripts-prune.js')
 
 // Minimal registry node: `matches` derives name/version from the resolved URL.
@@ -25,6 +26,26 @@ t.test('keeps entries that match an installed package with scripts', t => {
     [withScripts({ name: 'canvas' }), withScripts({ name: 'esbuild', version: '1.0.0' })]
   )
   t.same(remaining, { canvas: true, 'esbuild@1.0.0': true })
+  t.same(removed, [])
+  t.end()
+})
+
+t.test('keeps a local file key matching its absolute resolved source', t => {
+  const rootPath = path.resolve('project')
+  const key = `file:${path.resolve(rootPath, 'local.tgz')}`
+  const local = {
+    name: 'local',
+    version: '1.0.0',
+    resolved: key,
+    root: { path: rootPath },
+    isRegistryDependency: false,
+  }
+  const { remaining, removed } = classifyUnusedEntries(
+    { [key]: true },
+    [{ node: local, hasScripts: true }]
+  )
+
+  t.same(remaining, { [key]: true })
   t.same(removed, [])
   t.end()
 })

--- a/test/lib/utils/allow-scripts-writer.js
+++ b/test/lib/utils/allow-scripts-writer.js
@@ -4,6 +4,7 @@ const isScriptAllowed = require('../../../workspaces/arborist/lib/script-allowed
 const {
   applyApprovalForPackage,
   applyDenyForPackage,
+  keyTargetsNode,
   nameKeyFor,
   versionedKeyFor,
   isSingleVersionPin,
@@ -540,6 +541,7 @@ t.test('applyApprovalForPackage — remote tarball deny blocks approval', async 
     { pin: true }
   )
   t.match(warning, /denied|versioned deny/)
+  t.equal(keyTargetsNode('https://example.com/other.tgz', remote), false)
 })
 
 t.test('applyApprovalForPackage — no-pin with no name produces no-op', async t => {

--- a/test/lib/utils/allow-scripts-writer.js
+++ b/test/lib/utils/allow-scripts-writer.js
@@ -1,5 +1,6 @@
 const t = require('tap')
 const path = require('node:path')
+const isScriptAllowed = require('../../../workspaces/arborist/lib/script-allowed.js')
 const {
   applyApprovalForPackage,
   applyDenyForPackage,
@@ -379,6 +380,21 @@ t.test('applyApprovalForPackage — file dep uses resolved as both keys', async 
   t.strictSame(allowScripts, { 'file:../local': true })
 })
 
+t.test('versionedKeyFor — local file key round-trips through policy matching', async t => {
+  const rootPath = path.resolve('project')
+  const local = {
+    name: 'local',
+    packageName: 'local',
+    version: '1.0.0',
+    resolved: `file:${path.resolve(rootPath, 'local.tgz')}`,
+    root: { path: rootPath },
+    isRegistryDependency: false,
+  }
+  const key = versionedKeyFor(local)
+
+  t.equal(isScriptAllowed(local, { [key]: true }), true)
+})
+
 t.test('applyApprovalForPackage — empty nodes returns unchanged', async t => {
   const { allowScripts, changes } = applyApprovalForPackage({ x: true }, [], { pin: true })
   t.strictSame(allowScripts, { x: true })
@@ -490,6 +506,29 @@ t.test('applyApprovalForPackage — file dep with deny entry blocks approval', a
     [node({ name: 'local', resolved: 'file:../local' })],
     { pin: true }
   )
+  t.match(warning, /denied|versioned deny/)
+})
+
+t.test('applyApprovalForPackage — relative file deny matches absolute resolved', async t => {
+  const rootPath = path.resolve('project')
+  const resolved = `file:${path.resolve(rootPath, 'local.tgz')}`
+  const local = {
+    name: 'local',
+    packageName: 'local',
+    version: '1.0.0',
+    resolved,
+    root: { path: rootPath },
+    isRegistryDependency: false,
+  }
+  const existing = { 'file:local.tgz': false }
+  const { allowScripts, changes, warning } = applyApprovalForPackage(
+    existing,
+    [local],
+    { pin: true }
+  )
+
+  t.strictSame(allowScripts, existing)
+  t.strictSame(changes, [])
   t.match(warning, /denied|versioned deny/)
 })
 

--- a/workspaces/arborist/lib/script-allowed.js
+++ b/workspaces/arborist/lib/script-allowed.js
@@ -71,7 +71,7 @@ const isScriptAllowed = (node, policy) => {
 const matches = (node, key, failClosed) => {
   let parsed
   try {
-    parsed = npa(key)
+    parsed = npa(key, node?.root?.path)
   } catch {
     return false
   }
@@ -328,8 +328,15 @@ const matchGit = (node, parsed) => {
 }
 
 const matchFileOrDir = (node, parsed) => {
+  // consistentResolve stores local sources as `file:` plus npa's absolute,
+  // platform-native fetchSpec.
+  const absoluteFileSpec = parsed.fetchSpec && `file:${parsed.fetchSpec}`
   return resolvedSourceSpecs(node)
-    .some(resolved => resolved === parsed.saveSpec || resolved === parsed.fetchSpec)
+    .some(resolved =>
+      resolved === parsed.saveSpec ||
+      resolved === parsed.fetchSpec ||
+      resolved === absoluteFileSpec
+    )
 }
 
 const matchRemote = (node, parsed) => {
@@ -381,4 +388,5 @@ module.exports.matches = matches
 module.exports.isExactVersionDisjunction = isExactVersionDisjunction
 module.exports.getTrustedRegistryIdentity = getTrustedRegistryIdentity
 module.exports.resolvedSourceSpecs = resolvedSourceSpecs
+module.exports.matchFileOrDir = matchFileOrDir
 module.exports.trustedDisplay = trustedDisplay

--- a/workspaces/arborist/test/script-allowed.js
+++ b/workspaces/arborist/test/script-allowed.js
@@ -1,6 +1,6 @@
 const t = require('tap')
 const isScriptAllowed = require('../lib/script-allowed.js')
-const { trustedDisplay } = isScriptAllowed
+const { matchFileOrDir, trustedDisplay } = isScriptAllowed
 
 // Test nodes default to a consistent registry-tarball shape: the resolved
 // URL's name+version match the supplied name+version. Tests that need to
@@ -196,6 +196,90 @@ t.test('local tarball key — npa parses *.tgz paths as type=file', t => {
   t.end()
 })
 
+t.test('local tarball key — relative key resolves from the project root', t => {
+  const path = require('node:path')
+  const rootPath = path.resolve('project')
+  const tgzPath = path.resolve(rootPath, 'local-pkg.tgz')
+  const tgzNode = node({
+    name: 'local-pkg',
+    packageName: 'local-pkg',
+    version: '1.0.0',
+    resolved: `file:${tgzPath}`,
+    root: { path: rootPath },
+  })
+
+  t.equal(isScriptAllowed(tgzNode, { 'file:local-pkg.tgz': true }), true)
+  t.equal(isScriptAllowed(tgzNode, { 'file:other-pkg.tgz': true }), null)
+  t.end()
+})
+
+t.test('local tarball key — matches consistentResolve Windows representation', t => {
+  const resolved = String.raw`file:C:\absolute\path\local-pkg.tgz`
+  const parsed = {
+    saveSpec: 'file:C:/absolute/path/local-pkg.tgz',
+    fetchSpec: String.raw`C:\absolute\path\local-pkg.tgz`,
+  }
+
+  t.equal(matchFileOrDir({ resolved }, parsed), true)
+  t.equal(matchFileOrDir({ resolved }, {
+    saveSpec: 'file:C:/absolute/path/other-pkg.tgz',
+    fetchSpec: String.raw`C:\absolute\path\other-pkg.tgz`,
+  }), false)
+  t.end()
+})
+
+t.test('local tarball key — Windows absolute key forms match', {
+  skip: process.platform !== 'win32',
+}, t => {
+  const resolved = String.raw`file:C:\project\local-pkg.tgz`
+  const tgzNode = node({
+    name: 'local-pkg',
+    packageName: 'local-pkg',
+    version: '1.0.0',
+    resolved,
+    root: { path: String.raw`C:\project` },
+  })
+
+  t.equal(isScriptAllowed(tgzNode, {
+    [String.raw`file:C:\project\local-pkg.tgz`]: true,
+  }), true)
+  t.equal(isScriptAllowed(tgzNode, {
+    'file:C:/project/local-pkg.tgz': true,
+  }), true)
+  t.equal(isScriptAllowed(tgzNode, {
+    'file:C:/project/other-pkg.tgz': true,
+  }), null)
+  t.end()
+})
+
+t.test('local tarball key — Windows UNC key matches', {
+  skip: process.platform !== 'win32',
+}, t => {
+  const consistentResolve = require('../lib/consistent-resolve.js')
+  const key = 'file://server/share/local-pkg.tgz'
+  const tgzNode = node({
+    name: 'local-pkg',
+    packageName: 'local-pkg',
+    version: '1.0.0',
+    resolved: consistentResolve(key),
+    root: { path: String.raw`C:\project` },
+  })
+
+  t.equal(isScriptAllowed(tgzNode, { [key]: true }), true)
+  t.end()
+})
+
+t.test('file source matching keeps POSIX backslashes distinct', t => {
+  const resolved = String.raw`file:/tmp/local\pkg.tgz`
+  const parsed = {
+    saveSpec: 'file:/tmp/local/pkg.tgz',
+    fetchSpec: '/tmp/local/pkg.tgz',
+  }
+
+  t.equal(matchFileOrDir({ resolved }, parsed), false)
+  t.end()
+})
+
 t.test('remote tarball — exact resolved match', t => {
   const remoteNode = node({
     name: 'pkg',
@@ -205,6 +289,17 @@ t.test('remote tarball — exact resolved match', t => {
   })
   t.equal(isScriptAllowed(remoteNode, { 'https://example.com/pkg.tgz': true }), true)
   t.equal(isScriptAllowed(remoteNode, { 'https://example.com/other.tgz': true }), null)
+  t.end()
+})
+
+t.test('remote tarball key does not match a file source', t => {
+  const fileNode = node({
+    name: 'pkg',
+    packageName: 'pkg',
+    version: '1.0.0',
+    resolved: 'file:https://example.com/pkg.tgz',
+  })
+  t.equal(isScriptAllowed(fileNode, { 'https://example.com/pkg.tgz': true }), null)
   t.end()
 })
 

--- a/workspaces/arborist/test/script-allowed.js
+++ b/workspaces/arborist/test/script-allowed.js
@@ -256,7 +256,7 @@ t.test('local tarball key — Windows UNC key matches', {
   skip: process.platform !== 'win32',
 }, t => {
   const consistentResolve = require('../lib/consistent-resolve.js')
-  const key = 'file://server/share/local-pkg.tgz'
+  const key = 'file:////server/share/local-pkg.tgz'
   const tgzNode = node({
     name: 'local-pkg',
     packageName: 'local-pkg',


### PR DESCRIPTION
## Summary

Fixes `allowScripts` matching for local file and tarball dependencies, particularly on Windows.

Arborist stores a resolved Windows file source in this form:

```text
file:C:\project\vendor\pkg.tgz
```

However,  `npm-package-arg` parses an equivalent policy key into:

`saveSpec: file:C:/project/vendor/pkg.tgz`
`fetchSpec: C:\project\vendor\pkg.tgz`

The existing matcher compared `node.resolved` only with `saveSpec` and `fetchSpec`. Neither comparison could match because one uses different separators and the other lacks the `file:`  prefix.

## Changes

• Match local file and directory sources against `file:${parsed.fetchSpec}`, which is the same representation produced by Arborist's `consistentResolve()`.
• Resolve relative `allowScripts` file keys from the Arborist project root rather than the process working directory.
• Reuse the Arborist file/directory matcher in `allow-scripts-writer`, keeping runtime enforcement and policy updates consistent.
• Preserve the existing exact matching behavior for remote URLs.
• Preserve deny-wins behavior when an existing local-file policy entry is `false`.

The implementation intentionally does not globally normalize path separators. On POSIX systems, a backslash can be a literal filename character, so replacing every  `\`  with  `/`  could cause two different sources to share an approval.

The change also does not modify dependency resolution, lockfile generation, fetching, linking, or `consistentResolve()`.

## Security considerations

Local file and tarball dependencies continue to require an exact source identity.

This change does not:

• Match local packages by their self-reported name or version.
• Case-fold paths.
• Match by basename.
• Resolve paths through `realpath()`.
• Treat remote URLs as local file sources.
• Change registry or Git identity matching.

This preserves the manifest-confusion protections in `allowScripts` while recognizing the exact Windows representation npm already generates.

## Testing

Added regression coverage for:

• Backslash and forward-slash absolute Windows keys matching the same local tarball.
• Relative keys resolving from the project root.
• `versionedKeyFor()` producing a key accepted by `isScriptAllowed()`.
• Different local paths remaining unmatched.
• Existing `false` file entries continuing to block approval.
• Windows UNC paths matching through the same `file:${fetchSpec}` representation.
• POSIX filenames containing literal backslashes remaining distinct.
• Remote URL policies not matching `file:  sources`.
• `npm install-scripts prune` retaining valid local-file entries.

The focused Arborist matcher, policy-writer, and prune tests pass locally. Native Windows path and UNC behavior is covered by platform-specific tests and will run in the repository's Windows CI matrix.

Fixes #9900
