### PR TITLE
fix: disable lifecycle scripts during npm diff

### DIFF
--- a/lib/commands/diff.js
+++ b/lib/commands/diff.js
@@ -57,6 +57,9 @@ class Diff extends BaseCommand {
 
     const res = await libnpmdiff([a, b], {
       ...this.npm.flatOptions,
+      // `npm diff` is a read-only inspection command. Do not run lifecycle
+      // scripts from a local directory operand while creating its packument.
+      ignoreScripts: true,
       diffFiles: args,
       where: this.top,
     })

--- a/test/lib/commands/diff.js
+++ b/test/lib/commands/diff.js
@@ -85,6 +85,27 @@ const mockDiff = async (t, {
   return { npm, registry, ...res }
 }
 
+t.test('does not run lifecycle scripts while creating a diff', async t => {
+  let options
+  const { npm } = await mockDiff(t, {
+    prefixDir: {
+      'package.json': {
+        name: 'local-package',
+        version: '1.0.0',
+      },
+    },
+    mocks: {
+      libnpmdiff: async (_specs, opts) => {
+        options = opts
+        return ''
+      },
+    },
+  })
+
+  await npm.exec('diff', [])
+  t.equal(options.ignoreScripts, true)
+})
+
 // a more specific helper to call diff against a local package and a registry package
 // and assert the diff output contains the matching strings
 const assertFoo = async (t, arg) => {


### PR DESCRIPTION
Fixes #9955

## Summary

- Force `ignoreScripts: true` when `npm diff` calls `libnpmdiff`.
- Prevent local directory operands from running `prepare` while an inspection-only diff is being created.
- Add command-level coverage that verifies the option cannot be overridden by normal flat options.

## Testing

- `node_modules\.bin\tap.cmd --no-check-coverage test/lib/commands/diff.js` — passed.
- End-to-end temporary-package reproduction — `npm diff` exited successfully and did not create the `prepare` marker.

## Compatibility note

Generated files that exist only after running `prepare` will no longer be materialized by `npm diff`. This is the intended behavior change for an inspection command; registry-to-registry and ordinary diff behavior remain unchanged.