### PR TITLE
fix: log oidc failures at warn level

### DIFF
--- a/lib/utils/oidc.js
+++ b/lib/utils/oidc.js
@@ -93,12 +93,12 @@ async function oidc ({ packageName, registry, opts, config }) {
       const json = await response.json()
 
       if (!response.ok) {
-        log.verbose('oidc', `Failed to fetch id_token from GitHub: received an invalid response`)
+        log.warn('oidc', `Failed to fetch id_token from GitHub: received an invalid response`)
         return undefined
       }
 
       if (!json.value) {
-        log.verbose('oidc', `Failed to fetch id_token from GitHub: missing value`)
+        log.warn('oidc', `Failed to fetch id_token from GitHub: missing value`)
         return undefined
       }
 
@@ -123,12 +123,12 @@ async function oidc ({ packageName, registry, opts, config }) {
         method: 'POST',
       })
     } catch (error) {
-      log.verbose('oidc', `Failed token exchange request with body message: ${error?.body?.message || 'Unknown error'}`)
+      log.warn('oidc', `Failed token exchange request with body message: ${error?.body?.message || 'Unknown error'}`)
       return undefined
     }
 
     if (!response?.token) {
-      log.verbose('oidc', 'Failed because token exchange was missing the token in the response body')
+      log.warn('oidc', 'Failed because token exchange was missing the token in the response body')
       return undefined
     }
 
@@ -164,10 +164,10 @@ async function oidc ({ packageName, registry, opts, config }) {
         }
       }
     } catch (error) {
-      log.verbose('oidc', `Failed to set provenance with message: ${error?.message || 'Unknown error'}`)
+      log.warn('oidc', `Failed to set provenance with message: ${error?.message || 'Unknown error'}`)
     }
   } catch (error) {
-    log.verbose('oidc', `Failure with message: ${error?.message || 'Unknown error'}`)
+    log.warn('oidc', `Failure with message: ${error?.message || 'Unknown error'}`)
   }
   return undefined
 }

--- a/test/lib/commands/publish.js
+++ b/test/lib/commands/publish.js
@@ -1151,6 +1151,31 @@ t.test('oidc token exchange - no provenance', t => {
     ],
   }))
 
+  t.test('token exchange 500 with fallback at default loglevel', oidcPublishTest({
+    oidcOptions: { github: true },
+    config: {
+      loglevel: 'notice',
+      '//registry.npmjs.org/:_authToken': 'existing-fallback-token',
+    },
+    mockGithubOidcOptions: {
+      audience: 'npm:registry.npmjs.org',
+      idToken: githubPrivateIdToken,
+    },
+    mockOidcTokenExchangeOptions: {
+      statusCode: 500,
+      idToken: githubPrivateIdToken,
+      body: {
+        message: 'oidc token exchange failed',
+      },
+    },
+    publishOptions: {
+      token: 'existing-fallback-token',
+    },
+    logsContain: [
+      'warn oidc Failed token exchange request with body message: oidc token exchange failed',
+    ],
+  }))
+
   t.test('token exchange 500 with no body message with fallback', oidcPublishTest({
     oidcOptions: { github: true },
     config: {

--- a/test/lib/commands/publish.js
+++ b/test/lib/commands/publish.js
@@ -1106,7 +1106,7 @@ t.test('oidc token exchange - no provenance', t => {
       token: 'existing-fallback-token',
     },
     logsContain: [
-      'verbose oidc Failed to fetch id_token from GitHub: received an invalid response',
+      'warn oidc Failed to fetch id_token from GitHub: received an invalid response',
     ],
   }))
 
@@ -1123,7 +1123,7 @@ t.test('oidc token exchange - no provenance', t => {
       token: 'existing-fallback-token',
     },
     logsContain: [
-      'verbose oidc Failed to fetch id_token from GitHub: missing value',
+      'warn oidc Failed to fetch id_token from GitHub: missing value',
     ],
   }))
 
