### PR TITLE
chore(pack): select workspace through config

### DIFF
--- a/test/lib/commands/pack.js
+++ b/test/lib/commands/pack.js
@@ -251,7 +251,7 @@ t.test('invalid packument', async t => {
 })
 
 t.test('workspaces', async t => {
-  const loadWorkspaces = (t) => loadMockNpm(t, {
+  const loadWorkspaces = (t, config = { workspaces: true }) => loadMockNpm(t, {
     prefixDir: {
       'package.json': JSON.stringify(
         {
@@ -276,7 +276,7 @@ t.test('workspaces', async t => {
       },
     },
     config: {
-      workspaces: true,
+      ...config,
       // TODO: this is a workaround for npm run test-all
       // somehow leaking include-workspace-root
       'include-workspace-root': false,
@@ -296,8 +296,10 @@ t.test('workspaces', async t => {
   })
 
   t.test('one workspace', async t => {
-    const { npm, outputs } = await loadWorkspaces(t)
-    await npm.exec('pack', ['workspace-a'])
+    const { npm, outputs } = await loadWorkspaces(t, {
+      workspace: ['workspace-a'],
+    })
+    await npm.exec('pack', [])
     t.strictSame(outputs, ['workspace-a-1.0.0.tgz'])
   })
 


### PR DESCRIPTION
The one-workspace test passed `workspace-a` as an explicit pack target, which npm interprets as a registry package spec. Select the workspace through config instead and pack with no target so the test exercises workspace behavior without making an unintended registry request.

## Testing

- `node_modules/.bin/tap test/lib/commands/pack.js --no-coverage`