### PR TITLE
fix(arborist): recognize registry-mediated tarballs

### DIFF
--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -290,9 +290,9 @@ range. Please note that this could leave your tree incomplete and some
 packages may not function as intended or designed. Changing this setting
 will not remove dependencies that are already installed.
 
-As of npm 12 the default is \`none\`. Tarballs that share a hostname with the
-configured registry (the typical case for the npm registry, GitHub Packages,
-and most private registries) are still installed normally. If your registry
+As of npm 12 the default is \`none\`. Tarballs under the configured registry
+path are installed normally. npm also permits same-origin tarballs when it
+can verify their exact URL against registry metadata. If your registry
 serves tarballs from a different host, set \`replace-registry-host\` or
 override this setting. Opt in explicitly per project (in \`.npmrc\`) or per
 command (on the CLI) when you intentionally install from a URL.

--- a/tap-snapshots/test/lib/docs.js.test.cjs
+++ b/tap-snapshots/test/lib/docs.js.test.cjs
@@ -292,10 +292,13 @@ will not remove dependencies that are already installed.
 
 As of npm 12 the default is \`none\`. Tarballs under the configured registry
 path are installed normally. npm also permits same-origin tarballs when it
-can verify their exact URL against registry metadata. If your registry
-serves tarballs from a different host, set \`replace-registry-host\` or
-override this setting. Opt in explicitly per project (in \`.npmrc\`) or per
-command (on the CLI) when you intentionally install from a URL.
+can verify their exact URL against registry metadata. For these sibling-path
+tarballs, npm reuses metadata from resolution or cache when available;
+otherwise it requests package metadata. Offline installation requires cached
+registry metadata as well as the tarball. If your registry serves tarballs
+from a different host, set \`replace-registry-host\` or override this setting.
+Opt in explicitly per project (in \`.npmrc\`) or per command (on the CLI) when
+you intentionally install from a URL.
 
 \`all\` allows any url to be installed. \`none\` prevents any url from being
 installed. \`root\` only allows urls defined in your project's package.json to

--- a/test/lib/commands/ci.js
+++ b/test/lib/commands/ci.js
@@ -193,7 +193,7 @@ t.test('allow-remote=none blocks same-host tarball outside registry path', async
   lock.packages['node_modules/abbrev'].resolved = evilTarball
   lock.dependencies.abbrev.resolved = evilTarball
 
-  const { npm } = await loadMockNpm(t, {
+  const { npm, registry } = await loadMockNpm(t, {
     config: {
       audit: false,
       'allow-remote': 'none',
@@ -206,6 +206,8 @@ t.test('allow-remote=none blocks same-host tarball outside registry path', async
       'package-lock.json': JSON.stringify(lock),
     },
   })
+  const manifest = registry.manifest({ name: 'abbrev' })
+  await registry.package({ manifest })
 
   await t.rejects(
     npm.exec('ci', []),

--- a/test/lib/commands/ci.js
+++ b/test/lib/commands/ci.js
@@ -218,6 +218,49 @@ t.test('allow-remote=none blocks same-host tarball outside registry path', async
   t.equal(fs.existsSync(nmAbbrev), false, 'does not install tarball outside configured registry path')
 })
 
+t.test('allow-remote=none rejects an alias injected into a wildcard lockfile version', async t => {
+  const root = {
+    name: 'test-package',
+    version: '1.0.0',
+    dependencies: { expected: '*' },
+  }
+  const { npm } = await loadMockNpm(t, {
+    config: {
+      audit: false,
+      'allow-remote': 'none',
+      'fetch-retries': 0,
+      registry: 'https://registry.example.com/npm/',
+      '//registry.example.com/npm/:_authToken': 'registry-only-token',
+    },
+    prefixDir: {
+      'package.json': JSON.stringify(root),
+      'package-lock.json': JSON.stringify({
+        ...root,
+        lockfileVersion: 3,
+        requires: true,
+        packages: {
+          '': root,
+          'node_modules/expected': {
+            version: 'npm:other-package@1.0.0',
+            resolved: 'https://registry.example.com/download/other-package.tgz',
+          },
+        },
+      }),
+    },
+  })
+  const nock = require('nock')
+  const requests = []
+  const unexpectedRequest = req => requests.push(req.path)
+  nock.emitter.on('no match', unexpectedRequest)
+  t.teardown(() => nock.emitter.off('no match', unexpectedRequest))
+
+  await t.rejects(npm.exec('ci', []), { code: 'EALLOWREMOTE' },
+    'a wildcard cannot authorize another package through the locked version')
+  t.same(requests, [], 'does not request metadata or the attacker-controlled tarball')
+  t.equal(fs.existsSync(path.join(npm.prefix, 'node_modules/expected/package.json')), false,
+    'does not install the substituted package')
+})
+
 t.test('lifecycle scripts', async t => {
   const scripts = []
   const { npm, registry } = await loadMockNpm(t, {

--- a/workspaces/arborist/lib/arborist/build-ideal-tree.js
+++ b/workspaces/arborist/lib/arborist/build-ideal-tree.js
@@ -25,6 +25,7 @@ const debug = require('../debug.js')
 const fromPath = require('../from-path.js')
 const calcDepFlags = require('../calc-dep-flags.js')
 const { isReleaseAgeExcluded, trustedSpecName } = require('../release-age-exclude.js')
+const { rememberRegistryTarball } = require('../registry-tarball.js')
 const { resolvePatchedDependencies } = require('../patched-dependencies.js')
 const PackageExtensions = require('../package-extensions.js')
 const NpmExtension = require('../npm-extension.js')
@@ -699,6 +700,7 @@ module.exports = cls => class IdealTreeBuilder extends cls {
           _isRoot,
           before: this.#releaseAgeBefore(spec),
         })
+        rememberRegistryTarball(this, spec, mani)
         if (isTag) {
           // translate tag to a version
           spec = npa(`${mani.name}@${mani.version}`)
@@ -955,6 +957,7 @@ This is a one-time fix-up, please be patient...
             fullMetadata: false,
             before: this.#releaseAgeBefore(spec),
           })
+          rememberRegistryTarball(this, spec, mani)
           node.package = { ...mani, _id: `${mani.name}@${mani.version}` }
         } catch (er) {
           const warning = `Could not fetch metadata for ${name}@${id}`
@@ -1484,6 +1487,7 @@ This is a one-time fix-up, please be patient...
     } else {
       log.silly('fetch manifest', spec.raw.replace(spec.rawSpec, redact(spec.rawSpec)))
       const mani = await pacote.manifest(spec, options)
+      rememberRegistryTarball(this, spec, mani)
       this.#manifests.set(spec.raw, mani)
       return mani
     }

--- a/workspaces/arborist/lib/arborist/isolated-reifier.js
+++ b/workspaces/arborist/lib/arborist/isolated-reifier.js
@@ -3,6 +3,7 @@ const { depth } = require('treeverse')
 const crypto = require('node:crypto')
 const { IsolatedNode, IsolatedLink } = require('../isolated-classes.js')
 const nameFromFolder = require('@npmcli/name-from-folder')
+const { carryRegistryPackageName } = require('../registry-package-name.js')
 
 // generate short hash key based on the dependency tree starting at this node
 const getKey = (startNode) => {
@@ -59,6 +60,7 @@ module.exports = cls => class IsolatedReifier extends cls {
       resolved: node.resolved,
       root,
     })
+    carryRegistryPackageName(node, newChild)
     // XXX top is from place-dep not lib/node.js
     newChild.top = { path: this.idealGraph.localPath }
     root.children.set(newChild.location, newChild)
@@ -164,6 +166,8 @@ module.exports = cls => class IsolatedReifier extends cls {
     // Carry the source node's registry-dependency flag so the store node retains it.
     // IsolatedNode has no edges to recompute it from, and reify's registry-tarball allow-remote exemption depends on it.
     result.isRegistryDependency = node.isRegistryDependency
+    // Package metadata is not a trusted identity source, so preserve the name derived from source edges.
+    carryRegistryPackageName(node, result)
     // Same reasoning for allow-remote=root: the store node has no edgesIn, so capture from the source node whether it satisfies a valid edge from the project root or a workspace.
     result.isRootDependency = [...node.edgesIn].some(e =>
       e.valid && (e.from?.isProjectRoot || e.from?.isWorkspace)

--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -995,7 +995,9 @@ module.exports = cls => class Reifier extends cls {
   // pacote re-parses that with npa and gets spec.type === 'remote', so without an override the allow-remote gate would fire on every registry tarball (both =none and =root mis-fire).
   // Returns true only when we are confident this is a registry-mediated install.
   async #isRegistryResolvedTarball (node, packageName) {
-    if (!node.resolved || !node.isRegistryDependency || !packageName) {
+    // The caller only invokes this with a resolved URL and a trusted package
+    // name, but linked nodes retain an independent registry provenance flag.
+    if (!node.isRegistryDependency) {
       return false
     }
 

--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -27,6 +27,7 @@ const relpath = require('../relpath.js')
 const { applyPatchToDir, patchIntegrity } = require('../patch.js')
 const { readFile } = require('node:fs/promises')
 const retirePath = require('../retire-path.js')
+const { getRegistryPackageName } = require('../registry-package-name.js')
 const treeCheck = require('../tree-check.js')
 const Shrinkwrap = require('../shrinkwrap.js')
 const { defaultLockfileVersion } = Shrinkwrap
@@ -697,6 +698,11 @@ module.exports = cls => class Reifier extends cls {
     await this.#validateNodeModules(nm)
 
     if (!node.isLink) {
+      const isRoot = node.isRootDependency || [...node.edgesIn].some(e =>
+        e.valid && (e.from?.isProjectRoot || e.from?.isWorkspace)
+      )
+      const allowRemote = this.options.allowRemote ?? 'all'
+      const remoteAllowed = allowRemote === 'all' || (allowRemote !== 'none' && isRoot)
       // in normal cases, node.resolved should *always* be set by now.
       // however, it is possible when a lockfile is damaged, or very old,
       // or in some other race condition bugs in npm v6, that a previously
@@ -705,10 +711,15 @@ module.exports = cls => class Reifier extends cls {
       // Do the best with what we have, or else remove it from the tree
       // entirely, since we can't possibly reify it.
       let res = null
+      let registryTarballExemption = false
       if (node.resolved) {
         const registryResolved = this.#registryResolved(node.resolved)
         if (registryResolved) {
-          res = `${node.name}@${registryResolved}`
+          const registryPackageName = !remoteAllowed && getRegistryPackageName(node)
+          registryTarballExemption = !!registryPackageName &&
+            await this.#isRegistryResolvedTarball(node, registryPackageName)
+          const packageName = registryTarballExemption ? registryPackageName : node.name
+          res = `${packageName}@${registryResolved}`
         }
       } else if (node.package.name && node.version) {
         res = `${node.package.name}@${node.version}`
@@ -744,12 +755,10 @@ module.exports = cls => class Reifier extends cls {
         // A node counts as "root" for allow-* enforcement if it satisfies at least one valid dependency edge declared by the project root or a workspace.
         // node.parent is unsafe here: after hoisting, transitive packages can have the project root as their tree parent.
         // In the linked strategy the store node has no edgesIn, so isolated-reifier precomputes isRootDependency from the source node's edges.
-        _isRoot: node.isRootDependency || [...node.edgesIn].some(e =>
-          e.valid && (e.from?.isProjectRoot || e.from?.isWorkspace)
-        ),
+        _isRoot: isRoot,
         // pacote's npa re-parses our `name@URL` spec as type=remote, so allowRemote would mis-fire on registry tarballs.
         // Override only when we can prove the URL is registry-mediated; see #isRegistryResolvedTarball.
-        ...(this.#isRegistryResolvedTarball(node) ? { allowRemote: 'all' } : {}),
+        ...(registryTarballExemption ? { allowRemote: 'all' } : {}),
       })
       // store nodes don't use Node class so node.package doesn't get updated
       if (node.isInStore) {
@@ -985,20 +994,50 @@ module.exports = cls => class Reifier extends cls {
   // When extracting a registry-resolved package, the spec we hand to pacote is name@URL.
   // pacote re-parses that with npa and gets spec.type === 'remote', so without an override the allow-remote gate would fire on every registry tarball (both =none and =root mis-fire).
   // Returns true only when we are confident this is a registry-mediated install.
-  #isRegistryResolvedTarball (node) {
-    if (!node.resolved || !node.isRegistryDependency) {
+  async #isRegistryResolvedTarball (node, packageName) {
+    if (!node.resolved || !node.isRegistryDependency || !packageName) {
       return false
     }
+
+    let resolvedURL
+    let registry
     try {
       // Match the effective fetch URL, not the raw lockfile value.
       // #registryResolved applies replace-registry-host, rewriting a public-registry pin to the configured proxy/mirror so it matches.
-      const resolvedURL = new URL(this.#registryResolved(node.resolved))
-      // pickRegistry only consults spec.scope, so a bare-name (tag) parse is sufficient and avoids a node.version dependency.
-      const registry = new URL(pickRegistry(npa(node.name), this.options))
-      const registryPath = registry.pathname.replace(/\/?$/, '/')
-      return resolvedURL.origin === registry.origin &&
-        (registryPath === '/' || resolvedURL.pathname.startsWith(registryPath))
+      resolvedURL = new URL(this.#registryResolved(node.resolved))
+      registry = new URL(pickRegistry(npa(packageName), this.options))
     } catch {
+      return false
+    }
+
+    if (resolvedURL.origin !== registry.origin) {
+      return false
+    }
+
+    const registryPath = registry.pathname.replace(/\/?$/, '/')
+    if (registryPath === '/' || resolvedURL.pathname.startsWith(registryPath)) {
+      return true
+    }
+
+    if (!node.version) {
+      return false
+    }
+
+    // Some registries advertise tarballs from a sibling path on the same
+    // origin. Verify those URLs against registry metadata rather than
+    // widening the configured registry path boundary.
+    try {
+      const manifest = await pacote.manifest(npa.resolve(packageName, node.version), {
+        ...this.options,
+        before: null,
+        fullMetadata: true,
+      })
+      const advertisedURL = new URL(this.#registryResolved(manifest._resolved))
+      advertisedURL.hash = ''
+      resolvedURL.hash = ''
+      return advertisedURL.href === resolvedURL.href
+    } catch (error) {
+      log.verbose('reify', 'unable to verify registry tarball metadata', error)
       return false
     }
   }

--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -28,6 +28,7 @@ const { applyPatchToDir, patchIntegrity } = require('../patch.js')
 const { readFile } = require('node:fs/promises')
 const retirePath = require('../retire-path.js')
 const { getRegistryPackageName } = require('../registry-package-name.js')
+const { getRegistryTarball } = require('../registry-tarball.js')
 const treeCheck = require('../tree-check.js')
 const Shrinkwrap = require('../shrinkwrap.js')
 const { defaultLockfileVersion } = Shrinkwrap
@@ -715,10 +716,10 @@ module.exports = cls => class Reifier extends cls {
       if (node.resolved) {
         const registryResolved = this.#registryResolved(node.resolved)
         if (registryResolved) {
-          const registryPackageName = !remoteAllowed && getRegistryPackageName(node)
-          registryTarballExemption = !!registryPackageName &&
+          const registryPackageName = getRegistryPackageName(node)
+          registryTarballExemption = !remoteAllowed && !!registryPackageName &&
             await this.#isRegistryResolvedTarball(node, registryPackageName)
-          const packageName = registryTarballExemption ? registryPackageName : node.name
+          const packageName = registryPackageName || node.name
           res = `${packageName}@${registryResolved}`
         }
       } else if (node.package.name && node.version) {
@@ -1029,12 +1030,11 @@ module.exports = cls => class Reifier extends cls {
     // origin. Verify those URLs against registry metadata rather than
     // widening the configured registry path boundary.
     try {
-      const manifest = await pacote.manifest(npa.resolve(packageName, node.version), {
-        ...this.options,
-        before: null,
-        fullMetadata: true,
-      })
-      const advertisedURL = new URL(this.#registryResolved(manifest._resolved))
+      const tarball = await getRegistryTarball(this, packageName, node.version)
+      if (!tarball) {
+        return false
+      }
+      const advertisedURL = new URL(this.#registryResolved(tarball))
       advertisedURL.hash = ''
       resolvedURL.hash = ''
       return advertisedURL.href === resolvedURL.href

--- a/workspaces/arborist/lib/registry-package-name.js
+++ b/workspaces/arborist/lib/registry-package-name.js
@@ -1,0 +1,44 @@
+const npa = require('npm-package-arg')
+const { trustedSpecName } = require('./release-age-exclude.js')
+
+const carriedNames = new WeakMap()
+
+// Registry tarball exemptions widen fetch policy, so derive their package
+// identity from valid dependency specs and require every such edge to agree.
+const getRegistryPackageName = (node) => {
+  if (carriedNames.has(node)) {
+    return carriedNames.get(node)
+  }
+  if (!node.edgesIn || typeof node.edgesIn[Symbol.iterator] !== 'function') {
+    return null
+  }
+
+  const names = new Set()
+  for (const edge of node.edgesIn) {
+    if (!edge.valid) {
+      continue
+    }
+    let spec
+    try {
+      spec = npa.resolve(edge.name, edge.spec)
+    } catch {
+      return null
+    }
+    if (!spec.registry) {
+      return null
+    }
+    const name = trustedSpecName(spec)
+    if (!name) {
+      return null
+    }
+    names.add(name)
+  }
+
+  return names.size === 1 ? names.values().next().value : null
+}
+
+const carryRegistryPackageName = (from, to) => {
+  carriedNames.set(to, getRegistryPackageName(from))
+}
+
+module.exports = { carryRegistryPackageName, getRegistryPackageName }

--- a/workspaces/arborist/lib/registry-package-name.js
+++ b/workspaces/arborist/lib/registry-package-name.js
@@ -4,7 +4,7 @@ const { trustedSpecName } = require('./release-age-exclude.js')
 const carriedNames = new WeakMap()
 
 // Registry tarball exemptions widen fetch policy, so derive their package
-// identity from valid dependency specs and require every such edge to agree.
+// identity from valid dependency specs rather than package metadata.
 const getRegistryPackageName = (node) => {
   if (carriedNames.has(node)) {
     return carriedNames.get(node)
@@ -14,6 +14,9 @@ const getRegistryPackageName = (node) => {
   }
 
   const names = new Set()
+  const peerNames = new Set()
+  const rootNames = new Set()
+  const aliases = new Set()
   for (const edge of node.edgesIn) {
     if (!edge.valid) {
       continue
@@ -31,10 +34,29 @@ const getRegistryPackageName = (node) => {
     if (!name) {
       return null
     }
-    names.add(name)
+    if (spec.type === 'alias') {
+      aliases.add(name)
+    }
+    // Ordinary peers constrain the installed slot, not an alias's target.
+    // An explicit peer alias still selects a target and must agree.
+    if (edge.peer && spec.type !== 'alias') {
+      peerNames.add(name)
+    } else {
+      names.add(name)
+      if (edge.from?.isProjectRoot || edge.from?.isWorkspace) {
+        rootNames.add(name)
+      }
+    }
   }
 
-  return names.size === 1 ? names.values().next().value : null
+  // A project/workspace can select a fork for an installed slot also used
+  // by ordinary transitive requirements. Explicit alias targets must agree.
+  const identities = rootNames.size ? rootNames : names.size ? names : peerNames
+  if (identities.size !== 1) {
+    return null
+  }
+  const name = identities.values().next().value
+  return [...aliases].every(alias => alias === name) ? name : null
 }
 
 const carryRegistryPackageName = (from, to) => {

--- a/workspaces/arborist/lib/registry-tarball.js
+++ b/workspaces/arborist/lib/registry-tarball.js
@@ -1,0 +1,131 @@
+const npa = require('npm-package-arg')
+const pacote = require('pacote')
+const { pickRegistry } = require('npm-registry-fetch')
+const { parse } = require('semver')
+
+const exactVersion = value => {
+  const version = parse(value)
+  return version ? version.version +
+    (version.build.length ? `+${version.build.join('.')}` : '') : null
+}
+
+// Keep registry evidence separate from serializable node/lockfile metadata.
+const caches = new WeakMap()
+const getCache = arb => {
+  if (!caches.has(arb)) {
+    caches.set(arb, { manifests: new Map(), packuments: new Map() })
+  }
+  return caches.get(arb)
+}
+
+const context = (spec, options) => {
+  spec = spec.subSpec || spec
+  const registry = pickRegistry(spec, options).replace(/\/+$/, '')
+  const url = `${registry}/${spec.escapedName}`
+  return { spec, url }
+}
+
+const tarballFromManifest = (name, version, manifest) =>
+  manifest?.name === name && exactVersion(manifest.version) === version &&
+  typeof manifest.dist?.tarball === 'string' ? manifest.dist.tarball : null
+
+const manifestKey = (url, version, options = {}) => JSON.stringify([
+  url, version, !!options.verifySignatures, !!options.verifyAttestations,
+])
+
+// Called only with manifests returned by pacote, never with node.package.
+const rememberRegistryTarball = (arb, spec, manifest) => {
+  if (!spec.registry) {
+    return
+  }
+  const version = exactVersion(manifest.version)
+  const { spec: target, url } = context(spec, arb.options)
+  const tarball = tarballFromManifest(target.name, version, manifest)
+  if (version && tarball) {
+    // Resolution can use abbreviated metadata even with verifyAttestations.
+    // Capture URL evidence only; explicit verification must use the full
+    // metadata path below rather than inferring checks from Arborist options.
+    getCache(arb).manifests.set(manifestKey(url, version), tarball)
+  }
+}
+
+const loadPackument = async (arb, spec, url) => {
+  const { packumentCache } = arb.options
+  // Pacote distinguishes full/corgi responses, but either contains dist.tarball.
+  for (const format of ['full', 'corgi']) {
+    const key = `${format}:${url}`
+    if (packumentCache?.has(key)) {
+      return packumentCache.get(key)
+    }
+  }
+  const options = {
+    ...arb.options,
+    before: null,
+    fullMetadata: false,
+  }
+  try {
+    return await pacote.packument(spec, options)
+  } catch (error) {
+    if (!options.offline || error.code !== 'ENOTCACHED') {
+      throw error
+    }
+    // HTTP caches can vary on Accept. An offline install may have only the
+    // full response cached by a previous resolution, not the corgi variant.
+    return pacote.packument(spec, { ...options, fullMetadata: true })
+  }
+}
+
+const getRegistryTarball = async (arb, packageName, lockedVersion) => {
+  // A lockfile version is not a dependency spec: aliases, tags and ranges
+  // must not redirect this lookup to another package or version.
+  const version = exactVersion(lockedVersion)
+  if (!version) {
+    return null
+  }
+  const { spec, url } = context(npa(packageName), arb.options)
+  const cache = getCache(arb)
+  const key = manifestKey(url, version, arb.options)
+  if (cache.manifests.has(key)) {
+    return cache.manifests.get(key)
+  }
+
+  // Preserve explicit pacote verification options, which need more than
+  // the abbreviated metadata used for URL verification alone.
+  if (arb.options.verifySignatures || arb.options.verifyAttestations) {
+    const request = pacote.manifest(npa.resolve(packageName, version), {
+      ...arb.options,
+      before: null,
+      fullMetadata: true,
+    }).then(manifest => tarballFromManifest(packageName, version, manifest)).catch(error => {
+      cache.manifests.delete(key)
+      throw error
+    })
+    cache.manifests.set(key, request)
+    return request
+  }
+
+  if (!cache.packuments.has(url)) {
+    const request = loadPackument(arb, spec, url).then(packument => {
+      // Retain only URL evidence, including when the production packument
+      // cache discards a large response or one without Content-Length.
+      const tarballs = new Map()
+      for (const [entryVersion, manifest] of Object.entries(packument.versions || {})) {
+        const entry = exactVersion(entryVersion)
+        const tarball = tarballFromManifest(packageName, entry, manifest)
+        if (entry && tarball) {
+          tarballs.set(entry, tarball)
+        }
+      }
+      return tarballs
+    }).catch(error => {
+      cache.packuments.delete(url)
+      throw error
+    })
+    // Unlike pacote's completed-response cache, this shares pending requests.
+    cache.packuments.set(url, request)
+  }
+  const tarballs = await cache.packuments.get(url)
+  return tarballs.get(version) || null
+}
+
+module.exports = { getRegistryTarball, rememberRegistryTarball }

--- a/workspaces/arborist/test/arborist/reify.js
+++ b/workspaces/arborist/test/arborist/reify.js
@@ -3988,7 +3988,7 @@ t.test('should preserve exact ranges, missing actual tree', async (t) => {
     await t.resolves(arb.reify(), 'registry tarball under configured path is allowed')
   })
 
-  t.test('allowRemote=none blocks same-origin tarball outside registry path', async t => {
+  t.test('allowRemote=none allows registry-advertised tarball outside registry path', async t => {
     const abbrevPackument5 = JSON.stringify({
       _id: 'abbrev',
       _rev: 'lkjadflkjasdf',
@@ -4021,6 +4021,67 @@ t.test('should preserve exact ranges, missing actual tree', async (t) => {
       .get('/npm/abbrev')
       .reply(200, abbrevPackument5)
 
+    tnock(t, 'https://registry.example.com')
+      .get('/evil/abbrev-1.1.1.tgz')
+      .reply(200, abbrevTGZ)
+
+    const arb = new Arborist({
+      path: resolve(testdir, 'project'),
+      registry: 'https://registry.example.com/npm/',
+      cache: resolve(testdir, 'cache'),
+      allowRemote: 'none',
+      packumentCache: new Map(),
+    })
+
+    await t.resolves(arb.reify(), 'registry-advertised sibling-path tarball is allowed')
+  })
+
+  t.test('allowRemote=none verifies against dependency identity, not lockfile name', async t => {
+    const registryTarball = 'https://registry.example.com/npm/abbrev/-/abbrev-1.1.1.tgz'
+    const lockfileTarball = 'https://registry.example.com/evil/abbrev-1.1.1.tgz'
+    const packument = JSON.stringify({
+      name: 'abbrev',
+      'dist-tags': { latest: '1.1.1' },
+      versions: {
+        '1.1.1': {
+          name: 'abbrev',
+          version: '1.1.1',
+          dist: { tarball: registryTarball },
+        },
+      },
+    })
+    const testdir = t.testdir({
+      project: {
+        'package.json': JSON.stringify({
+          name: 'myproject',
+          version: '1.0.0',
+          dependencies: { abbrev: '1.1.1' },
+        }),
+        'package-lock.json': JSON.stringify({
+          name: 'myproject',
+          version: '1.0.0',
+          lockfileVersion: 3,
+          requires: true,
+          packages: {
+            '': {
+              name: 'myproject',
+              version: '1.0.0',
+              dependencies: { abbrev: '1.1.1' },
+            },
+            'node_modules/abbrev': {
+              name: 'lockfile-controlled-name',
+              version: '1.1.1',
+              resolved: lockfileTarball,
+            },
+          },
+        }),
+      },
+    })
+
+    tnock(t, 'https://registry.example.com')
+      .get('/npm/abbrev')
+      .reply(200, packument)
+
     const arb = new Arborist({
       path: resolve(testdir, 'project'),
       registry: 'https://registry.example.com/npm/',
@@ -4028,7 +4089,270 @@ t.test('should preserve exact ranges, missing actual tree', async (t) => {
       allowRemote: 'none',
     })
 
-    await t.rejects(arb.reify(), { code: 'EALLOWREMOTE' }, 'sibling path tarball is blocked')
+    await t.rejects(
+      arb.reify(),
+      { code: 'EALLOWREMOTE' },
+      'lockfile-only sibling-path tarball is blocked'
+    )
+  })
+
+  t.test('allowRemote=none reports EALLOWREMOTE when registry metadata is unavailable', async t => {
+    const tarballURL = 'https://registry.example.com/evil/abbrev-1.1.1.tgz'
+    const testdir = t.testdir({
+      project: {
+        'package.json': JSON.stringify({
+          name: 'myproject',
+          version: '1.0.0',
+          dependencies: { abbrev: '1.1.1' },
+        }),
+        'package-lock.json': JSON.stringify({
+          name: 'myproject',
+          version: '1.0.0',
+          lockfileVersion: 3,
+          requires: true,
+          packages: {
+            '': {
+              name: 'myproject',
+              version: '1.0.0',
+              dependencies: { abbrev: '1.1.1' },
+            },
+            'node_modules/abbrev': {
+              version: '1.1.1',
+              resolved: tarballURL,
+            },
+          },
+        }),
+      },
+    })
+
+    tnock(t, 'https://registry.example.com')
+      .get('/npm/abbrev')
+      .reply(404, { error: 'metadata unavailable' })
+
+    const arb = new Arborist({
+      path: resolve(testdir, 'project'),
+      registry: 'https://registry.example.com/npm/',
+      cache: resolve(testdir, 'cache'),
+      allowRemote: 'none',
+    })
+
+    await t.rejects(
+      arb.reify(),
+      { code: 'EALLOWREMOTE' },
+      'failed verification falls back to the configured remote policy'
+    )
+  })
+
+  for (const { label, allowRemote } of [
+    { label: 'implicit all' },
+    { label: 'all', allowRemote: 'all' },
+    { label: 'root for a root dependency', allowRemote: 'root' },
+  ]) {
+    t.test(`allowRemote=${label} does not verify an already-permitted registry tarball`, async t => {
+      const registryHost = `https://${label.replaceAll(' ', '-')}.example.com`
+      const tarballURL = `${registryHost}/evil/abbrev-1.1.1.tgz`
+      const testdir = t.testdir({
+        project: {
+          'package.json': JSON.stringify({
+            name: 'myproject',
+            version: '1.0.0',
+            dependencies: { abbrev: '1.1.1' },
+          }),
+          'package-lock.json': JSON.stringify({
+            name: 'myproject',
+            version: '1.0.0',
+            lockfileVersion: 3,
+            requires: true,
+            packages: {
+              '': {
+                name: 'myproject',
+                version: '1.0.0',
+                dependencies: { abbrev: '1.1.1' },
+              },
+              'node_modules/abbrev': {
+                version: '1.1.1',
+                resolved: tarballURL,
+              },
+            },
+          }),
+        },
+      })
+      const packumentCache = new Map()
+      const cacheHas = packumentCache.has.bind(packumentCache)
+      let packumentChecks = 0
+      packumentCache.has = key => {
+        packumentChecks++
+        return cacheHas(key)
+      }
+
+      tnock(t, registryHost)
+        .get('/evil/abbrev-1.1.1.tgz')
+        .reply(200, abbrevTGZ)
+
+      const arb = new Arborist({
+        path: resolve(testdir, 'project'),
+        registry: `${registryHost}/npm/`,
+        cache: resolve(testdir, 'cache'),
+        packumentCache,
+        ...(allowRemote ? { allowRemote } : {}),
+      })
+
+      await t.resolves(arb.reify(), 'permitted tarball installs without registry metadata')
+      t.equal(packumentChecks, 0, 'does not consult the packument cache')
+    })
+  }
+
+  t.test('allowRemote=none uses the target scope for an aliased registry tarball', async t => {
+    const aliasName = '@alias/code-frame'
+    const packageName = '@babel/code-frame'
+    const version = '7.5.5'
+    const targetToken = 'target-token'
+    const aliasToken = 'alias-token'
+    const tarballURL = `https://registry.example.com/download/${packageName}/-/code-frame-${version}.tgz`
+    const packument = JSON.stringify({
+      name: packageName,
+      'dist-tags': { latest: version },
+      versions: {
+        [version]: {
+          name: packageName,
+          version,
+          dist: { tarball: tarballURL },
+        },
+      },
+    })
+    const scopedTGZ = fs.readFileSync(resolve(
+      __dirname,
+      `../fixtures/registry-mocks/content/babel/code-frame/-/code-frame-${version}.tgz`
+    ))
+    const testdir = t.testdir({
+      project: {
+        'package.json': JSON.stringify({
+          name: 'myproject',
+          version: '1.0.0',
+          dependencies: {
+            [aliasName]: `npm:${packageName}@${version}`,
+          },
+        }),
+      },
+    })
+
+    tnock(t, 'https://registry.example.com')
+      .get('/npm/@babel%2fcode-frame')
+      .matchHeader('authorization', `Bearer ${targetToken}`)
+      .reply(200, packument)
+
+    tnock(t, 'https://registry.example.com')
+      .get(`/download/${packageName}/-/code-frame-${version}.tgz`)
+      .matchHeader('authorization', `Bearer ${targetToken}`)
+      .reply(200, scopedTGZ)
+
+    const arb = new Arborist({
+      path: resolve(testdir, 'project'),
+      registry: 'https://registry.npmjs.org/',
+      '@babel:registry': 'https://registry.example.com/npm/',
+      '@alias:registry': 'https://registry.example.com/alias/',
+      '//registry.example.com/npm/:_authToken': targetToken,
+      '//registry.example.com/alias/:_authToken': aliasToken,
+      cache: resolve(testdir, 'cache'),
+      allowRemote: 'none',
+      packumentCache: new Map(),
+    })
+
+    await t.resolves(arb.reify(), 'aliased scoped registry tarball is allowed')
+    const installed = JSON.parse(fs.readFileSync(
+      resolve(testdir, 'project/node_modules', aliasName, 'package.json'),
+      'utf8'
+    ))
+    t.equal(installed.name, packageName, 'target package is installed in the alias slot')
+  })
+
+  t.test('allowRemote=root verifies a locked transitive alias using its target scope', async t => {
+    const packageName = '@babel/code-frame'
+    const version = '7.5.5'
+    const token = 'target-token'
+    const registryHost = 'https://registry.example.com'
+    const abbrevTarball = `${registryHost}/npm/abbrev/-/abbrev-1.1.1.tgz`
+    const advertisedAliasTarball = `${registryHost}/download/${packageName}/-/code-frame-${version}.tgz`
+    const lockedAliasTarball = `${advertisedAliasTarball}#lockfile-integrity`
+    const packument = JSON.stringify({
+      name: packageName,
+      'dist-tags': { latest: version },
+      versions: {
+        [version]: {
+          name: packageName,
+          version,
+          dist: { tarball: advertisedAliasTarball },
+        },
+      },
+    })
+    const scopedTGZ = fs.readFileSync(resolve(
+      __dirname,
+      `../fixtures/registry-mocks/content/babel/code-frame/-/code-frame-${version}.tgz`
+    ))
+    const testdir = t.testdir({
+      project: {
+        'package.json': JSON.stringify({
+          name: 'myproject',
+          version: '1.0.0',
+          dependencies: { abbrev: '1.1.1' },
+        }),
+        'package-lock.json': JSON.stringify({
+          name: 'myproject',
+          version: '1.0.0',
+          lockfileVersion: 3,
+          requires: true,
+          packages: {
+            '': {
+              name: 'myproject',
+              version: '1.0.0',
+              dependencies: { abbrev: '1.1.1' },
+            },
+            'node_modules/abbrev': {
+              version: '1.1.1',
+              resolved: abbrevTarball,
+              dependencies: {
+                hoek: `npm:${packageName}@${version}`,
+              },
+            },
+            'node_modules/hoek': {
+              name: packageName,
+              version,
+              resolved: lockedAliasTarball,
+            },
+          },
+        }),
+      },
+    })
+
+    tnock(t, registryHost)
+      .get('/npm/abbrev/-/abbrev-1.1.1.tgz')
+      .reply(200, abbrevTGZ)
+
+    tnock(t, registryHost)
+      .get('/scoped/@babel%2fcode-frame')
+      .matchHeader('authorization', `Bearer ${token}`)
+      .reply(200, packument)
+
+    tnock(t, registryHost)
+      .get(`/download/${packageName}/-/code-frame-${version}.tgz`)
+      .matchHeader('authorization', `Bearer ${token}`)
+      .reply(200, scopedTGZ)
+
+    const arb = new Arborist({
+      path: resolve(testdir, 'project'),
+      registry: `${registryHost}/npm/`,
+      '@babel:registry': `${registryHost}/scoped/`,
+      '//registry.example.com/scoped/:_authToken': token,
+      cache: resolve(testdir, 'cache'),
+      allowRemote: 'root',
+    })
+
+    await t.resolves(arb.reify(), 'transitive registry alias is exempted rather than treated as root')
+    const installed = JSON.parse(fs.readFileSync(
+      resolve(testdir, 'project/node_modules/hoek/package.json'),
+      'utf8'
+    ))
+    t.equal(installed.name, packageName, 'locked alias retains its target package identity')
   })
 
   t.test('allowRemote=none allows same-origin tarball for root registry path', async t => {
@@ -4178,7 +4502,7 @@ t.test('should preserve exact ranges, missing actual tree', async (t) => {
     await t.resolves(arb.reify(), 'registry tarball routed through the configured registry is allowed')
   })
 
-  t.test('allowRemote=none allows registry tarball under linked install strategy', async t => {
+  t.test('allowRemote=none allows registry-advertised tarball under linked strategy', async t => {
     // The linked strategy extracts store nodes as IsolatedNode, which has no edges to recompute isRegistryDependency from.
     // The flag must be carried from the source tree node so the registry-tarball allow-remote exemption still applies.
     const abbrevPackument5 = JSON.stringify({
@@ -4191,7 +4515,7 @@ t.test('should preserve exact ranges, missing actual tree', async (t) => {
           name: 'abbrev',
           version: '1.1.1',
           dist: {
-            tarball: 'https://registry.example.com/npm/abbrev/-/abbrev-1.1.1.tgz',
+            tarball: 'https://registry.example.com/download/abbrev-1.1.1.tgz',
           },
         },
       },
@@ -4214,7 +4538,7 @@ t.test('should preserve exact ranges, missing actual tree', async (t) => {
       .reply(200, abbrevPackument5)
 
     tnock(t, 'https://registry.example.com')
-      .get('/npm/abbrev/-/abbrev-1.1.1.tgz')
+      .get('/download/abbrev-1.1.1.tgz')
       .reply(200, abbrevTGZ)
 
     const arb = new Arborist({
@@ -4223,9 +4547,10 @@ t.test('should preserve exact ranges, missing actual tree', async (t) => {
       cache: resolve(testdir, 'cache'),
       allowRemote: 'none',
       installStrategy: 'linked',
+      packumentCache: new Map(),
     })
 
-    await t.resolves(arb.reify(), 'registry tarball is allowed under linked strategy')
+    await t.resolves(arb.reify(), 'verified sibling-path tarball is allowed under linked strategy')
   })
 
   t.test('allowRemote=root allows root-direct remote tarball under linked install strategy', async t => {

--- a/workspaces/arborist/test/arborist/reify.js
+++ b/workspaces/arborist/test/arborist/reify.js
@@ -4143,6 +4143,107 @@ t.test('should preserve exact ranges, missing actual tree', async (t) => {
     )
   })
 
+  t.test('allowRemote=none fails closed for unverifiable registry tarball shapes', async t => {
+    const cases = [
+      {
+        label: 'non-registry provenance',
+        edgeSpec: '1.1.1',
+        invalidEdgeSpec: 'https://example.com/other-abbrev.tgz',
+        resolved: 'https://registry.example.com/download/abbrev-1.1.1.tgz',
+      },
+      {
+        label: 'invalid target registry URL',
+        nodeName: 'alias',
+        packageName: '@scope/pkg',
+        edgeSpec: 'npm:@scope/pkg@1.0.0',
+        resolved: 'https://registry.example.com/download/pkg-1.0.0.tgz',
+        version: '1.0.0',
+        options: { '@scope:registry': 'not a registry URL' },
+      },
+      {
+        label: 'cross-origin tarball URL',
+        edgeSpec: '1.1.1',
+        resolved: 'https://cdn.example.com/abbrev-1.1.1.tgz',
+      },
+      {
+        label: 'missing package version',
+        edgeSpec: '*',
+        resolved: 'https://registry.example.com/download/abbrev-1.1.1.tgz',
+        version: null,
+      },
+    ]
+
+    for (const testCase of cases) {
+      await t.test(testCase.label, async t => {
+        let extractOptions
+        let manifestCalls = 0
+        const pacote = {
+          extract: async (spec, path, options) => {
+            extractOptions = options
+          },
+          manifest: async () => {
+            manifestCalls++
+            throw new Error('unexpected manifest request')
+          },
+        }
+        const ArboristMock = t.mock('../../lib/arborist', {
+          ...mocks,
+          pacote,
+        })
+        const path = t.testdir()
+        const nodeName = testCase.nodeName || 'abbrev'
+        const packageName = testCase.packageName || nodeName
+        const version = testCase.version === undefined ? '1.1.1' : testCase.version
+        const root = new Node({
+          path,
+          pkg: {
+            name: 'project',
+            version: '1.0.0',
+            dependencies: {
+              [nodeName]: testCase.edgeSpec,
+              ...(testCase.invalidEdgeSpec ? { consumer: '1.0.0' } : {}),
+            },
+          },
+        })
+        const node = new Node({
+          name: nodeName,
+          resolved: testCase.resolved,
+          pkg: {
+            name: packageName,
+            ...(version ? { version } : {}),
+          },
+          parent: root,
+        })
+        if (testCase.invalidEdgeSpec) {
+          new Node({
+            name: 'consumer',
+            pkg: {
+              name: 'consumer',
+              version: '1.0.0',
+              dependencies: { [nodeName]: testCase.invalidEdgeSpec },
+            },
+            parent: root,
+          })
+        }
+
+        const arb = new ArboristMock({
+          audit: false,
+          path,
+          cache: path,
+          registry: 'https://registry.example.com/npm/',
+          allowRemote: 'none',
+          ...testCase.options,
+        })
+        arb.addTracker('reify')
+        arb.idealTree = root
+
+        await arb[Symbol.for('reifyNode')](node)
+        t.equal(extractOptions.allowRemote, 'none', 'does not widen the remote policy')
+        t.equal(manifestCalls, 0, 'does not request metadata for an unverifiable shape')
+      })
+    }
+  })
+
   for (const { label, allowRemote } of [
     { label: 'implicit all' },
     { label: 'all', allowRemote: 'all' },

--- a/workspaces/arborist/test/arborist/reify.js
+++ b/workspaces/arborist/test/arborist/reify.js
@@ -3999,7 +3999,7 @@ t.test('should preserve exact ranges, missing actual tree', async (t) => {
           name: 'abbrev',
           version: '1.1.1',
           dist: {
-            tarball: 'https://registry.example.com/evil/abbrev-1.1.1.tgz',
+            tarball: 'https://registry.example.com/download/abbrev-1.1.1.tgz',
           },
         },
       },
@@ -4022,7 +4022,7 @@ t.test('should preserve exact ranges, missing actual tree', async (t) => {
       .reply(200, abbrevPackument5)
 
     tnock(t, 'https://registry.example.com')
-      .get('/evil/abbrev-1.1.1.tgz')
+      .get('/download/abbrev-1.1.1.tgz')
       .reply(200, abbrevTGZ)
 
     const arb = new Arborist({

--- a/workspaces/arborist/test/arborist/reify.js
+++ b/workspaces/arborist/test/arborist/reify.js
@@ -4738,6 +4738,533 @@ t.test('should preserve exact ranges, missing actual tree', async (t) => {
   })
 })
 
+t.test('allowRemote registry evidence integration', async t => {
+  const pacote = require('pacote')
+  const registryHost = 'https://registry.example.com'
+  const registry = `${registryHost}/npm/`
+  const tarballURL = `${registryHost}/download/abbrev-1.1.1.tgz`
+  const corgi = 'application/vnd.npm.install-v1+json'
+  const abbrevTGZ = fs.readFileSync(resolve(__dirname,
+    '../fixtures/registry-mocks/content/abbrev/-/abbrev-1.1.1.tgz'))
+  const packument = (changes = {}) => ({
+    name: 'abbrev',
+    'dist-tags': { latest: '1.1.1' },
+    versions: {
+      '1.1.1': {
+        name: 'abbrev',
+        version: '1.1.1',
+        dist: { tarball: tarballURL },
+        ...changes,
+      },
+    },
+  })
+  const setup = (t, { version = '1.1.1', resolved = tarballURL,
+    locked = true, options = {} } = {}) => {
+    const root = {
+      name: 'project',
+      version: '1.0.0',
+      dependencies: { abbrev: '*' },
+    }
+    const testdir = t.testdir({
+      project: {
+        'package.json': JSON.stringify(root),
+        ...(locked ? {
+          'package-lock.json': JSON.stringify({
+            lockfileVersion: 3,
+            requires: true,
+            packages: {
+              '': root,
+              'node_modules/abbrev': { version, resolved },
+            },
+          }),
+        } : {}),
+      },
+    })
+    const arb = new Arborist({
+      audit: false,
+      ignoreScripts: true,
+      fetchRetries: 0,
+      path: resolve(testdir, 'project'),
+      cache: resolve(testdir, 'cache'),
+      registry,
+      allowRemote: 'none',
+      ...options,
+    })
+    const server = MockRegistry.tnock(t, registryHost, {}, { strict: true })
+    return { arb, server, testdir }
+  }
+  const installedVersion = (testdir, name = 'abbrev') => JSON.parse(fs.readFileSync(
+    resolve(testdir, 'project/node_modules', name, 'package.json'), 'utf8'
+  )).version
+
+  for (const version of [
+    'npm:other-package@1.0.0',
+    'latest',
+    '^1.1.0',
+    '*',
+    'https://registry.example.com/other-package.tgz',
+    'file:../other-package.tgz',
+    'git+https://github.com/example/other-package.git',
+  ]) {
+    await t.test(`rejects locked dependency spec ${version} without requests`, async t => {
+      const { arb, testdir } = setup(t, { version })
+      const virtual = await arb.loadVirtual()
+      t.ok(virtual.edgesOut.get('abbrev').valid, 'wildcard accepts the locked node')
+      const ideal = await arb.buildIdealTree()
+      t.equal(ideal.children.get('abbrev').version, version, 'locked value reaches reification')
+      await t.rejects(arb.reify(), { code: 'EALLOWREMOTE' },
+        'a locked spec is not registry evidence')
+      t.notOk(fs.existsSync(resolve(testdir, 'project/node_modules/abbrev/package.json')),
+        'does not install the tarball')
+    })
+  }
+
+  for (const { label, metadata, allowed } of [
+    { label: 'exact name and version', metadata: packument(), allowed: true },
+    { label: 'different package name', metadata: packument({ name: 'other-package' }) },
+    { label: 'different manifest version', metadata: packument({ version: '1.1.2' }) },
+    { label: 'missing locked version', metadata: { name: 'abbrev', versions: {} } },
+    {
+      label: 'different tarball query',
+      metadata: packument({ dist: { tarball: `${tarballURL}?different=1` } }),
+    },
+  ]) {
+    await t.test(`cold locked verification with ${label}`, async t => {
+      const { arb, server, testdir } = setup(t)
+      server.get('/npm/abbrev')
+        .matchHeader('accept', value => value.includes(corgi))
+        .reply(200, metadata)
+      if (allowed) {
+        server.get('/download/abbrev-1.1.1.tgz').reply(200, abbrevTGZ)
+        await t.resolves(arb.reify(), 'exact registry evidence authorizes extraction')
+        t.equal(installedVersion(testdir), '1.1.1')
+      } else {
+        await t.rejects(arb.reify(), { code: 'EALLOWREMOTE' },
+          'metadata cannot authorize a different package, version or URL')
+      }
+    })
+  }
+
+  for (const format of ['full', 'corgi']) {
+    await t.test(`locked verification reuses the ${format} packument cache`, async t => {
+      const packumentCache = new Map([[`${format}:${registry}abbrev`, packument()]])
+      const { arb, server, testdir } = setup(t, { options: { packumentCache } })
+      server.get('/download/abbrev-1.1.1.tgz').reply(200, abbrevTGZ)
+      await t.resolves(arb.reify(), 'does not request metadata already in memory')
+      t.equal(installedVersion(testdir), '1.1.1')
+    })
+  }
+
+  await t.test('old-lock abbreviated evidence cannot bypass attestation verification', async t => {
+    const integrity = require('ssri').fromData(abbrevTGZ).toString()
+    const root = {
+      name: 'project',
+      version: '1.0.0',
+      dependencies: { abbrev: '1.1.1' },
+    }
+    const testdir = t.testdir({
+      project: {
+        'package.json': JSON.stringify(root),
+        'package-lock.json': JSON.stringify({
+          name: root.name,
+          version: root.version,
+          lockfileVersion: 1,
+          requires: true,
+          dependencies: {
+            abbrev: { version: '1.1.1', resolved: tarballURL, integrity },
+          },
+        }),
+      },
+    })
+    const attestationsPath = '/-/npm/v1/attestations/abbrev@1.1.1'
+    const fullMetadata = packument({
+      dist: {
+        tarball: tarballURL,
+        integrity,
+        attestations: { url: `${registryHost}${attestationsPath}` },
+      },
+    })
+    const server = MockRegistry.tnock(t, registryHost, {}, { strict: true })
+    server.get('/npm/abbrev')
+      .matchHeader('accept', value => value.includes(corgi))
+      .reply(200, packument({ dist: { tarball: tarballURL, integrity } }), { vary: 'accept' })
+    server.get('/npm/abbrev')
+      .matchHeader('accept', 'application/json')
+      .reply(200, fullMetadata, { vary: 'accept' })
+    server.get(attestationsPath).reply(404, { error: 'attestation unavailable' })
+    const arb = new Arborist({
+      path: resolve(testdir, 'project'),
+      cache: resolve(testdir, 'cache'),
+      registry,
+      audit: false,
+      allowRemote: 'none',
+      verifyAttestations: true,
+      fetchRetries: 0,
+    })
+    await arb.buildIdealTree()
+    t.equal(arb.idealTree.children.get('abbrev').version, '1.1.1',
+      'old-lock hydration succeeds with abbreviated metadata')
+    await t.rejects(arb.reify(), { code: 'EALLOWREMOTE' },
+      'missing attestations fail closed after dedicated full-metadata verification')
+    t.notOk(fs.existsSync(resolve(testdir, 'project/node_modules/abbrev/package.json')),
+      'URL-only evidence never authorizes an unverified tarball')
+  })
+
+  for (const oversized of [false, true]) {
+    await t.test(`fresh resolution retains evidence with ${
+      oversized ? 'an oversized response' : 'no content-length'
+    }`, async t => {
+      const { arb, server, testdir } = setup(t, { locked: false })
+      const metadata = packument()
+      if (oversized) {
+        metadata.readme = 'x'.repeat(1_000_000)
+      }
+      const body = JSON.stringify(metadata)
+      server.get('/npm/abbrev').reply(200, body, oversized ? {
+        'content-length': Buffer.byteLength(body),
+      } : {})
+      server.get('/download/abbrev-1.1.1.tgz').reply(200, abbrevTGZ)
+      t.equal(arb.options.packumentCache.constructor.name, 'PackumentCache',
+        'uses the production memory cache')
+      await t.resolves(arb.reify(), 'one manifest request supplies extraction evidence')
+      t.equal(arb.options.packumentCache.size, 0, 'the packument is not retained')
+      t.equal(installedVersion(testdir), '1.1.1')
+    })
+  }
+
+  for (const { label, format, mismatch } of [
+    { label: 'tarball only' },
+    { label: 'tarball and full metadata', format: 'full' },
+    { label: 'tarball and abbreviated metadata', format: 'corgi' },
+    { label: 'tarball and mismatched metadata', format: 'corgi', mismatch: true },
+  ]) {
+    await t.test(`offline locked verification with ${label}`, async t => {
+      const { arb, server, testdir } = setup(t, { options: { offline: true } })
+      const seedOptions = {
+        cache: arb.options.cache,
+        registry,
+        fetchRetries: 0,
+      }
+      server.get('/download/abbrev-1.1.1.tgz').reply(200, abbrevTGZ)
+      await pacote.tarball(tarballURL, seedOptions)
+      if (format) {
+        const metadata = mismatch ? packument({
+          dist: { tarball: `${registryHost}/download/not-abbrev.tgz` },
+        }) : packument()
+        server.get('/npm/abbrev')
+          .matchHeader('accept', value => format === 'full'
+            ? value === 'application/json' : value.includes(corgi))
+          .reply(200, metadata, { vary: 'accept' })
+        await pacote.packument('abbrev', { ...seedOptions, fullMetadata: format === 'full' })
+      }
+      if (format === 'full') {
+        await t.rejects(pacote.packument('abbrev', {
+          ...seedOptions,
+          offline: true,
+          fullMetadata: false,
+        }), { code: 'ENOTCACHED' }, 'the abbreviated Accept variant is not cached')
+      }
+      const offlineArb = new Arborist({ ...arb.options, packumentCache: undefined })
+      t.not(offlineArb.options.packumentCache, arb.options.packumentCache,
+        'a fresh Arborist does not share the seeding memory cache')
+      if (format && !mismatch) {
+        await t.resolves(offlineArb.reify(), 'cached metadata and tarball suffice without network')
+        t.equal(installedVersion(testdir), '1.1.1')
+      } else {
+        await t.rejects(offlineArb.reify(), { code: 'EALLOWREMOTE' },
+          'cached tarball bytes do not establish registry provenance')
+      }
+    })
+  }
+
+  await t.test('concurrent versions share one abbreviated verification request', async t => {
+    const root = {
+      name: 'project',
+      version: '1.0.0',
+      dependencies: { abbrev: '1.1.1', widget: '1.0.0' },
+    }
+    const widget = {
+      name: 'widget',
+      version: '1.0.0',
+      dependencies: { abbrev: '2.0.0' },
+    }
+    const otherVersion = { name: 'abbrev', version: '2.0.0' }
+    const otherTarball = `${registryHost}/download/abbrev-2.0.0.tgz`
+    const widgetTarball = `${registry}widget/-/widget-1.0.0.tgz`
+    const testdir = t.testdir({
+      widget: { 'package.json': JSON.stringify(widget) },
+      other: { 'package.json': JSON.stringify(otherVersion) },
+      project: {
+        'package.json': JSON.stringify(root),
+        'package-lock.json': JSON.stringify({
+          lockfileVersion: 3,
+          requires: true,
+          packages: {
+            '': root,
+            'node_modules/abbrev': { version: '1.1.1', resolved: tarballURL },
+            'node_modules/widget': { ...widget, resolved: widgetTarball },
+            'node_modules/widget/node_modules/abbrev': {
+              version: '2.0.0',
+              resolved: otherTarball,
+            },
+          },
+        }),
+      },
+    })
+    const cache = resolve(testdir, 'cache')
+    const widgetTGZ = await pacote.tarball(resolve(testdir, 'widget'), { Arborist, cache })
+    const otherTGZ = await pacote.tarball(resolve(testdir, 'other'), { Arborist, cache })
+    const metadata = packument()
+    metadata.versions['2.0.0'] = { ...otherVersion, dist: { tarball: otherTarball } }
+    const server = MockRegistry.tnock(t, registryHost, {}, { strict: true })
+    server.get('/npm/abbrev')
+      .matchHeader('accept', value => value.includes(corgi))
+      .delay(50)
+      .reply(200, metadata)
+    server.get('/download/abbrev-1.1.1.tgz').reply(200, abbrevTGZ)
+    server.get('/download/abbrev-2.0.0.tgz').reply(200, otherTGZ)
+    server.get('/npm/widget/-/widget-1.0.0.tgz').reply(200, widgetTGZ)
+    const arb = new Arborist({
+      path: resolve(testdir, 'project'),
+      cache,
+      registry,
+      audit: false,
+      allowRemote: 'none',
+      fetchRetries: 0,
+    })
+    await t.resolves(arb.reify(), 'one packument authorizes both exact versions')
+    t.equal(installedVersion(testdir), '1.1.1')
+    t.equal(installedVersion(testdir, 'widget/node_modules/abbrev'), '2.0.0')
+    t.equal(arb.options.packumentCache.size, 0, 'does not depend on a retained full packument')
+  })
+
+  const aliasName = '@alias/code-frame'
+  const targetName = '@babel/code-frame'
+  const targetVersion = '7.5.5'
+  const targetToken = 'target-registry-token'
+  const targetTGZ = fs.readFileSync(resolve(__dirname,
+    '../fixtures/registry-mocks/content/babel/code-frame/-/code-frame-7.5.5.tgz'))
+  const aliasOptions = {
+    registry,
+    '@babel:registry': `${registryHost}/scoped/`,
+    '@alias:registry': `${registryHost}/alias/`,
+    '//registry.example.com/scoped/:_authToken': targetToken,
+    '//registry.example.com/alias/:_authToken': 'wrong-alias-token',
+    audit: false,
+    ignoreScripts: true,
+    fetchRetries: 0,
+  }
+  for (const allowRemote of [undefined, 'all', 'root', 'none']) {
+    await t.test(`locked alias keeps target authentication with allowRemote=${
+      allowRemote || 'omitted'
+    } without metadata`, async t => {
+      const root = {
+        name: 'project',
+        version: '1.0.0',
+        dependencies: { [aliasName]: `npm:${targetName}@${targetVersion}` },
+      }
+      const pathname = `${allowRemote === 'none' ? '/scoped' : '/download'}/code-frame.tgz`
+      const testdir = t.testdir({
+        project: {
+          'package.json': JSON.stringify(root),
+          'package-lock.json': JSON.stringify({
+            lockfileVersion: 3,
+            requires: true,
+            packages: {
+              '': root,
+              [`node_modules/${aliasName}`]: {
+                name: targetName,
+                version: targetVersion,
+                resolved: `${registryHost}${pathname}`,
+              },
+            },
+          }),
+        },
+      })
+      MockRegistry.tnock(t, registryHost, {}, { strict: true })
+        .get(pathname)
+        .matchHeader('authorization', `Bearer ${targetToken}`)
+        .reply(200, targetTGZ)
+      const arb = new Arborist({
+        ...aliasOptions,
+        path: resolve(testdir, 'project'),
+        cache: resolve(testdir, 'cache'),
+        ...(allowRemote ? { allowRemote } : {}),
+      })
+      await t.resolves(arb.reify(), 'permission mode does not change the authentication identity')
+      t.equal(installedVersion(testdir, aliasName), targetVersion)
+    })
+  }
+
+  for (const { installStrategy, optional, transitive, dependency, sibling } of [
+    { installStrategy: 'hoisted' },
+    { installStrategy: 'linked' },
+    { installStrategy: 'hoisted', optional: true },
+    { installStrategy: 'linked', transitive: true },
+    { installStrategy: 'hoisted', dependency: true },
+    { installStrategy: 'linked', dependency: true },
+    { installStrategy: 'hoisted', dependency: true, sibling: true },
+    { installStrategy: 'linked', dependency: true, sibling: true },
+  ]) {
+    const consumerType = dependency ? 'dependency' : 'peer'
+    await t.test(`alias and ordinary ${optional ? 'optional ' : ''}${consumerType} install with ${
+      installStrategy
+    } strategy${transitive ? ' transitively under root policy' : ''}${
+      sibling ? ' using a sibling tarball' : ''
+    }`, async t => {
+      const dependencies = {
+        [aliasName]: `npm:${targetName}@${targetVersion}`,
+        widget: '1.0.0',
+      }
+      const widget = {
+        name: 'widget',
+        version: '1.0.0',
+        [dependency ? 'dependencies' : 'peerDependencies']: { [aliasName]: '^7.0.0' },
+        ...(optional ? { peerDependenciesMeta: { [aliasName]: { optional: true } } } : {}),
+      }
+      const container = { name: 'container', version: '1.0.0', dependencies }
+      const root = {
+        name: 'project',
+        version: '1.0.0',
+        dependencies: transitive ? { container: '1.0.0' } : dependencies,
+      }
+      const pathname = `${optional || transitive || sibling ? '/download' : '/scoped'}/code-frame.tgz`
+      const testdir = t.testdir({
+        project: { 'package.json': JSON.stringify(root) },
+        widget: { 'package.json': JSON.stringify(widget) },
+        container: { 'package.json': JSON.stringify(container) },
+      })
+      const cache = resolve(testdir, 'cache')
+      const server = MockRegistry.tnock(t, registryHost, {}, { strict: true })
+      for (const manifest of transitive ? [container, widget] : [widget]) {
+        const tarball = await pacote.tarball(resolve(testdir, manifest.name), { Arborist, cache })
+        server.get(`/npm/${manifest.name}`).reply(200, {
+          name: manifest.name,
+          'dist-tags': { latest: manifest.version },
+          versions: {
+            [manifest.version]: {
+              ...manifest,
+              dist: { tarball: `${registry}${manifest.name}.tgz` },
+            },
+          },
+        })
+        server.get(`/npm/${manifest.name}.tgz`).reply(200, tarball)
+      }
+      server.get('/scoped/@babel%2fcode-frame')
+        .matchHeader('authorization', `Bearer ${targetToken}`)
+        .reply(200, {
+          name: targetName,
+          'dist-tags': { latest: targetVersion },
+          versions: {
+            [targetVersion]: {
+              name: targetName,
+              version: targetVersion,
+              dist: { tarball: `${registryHost}${pathname}` },
+            },
+          },
+        })
+      server.get(pathname)
+        .matchHeader('authorization', `Bearer ${targetToken}`)
+        .reply(200, targetTGZ)
+      const arb = new Arborist({
+        ...aliasOptions,
+        path: resolve(testdir, 'project'),
+        cache,
+        installStrategy,
+        allowRemote: transitive ? 'root' : 'none',
+      })
+      const ideal = await arb.buildIdealTree()
+      const target = [...ideal.inventory.values()].find(node => node.name === aliasName)
+      t.ok(target, 'alias target is present in the actual ideal tree')
+      t.same([...target.edgesIn].map(edge => edge.valid), [true, true],
+        `the selecting dependency and ordinary ${consumerType} are both valid`)
+      t.equal([...target.edgesIn].filter(edge => edge.peer).length, dependency ? 0 : 1,
+        'the consumer has the requested edge type')
+      await t.resolves(arb.reify(),
+        `an ordinary ${consumerType} does not conflict with the selected alias`)
+      const installed = JSON.parse(fs.readFileSync(
+        require.resolve(`${aliasName}/package.json`, {
+          paths: [fs.realpathSync(resolve(testdir, 'project/node_modules',
+            transitive ? 'container' : 'widget'))],
+        }),
+        'utf8'
+      ))
+      t.equal(installed.name, targetName, 'installs the authenticated target in the alias slot')
+    })
+  }
+
+  for (const { label, rootSpec, transitiveSpec } of [
+    {
+      label: 'conflicting explicit aliases',
+      rootSpec: `npm:${targetName}@${targetVersion}`,
+      transitiveSpec: `npm:@other/code-frame@${targetVersion}`,
+    },
+    {
+      label: 'a plain root dependency and a transitive alias',
+      rootSpec: targetVersion,
+      transitiveSpec: `npm:${targetName}@${targetVersion}`,
+    },
+  ]) {
+    await t.test(`${label} in a locked graph cannot select a tarball`, async t => {
+      const root = {
+        name: 'project',
+        version: '1.0.0',
+        dependencies: {
+          [aliasName]: rootSpec,
+          widget: '1.0.0',
+        },
+      }
+      const widget = {
+        name: 'widget',
+        version: '1.0.0',
+        dependencies: { [aliasName]: transitiveSpec },
+      }
+      const testdir = t.testdir({
+        widget: { 'package.json': JSON.stringify(widget) },
+        project: {
+          'package.json': JSON.stringify(root),
+          'package-lock.json': JSON.stringify({
+            lockfileVersion: 3,
+            requires: true,
+            packages: {
+              '': root,
+              [`node_modules/${aliasName}`]: {
+                name: targetName,
+                version: targetVersion,
+                resolved: `${registryHost}/download/code-frame.tgz`,
+              },
+              'node_modules/widget': {
+                ...widget,
+                resolved: `${registry}widget.tgz`,
+              },
+            },
+          }),
+        },
+      })
+      const cache = resolve(testdir, 'cache')
+      const widgetTGZ = await pacote.tarball(resolve(testdir, 'widget'), { Arborist, cache })
+      MockRegistry.tnock(t, registryHost, {}, { strict: true })
+        .get('/npm/widget.tgz')
+        .reply(200, widgetTGZ)
+      const arb = new Arborist({
+        ...aliasOptions,
+        '@other:registry': `${registryHost}/other/`,
+        path: resolve(testdir, 'project'),
+        cache,
+        allowRemote: 'none',
+      })
+      const ideal = await arb.buildIdealTree()
+      const target = ideal.children.get(aliasName)
+      t.same([...target.edgesIn].map(edge => edge.valid), [true, true],
+        'both selections are semver-valid despite selecting different packages')
+      await t.rejects(arb.reify(), { code: 'EALLOWREMOTE' },
+        'a transitive alias cannot replace the selected root identity')
+      t.notOk(fs.existsSync(resolve(testdir, 'project/node_modules', aliasName, 'package.json')),
+        'does not fetch or install the ambiguous alias tarball')
+    })
+  }
+})
+
 t.test('install strategy linked', async (t) => {
   const Arborist = require('../../lib/index.js')
   const abbrev = resolve(__dirname,

--- a/workspaces/arborist/test/registry-package-name.js
+++ b/workspaces/arborist/test/registry-package-name.js
@@ -1,0 +1,53 @@
+const t = require('tap')
+const {
+  carryRegistryPackageName,
+  getRegistryPackageName,
+} = require('../lib/registry-package-name.js')
+
+const edge = (name, spec, valid = true) => ({ name, spec, valid })
+const node = (...edgesIn) => ({ edgesIn: new Set(edgesIn) })
+
+t.equal(
+  getRegistryPackageName(node(edge('abbrev', '^1.0.0'))),
+  'abbrev',
+  'uses the dependency name for a registry range'
+)
+
+t.equal(
+  getRegistryPackageName(node(edge('hoek', 'npm:@npm/hoek@6.1.4'))),
+  '@npm/hoek',
+  'uses the target package name for an alias'
+)
+
+t.equal(
+  getRegistryPackageName(node(
+    edge('hoek', 'npm:@npm/hoek@6.1.4'),
+    edge('hoek', 'npm:@other/hoek@6.1.4', false)
+  )),
+  '@npm/hoek',
+  'ignores invalid inbound edges'
+)
+
+t.equal(
+  getRegistryPackageName(node(
+    edge('hoek', 'npm:@npm/hoek@6.1.4'),
+    edge('hoek', 'npm:@other/hoek@6.1.4')
+  )),
+  null,
+  'rejects conflicting valid registry identities'
+)
+
+t.equal(
+  getRegistryPackageName(node(edge('pkg', 'https://example.com/pkg.tgz'))),
+  null,
+  'rejects non-registry dependency specs'
+)
+
+const source = node(edge('hoek', 'npm:@npm/hoek@6.1.4'))
+const isolated = node()
+carryRegistryPackageName(source, isolated)
+t.equal(
+  getRegistryPackageName(isolated),
+  '@npm/hoek',
+  'carries the trusted identity to an isolated node'
+)

--- a/workspaces/arborist/test/registry-package-name.js
+++ b/workspaces/arborist/test/registry-package-name.js
@@ -43,6 +43,36 @@ t.equal(
   'rejects non-registry dependency specs'
 )
 
+t.equal(
+  getRegistryPackageName(node(edge('pkg', 'npm:'))),
+  null,
+  'rejects invalid dependency specs'
+)
+
+t.equal(
+  getRegistryPackageName(node(edge(undefined, '1.0.0'))),
+  null,
+  'rejects registry specs without a package name'
+)
+
+t.equal(
+  getRegistryPackageName({}),
+  null,
+  'rejects nodes without inbound edges'
+)
+
+t.equal(
+  getRegistryPackageName({ edgesIn: {} }),
+  null,
+  'rejects nodes whose inbound edges are not iterable'
+)
+
+t.equal(
+  getRegistryPackageName(node()),
+  null,
+  'rejects nodes without a valid inbound identity'
+)
+
 const source = node(edge('hoek', 'npm:@npm/hoek@6.1.4'))
 const isolated = node()
 carryRegistryPackageName(source, isolated)

--- a/workspaces/arborist/test/registry-package-name.js
+++ b/workspaces/arborist/test/registry-package-name.js
@@ -3,8 +3,10 @@ const {
   carryRegistryPackageName,
   getRegistryPackageName,
 } = require('../lib/registry-package-name.js')
+const Node = require('../lib/node.js')
 
 const edge = (name, spec, valid = true) => ({ name, spec, valid })
+const peer = (name, spec) => ({ ...edge(name, spec), peer: true })
 const node = (...edgesIn) => ({ edgesIn: new Set(edgesIn) })
 
 t.equal(
@@ -35,6 +37,96 @@ t.equal(
   )),
   null,
   'rejects conflicting valid registry identities'
+)
+
+t.equal(
+  getRegistryPackageName(node(
+    edge('react', 'npm:@org/react-fork@18.2.0'),
+    peer('react', '^18.0.0')
+  )),
+  '@org/react-fork',
+  'ordinary peer requirements constrain the alias slot, not its target'
+)
+
+t.equal(
+  getRegistryPackageName(node(
+    peer('react', '^18.0.0'),
+    peer('react', 'npm:@org/react-fork@18.2.0')
+  )),
+  '@org/react-fork',
+  'an explicit peer alias supplies the target for ordinary peers'
+)
+
+t.equal(
+  getRegistryPackageName(node(peer('react', '^18.0.0'), peer('react', '~18.2.0'))),
+  'react',
+  'ordinary peer-only installations still supply a registry identity'
+)
+
+t.equal(
+  getRegistryPackageName(node(
+    edge('react', 'npm:@org/react-fork@18.2.0'),
+    peer('react', 'npm:@other/react-fork@18.2.0')
+  )),
+  null,
+  'conflicting explicit peer aliases are not ignored'
+)
+
+t.equal(
+  getRegistryPackageName(node(
+    edge('react', 'npm:@org/react-fork@18.2.0'),
+    edge('react', '^18.0.0')
+  )),
+  null,
+  'conflicting non-peer selections remain ambiguous'
+)
+
+for (const from of [{ isProjectRoot: true }, { isWorkspace: true }]) {
+  t.equal(
+    getRegistryPackageName(node(
+      { ...edge('react', 'npm:@org/react-fork@18.2.0'), from },
+      edge('react', '^18.0.0')
+    )),
+    '@org/react-fork',
+    'ordinary consumers preserve an alias selected by the project or workspace'
+  )
+  t.equal(
+    getRegistryPackageName(node(
+      { ...edge('react', '^18.0.0'), from },
+      edge('react', 'npm:@org/react-fork@18.2.0')
+    )),
+    null,
+    'a transitive alias cannot replace the project or workspace selection'
+  )
+  t.equal(
+    getRegistryPackageName(node(
+      { ...edge('react', 'npm:@org/react-fork@18.2.0'), from },
+      edge('react', 'npm:@other/react-fork@18.2.0')
+    )),
+    null,
+    'a root alias does not excuse a conflicting explicit transitive alias'
+  )
+}
+
+t.equal(
+  getRegistryPackageName(node(
+    { ...edge('react', 'npm:@org/react-fork@18.2.0'), from: { isProjectRoot: true } },
+    { ...edge('react', 'npm:@other/react-fork@18.2.0'), from: { isWorkspace: true } }
+  )),
+  null,
+  'conflicting project and workspace selections remain ambiguous'
+)
+
+t.equal(
+  getRegistryPackageName(node(peer('react', 'https://example.com/react.tgz'))),
+  null,
+  'ordinary peers do not exempt non-registry specifications'
+)
+
+t.equal(
+  getRegistryPackageName(node(peer('react', '^18.0.0'), peer('other', '^18.0.0'))),
+  null,
+  'conflicting peer-only identities fail closed'
 )
 
 t.equal(
@@ -81,3 +173,93 @@ t.equal(
   '@npm/hoek',
   'carries the trusted identity to an isolated node'
 )
+
+const storeNode = node()
+carryRegistryPackageName(isolated, storeNode)
+t.equal(getRegistryPackageName(storeNode), '@npm/hoek', 'carries through both linked transformations')
+
+const untrusted = node()
+const misleading = node(edge('trusted', '1.0.0'))
+carryRegistryPackageName(untrusted, misleading)
+t.equal(getRegistryPackageName(misleading), null, 'a carried failure cannot be replaced by synthetic edges')
+
+t.test('real aliases satisfy regular and optional peers', t => {
+  for (const optional of [false, true]) {
+    const root = new Node({
+      path: t.testdirName,
+      pkg: {
+        dependencies: { react: 'npm:@org/react-fork@18.2.0', widget: '1.0.0' },
+      },
+    })
+    const target = new Node({
+      name: 'react',
+      parent: root,
+      pkg: { name: '@org/react-fork', version: '18.2.0' },
+    })
+    new Node({
+      name: 'widget',
+      parent: root,
+      pkg: {
+        name: 'widget',
+        version: '1.0.0',
+        peerDependencies: { react: '^18.0.0' },
+        ...(optional ? { peerDependenciesMeta: { react: { optional: true } } } : {}),
+      },
+    })
+    t.equal(target.edgesIn.size, 2, 'both declarations resolve to the installed alias')
+    t.ok([...target.edgesIn].every(e => e.valid), 'both edges are satisfied')
+    t.equal(getRegistryPackageName(target), '@org/react-fork', 'uses the selected alias target')
+  }
+  t.end()
+})
+
+t.test('uses the effective alias selected by an override', t => {
+  const root = new Node({
+    path: t.testdirName,
+    loadOverrides: true,
+    pkg: {
+      dependencies: { widget: '1.0.0' },
+      overrides: { react: 'npm:@org/react-fork@18.2.0' },
+    },
+  })
+  const consumer = new Node({
+    name: 'widget',
+    parent: root,
+    pkg: {
+      name: 'widget',
+      version: '1.0.0',
+      dependencies: { react: '^18.0.0' },
+    },
+  })
+  const target = new Node({
+    name: 'react',
+    parent: root,
+    pkg: { name: '@org/react-fork', version: '18.2.0' },
+  })
+  t.equal(consumer.edgesOut.get('react').rawSpec, '^18.0.0')
+  t.ok(consumer.edgesOut.get('react').valid)
+  t.equal(getRegistryPackageName(target), '@org/react-fork')
+  t.end()
+})
+
+t.test('accepted version ranges preserve the registry identity', t => {
+  const root = new Node({ path: t.testdirName })
+  const consumer = new Node({
+    name: 'widget',
+    parent: root,
+    pkg: {
+      name: 'widget',
+      version: '1.0.0',
+      dependencies: { abbrev: '^1.0.0' },
+      acceptDependencies: { abbrev: '^2.0.0' },
+    },
+  })
+  const target = new Node({
+    name: 'abbrev',
+    parent: root,
+    pkg: { name: 'abbrev', version: '2.0.0' },
+  })
+  t.ok(consumer.edgesOut.get('abbrev').valid, 'the accepted range satisfies this edge')
+  t.equal(getRegistryPackageName(target), 'abbrev')
+  t.end()
+})

--- a/workspaces/arborist/test/registry-tarball.js
+++ b/workspaces/arborist/test/registry-tarball.js
@@ -1,0 +1,376 @@
+const t = require('tap')
+const npa = require('npm-package-arg')
+const PackumentCache = require('../lib/packument-cache.js')
+
+const registry = 'https://registry.example.com/npm/'
+const url = 'https://registry.example.com/download/pkg-1.0.0.tgz'
+const arb = (options = {}) => ({ options: { registry, ...options } })
+const manifest = (version = '1.0.0', tarball = url, name = 'pkg') => ({
+  name,
+  version,
+  dist: { tarball },
+})
+const packument = (...versions) => ({
+  name: 'pkg',
+  versions: Object.fromEntries(versions.map(m => [m.version, m])),
+})
+
+t.test('preserves a snapshot of registry-sourced alias metadata', async t => {
+  const { getRegistryTarball, rememberRegistryTarball } = t.mock('../lib/registry-tarball.js', {
+    pacote: {
+      packument: () => {
+        throw new Error('unexpected metadata request')
+      },
+    },
+  })
+  const tree = arb({ '@scope:registry': registry })
+  const spec = npa.resolve('alias', 'npm:@scope/pkg@1.0.0')
+  const metadata = manifest('1.0.0', url, '@scope/pkg')
+  metadata._resolved = 'https://example.com/not-registry-evidence.tgz'
+  rememberRegistryTarball(tree, spec, metadata)
+  metadata.dist.tarball = 'https://example.com/changed-after-resolution.tgz'
+
+  t.equal(await getRegistryTarball(tree, '@scope/pkg', '1.0.0'), url)
+  t.equal(await getRegistryTarball(tree, '@scope/pkg', 'v1.0.0'), url,
+    'normalizes an exact version without reinterpreting it as a dependency spec')
+})
+
+t.test('ignores non-registry and incomplete manifest evidence', async t => {
+  for (const [spec, metadata] of [
+    [npa('https://example.com/pkg.tgz'), manifest()],
+    [npa('pkg'), manifest('not-a-version')],
+    [npa('pkg'), manifest('1.0.0', url, 'other-package')],
+    [npa('pkg'), { name: 'pkg', version: '1.0.0' }],
+    [npa('pkg'), { name: 'pkg', version: '1.0.0', dist: {} }],
+    [npa('pkg'), manifest('1.0.0', '')],
+    [npa('pkg'), {}],
+  ]) {
+    let calls = 0
+    const { getRegistryTarball, rememberRegistryTarball } = t.mock('../lib/registry-tarball.js', {
+      pacote: {
+        packument: async () => {
+          calls++
+          return { versions: {} }
+        },
+      },
+    })
+    const tree = arb()
+    rememberRegistryTarball(tree, spec, metadata)
+    t.equal(await getRegistryTarball(tree, 'pkg', '1.0.0'), null)
+    t.equal(calls, 1, 'unusable evidence cannot skip verification')
+  }
+})
+
+t.test('rejects locked specifications that are not exact versions', async t => {
+  const { getRegistryTarball } = t.mock('../lib/registry-tarball.js', {
+    pacote: {
+      packument: () => {
+        throw new Error('unexpected metadata request')
+      },
+      manifest: () => {
+        throw new Error('unexpected manifest request')
+      },
+    },
+  })
+  for (const version of [
+    undefined, null, 1, {}, '', '*', '^1.0.0', 'latest',
+    'npm:other-package@1.0.0', 'https://example.com/pkg.tgz',
+    'file:pkg.tgz', 'git+https://example.com/pkg.git',
+  ]) {
+    t.equal(await getRegistryTarball(arb(), 'pkg', version), null)
+  }
+})
+
+t.test('reuses full and abbreviated packuments, including pending cache entries', async t => {
+  for (const format of ['full', 'corgi']) {
+    for (const pending of [false, true]) {
+      const metadata = packument(manifest())
+      const cache = new Map([[`${format}:${registry}pkg`,
+        pending ? Promise.resolve(metadata) : metadata]])
+      const { getRegistryTarball } = t.mock('../lib/registry-tarball.js', {
+        pacote: {
+          packument: () => {
+            throw new Error('unexpected metadata request')
+          },
+        },
+      })
+      const tree = arb({ packumentCache: cache })
+      t.equal(await getRegistryTarball(tree, 'pkg', '1.0.0'), url)
+      t.equal(await getRegistryTarball(tree, 'pkg', '2.0.0'), null,
+        'does not select a different version when the locked version is absent')
+    }
+  }
+})
+
+t.test('prefers existing full metadata without requesting a second format', async t => {
+  const cache = new Map([
+    [`full:${registry}pkg`, packument(manifest())],
+    [`corgi:${registry}pkg`, packument(manifest('1.0.0', 'https://example.com/stale.tgz'))],
+  ])
+  const { getRegistryTarball } = require('../lib/registry-tarball.js')
+  t.equal(await getRegistryTarball(arb({ packumentCache: cache }), 'pkg', '1.0.0'), url)
+})
+
+t.test('an offline cache miss can reuse the full HTTP response variant', async t => {
+  const requests = []
+  const { getRegistryTarball } = t.mock('../lib/registry-tarball.js', {
+    pacote: {
+      packument: async (spec, options) => {
+        t.equal(options.offline, true, 'neither attempt can access the network')
+        requests.push(options.fullMetadata)
+        if (!options.fullMetadata) {
+          throw Object.assign(new Error('no cached abbreviated response'), { code: 'ENOTCACHED' })
+        }
+        return packument(manifest())
+      },
+    },
+  })
+  t.equal(await getRegistryTarball(arb({ offline: true }), 'pkg', '1.0.0'), url)
+  t.same(requests, [false, true])
+})
+
+t.test('does not retry arbitrary offline errors as another metadata format', async t => {
+  let calls = 0
+  const failure = Object.assign(new Error('bad cached data'), { code: 'EINTEGRITY' })
+  const { getRegistryTarball } = t.mock('../lib/registry-tarball.js', {
+    pacote: {
+      packument: async () => {
+        calls++
+        throw failure
+      },
+    },
+  })
+  await t.rejects(getRegistryTarball(arb({ offline: true }), 'pkg', '1.0.0'), failure)
+  t.equal(calls, 1)
+})
+
+t.test('coalesces versions and retains compact evidence rejected by the production cache', async t => {
+  for (const size of [undefined, 1_000_000]) {
+    const cache = new PackumentCache()
+    let calls = 0
+    let complete
+    const pending = new Promise(resolve => {
+      complete = resolve
+    })
+    const secondURL = 'https://registry.example.com/download/pkg-2.0.0.tgz'
+    const metadata = { ...packument(manifest(), manifest('2.0.0', secondURL)), _contentLength: size }
+    const { getRegistryTarball } = t.mock('../lib/registry-tarball.js', {
+      pacote: {
+        packument: async (spec, options) => {
+          calls++
+          t.equal(spec.name, 'pkg')
+          t.ok(spec.registry, 'requests the registry package, never the locked URL')
+          t.equal(options.fullMetadata, false, 'only requests installation metadata')
+          t.equal(options.before, null, 'does not reapply version-selection age filters')
+          t.equal(options.offline, true, 'preserves caller network/cache policy')
+          t.equal(options['//registry.example.com/npm/:_authToken'], 'test-token')
+          await pending
+          cache.set(`corgi:${registry}pkg`, metadata)
+          return metadata
+        },
+      },
+    })
+    const tree = arb({
+      packumentCache: cache,
+      before: new Date(),
+      offline: true,
+      '//registry.example.com/npm/:_authToken': 'test-token',
+    })
+    const first = getRegistryTarball(tree, 'pkg', '1.0.0')
+    const second = getRegistryTarball(tree, 'pkg', '2.0.0')
+    const duplicate = getRegistryTarball(tree, 'pkg', '1.0.0')
+    t.equal(calls, 1, 'concurrent cache misses share a request')
+    complete()
+    t.same(await Promise.all([first, second, duplicate]), [url, secondURL, url])
+    t.notOk(cache.has(`corgi:${registry}pkg`), 'the production cache does not retain this response')
+    t.equal(await getRegistryTarball(tree, 'pkg', '2.0.0'), secondURL)
+    t.equal(await getRegistryTarball(tree, 'pkg', '3.0.0'), null)
+    t.equal(calls, 1, 'completed evidence and absent versions do not trigger another request')
+  }
+})
+
+t.test('keeps registry endpoints and Arborist instances separate', async t => {
+  let calls = 0
+  const { getRegistryTarball, rememberRegistryTarball } = t.mock('../lib/registry-tarball.js', {
+    pacote: {
+      packument: async () => {
+        calls++
+        return { versions: {} }
+      },
+    },
+  })
+  const tree = arb()
+  rememberRegistryTarball(tree, npa('pkg'), manifest())
+  t.equal(await getRegistryTarball(tree, 'pkg', '1.0.0'), url)
+  t.equal(await getRegistryTarball(arb(), 'pkg', '1.0.0'), null, 'another tree has no trusted evidence')
+  tree.options.registry = 'https://registry.example.com/another-registry/'
+  t.equal(await getRegistryTarball(tree, 'pkg', '1.0.0'), null, 'a different registry path has no proof')
+  tree.options.registry = registry
+  t.equal(await getRegistryTarball(tree, 'pkg', '1.0.0'), url)
+  t.equal(calls, 2)
+})
+
+t.test('selects scoped registry metadata', async t => {
+  const { getRegistryTarball } = t.mock('../lib/registry-tarball.js', {
+    pacote: {
+      packument: async (spec, options) => {
+        t.equal(spec.name, '@scope/pkg')
+        t.equal(spec.scope, '@scope')
+        t.equal(options['@scope:registry'], registry)
+        return packument(manifest('1.0.0', url, '@scope/pkg'))
+      },
+    },
+  })
+  t.equal(await getRegistryTarball(arb({
+    registry: 'https://registry.npmjs.org/',
+    '@scope:registry': registry,
+  }), '@scope/pkg', '1.0.0'), url)
+})
+
+t.test('malformed metadata cannot authorize another identity or version', async t => {
+  for (const versions of [
+    undefined,
+    {},
+    { '1.0.0': null },
+    { '1.0.0': manifest('1.0.0', url, 'other') },
+    { '1.0.0': manifest('2.0.0') },
+    { '1.0.0': { name: 'pkg', version: '1.0.0' } },
+    { '1.0.0': manifest('1.0.0', 123) },
+    { '1.0.0': manifest('1.0.0', '') },
+    { 'npm:other@1.0.0': manifest('npm:other@1.0.0') },
+  ]) {
+    const { getRegistryTarball } = t.mock('../lib/registry-tarball.js', {
+      pacote: { packument: async () => ({ versions }) },
+    })
+    t.equal(await getRegistryTarball(arb(), 'pkg', '1.0.0'), null)
+  }
+})
+
+t.test('retains build metadata in exact-version evidence', async t => {
+  const one = 'https://registry.example.com/download/one.tgz'
+  const two = 'https://registry.example.com/download/two.tgz'
+  const { getRegistryTarball, rememberRegistryTarball } = t.mock('../lib/registry-tarball.js', {
+    pacote: {
+      packument: async () => packument(
+        manifest('1.0.0+one', one),
+        manifest('1.0.0+two', two)
+      ),
+    },
+  })
+  const tree = arb()
+  t.equal(await getRegistryTarball(tree, 'pkg', '1.0.0+one'), one)
+  t.equal(await getRegistryTarball(tree, 'pkg', '1.0.0+two'), two)
+  t.equal(await getRegistryTarball(tree, 'pkg', '1.0.0'), null)
+  const remembered = arb()
+  rememberRegistryTarball(remembered, npa('pkg'), manifest('1.0.0+one', one))
+  t.equal(await getRegistryTarball(remembered, 'pkg', '1.0.0+one'), one)
+  t.equal(await getRegistryTarball(remembered, 'pkg', '1.0.0+two'), two)
+})
+
+t.test('shares failures without swallowing errors and permits a later retry', async t => {
+  let calls = 0
+  let fail
+  const failure = new Error('registry unavailable')
+  const pending = new Promise((resolve, reject) => {
+    fail = reject
+  })
+  const { getRegistryTarball } = t.mock('../lib/registry-tarball.js', {
+    pacote: {
+      packument: async () => {
+        calls++
+        if (calls === 1) {
+          return pending
+        }
+        return packument(manifest())
+      },
+    },
+  })
+  const tree = arb()
+  const first = getRegistryTarball(tree, 'pkg', '1.0.0')
+  const second = getRegistryTarball(tree, 'pkg', '2.0.0')
+  const assertions = [
+    t.rejects(first, failure),
+    t.rejects(second, failure),
+  ]
+  fail(failure)
+  await Promise.all(assertions)
+  t.equal(calls, 1)
+  t.equal(await getRegistryTarball(tree, 'pkg', '1.0.0'), url)
+  t.equal(calls, 2)
+})
+
+t.test('does not substitute URL-only evidence for requested signature verification', async t => {
+  for (const flag of ['verifySignatures', 'verifyAttestations']) {
+    let calls = 0
+    const { getRegistryTarball, rememberRegistryTarball } = t.mock('../lib/registry-tarball.js', {
+      pacote: {
+        packument: () => {
+          throw new Error('unexpected unverified packument request')
+        },
+        manifest: async (spec, options) => {
+          calls++
+          t.equal(spec.name, 'pkg')
+          t.equal(spec.type, 'version')
+          t.equal(spec.fetchSpec, '1.0.0')
+          t.equal(options[flag], true)
+          t.equal(options.fullMetadata, true)
+          t.equal(options.before, null)
+          return manifest()
+        },
+      },
+    })
+    const tree = arb()
+    rememberRegistryTarball(tree, npa('pkg'), manifest())
+    tree.options[flag] = true
+    t.same(await Promise.all([
+      getRegistryTarball(tree, 'pkg', '1.0.0'),
+      getRegistryTarball(tree, 'pkg', '1.0.0'),
+    ]), [url, url])
+    t.equal(calls, 1, 'verification cannot reuse evidence recorded without the requested checks')
+
+    const enabledBeforeCapture = arb({ [flag]: true })
+    rememberRegistryTarball(enabledBeforeCapture, npa('pkg'), manifest())
+    t.equal(await getRegistryTarball(enabledBeforeCapture, 'pkg', '1.0.0'), url)
+    t.equal(calls, 2,
+      'flags at capture time do not prove that abbreviated metadata contained verification data')
+  }
+})
+
+t.test('abbreviated evidence cannot hide an attestation present in full metadata', async t => {
+  const failure = Object.assign(new Error('attestation unavailable'), { code: 'E404' })
+  let calls = 0
+  const { getRegistryTarball, rememberRegistryTarball } = t.mock('../lib/registry-tarball.js', {
+    pacote: {
+      manifest: async (spec, options) => {
+        calls++
+        t.equal(options.fullMetadata, true)
+        t.equal(options.verifyAttestations, true)
+        throw failure
+      },
+    },
+  })
+  const tree = arb({ verifyAttestations: true })
+  rememberRegistryTarball(tree, npa('pkg'), manifest())
+  await t.rejects(getRegistryTarball(tree, 'pkg', '1.0.0'), failure)
+  t.equal(calls, 1, 'still attempts full attestation verification after abbreviated resolution')
+})
+
+t.test('propagates signature verification errors and retries without accepting them', async t => {
+  let calls = 0
+  const failure = Object.assign(new Error('invalid registry signature'), { code: 'EINTEGRITYSIGNATURE' })
+  const { getRegistryTarball } = t.mock('../lib/registry-tarball.js', {
+    pacote: {
+      manifest: async () => {
+        calls++
+        if (calls === 1) {
+          throw failure
+        }
+        return manifest()
+      },
+    },
+  })
+  const tree = arb({ verifySignatures: true })
+  await t.rejects(getRegistryTarball(tree, 'pkg', '1.0.0'), failure)
+  t.equal(await getRegistryTarball(tree, 'pkg', '1.0.0'), url)
+  t.equal(calls, 2)
+})

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -253,13 +253,13 @@ const definitions = {
       Please note that this could leave your tree incomplete and some packages may not function as intended or designed.
       Changing this setting will not remove dependencies that are already installed.
 
-      As of npm 12 the default is \`none\`. Tarballs that share a hostname
-      with the configured registry (the typical case for the npm registry,
-      GitHub Packages, and most private registries) are still installed
-      normally. If your registry serves tarballs from a different host,
-      set \`replace-registry-host\` or override this setting. Opt in
-      explicitly per project (in \`.npmrc\`) or per command (on the CLI)
-      when you intentionally install from a URL.
+      As of npm 12 the default is \`none\`. Tarballs under the configured
+      registry path are installed normally. npm also permits same-origin
+      tarballs when it can verify their exact URL against registry metadata.
+      If your registry serves tarballs from a different host, set
+      \`replace-registry-host\` or override this setting. Opt in explicitly
+      per project (in \`.npmrc\`) or per command (on the CLI) when you
+      intentionally install from a URL.
 
       \`all\` allows any url to be installed.
       \`none\` prevents any url from being installed.

--- a/workspaces/config/lib/definitions/definitions.js
+++ b/workspaces/config/lib/definitions/definitions.js
@@ -256,6 +256,10 @@ const definitions = {
       As of npm 12 the default is \`none\`. Tarballs under the configured
       registry path are installed normally. npm also permits same-origin
       tarballs when it can verify their exact URL against registry metadata.
+      For these sibling-path tarballs, npm reuses metadata from resolution
+      or cache when available; otherwise it requests package metadata.
+      Offline installation requires cached registry metadata as well as
+      the tarball.
       If your registry serves tarballs from a different host, set
       \`replace-registry-host\` or override this setting. Opt in explicitly
       per project (in \`.npmrc\`) or per command (on the CLI) when you


### PR DESCRIPTION
## Summary

- recognize registry-mediated tarballs served from same-origin sibling paths without trusting arbitrary lockfile URLs
- preserve alias target identity and scoped authentication for ordinary peers, root-selected aliases shared with ordinary dependencies, and linked installs
- validate locked versions and use cache-first registry evidence with coalesced abbreviated metadata requests
- keep requested signature/attestation verification separate from URL-only evidence
- document cold-cache and offline requirements

## Problem

During reification, Arborist passes registry tarballs to pacote as `name@URL`. npm-package-arg parses that temporary spec as a remote dependency, so Arborist needs a narrow exemption for registry-mediated tarballs.

The existing classifier only recognized tarball paths beneath the configured registry path. Private registries can legitimately advertise tarballs from another path on the same origin. It also selected registries using the installed dependency slot: for `hoek: npm:@npm/hoek@6.1.4`, that loses the target scope and can select the wrong registry or credentials. Both cases can incorrectly fail with EALLOWREMOTE under the npm 12 default `allow-remote=none`.

## Implementation

### Package identity and compatibility

Identity comes from valid dependency specifications, not package/lockfile name fields. Aliases are unwrapped to target names. Ordinary peers constrain the installed slot rather than redefining an alias target. Project/workspace selections also take precedence over ordinary compatible transitive requirements, while disagreeing explicit alias targets remain rejected. A transitive alias cannot supersede a plain root selection.

Linked installs carry this identity through intermediate proxies and synthetic store nodes. Extraction uses the target identity independently of remote-permission mode, so authentication follows the target scope while the install location remains the alias slot.

### Sibling-path verification

The configured-registry-path fast path remains. A same-origin URL outside that path is permitted only when registry evidence for the trusted package and exact version advertises the same effective tarball URL.

Locked versions must be exact semantic versions; aliases, ranges, tags, URLs, and other dependency specifications in that field cannot redirect verification. Metadata names and versions must match. Host replacement is applied consistently to both URLs. Fragments are ignored; the remaining URL, including path and query, must match.

### Metadata reuse and request behavior

- Capture compact URL evidence from actual pacote manifest responses during resolution, never from serialized node/lockfile fields.
- Reuse full or abbreviated packuments already present in the memory cache.
- Request abbreviated metadata on a verification cache miss and inspect the exact version entry without treating the locked version as a dependency spec.
- Share pending verification requests per registry/package across instances and versions. Retain compact URL evidence even when the production cache discards large responses or responses without Content-Length.
- Keep offline requests offline. An abbreviated ENOTCACHED result permits an offline lookup of the full HTTP variant, accounting for Vary: Accept.
- Treat captured evidence as URL-only regardless of verification flags during resolution. Explicit signature/attestation verification still uses the dedicated full-metadata path; abbreviated old-lock hydration cannot bypass it.

Cold locked sibling-path installs can still require metadata requests. A cached tarball alone does not establish the additional evidence needed for an offline sibling-path install. This is an intentional availability/performance tradeoff, not a promise of zero additional requests.

### Policy boundaries

Already-permitted implicit/explicit `all`, and root-direct requests under `root`, skip URL verification. Metadata failures, mismatches, unverifiable identities, and cross-origin URLs do not grant an exemption. Explicit remote dependencies remain governed by the configured policy. Extraction continues to receive the locked integrity value.

## Regression coverage

- malformed locked-version specs, including an alias injected into a wildcard lockfile entry, without unauthorized metadata or tarball requests
- exact metadata name/version/URL matching, query mismatches, missing versions, and preserved semver build metadata
- full/abbreviated memory caches, real offline HTTP variants, tarball-only caches, concurrent versions, and production-cache eviction conditions
- alias credentials across permission modes; ordinary/optional peers; root-selected aliases with ordinary consumers; hoisted/linked installs; conflicting explicit selections
- effective alias overrides, accepted version ranges, and both linked-node transformations
- old-lock abbreviated metadata missing an attestation pointer present in full metadata, ensuring requested verification still runs and fails closed
- npm ci tampered-lockfile regressions and updated configuration documentation

Fixes #9796