@@ -1147,7 +1147,7 @@ t.test('oidc token exchange - no provenance', t => {
       token: 'existing-fallback-token',
     },
     logsContain: [
-      'verbose oidc Failed token exchange request with body message: oidc token exchange failed',
+      'warn oidc Failed token exchange request with body message: oidc token exchange failed',
     ],
   }))
 
@@ -1169,7 +1169,7 @@ t.test('oidc token exchange - no provenance', t => {
       token: 'existing-fallback-token',
     },
     logsContain: [
-      'verbose oidc Failed token exchange request with body message: Unknown error',
+      'warn oidc Failed token exchange request with body message: Unknown error',
     ],
   }))
 
@@ -1192,7 +1192,7 @@ t.test('oidc token exchange - no provenance', t => {
       token: 'existing-fallback-token',
     },
     logsContain: [
-      'verbose oidc Failed because token exchange was missing the token in the response body',
+      'warn oidc Failed because token exchange was missing the token in the response body',
     ],
   }))
 
@@ -1267,7 +1267,7 @@ t.test('oidc token exchange - no provenance', t => {
       token: 'existing-fallback-token',
     },
     logsContain: [
-      'verbose oidc Failure with message: Invalid URL',
+      'warn oidc Failure with message: Invalid URL',
     ],
   }))
 
@@ -1300,7 +1300,7 @@ t.test('oidc token exchange - no provenance', t => {
 
     await npm.exec('publish', [])
     t.match(joinedOutput(), '+ @npmcli/test-package@1.0.0')
-    t.ok(logs.includes('verbose oidc Failure with message: Unknown error'))
+    t.ok(logs.includes('warn oidc Failure with message: Unknown error'))
   })
 
   t.test('default registry success gitlab', oidcPublishTest({
@@ -1603,7 +1603,7 @@ t.test('oidc token exchange - provenance', (t) => {
       token: 'existing-fallback-token',
     },
     logsContain: [
-      'verbose oidc Failed token exchange request with body message: oidc token exchange failed',
+      'warn oidc Failed token exchange request with body message: oidc token exchange failed',
     ],
     provenance: false,
   }))
@@ -1654,10 +1654,10 @@ t.test('oidc token exchange - provenance', (t) => {
 
   const provenanceFailures = [[
     new Error('Valid error'),
-    'verbose oidc Failed to set provenance with message: Valid error',
+    'warn oidc Failed to set provenance with message: Valid error',
   ], [
     'Valid error',
-    'verbose oidc Failed to set provenance with message: Unknown error',
+    'warn oidc Failed to set provenance with message: Unknown error',
   ]]
 
   provenanceFailures.forEach(([error, logMessage], index) => {


### PR DESCRIPTION
## What / Why

When a trusted publish fails, npm falls back to the existing auth and the user only sees `ENEEDAUTH`. The reason the OIDC flow gave up is logged at `verbose`, so nothing shows at the default log level and there is no hint that `NPM_ID_TOKEN` was even picked up. Finding out takes a rerun at a higher log level.

These failure paths now log at `warn`: the two id_token fetch failures from GitHub, the token exchange request error, the missing token in the exchange response, the provenance auto-enable failure, and the outer catch. `warn` rather than `error` because publishing still goes ahead on whatever auth was already configured, so none of these are fatal. The two `Skipped because ...` messages stay at `silly`, since running outside a trusted publishing setup is not a failure and should stay quiet.

One consequence worth calling out: a workflow that sets `id-token: write` for provenance but has no trusted publishing configured for the package will now see the exchange 404 as a warning on an otherwise successful publish. Happy to narrow it to the `NPM_ID_TOKEN` case if you would rather keep that quiet. The message wording is left alone to keep the diff to the levels.

## Testing

The existing OIDC cases in `test/lib/commands/publish.js` already assert these exact log lines, so their expected level moved from `verbose` to `warn`. One case is added at the default log level, which is the part the issue is actually about: it fails on `latest` because nothing reaches stderr at all. `npx tap` passes with `lib/utils/oidc.js` still at 100% coverage.

## References

Fixes #9923
