### PR TITLE
chore: recognize prefixed Node.js PR titles

### DIFF
--- a/scripts/create-node-pr.js
+++ b/scripts/create-node-pr.js
@@ -238,9 +238,13 @@ const main = async (spec, branch = 'main', opts) => withTempDir(CWD, async (tmpD
 
   let existingPr = null
   const closePrs = []
+  const npmMessagePrefix = npmMessage('')
 
   for (const pr of npmPrs) {
-    const prVersion = pr.title.replace(npmMessage(''), '').trim()
+    const npmMessageIndex = pr.title.indexOf(npmMessagePrefix)
+    const prVersion = npmMessageIndex === -1
+      ? null
+      : pr.title.slice(npmMessageIndex + npmMessagePrefix.length).trim()
     log.silly('checking existing PR', prVersion, pr)
 
     if (!existingPr && prVersion === npmVersion.toString()) {
@@ -259,7 +263,7 @@ const main = async (spec, branch = 'main', opts) => withTempDir(CWD, async (tmpD
     nodePrArgs,
     (existingPr ? ['edit', existingPr.number] : ['create', '-H', `${npmHost.user}:${npmBranch}`]),
     '-B', nodeBranch,
-    '-t', npmMessage(),
+    (existingPr ? [] : ['-t', npmMessage()]),
   ].flat()
 
   if (dryRun) {


### PR DESCRIPTION
## Summary

- recognize existing Node.js npm update PRs with branch prefixes such as `[v22.x]`
- preserve an existing PR title when updating it

## Background

The create-node-pr workflow successfully regenerated and force-pushed nodejs/node#64884, but then failed because the existing-PR parser treated `[v22.x] 10.9.9` as the npm version. It attempted to create a duplicate PR instead of editing the existing one.

This extracts the version following the canonical `deps: upgrade npm to` text regardless of any title prefix. Existing base-branch filtering continues to distinguish PRs targeting different Node.js release lines.

Reproduction: https://github.com/npm/cli/actions/runs/32768286326