### PR TITLE
fix(libnpmexec): honor min-release-age-exclude when resolving specs

### DIFF
--- a/workspaces/libnpmexec/lib/index.js
+++ b/workspaces/libnpmexec/lib/index.js
@@ -24,10 +24,8 @@ const withLock = require('./with-lock.js')
 // spec.raw so we don't have to fetch again when we check npxCache
 const manifests = new Map()
 
-// The effective `before` filter for a spec, honoring `min-release-age-exclude`
-// the same way arborist does for installs. libnpmexec resolves the requested
-// spec with pacote directly, so without this an exempted package would still
-// be rejected by the `min-release-age` cutoff with ETARGET.
+// Apply `min-release-age-exclude` the same way arborist does for installs:
+// drop the `before` cutoff (set by `min-release-age`) for exempted specs.
 const releaseAgeBefore = (spec, { before, minReleaseAgeExclude }) => {
   if (!before) {
     return before

--- a/workspaces/libnpmexec/lib/index.js
+++ b/workspaces/libnpmexec/lib/index.js
@@ -5,6 +5,7 @@ const crypto = require('node:crypto')
 const { mkdir } = require('node:fs/promises')
 const Arborist = require('@npmcli/arborist')
 const strictAllowScriptsPreflight = require('./strict-allow-scripts-preflight.js')
+const { isReleaseAgeExcluded, trustedSpecName } = require('@npmcli/arborist/lib/release-age-exclude.js')
 const ciInfo = require('ci-info')
 const { log, input } = require('proc-log')
 const npa = require('npm-package-arg')
@@ -23,10 +24,22 @@ const withLock = require('./with-lock.js')
 // spec.raw so we don't have to fetch again when we check npxCache
 const manifests = new Map()
 
+// The effective `before` filter for a spec, honoring `min-release-age-exclude`
+// the same way arborist does for installs. libnpmexec resolves the requested
+// spec with pacote directly, so without this an exempted package would still
+// be rejected by the `min-release-age` cutoff with ETARGET.
+const releaseAgeBefore = (spec, { before, minReleaseAgeExclude }) => {
+  if (!before) {
+    return before
+  }
+  return isReleaseAgeExcluded(trustedSpecName(spec), minReleaseAgeExclude) ? null : before
+}
+
 const getManifest = async (spec, flatOptions) => {
   if (!manifests.has(spec.raw)) {
     const manifest = await pacote.manifest(spec, {
       ...flatOptions,
+      before: releaseAgeBefore(spec, flatOptions),
       preferOnline: true,
       Arborist,
       _isRoot: true,

--- a/workspaces/libnpmexec/test/registry.js
+++ b/workspaces/libnpmexec/test/registry.js
@@ -340,9 +340,8 @@ t.test('min-release-age-exclude exempts spec from before cutoff', async t => {
 
   await package({ registry, path })
 
-  // the mock registry stamps every version with a publish time of "now", so
-  // a `before` cutoff in the past blocks all versions unless the exclude
-  // pattern exempts the package
+  // the mock registry stamps every version as published "now", so a past
+  // `before` cutoff blocks everything unless the exclude pattern applies
   await exec({
     args: ['@npmcli/create-index'],
     globalPath: resolve(path, 'global'),

--- a/workspaces/libnpmexec/test/registry.js
+++ b/workspaces/libnpmexec/test/registry.js
@@ -328,3 +328,48 @@ t.test('override save to true when installing to npx cache', async t => {
     value: 'packages-2.0.0',
   })
 })
+
+t.test('min-release-age-exclude exempts spec from before cutoff', async t => {
+  const { fixtures, package } = createPkg({ versions: ['2.0.0'] })
+
+  const { exec, path, registry, readOutput } = setup(t, {
+    testdir: merge(fixtures, {
+      global: {},
+    }),
+  })
+
+  await package({ registry, path })
+
+  // the mock registry stamps every version with a publish time of "now", so
+  // a `before` cutoff in the past blocks all versions unless the exclude
+  // pattern exempts the package
+  await exec({
+    args: ['@npmcli/create-index'],
+    globalPath: resolve(path, 'global'),
+    before: new Date(Date.now() - 1000 * 60 * 60 * 24),
+    minReleaseAgeExclude: ['@npmcli/*'],
+  })
+
+  t.match(await readOutput('@npmcli-create-index'), {
+    value: 'packages-2.0.0',
+  })
+})
+
+t.test('min-release-age still blocks specs that match no exclude pattern', async t => {
+  const { fixtures, package } = createPkg({ versions: ['2.0.0'] })
+
+  const { exec, path, registry } = setup(t, {
+    testdir: merge(fixtures, {
+      global: {},
+    }),
+  })
+
+  await package({ registry, path, times: 1, tarballs: [] })
+
+  await t.rejects(exec({
+    args: ['@npmcli/create-index'],
+    globalPath: resolve(path, 'global'),
+    before: new Date(Date.now() - 1000 * 60 * 60 * 24),
+    minReleaseAgeExclude: ['@other-scope/*'],
+  }), { code: 'ENOVERSIONS' })
+})


### PR DESCRIPTION
### Description

`npx` resolves its spec with `pacote.manifest`, forwarding `flatOptions.before` (set by `min-release-age`). pacote knows nothing about `min-release-age-exclude`, so excluded packages still failed with `ETARGET`. `npm install` isn't affected because arborist drops `before` per-spec for exempted names.

This matters because it undermines the release-age protection itself: `min-release-age-exclude` exists so teams can keep a strict age window on third-party packages while still running their own trusted packages immediately. With `npx` ignoring it, the only workaround is `--min-release-age=0`, which turns the supply-chain safeguard off for the entire transitive tree instead of just the one exempted package.

This makes libnpmexec do the same before calling `pacote.manifest`, reusing arborist's `release-age-exclude.js` helper (`isReleaseAgeExcluded` + `trustedSpecName`, so `npm:` alias keys can't exempt the package they resolve to). The deep require follows the existing pattern in `strict-allow-scripts-preflight.js`; no new dependencies. The install into the npx cache already goes through arborist, so only the direct manifest lookup needed fixing.

### Testing

Two tests added to `workspaces/libnpmexec/test/registry.js`: an excluded spec resolves and runs despite a past `before` cutoff (fails with `ENOVERSIONS` without the fix), and a non-excluded spec is still blocked.

Verified manually from this checkout against the public registry, using a package version published inside the age window (`pnpm@11.25.0`, published 2026-08-29):

Before this change, the exclude pattern is ignored:

```
$ node . exec --min-release-age=10 --min-release-age-exclude=pnpm --yes -- pnpm@11.25.0 --version
npm error code ETARGET
npm error notarget No matching version found for pnpm@11.25.0 with a date before 24/08/2026 ...
```

After this change, the same command resolves and runs:

```
$ node . exec --min-release-age=10 --min-release-age-exclude=pnpm --yes -- pnpm@11.25.0 --version
11.25.0
```

The filter itself still applies — dropping `--min-release-age-exclude` from the command above still fails with `ETARGET` after this change.

Fixes #9765

Alternative to #9768 — reuses arborist's helper instead of duplicating the minimatch logic in libnpmexec.