### PR TITLE
fix: write registry allowScripts keys under install-strategy=linked

### DIFF
--- a/lib/utils/allow-scripts-cmd.js
+++ b/lib/utils/allow-scripts-cmd.js
@@ -221,13 +221,14 @@ class AllowScriptsCmd extends BaseCommand {
     // edge name. A version or range on the arg narrows the match to installed
     // versions that satisfy it. Bundled deps are excluded for the same reason
     // as --all. Args that match nothing are returned in `unmatched`.
+    // Links are skipped like collectUnreviewedScripts and prune do: scripts only run on the target, and keying policy off a Link's resolved spec writes store paths under install-strategy=linked (npm/cli#9939).
     const matched = []
     const unmatched = []
     for (const arg of args) {
       const { name: wantName, range } = parsePositional(arg)
       const found = []
       for (const node of arb.actualTree.inventory.values()) {
-        if (node.isProjectRoot || node.isWorkspace || node.inBundle) {
+        if (node.isProjectRoot || node.isWorkspace || node.isLink || node.inBundle) {
           continue
         }
         const { name, version } = trustedDisplay(node)

--- a/lib/utils/allow-scripts-cmd.js
+++ b/lib/utils/allow-scripts-cmd.js
@@ -221,16 +221,13 @@ class AllowScriptsCmd extends BaseCommand {
     // edge name. A version or range on the arg narrows the match to installed
     // versions that satisfy it. Bundled deps are excluded for the same reason
     // as --all. Args that match nothing are returned in `unmatched`.
-    // Links are skipped like collectUnreviewedScripts and prune do: scripts only run on the target, and keying policy off a Link's resolved spec writes store paths under install-strategy=linked (npm/cli#9939).
+    // Links stay matchable by their edge name (e.g. `foo` -> `file:./local-foo`), but each match is dereferenced to its target and deduplicated, since scripts only run on the target and keying policy off a Link's resolved spec writes store paths under install-strategy=linked (npm/cli#9939).
     const matched = []
     const unmatched = []
     for (const arg of args) {
       const { name: wantName, range } = parsePositional(arg)
-      const found = []
+      const found = new Set()
       for (const node of arb.actualTree.inventory.values()) {
-        if (node.isProjectRoot || node.isWorkspace || node.isLink || node.inBundle) {
-          continue
-        }
         const { name, version } = trustedDisplay(node)
         if (!name || name !== wantName) {
           continue
@@ -238,9 +235,13 @@ class AllowScriptsCmd extends BaseCommand {
         if (range && (!version || !semver.satisfies(version, range, { loose: true }))) {
           continue
         }
-        found.push(node)
+        const target = node.isLink ? node.target : node
+        if (!target || target.isProjectRoot || target.isWorkspace || target.inBundle) {
+          continue
+        }
+        found.add(target)
       }
-      if (found.length === 0) {
+      if (found.size === 0) {
         unmatched.push(arg)
       } else {
         matched.push(...found)

--- a/lib/utils/allow-scripts-prune.js
+++ b/lib/utils/allow-scripts-prune.js
@@ -29,7 +29,8 @@ const classifyUnusedEntries = (allowScripts, nodes) => {
       continue
     }
 
-    const matching = nodes.filter(({ node }) => matches(node, key))
+    // Pass deny intent so an unverifiable version fails closed: an active versioned deny must not be classified as unused while its broad allow survives.
+    const matching = nodes.filter(({ node }) => matches(node, key, value === false))
     if (matching.length === 0) {
       removed.push({ key, value, reason: 'not-installed' })
       continue

--- a/test/lib/commands/approve-scripts.js
+++ b/test/lib/commands/approve-scripts.js
@@ -859,3 +859,131 @@ t.test('approve-scripts --all with only bundled deps has nothing to review', asy
   const pkg = JSON.parse(fs.readFileSync(resolve(prefix, 'package.json'), 'utf8'))
   t.notOk(pkg.allowScripts, 'no allowScripts written')
 })
+
+// Layout produced by install-strategy=linked: the real package lives in the store, node_modules holds a symlink to it, and the hidden lockfile records that isolated layout (npm/cli#9939).
+const setupLinkedProject = (t, { allowScripts, noResolved = false } = {}) => {
+  const storeDir = 'canvas@1.0.0-c2FsdHNhbHRzYWx0c2FsdA'
+  const storeLoc = `node_modules/.store/${storeDir}/node_modules/canvas`
+  const tarUrl = noResolved
+    ? undefined
+    : 'https://registry.npmjs.org/canvas/-/canvas-1.0.0.tgz'
+  const pkg = {
+    name: 'host',
+    version: '1.0.0',
+    dependencies: { canvas: '^1.0.0' },
+  }
+  if (allowScripts !== undefined) {
+    pkg.allowScripts = allowScripts
+  }
+  return {
+    'package.json': JSON.stringify(pkg, null, 2),
+    'package-lock.json': JSON.stringify({
+      name: pkg.name,
+      version: pkg.version,
+      lockfileVersion: 3,
+      requires: true,
+      packages: {
+        '': pkg,
+        'node_modules/canvas': {
+          version: '1.0.0',
+          resolved: tarUrl,
+          hasInstallScript: true,
+        },
+      },
+    }),
+    node_modules: {
+      '.package-lock.json': JSON.stringify({
+        lockfileVersion: 3,
+        requires: true,
+        packages: {
+          [`node_modules/.store/${storeDir}`]: {},
+          [storeLoc]: {
+            version: '1.0.0',
+            resolved: tarUrl,
+            hasInstallScript: true,
+          },
+          'node_modules/canvas': {
+            resolved: storeLoc,
+            link: true,
+          },
+        },
+      }),
+      '.store': {
+        [storeDir]: {
+          node_modules: {
+            canvas: {
+              'package.json': JSON.stringify({
+                name: 'canvas',
+                version: '1.0.0',
+                scripts: { install: 'echo install' },
+              }),
+            },
+          },
+        },
+      },
+      canvas: t.fixture('symlink', `.store/${storeDir}/node_modules/canvas`),
+    },
+  }
+}
+
+// loadActual only trusts the hidden lockfile when it is newer than every dir under node_modules (assertNoNewer allows 10ms), and fixture creation order makes that racy, so bump its mtime past the fixture writes.
+const trustHiddenLockfile = (prefix) => {
+  const future = new Date(Date.now() + 60_000)
+  fs.utimesSync(resolve(prefix, 'node_modules', '.package-lock.json'), future, future)
+}
+
+t.test('approve-scripts <pkg> under linked strategy writes a registry pin, not store paths', async t => {
+  const { npm, prefix } = await mockNpm(t, {
+    prefixDir: setupLinkedProject(t),
+  })
+  trustHiddenLockfile(prefix)
+  await npm.exec('approve-scripts', ['canvas'])
+
+  const pkg = JSON.parse(fs.readFileSync(resolve(prefix, 'package.json'), 'utf8'))
+  t.strictSame(pkg.allowScripts, { 'canvas@1.0.0': true })
+})
+
+t.test('approve-scripts --all under linked strategy writes a registry pin, not store paths', async t => {
+  const { npm, prefix } = await mockNpm(t, {
+    prefixDir: setupLinkedProject(t),
+    config: { all: true },
+  })
+  trustHiddenLockfile(prefix)
+  await npm.exec('approve-scripts', [])
+
+  const pkg = JSON.parse(fs.readFileSync(resolve(prefix, 'package.json'), 'utf8'))
+  t.strictSame(pkg.allowScripts, { 'canvas@1.0.0': true })
+})
+
+t.test('approve-scripts --pending is empty when the registry pin covers a linked store package', async t => {
+  const { npm, prefix, joinedOutput } = await mockNpm(t, {
+    prefixDir: setupLinkedProject(t, { allowScripts: { 'canvas@1.0.0': true } }),
+    config: { 'allow-scripts-pending': true },
+  })
+  trustHiddenLockfile(prefix)
+  await npm.exec('approve-scripts', [])
+  t.match(joinedOutput(), /No packages with unreviewed install scripts/)
+})
+
+t.test('deny-scripts under linked strategy writes a name-only deny', async t => {
+  const { npm, prefix } = await mockNpm(t, {
+    prefixDir: setupLinkedProject(t),
+  })
+  trustHiddenLockfile(prefix)
+  await npm.exec('deny-scripts', ['canvas'])
+
+  const pkg = JSON.parse(fs.readFileSync(resolve(prefix, 'package.json'), 'utf8'))
+  t.strictSame(pkg.allowScripts, { canvas: false })
+})
+
+t.test('approve-scripts <pkg> under linked strategy without resolved URLs approves by name', async t => {
+  // omit-lockfile-registry-resolved: the store package has no resolved URL, so it cannot be pinned but must still be approved by name via the incoming Link's edge.
+  const { npm, prefix } = await mockNpm(t, {
+    prefixDir: setupLinkedProject(t, { noResolved: true }),
+  })
+  trustHiddenLockfile(prefix)
+  await npm.exec('approve-scripts', ['canvas'])
+
+  const pkg = JSON.parse(fs.readFileSync(resolve(prefix, 'package.json'), 'utf8'))
+  t.strictSame(pkg.allowScripts, { canvas: true })
+})

--- a/test/lib/commands/approve-scripts.js
+++ b/test/lib/commands/approve-scripts.js
@@ -976,6 +976,66 @@ t.test('deny-scripts under linked strategy writes a name-only deny', async t => 
   t.strictSame(pkg.allowScripts, { canvas: false })
 })
 
+const setupLocalFileDepProject = (t) => {
+  const pkg = {
+    name: 'host',
+    version: '1.0.0',
+    dependencies: { foo: 'file:./local-foo' },
+  }
+  return {
+    'package.json': JSON.stringify(pkg, null, 2),
+    'package-lock.json': JSON.stringify({
+      name: 'host',
+      version: '1.0.0',
+      lockfileVersion: 3,
+      requires: true,
+      packages: {
+        '': pkg,
+        'local-foo': {
+          name: 'local-foo',
+          version: '1.0.0',
+          hasInstallScript: true,
+        },
+        'node_modules/foo': {
+          resolved: 'local-foo',
+          link: true,
+        },
+      },
+    }),
+    'local-foo': {
+      'package.json': JSON.stringify({
+        name: 'local-foo',
+        version: '1.0.0',
+        scripts: { install: 'echo install' },
+      }),
+    },
+    node_modules: {
+      foo: t.fixture('symlink', '../local-foo'),
+    },
+  }
+}
+
+t.test('approve-scripts <name> finds a local file: dep through its link', async t => {
+  // The Link is named `foo` while its target is named `local-foo`; positional matching must dereference the Link instead of skipping it (npm/cli#9939 review).
+  const { npm, prefix } = await mockNpm(t, {
+    prefixDir: setupLocalFileDepProject(t),
+  })
+  await npm.exec('approve-scripts', ['foo'])
+
+  const pkg = JSON.parse(fs.readFileSync(resolve(prefix, 'package.json'), 'utf8'))
+  t.strictSame(pkg.allowScripts, { 'file:../local-foo': true })
+})
+
+t.test('deny-scripts <name> finds a local file: dep through its link', async t => {
+  const { npm, prefix } = await mockNpm(t, {
+    prefixDir: setupLocalFileDepProject(t),
+  })
+  await npm.exec('deny-scripts', ['foo'])
+
+  const pkg = JSON.parse(fs.readFileSync(resolve(prefix, 'package.json'), 'utf8'))
+  t.strictSame(pkg.allowScripts, { 'file:../local-foo': false })
+})
+
 t.test('approve-scripts <pkg> under linked strategy without resolved URLs approves by name', async t => {
   // omit-lockfile-registry-resolved: the store package has no resolved URL, so it cannot be pinned but must still be approved by name via the incoming Link's edge.
   const { npm, prefix } = await mockNpm(t, {

--- a/test/lib/commands/approve-scripts.js
+++ b/test/lib/commands/approve-scripts.js
@@ -1047,3 +1047,62 @@ t.test('approve-scripts <pkg> under linked strategy without resolved URLs approv
   const pkg = JSON.parse(fs.readFileSync(resolve(prefix, 'package.json'), 'utf8'))
   t.strictSame(pkg.allowScripts, { canvas: true })
 })
+
+for (const state of ['missing', 'stale']) {
+  t.test(`prune keeps denies with a ${state} hidden lockfile`, async t => {
+    // With no trusted version, the versioned deny still blocks at runtime, so prune must fail closed and keep it instead of flipping the effective policy to allowed (npm/cli#9941 review).
+    const Arborist = require('@npmcli/arborist')
+    const isScriptAllowed = require('@npmcli/arborist/lib/script-allowed.js')
+    const allowScripts = {
+      canvas: true,
+      'canvas@1.0.0': false,
+    }
+
+    const { npm, prefix } = await mockNpm(t, {
+      prefixDir: setupLinkedProject(t, { allowScripts }),
+      config: { 'install-strategy': 'linked' },
+    })
+
+    const hidden = resolve(prefix, 'node_modules', '.package-lock.json')
+    if (state === 'missing') {
+      fs.unlinkSync(hidden)
+    } else {
+      fs.utimesSync(hidden, new Date(0), new Date(0))
+    }
+
+    t.equal(npm.config.get('omit-lockfile-registry-resolved'), false)
+
+    const arb = new Arborist({ ...npm.flatOptions, path: prefix })
+    const tree = await arb.loadActual()
+    const target = [...tree.inventory.values()]
+      .find(node => !node.isLink && node.name === 'canvas')
+
+    t.ok(target, 'finds the installed target')
+    t.strictSame(
+      isScriptAllowed.getTrustedRegistryIdentity(target),
+      { name: 'canvas', version: null },
+      'recovers the registry name without inventing a trusted version'
+    )
+    t.equal(
+      isScriptAllowed(target, allowScripts),
+      false,
+      'the versioned deny blocks the package before pruning'
+    )
+
+    await npm.exec('install-scripts', ['prune'])
+
+    const pkg = JSON.parse(
+      fs.readFileSync(resolve(prefix, 'package.json'), 'utf8')
+    )
+    t.strictSame(
+      pkg.allowScripts,
+      allowScripts,
+      'pruning preserves both the allow and its active deny exception'
+    )
+    t.equal(
+      isScriptAllowed(target, pkg.allowScripts),
+      false,
+      'the package remains denied after pruning'
+    )
+  })
+}

--- a/test/lib/commands/install-scripts.js
+++ b/test/lib/commands/install-scripts.js
@@ -334,3 +334,64 @@ t.test('install-scripts prune fails for global installs', async t => {
     { code: 'EGLOBAL' }
   )
 })
+
+t.test('install-scripts prune under linked strategy keeps the registry pin, drops store paths', async t => {
+  // Regression for npm/cli#9939: the buggy writer produced file:.store keys; prune must drop those and keep the valid registry pin covering the store package.
+  const storeDir = 'canvas@1.0.0-c2FsdHNhbHRzYWx0c2FsdA'
+  const storeLoc = `node_modules/.store/${storeDir}/node_modules/canvas`
+  const tarUrl = 'https://registry.npmjs.org/canvas/-/canvas-1.0.0.tgz'
+  const pkg = {
+    name: 'host',
+    version: '1.0.0',
+    dependencies: { canvas: '^1.0.0' },
+    allowScripts: {
+      'canvas@1.0.0': true,
+      [`file:.store/${storeDir}/node_modules/canvas`]: true,
+    },
+  }
+  const { npm, prefix, joinedOutput } = await mockNpm(t, {
+    prefixDir: {
+      'package.json': JSON.stringify(pkg, null, 2),
+      node_modules: {
+        '.package-lock.json': JSON.stringify({
+          lockfileVersion: 3,
+          requires: true,
+          packages: {
+            [`node_modules/.store/${storeDir}`]: {},
+            [storeLoc]: {
+              version: '1.0.0',
+              resolved: tarUrl,
+              hasInstallScript: true,
+            },
+            'node_modules/canvas': {
+              resolved: storeLoc,
+              link: true,
+            },
+          },
+        }),
+        '.store': {
+          [storeDir]: {
+            node_modules: {
+              canvas: {
+                'package.json': JSON.stringify({
+                  name: 'canvas',
+                  version: '1.0.0',
+                  scripts: { install: 'echo install' },
+                }),
+              },
+            },
+          },
+        },
+        canvas: t.fixture('symlink', `.store/${storeDir}/node_modules/canvas`),
+      },
+    },
+  })
+  // loadActual only trusts the hidden lockfile when it is newer than every dir under node_modules (assertNoNewer allows 10ms), and fixture creation order makes that racy, so bump its mtime past the fixture writes.
+  const future = new Date(Date.now() + 60_000)
+  fs.utimesSync(resolve(prefix, 'node_modules', '.package-lock.json'), future, future)
+  await npm.exec('install-scripts', ['prune'])
+
+  const updated = JSON.parse(fs.readFileSync(resolve(prefix, 'package.json'), 'utf8'))
+  t.strictSame(updated.allowScripts, { 'canvas@1.0.0': true })
+  t.match(joinedOutput(), /file:\.store.*\(package not installed\)/)
+})

--- a/workspaces/arborist/lib/script-allowed.js
+++ b/workspaces/arborist/lib/script-allowed.js
@@ -1,3 +1,4 @@
+const { sep } = require('node:path')
 const npa = require('npm-package-arg')
 const semver = require('semver')
 const versionFromTgz = require('./version-from-tgz.js')
@@ -99,6 +100,15 @@ const matches = (node, key, failClosed) => {
   }
 }
 
+// True when the node lives in the linked install strategy's `node_modules/.store` directory; such registry-managed packages must never derive identity from the store's internal `file:` link specs.
+const isStoreBacked = (node) => {
+  if (node?.isInStore) {
+    return true
+  }
+  const real = node?.realpath || node?.path
+  return typeof real === 'string' && real.includes(`${sep}node_modules${sep}.store${sep}`)
+}
+
 const resolvedSourceSpecs = (node) => {
   const specs = []
   const seen = new Set()
@@ -112,7 +122,8 @@ const resolvedSourceSpecs = (node) => {
 
   add(node?.resolved)
 
-  if (!node?.resolved && node?.linksIn && typeof node.linksIn[Symbol.iterator] === 'function') {
+  if (!node?.resolved && !isStoreBacked(node) &&
+      node?.linksIn && typeof node.linksIn[Symbol.iterator] === 'function') {
     let hasIncomingLink = false
     for (const link of node.linksIn) {
       hasIncomingLink = true
@@ -235,10 +246,32 @@ const getTrustedRegistryIdentity = (node) => {
 }
 
 const nameFromEdges = (node) => {
-  if (!node.edgesIn || typeof node.edgesIn[Symbol.iterator] !== 'function') {
+  const name = nameFromEdgeSet(node?.edgesIn)
+  if (name) {
+    return name
+  }
+  // A link target carries no edges of its own; they land on the incoming Links (e.g. the linked strategy's store packages), so consult their edges too, failing closed when the Links disagree on the registry name rather than trusting insertion order.
+  let linkName = null
+  if (node?.linksIn && typeof node.linksIn[Symbol.iterator] === 'function') {
+    for (const link of node.linksIn) {
+      const name = nameFromEdgeSet(link.edgesIn)
+      if (!name) {
+        continue
+      }
+      if (linkName && linkName !== name) {
+        return null
+      }
+      linkName = name
+    }
+  }
+  return linkName
+}
+
+const nameFromEdgeSet = (edgesIn) => {
+  if (!edgesIn || typeof edgesIn[Symbol.iterator] !== 'function') {
     return null
   }
-  for (const edge of node.edgesIn) {
+  for (const edge of edgesIn) {
     let parsed
     try {
       parsed = npa.resolve(edge.name, edge.spec)
@@ -350,7 +383,14 @@ const isRegistryNode = (node) => {
   // edge resolves to a registry spec, which is much harder to spoof than
   // the URL.
   if (typeof node.isRegistryDependency === 'boolean') {
-    return node.isRegistryDependency
+    if (node.isRegistryDependency) {
+      return true
+    }
+    // A link target carries no edges of its own; they land on the incoming Links (e.g. the linked strategy's store packages, npm/cli#9939), so delegate the edge-based check to them.
+    if (node.edgesIn?.size === 0 && node.linksIn?.size > 0) {
+      return [...node.linksIn].every(link => link.isRegistryDependency)
+    }
+    return false
   }
   // Fall back to URL parsing for nodes without the arborist getter
   // (e.g. test fixtures, lockfiles with omit-lockfile-registry-resolved).

--- a/workspaces/arborist/lib/script-allowed.js
+++ b/workspaces/arborist/lib/script-allowed.js
@@ -1,4 +1,4 @@
-const { sep } = require('node:path')
+const { resolve, sep } = require('node:path')
 const npa = require('npm-package-arg')
 const semver = require('semver')
 const versionFromTgz = require('./version-from-tgz.js')
@@ -105,8 +105,16 @@ const isStoreBacked = (node) => {
   if (node?.isInStore) {
     return true
   }
-  const real = node?.realpath || node?.path
-  return typeof real === 'string' && real.includes(`${sep}node_modules${sep}.store${sep}`)
+  // Nodes loaded from the hidden lockfile do not retain isInStore, so fall back to the path, anchored to this tree's own store so an unrelated project's `.store` never qualifies.
+  const paths = [node?.path, node?.realpath].filter(p => typeof p === 'string')
+  const roots = [node?.root?.path, node?.root?.realpath].filter(p => typeof p === 'string')
+  for (const root of roots) {
+    const store = resolve(root, 'node_modules', '.store')
+    if (paths.some(path => path.startsWith(`${store}${sep}`))) {
+      return true
+    }
+  }
+  return false
 }
 
 const resolvedSourceSpecs = (node) => {
@@ -247,18 +255,18 @@ const getTrustedRegistryIdentity = (node) => {
 
 const nameFromEdges = (node) => {
   const name = nameFromEdgeSet(node?.edgesIn)
-  if (name) {
+  if (name || !isStoreBacked(node) || node?.edgesIn?.size !== 0) {
     return name
   }
-  // A link target carries no edges of its own; they land on the incoming Links (e.g. the linked strategy's store packages), so consult their edges too, failing closed when the Links disagree on the registry name rather than trusting insertion order.
+  // A store-backed link target carries no edges of its own; they land on the incoming Links, so consult their edges instead, refusing when a Link is non-registry, unidentified, or disagrees with another Link.
   let linkName = null
   if (node?.linksIn && typeof node.linksIn[Symbol.iterator] === 'function') {
     for (const link of node.linksIn) {
-      const name = nameFromEdgeSet(link.edgesIn)
-      if (!name) {
-        continue
+      if (!link.isRegistryDependency) {
+        return null
       }
-      if (linkName && linkName !== name) {
+      const name = nameFromEdgeSet(link.edgesIn)
+      if (!name || (linkName && linkName !== name)) {
         return null
       }
       linkName = name
@@ -386,8 +394,8 @@ const isRegistryNode = (node) => {
     if (node.isRegistryDependency) {
       return true
     }
-    // A link target carries no edges of its own; they land on the incoming Links (e.g. the linked strategy's store packages, npm/cli#9939), so delegate the edge-based check to them.
-    if (node.edgesIn?.size === 0 && node.linksIn?.size > 0) {
+    // A store-backed link target carries no edges of its own; they land on the incoming Links (npm/cli#9939), so delegate the edge-based check to them, but never for ordinary local symlink targets that share the same topology.
+    if (isStoreBacked(node) && node.edgesIn?.size === 0 && node.linksIn?.size > 0) {
       return [...node.linksIn].every(link => link.isRegistryDependency)
     }
     return false

--- a/workspaces/arborist/test/script-allowed.js
+++ b/workspaces/arborist/test/script-allowed.js
@@ -865,3 +865,127 @@ t.test('trustedDisplay falls back to node.name/version when URL has no identity'
   t.strictSame(trustedDisplay(n), { name: 'bar', version: '1.2.3' })
   t.end()
 })
+
+t.test('registry — link target delegates edge check to incoming links (linked strategy)', t => {
+  // Under install-strategy=linked, the store package carries no edges of its own; they land on the incoming Link nodes (npm/cli#9939).
+  const target = node({
+    name: 'canvas',
+    version: '1.0.0',
+    location: 'node_modules/.store/canvas@1.0.0-hash/node_modules/canvas',
+  })
+  target.isRegistryDependency = false
+  target.edgesIn = new Set()
+  target.linksIn = new Set([{ isRegistryDependency: true }])
+
+  t.equal(isScriptAllowed(target, { 'canvas@1.0.0': true }), true)
+  t.equal(isScriptAllowed(target, { canvas: true }), true)
+  t.equal(isScriptAllowed(target, { canvas: false }), false)
+  t.equal(isScriptAllowed(target, { 'canvas@2.0.0': true }), null)
+  t.end()
+})
+
+t.test('registry — link target refuses when an incoming link is not a registry dep', t => {
+  const target = node({ name: 'canvas', version: '1.0.0' })
+  target.isRegistryDependency = false
+  target.edgesIn = new Set()
+  target.linksIn = new Set([{ isRegistryDependency: true }, { isRegistryDependency: false }])
+
+  t.equal(isScriptAllowed(target, { 'canvas@1.0.0': true }), null)
+  t.end()
+})
+
+t.test('registry — direct non-registry edges refuse regardless of links', t => {
+  const target = node({ name: 'canvas', version: '1.0.0' })
+  target.isRegistryDependency = false
+  target.edgesIn = new Set([{ spec: 'file:../canvas' }])
+  target.linksIn = new Set([{ isRegistryDependency: true }])
+
+  t.equal(isScriptAllowed(target, { 'canvas@1.0.0': true }), null)
+  t.end()
+})
+
+t.test('store-backed link target never matches store file specs', t => {
+  // A store package whose resolved is unknown (fs-scan fallback) must not take identity from the store's internal file: link specs (npm/cli#9939).
+  const real = require('node:path').resolve('node_modules/.store/canvas@1.0.0-hash/node_modules/canvas')
+  const target = node({ name: 'canvas', version: '1.0.0' })
+  target.resolved = null
+  target.path = real
+  target.realpath = real
+  target.linksIn = new Set([{ resolved: 'file:.store/canvas@1.0.0-hash/node_modules/canvas' }])
+
+  t.equal(isScriptAllowed(target, { 'file:.store/canvas@1.0.0-hash/node_modules/canvas': true }), null)
+  t.end()
+})
+
+t.test('isInStore link target never matches store file specs', t => {
+  const target = node({ name: 'canvas', version: '1.0.0' })
+  target.resolved = null
+  target.isInStore = true
+  target.linksIn = new Set([{ resolved: 'file:.store/canvas@1.0.0-hash/node_modules/canvas' }])
+
+  t.equal(isScriptAllowed(target, { 'file:.store/canvas@1.0.0-hash/node_modules/canvas': true }), null)
+  t.end()
+})
+
+t.test('registry — link target without resolved takes trusted name from link edges', t => {
+  // omit-lockfile-registry-resolved under install-strategy=linked: the store package has no resolved URL and no edges; the name comes from the incoming Link's consumer-written edge.
+  const target = node({ name: 'canvas', version: '1.0.0' })
+  target.resolved = null
+  target.isRegistryDependency = false
+  target.edgesIn = new Set()
+  target.linksIn = new Set([{
+    isRegistryDependency: true,
+    edgesIn: new Set([{ name: 'canvas', spec: '^1.0.0' }]),
+  }])
+
+  t.equal(isScriptAllowed(target, { canvas: true }), true)
+  t.equal(isScriptAllowed(target, { canvas: false }), false)
+  t.equal(isScriptAllowed(target, { other: true }), null)
+  // With no verifiable version, an exact pin is refused but a deny still blocks.
+  t.equal(isScriptAllowed(target, { 'canvas@1.0.0': true }), null)
+  t.equal(isScriptAllowed(target, { 'canvas@1.0.0': false }), false)
+  t.end()
+})
+
+t.test('registry — link target with no registry name on any link edge stays untrusted', t => {
+  const target = node({ name: 'canvas', version: '1.0.0' })
+  target.resolved = null
+  target.isRegistryDependency = false
+  target.edgesIn = new Set()
+  target.linksIn = new Set([{
+    isRegistryDependency: true,
+    edgesIn: new Set([{ name: 'canvas', spec: 'file:../canvas' }]),
+  }])
+
+  t.equal(isScriptAllowed(target, { canvas: true }), null)
+  t.end()
+})
+
+t.test('registry — link target with agreeing links keeps the trusted name', t => {
+  const target = node({ name: 'canvas', version: '1.0.0' })
+  target.resolved = null
+  target.isRegistryDependency = false
+  target.edgesIn = new Set()
+  target.linksIn = new Set([
+    { isRegistryDependency: true, edgesIn: new Set([{ name: 'canvas', spec: '^1.0.0' }]) },
+    { isRegistryDependency: true, edgesIn: new Set([{ name: 'canvas', spec: '~1.0.0' }]) },
+  ])
+
+  t.equal(isScriptAllowed(target, { canvas: true }), true)
+  t.end()
+})
+
+t.test('registry — link target with disagreeing link names fails closed', t => {
+  const target = node({ name: 'canvas', version: '1.0.0' })
+  target.resolved = null
+  target.isRegistryDependency = false
+  target.edgesIn = new Set()
+  target.linksIn = new Set([
+    { isRegistryDependency: true, edgesIn: new Set([{ name: 'canvas', spec: '^1.0.0' }]) },
+    { isRegistryDependency: true, edgesIn: new Set([{ name: 'sharp', spec: '^1.0.0' }]) },
+  ])
+
+  t.equal(isScriptAllowed(target, { canvas: true }), null)
+  t.equal(isScriptAllowed(target, { sharp: true }), null)
+  t.end()
+})

--- a/workspaces/arborist/test/script-allowed.js
+++ b/workspaces/arborist/test/script-allowed.js
@@ -874,6 +874,7 @@ t.test('registry — link target delegates edge check to incoming links (linked 
     location: 'node_modules/.store/canvas@1.0.0-hash/node_modules/canvas',
   })
   target.isRegistryDependency = false
+  target.isInStore = true
   target.edgesIn = new Set()
   target.linksIn = new Set([{ isRegistryDependency: true }])
 
@@ -884,9 +885,27 @@ t.test('registry — link target delegates edge check to incoming links (linked 
   t.end()
 })
 
+t.test('registry — link target outside the store never delegates to incoming links', t => {
+  // An ordinary local symlink target has the same empty-edgesIn topology as a store package, but must not borrow registry identity from its Links (npm/cli#9939 review).
+  const target = node({ name: 'canvas', version: '1.0.0' })
+  target.resolved = null
+  target.isRegistryDependency = false
+  target.edgesIn = new Set()
+  target.linksIn = new Set([{
+    isRegistryDependency: true,
+    edgesIn: new Set([{ name: 'canvas', spec: '^1.0.0' }]),
+  }])
+
+  t.equal(isScriptAllowed(target, { 'canvas@1.0.0': true }), null)
+  t.equal(isScriptAllowed(target, { canvas: true }), null)
+  t.equal(isScriptAllowed.getTrustedRegistryIdentity(target), null)
+  t.end()
+})
+
 t.test('registry — link target refuses when an incoming link is not a registry dep', t => {
   const target = node({ name: 'canvas', version: '1.0.0' })
   target.isRegistryDependency = false
+  target.isInStore = true
   target.edgesIn = new Set()
   target.linksIn = new Set([{ isRegistryDependency: true }, { isRegistryDependency: false }])
 
@@ -897,6 +916,7 @@ t.test('registry — link target refuses when an incoming link is not a registry
 t.test('registry — direct non-registry edges refuse regardless of links', t => {
   const target = node({ name: 'canvas', version: '1.0.0' })
   target.isRegistryDependency = false
+  target.isInStore = true
   target.edgesIn = new Set([{ spec: 'file:../canvas' }])
   target.linksIn = new Set([{ isRegistryDependency: true }])
 
@@ -906,14 +926,48 @@ t.test('registry — direct non-registry edges refuse regardless of links', t =>
 
 t.test('store-backed link target never matches store file specs', t => {
   // A store package whose resolved is unknown (fs-scan fallback) must not take identity from the store's internal file: link specs (npm/cli#9939).
-  const real = require('node:path').resolve('node_modules/.store/canvas@1.0.0-hash/node_modules/canvas')
+  const { resolve } = require('node:path')
+  const root = resolve('/project')
+  const real = resolve(root, 'node_modules/.store/canvas@1.0.0-hash/node_modules/canvas')
   const target = node({ name: 'canvas', version: '1.0.0' })
   target.resolved = null
+  target.root = { path: root }
   target.path = real
   target.realpath = real
   target.linksIn = new Set([{ resolved: 'file:.store/canvas@1.0.0-hash/node_modules/canvas' }])
 
   t.equal(isScriptAllowed(target, { 'file:.store/canvas@1.0.0-hash/node_modules/canvas': true }), null)
+  t.end()
+})
+
+t.test('store path fallback is anchored to the current root', t => {
+  // isStoreBacked has no isInStore on hidden-lockfile loads; the path fallback must only trust this tree's own `.store` (npm/cli#9939 review).
+  const { resolve } = require('node:path')
+  const storeTail = 'node_modules/.store/canvas@1.0.0-hash/node_modules/canvas'
+  const storeTarget = (path, root) => {
+    const target = node({ name: 'canvas', version: '1.0.0' })
+    target.isRegistryDependency = false
+    target.edgesIn = new Set()
+    target.linksIn = new Set([{ isRegistryDependency: true }])
+    target.path = path
+    target.realpath = path
+    target.root = root
+    return target
+  }
+
+  const root = resolve('/project')
+  const inRoot = storeTarget(resolve(root, storeTail), { path: root })
+  t.equal(isScriptAllowed(inRoot, { 'canvas@1.0.0': true }), true, 'inside the current root store')
+
+  const linkedRoot = { path: resolve('/proj-link'), realpath: resolve('/actual/proj') }
+  const inRealRoot = storeTarget(resolve('/actual/proj', storeTail), linkedRoot)
+  t.equal(isScriptAllowed(inRealRoot, { 'canvas@1.0.0': true }), true, 'inside the symlinked root realpath store')
+
+  const plainDir = storeTarget(resolve(root, 'local-canvas'), { path: root })
+  t.equal(isScriptAllowed(plainDir, { 'canvas@1.0.0': true }), null, 'ordinary local directory')
+
+  const otherStore = storeTarget(resolve('/other', storeTail), { path: root })
+  t.equal(isScriptAllowed(otherStore, { 'canvas@1.0.0': true }), null, 'another project store')
   t.end()
 })
 
@@ -932,6 +986,7 @@ t.test('registry — link target without resolved takes trusted name from link e
   const target = node({ name: 'canvas', version: '1.0.0' })
   target.resolved = null
   target.isRegistryDependency = false
+  target.isInStore = true
   target.edgesIn = new Set()
   target.linksIn = new Set([{
     isRegistryDependency: true,
@@ -947,10 +1002,34 @@ t.test('registry — link target without resolved takes trusted name from link e
   t.end()
 })
 
+t.test('registry — link target name is refused when an incoming link is not a registry dep', t => {
+  // isRegistryNode already refuses the match; getTrustedRegistryIdentity is called directly by the writer and must refuse too.
+  const target = node({ name: 'canvas', version: '1.0.0' })
+  target.resolved = null
+  target.isRegistryDependency = false
+  target.isInStore = true
+  target.edgesIn = new Set()
+  target.linksIn = new Set([{
+    isRegistryDependency: false,
+    edgesIn: new Set([{ name: 'canvas', spec: '^1.0.0' }]),
+  }])
+
+  t.equal(isScriptAllowed.getTrustedRegistryIdentity(target), null)
+
+  const noLinks = node({ name: 'canvas', version: '1.0.0' })
+  noLinks.resolved = null
+  noLinks.isRegistryDependency = false
+  noLinks.isInStore = true
+  noLinks.edgesIn = new Set()
+  t.equal(isScriptAllowed.getTrustedRegistryIdentity(noLinks), null)
+  t.end()
+})
+
 t.test('registry — link target with no registry name on any link edge stays untrusted', t => {
   const target = node({ name: 'canvas', version: '1.0.0' })
   target.resolved = null
   target.isRegistryDependency = false
+  target.isInStore = true
   target.edgesIn = new Set()
   target.linksIn = new Set([{
     isRegistryDependency: true,
@@ -965,6 +1044,7 @@ t.test('registry — link target with agreeing links keeps the trusted name', t 
   const target = node({ name: 'canvas', version: '1.0.0' })
   target.resolved = null
   target.isRegistryDependency = false
+  target.isInStore = true
   target.edgesIn = new Set()
   target.linksIn = new Set([
     { isRegistryDependency: true, edgesIn: new Set([{ name: 'canvas', spec: '^1.0.0' }]) },
@@ -979,6 +1059,7 @@ t.test('registry — link target with disagreeing link names fails closed', t =>
   const target = node({ name: 'canvas', version: '1.0.0' })
   target.resolved = null
   target.isRegistryDependency = false
+  target.isInStore = true
   target.edgesIn = new Set()
   target.linksIn = new Set([
     { isRegistryDependency: true, edgesIn: new Set([{ name: 'canvas', spec: '^1.0.0' }]) },


### PR DESCRIPTION

Under `install-strategy=linked`, `npm install-scripts approve <pkg>` wrote verbose, duplicated `file:` entries pointing into `node_modules/.store` (one per incoming symlink depth) instead of `name@version` pins, and those store-path entries never matched at install time.

There are two root causes.
In `findNodesForArgs` (allow-scripts-cmd.js), positional args matched every `Link` pointing at the store package; each Link's relative `file:.store/...` resolved spec became its own policy key and could even strip the correct pin as stale.
In `script-allowed.js`, a store package has no `edgesIn` (they land on its incoming Links), so `isRegistryNode` refused registry keys, and `ls`, the post-install advisory, and prune treated a correct `name@version` entry as matching nothing.

The fix skips `Link` nodes when matching positional args, mirroring `collectUnreviewedScripts` and prune, so approvals key off the real package's trusted registry identity.
`isRegistryNode` and `nameFromEdges` now delegate edge-based checks to a link target's incoming Links, which also covers `omit-lockfile-registry-resolved` (approve by name, like the hoisted #9558 path).
`resolvedSourceSpecs` no longer fabricates `file:` specs from links into the store, so store packages are never keyed by store paths and prune cleans up the buggy entries while keeping the valid pin.

## References

Fixes #9939
