### PR TITLE
fix(arborist): preserve `bundleDependencies: true` when saving package.json

### DIFF
--- a/workspaces/arborist/lib/arborist/reify.js
+++ b/workspaces/arborist/lib/arborist/reify.js
@@ -1992,7 +1992,7 @@ module.exports = cls => class Reifier extends cls {
         // refresh the edges so they have the correct specs
         tree.package = tree.package
         const pkgJson = await PackageJson.load(tree.path, { create: true })
-        const {
+        let {
           dependencies = {},
           devDependencies = {},
           optionalDependencies = {},
@@ -2005,6 +2005,13 @@ module.exports = cls => class Reifier extends cls {
           // resolvePatchedDependencies drops entries orphaned by uninstall; persist that removal
           patchedDependencies,
         } = tree.package
+
+        // If the original package.json used bundleDependencies: true, preserve
+        // the boolean rather than overwriting it with the normalized list of
+        // packages.
+        if (pkgJson.content.bundleDependencies === true) {
+          bundleDependencies = true
+        }
 
         pkgJson.update({
           dependencies,

--- a/workspaces/arborist/tap-snapshots/test/arborist/reify.js.test.cjs
+++ b/workspaces/arborist/tap-snapshots/test/arborist/reify.js.test.cjs
@@ -17228,6 +17228,10 @@ exports[`test/arborist/reify.js TAP packageLockOnly can add deps > must match sn
 
 `
 
+exports[`test/arborist/reify.js TAP preserves bundleDependencies: true when saving package.json > must match snapshot 1`] = `
+{"dependencies":{"abbrev":"*","wrappy":"^1.0.2"},"bundleDependencies":["abbrev"]}
+`
+
 exports[`test/arborist/reify.js TAP project with bundled deps and a link dep on itself > result 1`] = `
 ArboristNode {
   "bundleDependencies": Array [

--- a/workspaces/arborist/tap-snapshots/test/arborist/reify.js.test.cjs
+++ b/workspaces/arborist/tap-snapshots/test/arborist/reify.js.test.cjs
@@ -17229,7 +17229,7 @@ exports[`test/arborist/reify.js TAP packageLockOnly can add deps > must match sn
 `
 
 exports[`test/arborist/reify.js TAP preserves bundleDependencies: true when saving package.json > must match snapshot 1`] = `
-{"dependencies":{"abbrev":"*","wrappy":"^1.0.2"},"bundleDependencies":["abbrev"]}
+{"dependencies":{"abbrev":"*","wrappy":"^1.0.2"},"bundleDependencies":true}
 `
 
 exports[`test/arborist/reify.js TAP project with bundled deps and a link dep on itself > result 1`] = `

--- a/workspaces/arborist/test/arborist/reify.js
+++ b/workspaces/arborist/test/arborist/reify.js
@@ -2181,6 +2181,19 @@ t.test('saveBundle', async t => {
   t.matchSnapshot(fs.readFileSync(path + '/package.json', 'utf8'))
 })
 
+t.test('preserves bundleDependencies: true when saving package.json', async t => {
+  const path = t.testdir({
+    'package.json': JSON.stringify({
+      dependencies: { abbrev: '*' },
+      bundleDependencies: true,
+    }),
+  })
+  createRegistry(t, true)
+  const arb = newArb({ path })
+  await arb.reify({ add: ['wrappy'], saveType: 'prod' })
+  t.matchSnapshot(fs.readFileSync(path + '/package.json', 'utf8'))
+})
+
 t.test('no saveType: dev w/ compatible peer', async t => {
   const path = t.testdir({
     'package.json': JSON.stringify({


### PR DESCRIPTION
If the original package.json used `bundleDependencies: true`, preserve that boolean value when updating `package.json`, rather than overwriting it with the normalized list of packages.

> [!NOTE]
> This is my first time contributing to the codebase – please review with this in mind. I had some help from CoPilot understanding the codebase and where the change should be made, but the code changes are my own.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

Fixes #6498 
