### PR TITLE
fix(config): allow setting a string option to an empty value

### DIFF
--- a/docs/lib/content/commands/npm-config.md
+++ b/docs/lib/content/commands/npm-config.md
@@ -33,6 +33,8 @@ Sets each of the config keys to the value provided.
 Modifies the user configuration file unless [`location`](/commands/npm-config#location) is passed.
 
 If value is omitted, the key will be removed from your config file entirely.
+An explicitly empty value (`npm config set key ""` or `npm config set key=`) sets a string-valued option to the empty string without removing it.
+For any other option an empty value removes the key, since an empty string is not a value those options can hold.
 
 Note: for backwards compatibility, `npm config set key value` is supported as an alias for `npm config set key=value`.
 

--- a/lib/commands/config.js
+++ b/lib/commands/config.js
@@ -30,10 +30,13 @@ const keyValues = args => {
   for (let i = 0; i < args.length; i++) {
     const arg = args[i].split('=')
     const key = arg.shift()
+    // null marks a value that was omitted entirely, which is what removes a
+    // key, as opposed to an explicit empty string, which is distinguishable
+    // from it and is only a value of its own for string options.
     const val = arg.length ? arg.join('=')
       : i < args.length - 1 ? args[++i]
-      : ''
-    kv[key.trim()] = val.trim()
+      : null
+    kv[key.trim()] = val === null ? null : val.trim()
   }
   return kv
 }
@@ -164,19 +167,24 @@ class Config extends BaseCommand {
 
     const where = this.npm.flatOptions.location
     for (const [key, val] of Object.entries(keyValues(args))) {
-      log.info('config', 'set %j %j', key, val)
       const baseKey = key.split(':').pop()
-      if (!this.npm.config.definitions[baseKey] && !nerfDarts.includes(baseKey)) {
+      const definition = this.npm.config.definitions[baseKey]
+      // A value that was omitted removes the key.  An empty value only has a
+      // meaning of its own for string options, so for every other type it keeps
+      // removing the key rather than persisting a value the type cannot hold.
+      const remove = val === null || (val === '' && definition?.type !== String)
+      log.info('config', 'set %j %j', key, remove ? '' : val)
+      if (!definition && !nerfDarts.includes(baseKey)) {
         throw new Error(`\`${baseKey}\` is not a valid npm option`)
       }
-      const deprecated = this.npm.config.definitions[baseKey]?.deprecated
+      const deprecated = definition?.deprecated
       if (deprecated) {
         throw new Error(
           `The \`${baseKey}\` option is deprecated, and cannot be set in this way${deprecated}`
         )
       }
 
-      if (val === '') {
+      if (remove) {
         this.npm.config.delete(key, where)
       } else {
         this.npm.config.set(key, val, where)

--- a/test/lib/commands/config.js
+++ b/test/lib/commands/config.js
@@ -386,6 +386,69 @@ t.test('config set key', async t => {
   await t.rejects(fs.stat(join(home, '.npmrc'), { encoding: 'utf8' }), 'removed empty config')
 })
 
+for (const [name, args] of [
+  ['config set key empty value', ['set', 'tag-version-prefix', '']],
+  ['config set key empty value with equals', ['set', 'tag-version-prefix=']],
+]) {
+  t.test(name, async t => {
+    const { npm, home } = await loadMockNpm(t, {
+      homeDir: {
+        '.npmrc': 'tag-version-prefix=v',
+      },
+    })
+
+    await npm.exec('config', args)
+
+    t.equal(npm.config.get('tag-version-prefix'), '', 'set the value to the empty string')
+
+    const contents = await fs.readFile(join(home, '.npmrc'), { encoding: 'utf8' })
+    const rc = ini.parse(contents)
+    t.equal(rc['tag-version-prefix'], '', 'tag-version-prefix is set to the empty string')
+  })
+}
+
+t.test('config set key empty value with omitted key', async t => {
+  const { npm, home } = await loadMockNpm(t, {
+    homeDir: {
+      '.npmrc': 'tag-version-prefix=v\naccess=public',
+    },
+  })
+
+  await npm.exec('config', ['set', 'tag-version-prefix', '', 'access'])
+  t.equal(npm.config.get('tag-version-prefix'), '', 'the empty value was set')
+  t.equal(npm.config.get('access'), null, 'the omitted value was removed')
+
+  const contents = await fs.readFile(join(home, '.npmrc'), { encoding: 'utf8' })
+  const rc = ini.parse(contents)
+  t.equal(rc['tag-version-prefix'], '', 'tag-version-prefix is set to the empty string')
+  t.equal(rc.access, undefined, 'access is removed')
+})
+
+for (const [name, key, seeded, expected] of [
+  ['boolean', 'save-exact', 'save-exact=false', false],
+  ['number', 'fetch-retries', 'fetch-retries=5', 2],
+  ['url', 'registry', 'registry=https://registry.npmjs.org/', 'https://registry.npmjs.org/'],
+  ['enum', 'access', 'access=public', null],
+]) {
+  t.test(`config set key empty value on a ${name} option removes the key`, async t => {
+    const { npm, home } = await loadMockNpm(t, {
+      homeDir: {
+        '.npmrc': seeded,
+      },
+    })
+
+    await npm.exec('config', ['set', key, ''])
+
+    t.equal(npm.config.get(key), expected, `${key} falls back to its default`)
+
+    // the key is the only entry, so removing it empties (and removes) the file
+    const contents = await fs.readFile(join(home, '.npmrc'), { encoding: 'utf8' })
+      .catch(() => '')
+    const rc = ini.parse(contents)
+    t.equal(rc[key], undefined, `${key} is removed from the config file`)
+  })
+}
+
 t.test('config set key value', async t => {
   const { npm, home } = await loadMockNpm(t, {
     homeDir: {


### PR DESCRIPTION
<!-- What / Why -->

`npm config set <key> ""` silently deleted the key instead of persisting an empty
string, because `keyValues()` collapsed "no value given" and "explicitly empty
value" into the same `''` fallback, and `set()` mapped `''` to `config.delete()`.

This made the documented `tag-version-prefix=""` workflow unreachable from the CLI:
config options that are meaningful when empty could not be set to empty. It has
been broken since npm v9.6.5, when the `val === ''` delete branch was introduced
alongside the matching docs sentence.

## What this changes

`lib/commands/config.js` now uses a `null` sentinel for a value that was omitted
entirely, so the two intents stay distinct:

- `npm config set <key>` — value omitted, the key is removed (unchanged)
- `npm config set <key> ""` — an explicit empty string, persisted as `<key>=`

An empty value is only persisted for options whose type is `String`, since that is
the only type for which an empty string is a real value. For every other type an
empty value keeps removing the key, which is exactly what it did before this
change. This matters because config parsing coerces an empty string to `true` for
`Boolean` options and to `0` for `Number` options, and rejects it for URL and enum
options — so persisting it generally would mean `npm config set save-exact ""`
silently *enables* `save-exact`, and `npm config set registry "$UNSET_VAR"` would
write `registry=` and make every later npm command fail with `ERR_INVALID_URL`.
Keys with no definition, such as a nerf-darted credential, also keep deleting.

The delete branch keys off whether the value is usable rather than whether it is
literally empty, and the debug log line still reports `""` for an omitted value so
existing verbose output is unchanged. An empty value was already handled correctly
everywhere downstream — this only fixes the path that never let one through.

One small semantic consequence worth flagging: values are trimmed as before, so
`npm config set tag-version-prefix "   "` is treated as an explicit empty value for
a string option and now persists the empty string instead of deleting the key. For
non-string options a whitespace-only value still deletes, as it did before. Happy to
change this if you would rather a whitespace-only value keep meaning "remove".

## Verification

`npm config set tag-version-prefix ""` followed by `npm version patch` in a git
repo now prints `1.0.1` and creates the `1.0.1` git tag and commit message, with no
`v` prefix. `npm config set tag-version-prefix` still removes the key and
`npm config get` falls back to the `v` default.

Typed options are unchanged: after `npm config set save-exact ""`,
`npm config get save-exact` is still `false` (not `true`); `fetch-retries` stays at
its default `2` (not `0`); and `registry` keeps its default with subsequent
commands working normally.

- `npx tap test/lib/commands/config.js --no-coverage` — pass
- `node . run eslint` — pass
- `node . run test` — pass

The tests cover the explicit empty value, the `key=` form, a mixed invocation that
pairs an empty value with an omitted key, and one case per non-string option type
(`Boolean`, `Number`, URL, enum); the existing omitted-value deletion test still
passes unchanged.

## References

Fixes #6719
