### PR TITLE
fix(arborist): drop stale top-level lockfile version

### DIFF
--- a/workspaces/arborist/lib/shrinkwrap.js
+++ b/workspaces/arborist/lib/shrinkwrap.js
@@ -1026,6 +1026,14 @@ class Shrinkwrap {
       this.#buildLegacyLockfile(this.tree, this.data)
     }
 
+    // A root without a version must not keep the stale version recorded by the
+    // previous lockfile. The legacy builder above assigns a version only when
+    // the root has one, and version 4 lockfiles skip that builder entirely, so
+    // clear the stale value here for every non-hidden lockfile.
+    if (!this.hiddenLockfile && this.tree && !this.tree.version) {
+      delete this.data.version
+    }
+
     // lf version 1 = dependencies only
     // lf version 2 = dependencies and packages
     // lf version 3 = packages only

--- a/workspaces/arborist/test/shrinkwrap.js
+++ b/workspaces/arborist/test/shrinkwrap.js
@@ -1012,6 +1012,47 @@ t.test('skip inert nodes in commit', async t => {
   )
 })
 
+t.test('drop a stale root version from the lockfile', async t => {
+  const path = t.testdir({
+    'package.json': JSON.stringify({ name: 'no-version' }),
+  })
+
+  const commit = ({ lockfileVersion, pkg }) => {
+    const sw = new Shrinkwrap({ path, lockfileVersion })
+    sw.data = {
+      name: 'no-version',
+      version: '1.0.1',
+      lockfileVersion,
+      requires: true,
+      packages: { '': { name: 'no-version', version: '1.0.1' } },
+    }
+    sw.tree = new Node({ pkg, path, realpath: path })
+    return sw.commit()
+  }
+
+  // A root without a version must not keep the version recorded by the
+  // previous lockfile. This has to hold on the version 4 path too, which
+  // skips the legacy lockfile builder that clears it for versions 1 to 3.
+  for (const lockfileVersion of [3, 4]) {
+    const committed = commit({ lockfileVersion, pkg: { name: 'no-version' } })
+    t.notOk('version' in committed, `v${lockfileVersion}: stale root version is dropped`)
+    t.equal(committed.lockfileVersion, lockfileVersion, `v${lockfileVersion}: lockfileVersion is preserved`)
+    t.equal(committed.name, 'no-version', `v${lockfileVersion}: name is preserved`)
+    t.notOk('version' in committed.packages[''], `v${lockfileVersion}: root packages entry has no version`)
+  }
+
+  // An existing root version is still recorded.
+  const withVersion = commit({ lockfileVersion: 3, pkg: { name: 'no-version', version: '2.5.0' } })
+  t.equal(withVersion.version, '2.5.0', 'root version is recorded when present')
+
+  // No other root field changes.
+  const committed = commit({ lockfileVersion: 3, pkg: { name: 'no-version' } })
+  t.equal(committed.requires, true, 'requires is preserved')
+  t.equal(committed.packages[''].name, 'no-version', 'root packages entry keeps its name')
+
+  t.end()
+})
+
 t.test('load a fresh hidden lockfile', async t => {
   const sw = await Shrinkwrap.reset({
     path: hiddenLockfileFixture,


### PR DESCRIPTION
Removing `version` from the root `package.json` no longer leaves the previous number at the top level of `package-lock.json`.

Before, the lockfile contradicted itself: `packages[""]` was rebuilt without a version while the top-level `version` kept the old one. `Shrinkwrap.load()` copies the on-disk lockfile into `this.data`, and nothing cleared that top-level value - the legacy builder assigns a version only when the root has one, and lockfileVersion 4 skips that builder entirely. `commit()` now clears it for every non-hidden lockfile.

Verified: a new regression test covers removal, retention, and unchanged sibling fields across lockfileVersion 3 and 4; `npm install --package-lock-only` reproductions pass for both lockfile versions; the full `@npmcli/arborist` suite is green with `shrinkwrap.js` at 100% coverage; eslint clean.

Known limitation: this clears a version the manifest no longer has, but lockfileVersion 4 still does not resync a *changed* version. Doing that safely needs a link-root-aware contract - a blanket reassignment overwrites the `file:...` value link roots legitimately record and fails the existing `loadActual` fixtures.

Fixes #8831
