### PR TITLE
fix(arborist): avoid repeated peer placement checks

### DIFF
--- a/workspaces/arborist/lib/can-place-dep.js
+++ b/workspaces/arborist/lib/can-place-dep.js
@@ -63,6 +63,7 @@ class CanPlaceDep {
       preferDedupe,
       parent = null,
       peerPath = [],
+      peerChecks = new Map(),
       explicitRequest = false,
       auditReport = null,
     } = options
@@ -99,6 +100,7 @@ class CanPlaceDep {
 
     // preventing cycles when we check peer sets
     this.peerPath = peerPath
+    this.peerChecks = peerChecks
     // we always prefer to dedupe peers, because they are trying
     // a bit harder to be singletons.
     this.preferDedupe = !!preferDedupe || edge.peer
@@ -387,12 +389,30 @@ class CanPlaceDep {
       // of that dep needs to be placed shallower, because the target has
       // a peer dep on the peer as well.
       const target = deepestNestingTarget(this.target, peer.name)
+      const deepestTarget = deepestNestingTarget(this.deepestNestingTarget, peer.name)
+      // Dense peer graphs can reach the same placement through many paths.
+      // Each edge only needs one check for a given pair of placement targets.
+      let targetChecks = this.peerChecks.get(peerEdge)
+      if (!targetChecks) {
+        targetChecks = new Map()
+        this.peerChecks.set(peerEdge, targetChecks)
+      }
+      let deepestChecks = targetChecks.get(target)
+      if (!deepestChecks) {
+        deepestChecks = new Set()
+        targetChecks.set(target, deepestChecks)
+      }
+      if (deepestChecks.has(deepestTarget)) {
+        continue
+      }
+      deepestChecks.add(deepestTarget)
       const cpp = new CanPlaceDep({
         dep: peer,
         target,
         parent: this,
         edge: peerEdge,
         peerPath,
+        peerChecks: this.peerChecks,
         auditReport: this.auditReport,
         // always place peers in preferDedupe mode
         preferDedupe: true,

--- a/workspaces/arborist/tap-snapshots/test/can-place-dep.js.test.cjs
+++ b/workspaces/arborist/tap-snapshots/test/can-place-dep.js.test.cjs
@@ -79,6 +79,10 @@ exports[`test/can-place-dep.js TAP basic placement check tests cycle of peers ha
 Array []
 `
 
+exports[`test/can-place-dep.js TAP basic placement check tests dense peer graph > conflict children 1`] = `
+Array []
+`
+
 exports[`test/can-place-dep.js TAP basic placement check tests do not keep existing dep that matches, but does not satisfy > conflict children 1`] = `
 Array []
 `

--- a/workspaces/arborist/test/can-place-dep.js
+++ b/workspaces/arborist/test/can-place-dep.js
@@ -37,6 +37,8 @@ t.test('basic placement check tests', t => {
     explicitRequest,
     // an audit report, telling us which nodes are vulnerable
     auditReport,
+    // upper bound for the number of peer placement checks
+    maxChecks,
   }) => {
     const target = tree.inventory.get(targetLoc)
     const node = tree.inventory.get(nodeLoc)
@@ -86,6 +88,9 @@ t.test('basic placement check tests', t => {
       }
       if (expectSelf) {
         t.equal(cpd.canPlaceSelf, expectSelf, msg)
+      }
+      if (maxChecks) {
+        t.ok(cpd.allChildren.length <= maxChecks, 'avoids duplicate peer placement checks')
       }
       t.equal(cpd.description, cpd.canPlace.description || cpd.canPlace)
       t.matchSnapshot([...cpd.conflictChildren].map(c => ({
@@ -619,6 +624,31 @@ t.test('basic placement check tests', t => {
       { pkg: { name: 'c', version: '1.2.3', peerDependencies: { d: '1' } } },
       { pkg: { name: 'd', version: '1.2.3', peerDependencies: { b: '1' } } },
     ],
+  })
+
+  const densePeerNames = Array.from({ length: 8 }, (_, index) => `peer-${index}`)
+  const densePeerPackage = name => ({
+    name,
+    version: '1.0.0',
+    peerDependencies: Object.fromEntries(
+      densePeerNames.filter(peer => peer !== name).map(peer => [peer, '1'])
+    ),
+  })
+  runTest('dense peer graph', {
+    tree: new Node({
+      path,
+      pkg: {
+        name: 'project',
+        version: '1.2.3',
+        dependencies: { [densePeerNames[0]]: '1' },
+      },
+    }),
+    targetLoc: '',
+    nodeLoc: '',
+    dep: new Node({ pkg: densePeerPackage(densePeerNames[0]) }),
+    expect: OK,
+    peerSet: densePeerNames.slice(1).map(name => ({ pkg: densePeerPackage(name) })),
+    maxChecks: densePeerNames.length ** 2,
   })
 
   runTest('peers with peerConflicted edges in peerSet', {


### PR DESCRIPTION
## Summary

Dense cyclic peer graphs can reach the same placement state through many different paths. The existing `peerPath` guard prevents direct recursion, but still repeats equivalent checks and can leave `npm install` CPU-bound indefinitely.

This keeps a traversal-scoped record of peer checks keyed by the peer edge, placement target, and deepest target. Distinct placement contexts are still evaluated, while duplicate paths are skipped.

The reported install now completes successfully with 454 packages instead of remaining CPU-bound.

Fixes #9934

## Testing

- Full `@npmcli/arborist` test suite
- `npm run eslint -w @npmcli/arborist`
- `npm install @deepseek-ai/dsh@0.1.1-rc.2 --package-lock-only --ignore-scripts` on Node 24.15.0 and npm 12.0.2